### PR TITLE
Allow plotting partially irregular QuadMesh

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -50,7 +50,10 @@ class XArrayInterface(GridInterface):
                      if kd.name in array.dims][::-1]
             if not all(d in names for d in array.dims):
                 array = np.squeeze(array)
-            array = array.transpose(*names)
+            try:
+                array = array.transpose(*names, transpose_coords=False)
+            except:
+                array = array.transpose(*names) # Handle old xarray
         shape = array.shape
         if gridded:
             return shape

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1819,10 +1819,17 @@ def expand_grid_coords(dataset, dim):
     dataset into an ND-array matching the dimensionality of
     the dataset.
     """
-    arrays = [dataset.interface.coords(dataset, d.name, True)
-              for d in dataset.kdims]
-    idx = dataset.get_dimension_index(dim)
-    return cartesian_product(arrays, flat=False)[idx].T
+    irregular = [d.name for d in dataset.kdims
+                 if d is not dim and dataset.interface.irregular(dataset, d)]
+    if irregular:
+        array = dataset.interface.coords(dataset, dim, True)
+        example = dataset.interface.values(dataset, irregular[0], True, False)
+        return array * np.ones_like(example)
+    else:
+        arrays = [dataset.interface.coords(dataset, d.name, True)
+                  for d in dataset.kdims]
+        idx = dataset.get_dimension_index(dim)
+        return cartesian_product(arrays, flat=False)[idx].T
 
 
 def dt64_to_dt(dt64):

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -207,7 +207,8 @@ class QuadMeshPlot(ColorbarPlot):
         cmapper = self._get_colormapper(z, element, ranges, style)
         cmapper = {'field': z.name, 'transform': cmapper}
 
-        irregular = element.interface.irregular(element, x)
+        irregular = (element.interface.irregular(element, x) or
+                     element.interface.irregular(element, y))
         if irregular:
             mapping = dict(xs='xs', ys='ys', fill_color=cmapper)
         else:


### PR DESCRIPTION
Fixes https://github.com/pyviz/hvplot/issues/244

Allows things like:

```python
xs = np.arange(100)
hv.QuadMesh((xs, xs * np.arange(50)[:, np.newaxis], np.random.rand(50, 100)))
```

![bokeh_plot - 2019-09-12T163658 918](https://user-images.githubusercontent.com/1550771/64793576-8fb1d200-d57b-11e9-88ec-1e63acdeec9e.png)
