### PR TITLE
Guess at how to fix up user guide's Deploying Bokeh Apps

### DIFF
--- a/examples/user_guide/Deploying_Bokeh_Apps.ipynb
+++ b/examples/user_guide/Deploying_Bokeh_Apps.ipynb
@@ -118,15 +118,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```python\n",
-    "BokehRenderer()\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "All ``Renderer`` classes in HoloViews are so called ParameterizedFunctions; they provide both classmethods and instance methods to render an object. You can easily create a new ``Renderer`` instance using the ``.instance`` method:"
    ]
   },
@@ -152,7 +143,7 @@
    "source": [
     "### Figures\n",
     "\n",
-    "The BokehRenderer converts the HoloViews object to a HoloViews ``Plot``, which holds the Bokeh models that will be rendered to screen. As a very simple example we can convert a HoloViews ``Image`` to a HoloViews plot:"
+    "The BokehRenderer converts the HoloViews object to a HoloViews ``Plot``, which holds the Bokeh models that will be rendered to screen. As a very simple example we can convert a HoloViews ``Layout`` to a HoloViews plot:"
    ]
   },
   {
@@ -161,17 +152,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "layout = points + selected_points\n",
     "hvplot = renderer.get_plot(layout)\n",
     "print(hvplot)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```\n",
-    "<LayoutPlot LayoutPlot01808>\n",
-    "```"
    ]
   },
   {
@@ -188,13 +171,6 @@
    "outputs": [],
    "source": [
     "hvplot.state"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Column**(\tid = '5a8b7949-decd-4a96-b1f8-8f77ec90e5bf', …)\n"
    ]
   },
   {
@@ -229,16 +205,6 @@
    "outputs": [],
    "source": [
     "renderer(layout)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```\n",
-    "(<bokeh.document.Document at 0x11afc7590>,\n",
-    " {'file-ext': 'html', 'mime_type': u'text/html'})\n",
-    "```"
    ]
   },
   {
@@ -336,15 +302,6 @@
     "\n",
     "app = renderer.app(dmap)\n",
     "print(app)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```\n",
-    "<bokeh.application.application.Application object at 0x11c0ab090>\n",
-    "```"
    ]
   },
   {
@@ -545,7 +502,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "\n",
-    "from bokeh.io import show, curdoc\n",
+    "from bokeh.io import show, curdoc  # noqa: curdoc is a commented-out option\n",
     "from bokeh.layouts import layout\n",
     "from bokeh.models import Slider, Button\n",
     "\n",


### PR DESCRIPTION
Since #4108 was merged, and given existing comments on this PR, I removed #4108's changes from here and made this PR be just about fixing the error in 'Deploying Bokeh Apps':

```
pytest -v --nbsmoke-lint examples
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.7.3, pytest-5.2.2, py-1.8.0, pluggy-0.13.0 -- /home/sefkw/mc3/envs/miscdev37/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.7.3', 'Platform': 'Linux-5.3.0-18-generic-x86_64-with-debian-buster-sid', 'Packages': {'pytest': '5.2.2', 'py': '1.8.0', 'pluggy': '0.13.0'}, 'Plugins': {'html': '2.0.0', 'nbsmoke': '0.3.0', 'metadata': '1.8.0', 'cov': '2.8.1', 'nbval': '0.9.3'}}
rootdir: /home/sefkw/code/holoviz/holoviews
plugins: html-2.0.0, nbsmoke-0.3.0, metadata-1.8.0, cov-2.8.1, nbval-0.9.3
[...]
examples/user_guide/Deploying_Bokeh_Apps.ipynb::/home/sefkw/code/holoviz/holoviews/examples/user_guide/Deploying_Bokeh_Apps.ipynb FAILED                            [ 96%]
[...]
______________________________________________________________________________ test session _______________________________________________________________________________
/home/sefkw/code/holoviz/holoviews/examples/user_guide/Deploying_Bokeh_Apps.ipynb
** line 117 col 27: undefined name 'layout'
** line 151 col 9: undefined name 'layout'
** line 164 col 26: undefined name 'layout'
** line 325 col 0: 'bokeh.io.curdoc' imported but unused
To see python source that was checked by pyflakes: /home/sefkw/code/holoviz/holoviews/examples/user_guide/Deploying_Bokeh_Apps.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: /home/sefkw/code/holoviz/holoviews/examples/user_guide/Deploying_Bokeh_Apps.nbsmoke-debug-premagicprocess.py
```

I have no idea what was supposed to be there, though :)
