### PR TITLE
Add cuDFInterface to work with cuDF GPU dataframes and cupy support for XArrayInterface

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -55,6 +55,12 @@ try:
 except ImportError:
     pass
 
+try:
+    from .cudf import cuDFInterface   # noqa (Conditional API import)
+    datatypes.append('cuDF')
+except ImportError:
+    pass
+
 if 'array' not in datatypes:
     datatypes.append('array')
 if 'multitabular' not in datatypes:

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -11,9 +11,9 @@ except ImportError:
 import numpy as np
 
 from .. import util
-from ...dimension import dimension_name
+from ..dimension import dimension_name
 from ..element import Element
-from ...ndmapping import NdMapping, item_check, sorted_context
+from ..ndmapping import NdMapping, item_check, sorted_context
 from .interface import DataError, Interface
 from .pandas import PandasInterface
 
@@ -126,15 +126,8 @@ class cuDFInterface(PandasInterface):
 
 
     @classmethod
-    def values(
-            cls,
-            dataset,
-            dim,
-            expanded=True,
-            flat=True,
-            compute=True,
-            keep_index=False,
-    ):
+    def values(cls, dataset, dim, expanded=True, flat=True, compute=True,
+               keep_index=False):
         dim = dataset.get_dimension(dim, strict=True)
         data = dataset.data[dim.name]
         if not expanded:

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -24,7 +24,7 @@ class cuDFInterface(PandasInterface):
     """
     The cuDFInterface allows a Dataset objects to wrap a cuDF
     DataFrame object. Using cuDF allows working with columnar
-    data on a GPU. Most operation leave the data in GPU memory,
+    data on a GPU. Most operations leave the data in GPU memory,
     however to plot the data it has to be loaded into memory.
 
     The cuDFInterface covers almost the complete API exposed

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -30,10 +30,9 @@ class cuDFInterface(PandasInterface):
     The cuDFInterface covers almost the complete API exposed
     by the PandasInterface with two notable exceptions:
 
-    1) Sorting is not supported and any attempt at sorting will
-       be ignored with an warning.
-    2) Aggregation and groupby do not have a consistent sort order.
-    3) Not all functions can be easily applied to a dask dataframe so
+    1) Aggregation and groupby do not have a consistent sort order
+       (see https://github.com/rapidsai/cudf/issues/4237)
+    3) Not all functions can be easily applied to a cuDF so
        some functions applied with aggregate and reduce will not work.
     """
 

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -159,6 +159,9 @@ class cuDFInterface(PandasInterface):
             group_kwargs['kdims'] = kdims
         group_kwargs.update(kwargs)
 
