### PR TITLE
Add an example of the first Image constructor

### DIFF
--- a/examples/reference/elements/bokeh/Image.ipynb
+++ b/examples/reference/elements/bokeh/Image.ipynb
@@ -41,8 +41,7 @@
     "\n",
     "where ``Z`` is a 2D array of shape ``NxM`` defining the intensity values and the bounds define the (left, bottom, right, top) edges of four corners of the grid. Other gridded formats which support declaring of explicit x/y-coordinate arrays such as xarray are also supported. See the [Gridded Datasets](../../../user_guide/09-Gridded_Datasets.ipynb) user guide for all the other accepted data formats.\n",
     "\n",
-    "Note that the first constructor uses `X` and `Y` to annotate the column and row indices to `Z` with 2D Cartesian coordinates, respectively. This means, the image of `Z` will be flipped over the yaxis if  `Y` is in increasing order (eg. `np.linspace(-1,1,num=10)`, which is the opposite of row index order in `Z`.  \n",
-    "Compare the two examples:"
+    "Note that the first constructor uses `X` and `Y` to annotate the column and row indices to `Z` with 2D Cartesian coordinates, respectively. This means, the image of `Z` will be flipped over the yaxis if  `Y` is in increasing order (eg. `np.linspace(-1,1,num=10)`, which is the opposite of row index order in `Z`. Compare the two examples:"
    ]
   },
   {

--- a/examples/reference/elements/bokeh/Image.ipynb
+++ b/examples/reference/elements/bokeh/Image.ipynb
@@ -41,7 +41,8 @@
     "\n",
     "where ``Z`` is a 2D array of shape ``NxM`` defining the intensity values and the bounds define the (left, bottom, right, top) edges of four corners of the grid. Other gridded formats which support declaring of explicit x/y-coordinate arrays such as xarray are also supported. See the [Gridded Datasets](../../../user_guide/09-Gridded_Datasets.ipynb) user guide for all the other accepted data formats.\n",
     "\n",
-    "Note that the two constructors may interpret the direction of axis differently, depending on whether `X` and `Y` array (for the first contructor) are in the increasting or decreasing order.  For example, `Y` need be in decreasing order (eg. ``np.linspace(2,-2,num=10)``) in order for the underlying dataset in `Z` to be plotted without its `y`-axis flipped.  Compare the two examples:"
+    "Note that the first constructor uses `X` and `Y` to annotate the column and row indices to `Z` with 2D Cartesian coordinates, respectively. This means, the image of `Z` will be flipped over the yaxis if  `Y` is in increasing order (eg. `np.linspace(-1,1,num=10)`, which is the opposite of row index order in `Z`.  \n",
+    "Compare the two examples:"
    ]
   },
   {
@@ -52,7 +53,7 @@
    "source": [
     "xs = np.linspace(-1,1,10)\n",
     "ys = np.linspace(-1,1,10)\n",
-    "zz = np.empty((len(ys), len(xs)))\n",
+    "zz = np.zeros((len(ys), len(xs)))\n",
     "for i in range(len(xs)):\n",
     "    for j in range(len(ys)):\n",
     "        zz[j,i] = ys[j]\n",
@@ -68,8 +69,8 @@
    "outputs": [],
    "source": [
     "%%opts Image [tools=['hover']] (cmap='viridis')\n",
-    "img1 = hv.Image((xs,ys,zz), label='ys in increasing order')\n",
-    "img2 = hv.Image((xs,ys[::-1],zz), label='ys in decreasing order')\n",
+    "img1 = hv.Image((xs,ys,zz), label='opposite orders' )\n",
+    "img2 = hv.Image((xs,ys[::-1],zz), label='synced orders')\n",
     "img1 + img2"
    ]
   },
@@ -95,8 +96,8 @@
    "outputs": [],
    "source": [
     "%%opts Image [tools=['hover']] (cmap='viridis')\n",
-    "img1 = hv.Image((xs,ys,zz), label='array index and y-coordinate reversed')\n",
-    "img2 = hv.Image((xs,ys[::-1],zz), label='array index and y-coordinate aligned')\n",
+    "img1 = hv.Image((xs,ys,zz), label='opposite orders')#'array index and y-coordinate reversed')\n",
+    "img2 = hv.Image((xs,ys[::-1],zz), label='synced orders') #'array index and y-coordinate aligned')\n",
     "img1 +img2"
    ]
   },

--- a/examples/reference/elements/bokeh/Image.ipynb
+++ b/examples/reference/elements/bokeh/Image.ipynb
@@ -20,8 +20,10 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
     "import holoviews as hv\n",
     "from holoviews import opts\n",
+    "\n",
     "hv.extension('bokeh')"
    ]
   },
@@ -33,11 +35,76 @@
     "\n",
     "    Image((X, Y, Z))\n",
     "\n",
