### PR TITLE
Replaced nose.plugins.skip.SkipTest with unittest.SkipTest to avoid dependency on nose.

### DIFF
--- a/dataviews/ipython/magics.py
+++ b/dataviews/ipython/magics.py
@@ -6,7 +6,7 @@ from IPython.core import page
 try:
     from IPython.core.magic import Magics, magics_class, cell_magic, line_cell_magic
 except:
-    from nose.plugins.skip import SkipTest
+    from unittest import SkipTest
     raise SkipTest("IPython extension requires IPython >= 0.13")
 
 from ..dataviews import Stack, View

--- a/dataviews/ipython/widgets.py
+++ b/dataviews/ipython/widgets.py
@@ -3,7 +3,7 @@ import sys, math, time
 import numpy as np
 from collections import OrderedDict
 
-from nose.plugins.skip import SkipTest
+from unittest import SkipTest
 
 try:
     import IPython


### PR DESCRIPTION
As discussed as part of ioam/topographica#597, this replaces the import of SkipTest from nose with the standard library version from unittest. 