+        # Propagate dataset
+        group_kwargs['dataset'] = dataset.dataset
+
         # Find all the keys along supplied dimensions
         keys = product(*(dataset.data[dimensions[0]].unique() for d in dimensions))
 

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -1,0 +1,283 @@
+from __future__ import absolute_import
+
+import sys
+import warnings
+
+try:
+    import itertools.izip as zip
+except ImportError:
+    pass
+
+import numpy as np
+
+from .. import util
+from ...dimension import dimension_name
+from ..element import Element
+from ...ndmapping import NdMapping, item_check, sorted_context
+from .interface import DataError, Interface
+from .pandas import PandasInterface
+
+
+class cuDFInterface(PandasInterface):
+    """
+    The cuDFInterface allows a Dataset objects to wrap a cuDF
+    DataFrame object. Using cuDF allows working with columnar
+    data on a GPU. Most operation leave the data in GPU memory,
+    however to plot the data it has to be loaded into memory.
+
+    The cuDFInterface covers almost the complete API exposed
+    by the PandasInterface with two notable exceptions:
+
+    1) Sorting is not supported and any attempt at sorting will
+       be ignored with an warning.
+    2) cuDF does not easily support adding a new column to an existing
+       dataframe unless it is a scalar, add_dimension will therefore
+       error when supplied a non-scalar value.
+    3) Not all functions can be easily applied to a dask dataframe so
+       some functions applied with aggregate and reduce will not work.
+    """
+
+    datatype = 'cuDF'
+
+    types = ()
+
+    @classmethod
+    def loaded(cls):
+        return 'cudf' in sys.modules
+
+    @classmethod
+    def applies(cls, obj):
+        if not cls.loaded():
+            return False
+        import cudf
+        return isinstance(obj, (cudf.DataFrame, cudf.Series))
+
+    @classmethod
+    def init(cls, eltype, data, kdims, vdims):
+        import cudf
+
+        element_params = eltype.param.objects()
+        kdim_param = element_params['kdims']
+        vdim_param = element_params['vdims']
+        ncols = len(data.columns)
+
+        if isinstance(data, cudf.Series):
+            data = data.to_frame()
+
+        index_names = [data.index.name]
+        if index_names == [None]:
+            index_names = ['index']
+        if eltype._auto_indexable_1d and ncols == 1 and kdims is None:
+            kdims = list(index_names)
+
+        if isinstance(kdim_param.bounds[1], int):
+            ndim = min([kdim_param.bounds[1], len(kdim_param.default)])
+        else:
+            ndim = None
+        nvdim = vdim_param.bounds[1] if isinstance(vdim_param.bounds[1], int) else None
+        if kdims and vdims is None:
+            vdims = [c for c in data.columns if c not in kdims]
+        elif vdims and kdims is None:
+            kdims = [c for c in data.columns if c not in vdims][:ndim]
+        elif kdims is None:
+            kdims = list(data.columns[:ndim])
+            if vdims is None:
+                vdims = [d for d in data.columns[ndim:((ndim+nvdim) if nvdim else None)]
+                         if d not in kdims]
+        elif kdims == [] and vdims is None:
+            vdims = list(data.columns[:nvdim if nvdim else None])
+
+        # Handle reset of index if kdims reference index by name
+        for kd in kdims:
+            kd = dimension_name(kd)
+            if kd in data.columns:
+                continue
+            if any(kd == ('index' if name is None else name)
+                   for name in index_names):
+                data = data.reset_index()
+                break
+        if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
+            raise DataError("cudf DataFrame column names used as dimensions "
+                            "must be strings not integers.", cls)
+
+        if kdims:
+            kdim = dimension_name(kdims[0])
+            if eltype._auto_indexable_1d and ncols == 1 and kdim not in data.columns:
+                data = data.copy()
+                data.insert(0, kdim, np.arange(len(data)))
+
+        for d in kdims+vdims:
+            d = dimension_name(d)
+            if len([c for c in data.columns if c == d]) > 1:
+                raise DataError('Dimensions may not reference duplicated DataFrame '
+                                'columns (found duplicate %r columns). If you want to plot '
+                                'a column against itself simply declare two dimensions '
+                                'with the same name. '% d, cls)
+        return data, {'kdims':kdims, 'vdims':vdims}, {}
+
+
+    @classmethod
+    def range(cls, dataset, dimension):
+        column = dataset.data[dataset.get_dimension(dimension, strict=True).name]
+        if column.dtype.kind == 'O':
+            return np.NaN, np.NaN
+        else:
+            return (column.min(), column.max())
+
+
+    @classmethod
+    def values(
+            cls,
+            dataset,
+            dim,
+            expanded=True,
+            flat=True,
+            compute=True,
+            keep_index=False,
+    ):
+        dim = dataset.get_dimension(dim, strict=True)
+        data = dataset.data[dim.name]
+        if not expanded:
+            data = data.unique()
+            return data.to_array() if compute else data
+        elif keep_index:
+            return data
+        elif compute:
+            return data.to_array()
+        return data
+
+
+    @classmethod
+    def groupby(cls, dataset, dimensions, container_type, group_type, **kwargs):
+        # Get dimensions information
+        dimensions = [dataset.get_dimension(d).name for d in dimensions]
+        kdims = [kdim for kdim in dataset.kdims if kdim not in dimensions]
+
+        # Update the kwargs appropriately for Element group types
+        group_kwargs = {}
+        group_type = dict if group_type == 'raw' else group_type
+        if issubclass(group_type, Element):
+            group_kwargs.update(util.get_param_values(dataset))
+            group_kwargs['kdims'] = kdims
+        group_kwargs.update(kwargs)
+
+        # Find all the keys along supplied dimensions
+        indices = [dataset.get_dimension_index(d) for d in dimensions]
+        keys = (tuple(dataset.iloc[i, d] for d in indices)
+                for i in range(len(dataset)))
+
+        # Iterate over the unique entries applying selection masks
+        grouped_data = []
+        for unique_key in util.unique_iterator(keys):
+            group_data = dataset.select(**dict(zip(dimensions, unique_key)))
+            group_data = group_type(group_data, **group_kwargs)
+            grouped_data.append((unique_key, group_data))
+
+        if issubclass(container_type, NdMapping):
+            with item_check(False), sorted_context(False):
+                return container_type(grouped_data, kdims=dimensions)
+        else:
+            return container_type(grouped_data)
+
+
+    @classmethod
+    def select_mask(cls, dataset, selection):
+        """
+        Given a Dataset object and a dictionary with dimension keys and
+        selection keys (i.e tuple ranges, slices, sets, lists or literals)
+        return a boolean mask over the rows in the Dataset object that
+        have been selected.
+        """
+        mask = None
+        for dim, sel in selection.items():
+            if isinstance(sel, tuple):
+                sel = slice(*sel)
+            arr = cls.values(dataset, dim, compute=False)
+            if util.isdatetime(arr) and util.pd:
+                try:
+                    sel = util.parse_datetime_selection(sel)
+                except:
+                    pass
+
+            new_masks = []
+            if isinstance(sel, slice):
+                with warnings.catch_warnings():
+                    warnings.filterwarnings('ignore', r'invalid value encountered')
+                    if sel.start is not None:
+                        new_masks.append(sel.start <= arr)
+                    if sel.stop is not None:
+                        new_masks.append(arr < sel.stop)
+                new_mask = new_masks[0]
+                for imask in new_masks[1:]:
+                    new_mask &= imask
+            elif isinstance(sel, (set, list)):
+                for v in sel:
+                    new_masks.append(arr==v)
+                new_mask = new_masks[0]
+                for imask in new_masks[1:]:
+                    new_mask |= imask
+            elif callable(sel):
+                new_mask = sel(arr)
+            else:
+                new_mask = arr == sel
+
+            if mask is None:
+                mask = new_mask
+            else:
+                mask &= new_mask
+        return mask
+
+
+    @classmethod
+    def select(cls, dataset, selection_mask=None, **selection):
+        df = dataset.data
+        if selection_mask is None:
+            selection_mask = cls.select_mask(dataset, selection)
+
+        indexed = cls.indexed(dataset, selection)
+        df = df[selection_mask]
+        if indexed and len(df) == 1 and len(dataset.vdims) == 1:
+            return df[dataset.vdims[0].name].iloc[0]
+        return df
+
+
+    @classmethod
+    def aggregate(cls, dataset, dimensions, function, **kwargs):
+        data = dataset.data
+        cols = [d.name for d in dataset.kdims if d in dimensions]
+        vdims = dataset.dimensions('value', label='name')
+        reindexed = data[cols+vdims]
+        agg = function.__name__
+        if agg in ('amin', 'amax'):
+            agg = agg[1:]
+        if not hasattr(data, agg):
+            raise ValueError('%s aggregation is not supported on cudf DataFrame.' % agg)
+        if len(dimensions):
+            grouped = reindexed.groupby(cols, sort=False)
+            df = getattr(grouped, agg)().reset_index()
+        else:
+            agg = getattr(reindexed, agg)()
+            data = dict(((col, [v]) for col, v in zip(agg.index, agg.to_array())))
+            df = util.pd.DataFrame(data, columns=list(agg.index))
+
+        dropped = []
+        for vd in vdims:
+            if vd not in df.columns:
+                dropped.append(vd)
+        return df, dropped
+
+
+    @classmethod
+    def sort(cls, dataset, by=[], reverse=False):
+        raise NotImplementedError('Sorting is not supported by cudf DataFrames.')
+
+
+    @classmethod
+    def dframe(cls, dataset, dimensions):
+        if dimensions:
+            return dataset.data[dimensions].to_pandas()
+        else:
+            return dataset.data.to_pandas()
+
+
+Interface.register(cuDFInterface)

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -264,8 +264,8 @@ class cuDFInterface(PandasInterface):
 
     @classmethod
     def sort(cls, dataset, by=[], reverse=False):