-    "where ``X`` is a 1D array of shape ``M``, ``Y`` is a 1D array of shape ``N`` and ``Z`` is a 2D array of shape ``NxM``, or equivalently:\n",
+    "where ``X`` is a 1D array of shape ``M``, ``Y`` is a 1D array of shape ``N`` and ``Z`` is a 2D array of shape ``NxM`` such that ``Z[j,i]`` is the intensity value at xy coordinate ``(xs[i],ys[j])``, or equivalently:\n",
     "\n",
     "    Image(Z, bounds=(x0, y0, x1, y1))\n",
     "\n",
-    "where ``Z`` is a 2D array of shape ``NxM`` defining the intensity values and the bounds define the (left, bottom, right, top) edges of four corners of the grid. Other gridded formats which support declaring of explicit x/y-coordinate arrays such as xarray are also supported. See the [Gridded Datasets](../../../user_guide/09-Gridded_Datasets.ipynb) user guide for all the other accepted data formats."
+    "where ``Z`` is a 2D array of shape ``NxM`` defining the intensity values and the bounds define the (left, bottom, right, top) edges of four corners of the grid. Other gridded formats which support declaring of explicit x/y-coordinate arrays such as xarray are also supported. See the [Gridded Datasets](../../../user_guide/09-Gridded_Datasets.ipynb) user guide for all the other accepted data formats.\n",
+    "\n",
+    "Note that the two constructors may interpret the direction of axis differently, depending on whether `X` and `Y` array (for the first contructor) are in the increasting or decreasing order.  For example, `Y` need be in decreasing order (eg. ``np.linspace(2,-2,num=10)``) in order for the underlying dataset in `Z` to be plotted without its `y`-axis flipped.  Compare the two examples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.linspace(-1,1,10)\n",
+    "ys = np.linspace(-1,1,10)\n",
+    "zz = np.empty((len(ys), len(xs)))\n",
+    "for i in range(len(xs)):\n",
+    "    for j in range(len(ys)):\n",
+    "        zz[j,i] = ys[j]\n",
+    "        \n",
+    "plt.imshow(zz);\n",
+    "plt.title('Upderlying data array');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Image [tools=['hover']] (cmap='viridis')\n",
+    "img1 = hv.Image((xs,ys,zz), label='ys in increasing order')\n",
+    "img2 = hv.Image((xs,ys[::-1],zz), label='ys in decreasing order')\n",
+    "img1 + img2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.linspace(0, 10, 200)\n",
+    "ys = np.linspace(0, 10, 200)\n",
+    "xx, yy = np.meshgrid(xs, xs) ## ycoord values in `yy` decreases as the array index to `yy` increases\n",
+    "zz = np.sin(xx)*np.cos(yy)\n",
+    "\n",
+    "plt.title('Upderlying array');\n",
+    "plt.imshow(zz);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Image [tools=['hover']] (cmap='viridis')\n",
+    "img1 = hv.Image((xs,ys,zz), label='array index and y-coordinate reversed')\n",
+    "img2 = hv.Image((xs,ys[::-1],zz), label='array index and y-coordinate aligned')\n",
+    "img1 +img2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The second constructor can be used like the following:"
    ]
   },
   {
@@ -135,9 +202,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:earthml_v2]",
+   "language": "python",
+   "name": "conda-env-earthml_v2-py"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/bokeh/Image.ipynb
+++ b/examples/reference/elements/bokeh/Image.ipynb
@@ -96,8 +96,8 @@
    "outputs": [],
    "source": [
     "%%opts Image [tools=['hover']] (cmap='viridis')\n",
-    "img1 = hv.Image((xs,ys,zz), label='opposite orders')#'array index and y-coordinate reversed')\n",
-    "img2 = hv.Image((xs,ys[::-1],zz), label='synced orders') #'array index and y-coordinate aligned')\n",
+    "img1 = hv.Image((xs,ys,zz), label='opposite orders') #array index and y-coordinate in reverse order\n",
+    "img2 = hv.Image((xs,ys[::-1],zz), label='synced orders') # in aligned order\n",
     "img1 +img2"
    ]
   },


### PR DESCRIPTION
It took me some time to grasp how the indices to `X`,`Y` and `Z` are aligned when the first Image constructor is used. I thought it would be helpful to add a note that the axes may flip depending on how one specifies the coordinate inputs.  I chose to explicitly show how `Z` is constructed from `xs` and `ys` in the first example to be clear about the relationship between indices to `Z` and x-y coordinate (ie. the values in `xs` and `ys`).  I found using `meshgrid` and numpy functions to get `Z` (as in the second added example) less explicit in showing the relationship.  You may find having two examples redundant though.  Please let me know if you have suggestions to improve the wording and example itself. Thanks!