### PR TITLE
Ability to specify transforms for `Params` streams on parameters when .contents is accessed

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -198,6 +198,14 @@ class Stream(param.Parameterized):
 
         Some streams are configured to automatically link to the source
         plot, to disable this set linked=False
+
+        Transforms: an optional dictionary of functions/callables where keys
+        correspond to (renamed) stream parameters and values are functions
+        to be applied to particular parameters whenever the stream's contents
+        are accessed. These functions transform their corresponding parameters'
+        values (e.g., string to int casting), which can be useful when elements
+        like HeatMap convert their supplied kdims to strings from numeric values
+        (Unrelated to transform() function.)
         """
         self._source = source
         self._subscribers = []

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -641,10 +641,8 @@ class Params(Stream):
 
         transforms = self.contents_transforms
 
-        transformed = {
-            k: transforms[k](v) if k in transforms else v
-            for k, v in renamed.items()
-        }
+        transformed = {k: transforms[k](v) if k in transforms else v
+                       for k, v in renamed.items()}
 
         return transformed
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -217,6 +217,11 @@ class Stream(param.Parameterized):
 
         super(Stream, self).__init__(**params)
         self._rename = self._validate_rename(rename)
+
+        if transforms:
+            if not isinstance(transforms, dict) or any(not callable(v) for v in transforms.values()):
+                raise TypeError('transforms must be dict of callables')
+
         self._transforms = transforms
         if source is not None:
             self.registry[id(source)].append(self)


### PR DESCRIPTION
As discussed with @philippjfr. 

I just ended up sticking this in `hv.streams.Params` for now instead of `hv.streams.Stream` as a proof-of-concept. I wasn't sure whether it was desired to have this functionality for all `Stream`s or just this specialized one. Also wasn't 100% sure what to call the optional transformation parameter. Let me know what you think. 

As an alternative to the style used in the `Tap` example documentation, where the `Year` `kdim` has to be converted back to an integer after being casted to a string by the `HeatMap`:

```python
# Declare HeatMap
heatmap = hv.HeatMap(dataset.aggregate(['Year', 'State'], np.mean),
                     label='Measles Incidence').select(Year=(1928, 2002))

# Declare Tap stream with heatmap as source and initial values
posxy = hv.streams.Tap(source=heatmap, x=1951, y='New York')
# Define function to compute histogram based on tap location
def tap_histogram(x, y):
    return hv.Curve(dataset.select(State=y, Year=int(x)), kdims='Week',
                   label='Year: %s, State: %s' % (x, y))

heatmap + hv.DynamicMap(tap_histogram, kdims=[], streams=[posxy])
```

New style - conversions/casting can be handled without having to define a `DynamicMap` / callable pair in the case where you need to cast (for example) the `HeatMap`'s string `kdim` back to the `kdim` type of your actual `Dataset`:

```python
hv_heatmap = ds.to(hv.HeatMap)

tap_stream = Params(
    Tap(source=hv_heatmap, y=coeffs[0]), 
    ['y'], rename={'y': 'coeff'},
    contents_transforms={'coeff': int}
)

(
    hv_heatmap
    +
    Dynamic(ds.to(hv.Curve).redim.range(y=(da.min(), da.max())), streams=[tap_stream])
).cols(1)
```

Note that I was using `Params` here in the first place because in my application that eventually resulted in this PR I only wanted the y coordinate from the `Tap` as a `kdim`.

See https://anaconda.org/zbarry/2018-10-13_stream_transforms_work/notebook for the complete example.

P.S.: first PR. Let me know if I've done something silly.