### PR TITLE
pprint_value_unit func for printing value and unit

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -395,7 +395,7 @@ class Dimension(param.Parameterized):
         return 'Dimension({spec}, {kws})'.format(spec=repr(self.name), kws=kws)
 
 
-    def pprint_value(self, value):
+    def pprint_value(self, value, print_unit=False):
         """Applies the applicable formatter to the value.
 
         Args:
@@ -409,20 +409,25 @@ class Dimension(param.Parameterized):
                      else self.type_formatters.get(own_type))
         if formatter:
             if callable(formatter):
-                return formatter(value)
+                formatted_value = formatter(value)
             elif isinstance(formatter, basestring):
                 if isinstance(value, (dt.datetime, dt.date)):
-                    return value.strftime(formatter)
+                    formatted_value = value.strftime(formatter)
                 elif isinstance(value, np.datetime64):
-                    return util.dt64_to_dt(value).strftime(formatter)
+                    formatted_value = util.dt64_to_dt(value).strftime(formatter)
                 elif re.findall(r"\{(\w+)\}", formatter):
-                    return formatter.format(value)
+                    formatted_value = formatter.format(value)
                 else:
-                    return formatter % value
-        return unicode(bytes_to_unicode(value))
+                    formatted_value = formatter % value
+        else:
+            formatted_value = unicode(bytes_to_unicode(value))
+
+        if print_unit and self.unit is not None:
+            formatted_value = formatted_value + ' ' + bytes_to_unicode(self.unit)
+        return formatted_value
 
     def pprint_value_string(self, value):
-        """Pretty print the dimension value and unit.
+        """Pretty print the dimension value and unit with title_format
 
         Args:
             value: Dimension value to format

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1091,7 +1091,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         properties = dict(style, source=source)
         if self.show_legend:
             if self.overlay_dims:
-                legend = ', '.join([d.pprint_value(v) for d, v in
+                legend = ', '.join([d.pprint_value(v, print_unit=True) for d, v in
                                     self.overlay_dims.items()])
             else:
                 legend = element.label

--- a/holoviews/plotting/bokeh/sankey.py
+++ b/holoviews/plotting/bokeh/sankey.py
@@ -181,13 +181,11 @@ class SankeyPlot(GraphPlot):
             else:
                 label = ''
             if self.show_values:
-                value = value_dim.pprint_value(node['value'])
+                value = value_dim.pprint_value(node['value'], print_unit=True)
                 if label:
                     label = '%s - %s' % (label, value)
                 else:
                     label = value
-            if value_dim.unit:
-                label += ' %s' % value_dim.unit
             if label:
                 text_labels.append(label)
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -1044,9 +1044,8 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             handle = subplot.traverse(lambda p: p.handles['artist'],
                                       [lambda p: 'artist' in p.handles])
             if isinstance(overlay, NdOverlay):
-                key = (dim.pprint_value(k) for k, dim in zip(key, dimensions))
-                label = ','.join([str(k) + dim.unit if dim.unit else str(k) for dim, k in
-                                  zip(dimensions, key)])
+                label = ','.join([dim.pprint_value(k, print_unit=True)
+                                  for k, dim in zip(key, dimensions)])
                 if handle:
                     legend_data.append((handle, label))
             else:

--- a/holoviews/plotting/mpl/sankey.py
+++ b/holoviews/plotting/mpl/sankey.py
@@ -104,13 +104,11 @@ class SankeyPlot(GraphPlot):
             else:
                 label = ''
             if self.show_values:
-                value = value_dim.pprint_value(node['value'])
+                value = value_dim.pprint_value(node['value'], print_unit=True)
                 if label:
                     label = '%s - %s' % (label, value)
                 else:
                     label = value
-            if value_dim.unit:
-                label += ' %s' % value_dim.unit
             if label:
                 x = x1+(x1-x0)/4. if self.label_position == 'right' else x0-(x1-x0)/4.
                 text_labels.append((label, (x, (y0+y1)/2.)))

--- a/holoviews/tests/core/testndmapping.py
+++ b/holoviews/tests/core/testndmapping.py
@@ -26,7 +26,9 @@ class DimensionTest(ComparisonTestCase):
     def test_dimension_pprint(self):
         dim = Dimension('Test dimension', cyclic=True, type=float, unit='Twilight zones')
         self.assertEqual(dim.pprint_value_string(3.23451), 'Test dimension: 3.2345 Twilight zones')
-        self.assertEqual(dim.pprint_value_string(4.23441),  'Test dimension: 4.2344 Twilight zones')
+        self.assertEqual(dim.pprint_value_string(4.23441), 'Test dimension: 4.2344 Twilight zones')
+        self.assertEqual(dim.pprint_value(3.23451, print_unit=True), '3.2345 Twilight zones')
+        self.assertEqual(dim.pprint_value(4.23441, print_unit=True), '4.2344 Twilight zones')
 
 
 class NdIndexableMappingTest(ComparisonTestCase):


### PR DESCRIPTION
The printing of dimension value with unit is not consistent throughout,
eg missing space between unit and value. This is due to lack of
consistency in logic within construction of the value with unit string.
This PR adds a new function `pprint_value_unit` to `Dimension` based on
`pprint_value_string` that prints just a value and unit, if exists,
with a space between them.
This function replaces the `pprint_value` along with checks for unit.
This concentrates the logic within one place and this will improve 
maintainability