### PR TITLE
Ensure RGBPlot is not a ColorbarPlot

### DIFF
--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -70,7 +70,7 @@ class RasterPlot(ColorbarPlot):
 
 
 
-class RGBPlot(RasterPlot):
+class RGBPlot(ElementPlot):
 
     style_opts = ['alpha']
     _plot_methods = dict(single='image_rgba')
@@ -112,10 +112,6 @@ class RGBPlot(RasterPlot):
 
         data = dict(image=[img], x=[l], y=[b], dw=[dw], dh=[dh])
         return (data, mapping, style)
-
-    def _glyph_properties(self, plot, element, source, ranges, style):
-        return ElementPlot._glyph_properties(self, plot, element,
-                                             source, ranges, style)
 
 
 

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -155,8 +155,8 @@ Store.register({Curve: CurvePlot,
                                        False: HeatMapPlot},
                                       True),
                 Image: RasterPlot,
-                RGB: RasterPlot,
-                HSV: RasterPlot,
+                RGB: RGBPlot,
+                HSV: RGBPlot,
 
                 # Graph Elements
                 Graph: GraphPlot,


### PR DESCRIPTION
Ensures that RGBPlot is separate from RasterPlot to ensure it does not inherit plot and style options related to colormapping.

- [x] Fixes https://github.com/ioam/holoviews/issues/2873