### PR TITLE
Fixed usage of dynamic Overlay as a stream source

### DIFF
--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -142,7 +142,7 @@ def compute_overlayable_zorders(obj, path=[]):
 
     isoverlay = isinstance(obj.last, CompositeOverlay)
     isdynoverlay = obj.callback._is_overlay
-    if obj not in zorder_map[0] and not isoverlay:
+    if obj not in zorder_map[0]:
         zorder_map[0].append(obj)
     depth = overlay_depth(obj)
 


### PR DESCRIPTION
Need to determine why this condition was added in the first place before this can be merged in case there is a good reason.

- [x] Closes https://github.com/ioam/holoviews/issues/2529