### PR TITLE
Fixed colorbar on RadialHeatMapPlot

### DIFF
--- a/holoviews/plotting/bokeh/heatmap.py
+++ b/holoviews/plotting/bokeh/heatmap.py
@@ -550,3 +550,9 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
                 'arc_1': data_ymarks}
 
         return data, mapping, style
+
+    def _init_glyph(self, plot, mapping, properties, key):
+        ret = super(RadialHeatMapPlot, self)._init_glyph(plot, mapping, properties, key)
+        if self.colorbar and 'color_mapper' in self.handles:
+            self._draw_colorbar(plot, self.handles['color_mapper'])
+        return ret

--- a/tests/plotting/bokeh/testradialheatmap.py
+++ b/tests/plotting/bokeh/testradialheatmap.py
@@ -8,6 +8,7 @@ from holoviews.core.spaces import HoloMap
 from holoviews.element.raster import HeatMap
 
 try:
+    from bokeh.models import ColorBar
     from holoviews.plotting.bokeh import RadialHeatMapPlot
 except:
     pass
@@ -282,3 +283,9 @@ class BokehRadialHeatMapPlotTests(TestBokehPlot):
                       'B': HeatMap(np.random.randint(0, 10, (100, 3)))})
         plot = bokeh_renderer.get_plot(hm.options(radial=True))
         self.assertIsInstance(plot, RadialHeatMapPlot)
+
+    def test_radial_heatmap_colorbar(self):
+        hm = HeatMap([(0, 0, 1), (0, 1, 2), (1, 0, 3)]).options(radial=True, colorbar=True)
+        plot = bokeh_renderer.get_plot(hm)
+        self.assertIsInstance(plot.handles.get('colorbar'), ColorBar)
+


### PR DESCRIPTION
The bokeh RadialHeatMapPlot was not drawing a colorbar.

- [x] Adds unit test