### PR TITLE
New pipe method for more intuitive multidimensional dim transforms

### DIFF
--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -171,6 +171,19 @@ class dim(object):
         """
         cls._custom_funcs[key] = function
 
+    @classmethod
+    def pipe(cls, func, *args, **kwargs):
+        """
+        Wrapper to give multidimensional transforms a more intuitive syntax.
+        For a custom function 'func' with signature (*args, **kwargs), call as
+        dim.pipe(func, *args, **kwargs).
+        """
+        args = list(args) # make mutable
+        for k, arg in enumerate(args):
+            if isinstance(arg, basestring):
+                args[k] = dim(arg)
+        return dim(args[0], func, *args[1:], **kwargs)
+
     # Builtin functions
     def __abs__(self):            return dim(self, abs)
     def __round__(self, ndigits=None):


### PR DESCRIPTION
As discussed in #3636, I propose a thin wrapper around the already present capability of dim transforms to handle custom functions with multiple input dimensions.

I used `pipe` as name for the new class method, inspired by https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.pipe.html

The following is now possible (example a bit convoluted for the sake of demonstration):
```
import numpy as np
import pandas as pd
import holoviews as hv
from holoviews import dim

df = pd.DataFrame(np.random.rand(10, 3), columns=['x', 'y', 'z']).cumsum()
e = hv.Scatter(df, 'x', ['y', 'z'])

def func(x, y, z, u, v=None):
    return u+z*np.polyfit(x, y, 1)[1]

dim.pipe(func, 'x', 'y', 10, np.random.rand(10)).max().apply(e)
```

Edit: Although I start wondering whether it wouldn't be more general to allow passing `str` arguments instead of transforming them into `dim`s by default. Perhaps a keyword `dim_as_str=True` could help?