-        raise NotImplementedError('Sorting is not supported by cudf DataFrames.')
-
+        dataset.param.warning("cuDF DataFrames do not yet support sorting.")
+        return dataset.data
 
     @classmethod
     def dframe(cls, dataset, dimensions):

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -32,9 +32,7 @@ class cuDFInterface(PandasInterface):
 
     1) Sorting is not supported and any attempt at sorting will
        be ignored with an warning.
-    2) cuDF does not easily support adding a new column to an existing
-       dataframe unless it is a scalar, add_dimension will therefore
-       error when supplied a non-scalar value.
+    2) Aggregation and groupby do not have a consistent sort order.
     3) Not all functions can be easily applied to a dask dataframe so
        some functions applied with aggregate and reduce will not work.
     """

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -8,6 +8,8 @@ try:
 except ImportError:
     pass
 
+from itertools import product
+
 import numpy as np
 
 from .. import util
@@ -155,14 +157,14 @@ class cuDFInterface(PandasInterface):
         group_kwargs.update(kwargs)
 
         # Find all the keys along supplied dimensions
-        indices = [dataset.get_dimension_index(d) for d in dimensions]
-        keys = (tuple(dataset.iloc[i, d] for d in indices)
-                for i in range(len(dataset)))
+        keys = product(*(dataset.data[dimensions[0]].unique() for d in dimensions))
 
         # Iterate over the unique entries applying selection masks
         grouped_data = []
         for unique_key in util.unique_iterator(keys):
             group_data = dataset.select(**dict(zip(dimensions, unique_key)))
+            if not len(group_data):
+                continue
             group_data = group_type(group_data, **group_kwargs)
             grouped_data.append((unique_key, group_data))
 

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -326,8 +326,9 @@ class cuDFInterface(PandasInterface):
 
     @classmethod
     def sort(cls, dataset, by=[], reverse=False):
-        dataset.param.warning("cuDF DataFrames do not yet support sorting.")
-        return dataset.data
+        cols = [dataset.get_dimension(d, strict=True).name for d in by]
+        return dataset.data.sort_values(by=cols, ascending=not reverse)
+
 
     @classmethod
     def dframe(cls, dataset, dimensions):

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -117,6 +117,7 @@ class cuDFInterface(PandasInterface):
                                 'with the same name. '% d, cls)
         return data, {'kdims':kdims, 'vdims':vdims}, {}
 
+    
 
     @classmethod
     def range(cls, dataset, dimension):
@@ -234,6 +235,12 @@ class cuDFInterface(PandasInterface):
         if indexed and len(df) == 1 and len(dataset.vdims) == 1:
             return df[dataset.vdims[0].name].iloc[0]
         return df
+
+
+    @classmethod
+    def concat_fn(cls, dataframes, **kwargs):
+        import cudf
+        return cudf.concat(dataframes, **kwargs)
 
 
     @classmethod

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -270,15 +270,8 @@ class DaskInterface(PandasInterface):
         return data
 
     @classmethod
-    def concat(cls, datasets, dimensions, vdims):
-        import dask.dataframe as dd
-        dataframes = []
-        for key, ds in datasets:
-            data = ds.data.copy()
-            for d, k in zip(dimensions, key):
-                data[d.name] = k
-            dataframes.append(data)
-        return dd.concat(dataframes)
+    def concat_fn(cls, dataframe, **kwargs):
+        return dd.concat(dataframes, **kwargs)
 
     @classmethod
     def dframe(cls, dataset, dimensions):

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -270,7 +270,8 @@ class DaskInterface(PandasInterface):
         return data
 
     @classmethod
-    def concat_fn(cls, dataframe, **kwargs):
+    def concat_fn(cls, dataframes, **kwargs):
+        import dask.dataframe as dd
         return dd.concat(dataframes, **kwargs)
 
     @classmethod

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -321,13 +321,20 @@ class PandasInterface(Interface):
     @classmethod
     def sample(cls, dataset, samples=[]):
         data = dataset.data
-        mask = False
+        mask = None
         for sample in samples:
-            sample_mask = True
+            sample_mask = None
             if np.isscalar(sample): sample = [sample]
             for i, v in enumerate(sample):
-                sample_mask = np.logical_and(sample_mask, data.iloc[:, i]==v)
-            mask |= sample_mask
+                submask = data.iloc[:, i]==v
+                if sample_mask is None:
+                    sample_mask = submask
+                else:
+                    sample_mask &= submask
+            if mask is None:
+                mask = sample_mask
+            else:
+                mask |= sample_mask
         return data[mask]
 
 

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -174,6 +174,13 @@ class PandasInterface(Interface):
 
 
     @classmethod
+    def concat_fn(cls, dataframes, **kwargs):
+        if util.pandas_version >= '0.23.0':
+            kwargs['sort'] = False
+        return pd.concat(dataframes, **kwargs)
+
+        
+    @classmethod
     def concat(cls, datasets, dimensions, vdims):
         dataframes = []
         for key, ds in datasets:
@@ -181,8 +188,7 @@ class PandasInterface(Interface):
             for d, k in zip(dimensions, key):
                 data[d.name] = k
             dataframes.append(data)
-        kwargs = dict(sort=False) if util.pandas_version >= '0.23.0' else {}
-        return pd.concat(dataframes, **kwargs)
+        return cls.concat_fn(dataframes)
 
 
     @classmethod

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -13,6 +13,13 @@ from .grid import GridInterface
 from .interface import Interface, DataError, dask_array_module
 
 
+def is_cupy(array):
+    if 'cupy' not in sys.modules:
+        return False
+    from cupy import ndarray
+    return isinstance(array, ndarray) 
+
+
 class XArrayInterface(GridInterface):
 
     types = ()
@@ -359,6 +366,9 @@ class XArrayInterface(GridInterface):
             da = dask_array_module()
             if compute and da and isinstance(data, da.Array):
                 data = data.compute()
+            if is_cupy(data):
+                import cupy
+                data = cupy.asnumpy(data)
             data = cls.canonicalize(dataset, data, data_coords=data_coords,
                                     virtual_coords=virtual_coords)
             return data.T.flatten() if flat else data

--- a/holoviews/tests/core/data/testcudfinterface.py
+++ b/holoviews/tests/core/data/testcudfinterface.py
@@ -41,4 +41,5 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
     def test_dataset_sort_string_ht(self):
         raise SkipTest("Not supported")
 
-
+    def test_dataset_2D_aggregate_spread_fn_with_duplicates(self):
+        raise SkipTest("cuDF does not support variance aggregation")

--- a/holoviews/tests/core/data/testcudfinterface.py
+++ b/holoviews/tests/core/data/testcudfinterface.py
@@ -19,6 +19,8 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
     datatype = 'cuDF'
     data_type = cudf.DataFrame
 
+    __test__ = True
+
     def setUp(self):
         super(cuDFInterfaceTests, self).setUp()
         logging.getLogger('numba.cuda.cudadrv.driver').setLevel(30)

--- a/holoviews/tests/core/data/testcudfinterface.py
+++ b/holoviews/tests/core/data/testcudfinterface.py
@@ -46,7 +46,7 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
         group2 = {'Age':[12], 'Weight':[10], 'Height':[0.8]}
         grouped = HoloMap([('M', Dataset(group1, kdims=['Age'], vdims=self.vdims)),
                            ('F', Dataset(group2, kdims=['Age'], vdims=self.vdims))],
-                          kdims=['Gender'], sort=False)
+                          kdims=['Gender'])
         self.assertEqual(self.table.groupby(['Gender']).apply('sort'), grouped.apply('sort'))
 
     def test_dataset_groupby_alias(self):
@@ -56,9 +56,9 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
                                          vdims=self.alias_vdims)),
                            ('F', Dataset(group2, kdims=[('age', 'Age')],
                                          vdims=self.alias_vdims))],
-                          kdims=[('gender', 'Gender')], sort=False)
+                          kdims=[('gender', 'Gender')])
         self.assertEqual(self.alias_table.groupby('Gender').apply('sort'),
-                         grouped.apply('sort'))
+                         grouped)
 
     def test_dataset_aggregate_ht(self):
         aggregated = Dataset({'Gender':['M', 'F'], 'Weight':[16.5, 10], 'Height':[0.7, 0.8]},
@@ -83,3 +83,15 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
         reduced = Dataset({'x':self.xs, 'z':self.zs},
                           kdims=['x'], vdims=['z'])
         self.assertEqual(dataset.aggregate(['x'], np.mean).sort(), reduced.sort())
+
+    def test_dataset_2D_aggregate_partial_hm(self):
+        z_ints = [el**2 for el in self.y_ints]
+        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z':z_ints},
+                          kdims=['x', 'y'], vdims=['z'])
+        self.assertEqual(dataset.aggregate(['x'], np.mean).sort(),
+                         Dataset({'x':self.xs, 'z':z_ints}, kdims=['x'], vdims=['z']).sort())
+
+    def test_dataset_reduce_ht(self):
+        reduced = Dataset({'Age':self.age, 'Weight':self.weight, 'Height':self.height},
+                          kdims=self.kdims[1:], vdims=self.vdims)
+        self.assertEqual(self.table.reduce(['Gender'], np.mean).sort(), reduced.sort())

--- a/holoviews/tests/core/data/testcudfinterface.py
+++ b/holoviews/tests/core/data/testcudfinterface.py
@@ -2,12 +2,15 @@ import logging
 
 from unittest import SkipTest
 
+import numpy as np
+
 try:
     import cudf
 except:
     raise SkipTest("Could not import cuDF, skipping cuDFInterface tests.")
 
 from holoviews.core.data import Dataset
+from holoviews.core.spaces import HoloMap
 
 from .base import HeterogeneousColumnTests, InterfaceTests
 

--- a/holoviews/tests/core/data/testcudfinterface.py
+++ b/holoviews/tests/core/data/testcudfinterface.py
@@ -39,7 +39,9 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
 
     def test_dataset_mixed_type_range(self):
         ds = Dataset((['A', 'B', 'C', None],), 'A')
-        self.assertEqual(ds.range(0), (np.nan, np.nan))
+        vmin, vmax = ds.range(0)
+        self.assertTrue(np.isnan(vmin))
+        self.assertTrue(np.isnan(vmax))
 
     def test_dataset_groupby(self):
         group1 = {'Age':[10,16], 'Weight':[15,18], 'Height':[0.8,0.6]}
@@ -95,3 +97,16 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
         reduced = Dataset({'Age':self.age, 'Weight':self.weight, 'Height':self.height},
                           kdims=self.kdims[1:], vdims=self.vdims)
         self.assertEqual(self.table.reduce(['Gender'], np.mean).sort(), reduced.sort())
+
+    def test_dataset_groupby_second_dim(self):
+        group1 = {'Gender':['M'], 'Weight':[15], 'Height':[0.8]}
+        group2 = {'Gender':['M'], 'Weight':[18], 'Height':[0.6]}
+        group3 = {'Gender':['F'], 'Weight':[10], 'Height':[0.8]}
+        grouped = HoloMap([(10, Dataset(group1, kdims=['Gender'], vdims=self.vdims)),
+                           (16, Dataset(group2, kdims=['Gender'], vdims=self.vdims)),
+                           (12, Dataset(group3, kdims=['Gender'], vdims=self.vdims))],
+                          kdims=['Age'])
+        self.assertEqual(self.table.groupby(['Age']).apply('sort'), grouped)
+
+    def test_dataset_aggregate_string_types_size(self):
+        raise SkipTest("cuDF does not support variance aggregation")

--- a/holoviews/tests/core/data/testcudfinterface.py
+++ b/holoviews/tests/core/data/testcudfinterface.py
@@ -32,11 +32,6 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
     def test_dataset_2D_aggregate_spread_fn_with_duplicates(self):
         raise SkipTest("cuDF does not support variance aggregation")
 
-    def test_dataset_reduce_ht(self):
-        reduced = Dataset({'Age':self.age, 'Weight':self.weight, 'Height':self.height},
-                          kdims=self.kdims[1:], vdims=self.vdims)
-        self.assertEqual(self.table.reduce(['Gender'], np.mean), reduced)
-
     def test_dataset_mixed_type_range(self):
         ds = Dataset((['A', 'B', 'C', None],), 'A')
         vmin, vmax = ds.range(0)

--- a/holoviews/tests/core/data/testcudfinterface.py
+++ b/holoviews/tests/core/data/testcudfinterface.py
@@ -1,3 +1,5 @@
+import logging
+
 from unittest import SkipTest
 
 try:
@@ -5,10 +7,9 @@ try:
 except:
     raise SkipTest("Could not import cuDF, skipping cuDFInterface tests.")
 
+from holoviews.core.data import Dataset
+
 from .base import HeterogeneousColumnTests, InterfaceTests
-
-import logging
-
 
 
 class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
@@ -32,3 +33,50 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
         reduced = Dataset({'Age':self.age, 'Weight':self.weight, 'Height':self.height},
                           kdims=self.kdims[1:], vdims=self.vdims)
         self.assertEqual(self.table.reduce(['Gender'], np.mean), reduced)
+
+    def test_dataset_mixed_type_range(self):
+        ds = Dataset((['A', 'B', 'C', None],), 'A')
+        self.assertEqual(ds.range(0), (np.nan, np.nan))
+
+    def test_dataset_groupby(self):
+        group1 = {'Age':[10,16], 'Weight':[15,18], 'Height':[0.8,0.6]}
+        group2 = {'Age':[12], 'Weight':[10], 'Height':[0.8]}
+        grouped = HoloMap([('M', Dataset(group1, kdims=['Age'], vdims=self.vdims)),
+                           ('F', Dataset(group2, kdims=['Age'], vdims=self.vdims))],
+                          kdims=['Gender'], sort=False)
+        self.assertEqual(self.table.groupby(['Gender']).apply('sort'), grouped.apply('sort'))
+
+    def test_dataset_groupby_alias(self):
+        group1 = {'age':[10,16], 'weight':[15,18], 'height':[0.8,0.6]}
+        group2 = {'age':[12], 'weight':[10], 'height':[0.8]}
+        grouped = HoloMap([('M', Dataset(group1, kdims=[('age', 'Age')],
+                                         vdims=self.alias_vdims)),
+                           ('F', Dataset(group2, kdims=[('age', 'Age')],
+                                         vdims=self.alias_vdims))],
+                          kdims=[('gender', 'Gender')], sort=False)
+        self.assertEqual(self.alias_table.groupby('Gender').apply('sort'),
+                         grouped.apply('sort'))
+
+    def test_dataset_aggregate_ht(self):
+        aggregated = Dataset({'Gender':['M', 'F'], 'Weight':[16.5, 10], 'Height':[0.7, 0.8]},
+                             kdims=self.kdims[:1], vdims=self.vdims)
+        self.compare_dataset(self.table.aggregate(['Gender'], np.mean).sort(), aggregated.sort())
+
+    def test_dataset_aggregate_ht_alias(self):
+        aggregated = Dataset({'gender':['M', 'F'], 'weight':[16.5, 10], 'height':[0.7, 0.8]},
+                             kdims=self.alias_kdims[:1], vdims=self.alias_vdims)
+        self.compare_dataset(self.alias_table.aggregate('Gender', np.mean).sort(), aggregated.sort())
+
+    def test_dataset_2D_partial_reduce_ht(self):
+        dataset = Dataset({'x':self.xs, 'y':self.ys, 'z':self.zs},
+                          kdims=['x', 'y'], vdims=['z'])
+        reduced = Dataset({'x':self.xs, 'z':self.zs},
+                          kdims=['x'], vdims=['z'])
+        self.assertEqual(dataset.reduce(['y'], np.mean).sort(), reduced.sort())
+
+    def test_dataset_2D_aggregate_partial_ht(self):
+        dataset = Dataset({'x':self.xs, 'y':self.ys, 'z':self.zs},
+                          kdims=['x', 'y'], vdims=['z'])
+        reduced = Dataset({'x':self.xs, 'z':self.zs},
+                          kdims=['x'], vdims=['z'])
+        self.assertEqual(dataset.aggregate(['x'], np.mean).sort(), reduced.sort())

--- a/holoviews/tests/core/data/testcudfinterface.py
+++ b/holoviews/tests/core/data/testcudfinterface.py
@@ -1,0 +1,44 @@
+from unittest import SkipTest
+
+try:
+    import cudf
+except:
+    raise SkipTest("Could not import cuDF, skipping cuDFInterface tests.")
+
+from .base import HeterogeneousColumnTests, InterfaceTests
+
+import logging
+
+
+
+class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
+    """
+    Tests for the cuDFInterface.
+    """
+
+    datatype = 'cuDF'
+    data_type = cudf.DataFrame
+
+    def setUp(self):
+        super(cuDFInterfaceTests, self).setUp()
+        logging.getLogger('numba.cuda.cudadrv.driver').setLevel(30)
+
+    def test_dataset_sort_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_reverse_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_vdim_ht(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_vdim_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_vdim_hm_alias(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_string_ht(self):
+        raise SkipTest("Not supported")
+
+

--- a/holoviews/tests/core/data/testcudfinterface.py
+++ b/holoviews/tests/core/data/testcudfinterface.py
@@ -23,23 +23,10 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
         super(cuDFInterfaceTests, self).setUp()
         logging.getLogger('numba.cuda.cudadrv.driver').setLevel(30)
 
-    def test_dataset_sort_hm(self):
-        raise SkipTest("Not supported")
-
-    def test_dataset_sort_reverse_hm(self):
-        raise SkipTest("Not supported")
-
-    def test_dataset_sort_vdim_ht(self):
-        raise SkipTest("Not supported")
-
-    def test_dataset_sort_vdim_hm(self):
-        raise SkipTest("Not supported")
-
-    def test_dataset_sort_vdim_hm_alias(self):
-        raise SkipTest("Not supported")
-
-    def test_dataset_sort_string_ht(self):
-        raise SkipTest("Not supported")
-
     def test_dataset_2D_aggregate_spread_fn_with_duplicates(self):
         raise SkipTest("cuDF does not support variance aggregation")
+
+    def test_dataset_reduce_ht(self):
+        reduced = Dataset({'Age':self.age, 'Weight':self.weight, 'Height':self.height},
+                          kdims=self.kdims[1:], vdims=self.vdims)
+        self.assertEqual(self.table.reduce(['Gender'], np.mean), reduced)


### PR DESCRIPTION
This PR adds a new data interface to allow HoloViews to work directly with cuDF GPU dataframes.

- [x] values
- [x] range
- [x] dframe
- [x] select
- [x] groupby (look at optimizing) 
- [x] aggregate
- [x] iloc
- [x] add_dimension
- [x] sort
- [x] sample
- [x] concat

Datashader support:

- [x] Points/Scatter
- [x] Curve/Path/Area
- [x] QuadMesh: rectilinear and curvilinear

Other things to do:

- [x] Implement cuDatashader support once integrated with datashader itself

One major thing to figure out is how we will set up CI tests for the GPU.