### PR TITLE
Add a gitfilter to clean the output and metadata from an ipynb

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
  __init__.py export-subst
  setup.py export-subst
+*.ipynb filter=nbstrip_jq

--- a/nbstrip_jq.sh
+++ b/nbstrip_jq.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# `nbstrip_jq.sh`:
+# This is a git filters that strips out Jupyter notebook outputs and meta data.
+# Execute the following lines in order to activate this filter:
+# conda install --yes jq  # or `brew install jq` or `apt-get install jq`
+# 
+# git config filter.nbstrip_jq.clean './nbstrip_jq.sh'
+# git config filter.nbstrip_jq.smudge cat
+# git config filter.nbstrip_jq.required true
+# 
+# Add the following line to your `.gitattributes`.
+# *.ipynb filter=nbstrip_jq
+
+
+jq --indent 1 \
+    '
+    (.cells[] | select(has("outputs")) | .outputs) = []
+    | (.cells[] | select(has("execution_count")) | .execution_count) = null
+    | .metadata = {}
+    | .cells[].metadata = {}
+    '


### PR DESCRIPTION
Regarding https://github.com/ioam/holoviews/issues/1617 and https://github.com/ioam/holoviews/pull/2507.

What about this?

You activate the filter with:
```bash
git config filter.nbstrip_jq.clean './nbstrip_jq.sh'
git config filter.nbstrip_jq.smudge cat
git config filter.nbstrip_jq.required true
```