### PR TITLE
Allow spike_length to override second Spikes vdim behavior

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -79,6 +79,22 @@ def cleanup_custom_options(id, weakref=None):
                         'an unreferenced orphan tree may persist in '
                         'memory' % (e, id))
 
+def lookup_options(obj, group, backend):
+    plot_class = None
+    try:
+        plot_class = Store.renderers[backend].plotting_class(obj)
+        style_opts = plot_class.style_opts
+    except SkipRendering:
+        style_opts = None
+
+    node = Store.lookup_options(backend, obj, group)
+    if group == 'style' and style_opts is not None:
+        return node.filtered(style_opts)
+    elif group == 'plot' and plot_class:
+        return node.filtered(list(plot_class.params().keys()))
+    else:
+        return node
+
 
 class SkipRendering(Exception):
     """

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -80,6 +80,10 @@ def cleanup_custom_options(id, weakref=None):
                         'memory' % (e, id))
 
 def lookup_options(obj, group, backend):
+    """
+    Given a HoloViews object, a plot option group (e.g 'style') and
+    backend, return the corresponding Options object.
+    """
     plot_class = None
     try:
         plot_class = Store.renderers[backend].plotting_class(obj)

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -671,8 +671,8 @@ class spikes_aggregate(AggregationOperation):
         if y is None:
             df = element.dframe([x]).copy()
             y = Dimension('y')
-            df['y0'] = float(y_range[0])
-            df['y1'] = float(y_range[1])
+            df['y0']  = float(self.p.offset)
+            df['y1']  = float(self.p.offset + spike_length)
             yagg = ['y0', 'y1']
             height = 1
         else:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -646,7 +646,7 @@ class spikes_aggregate(AggregationOperation):
         x, y = element.kdims[0], None
 
         spike_length = 0.5 if self.p.spike_length is None else self.p.spike_length
-        if element.vdims and spike_length is None:
+        if element.vdims and self.p.spike_length is None:
             x, y = element.dimensions()[:2]
             rename_dict = {'x': x.name, 'y':y.name}
             if not self.p.y_range:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -646,7 +646,7 @@ class spikes_aggregate(AggregationOperation):
         x, y = element.kdims[0], None
 
         spike_length = 0.5 if self.p.spike_length is None else self.p.spike_length
-        if element.vdims and self.p.spike_length is None:
+        if element.vdims and spike_length is None:
             x, y = element.dimensions()[:2]
             rename_dict = {'x': x.name, 'y':y.name}
             if not self.p.y_range:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -674,7 +674,7 @@ class spikes_aggregate(AggregationOperation):
             df['y0']  = float(self.p.offset)
             df['y1']  = float(self.p.offset + spike_length)
             yagg = ['y0', 'y1']
-            height = 1
+            if not self.p.expand: height = 1
         else:
             df = element.dframe([x, y]).copy()
             df['y0'] = np.array(0, df.dtypes[y.name])

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -72,11 +72,11 @@ class ResamplingOperation(LinkableOperation):
     width = param.Integer(default=400, doc="""
        The width of the output image in pixels.""")
 
-    x_range  = param.NumericTuple(default=None, length=2, doc="""
+    x_range  = param.Tuple(default=None, length=2, doc="""
        The x_range as a tuple of min and max x-value. Auto-ranges
        if set to None.""")
 
-    y_range  = param.NumericTuple(default=None, length=2, doc="""
+    y_range  = param.Tuple(default=None, length=2, doc="""
        The y-axis range as a tuple of min and max y value. Auto-ranges
        if set to None.""")
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -668,15 +668,16 @@ class spikes_aggregate(AggregationOperation):
         (x_range, y_range), (xs, ys), (width, height), (xtype, ytype) = info
         ((x0, x1), (y0, y1)), (xs, ys) = self._dt_transform(x_range, y_range, xs, ys, xtype, ytype)
 
+        value_cols = [] if agg_fn.column is None else [agg_fn.column]
         if y is None:
-            df = element.dframe([x]).copy()
+            df = element.dframe([x]+value_cols).copy()
             y = Dimension('y')
             df['y0']  = float(self.p.offset)
             df['y1']  = float(self.p.offset + spike_length)
             yagg = ['y0', 'y1']
             if not self.p.expand: height = 1
         else:
-            df = element.dframe([x, y]).copy()
+            df = element.dframe([x, y]+value_cols).copy()
             df['y0'] = np.array(0, df.dtypes[y.name])
             yagg = ['y0', y.name]
         if xtype == 'datetime':

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -670,9 +670,9 @@ class spikes_aggregate(AggregationOperation):
 
         if y is None:
             df = element.dframe([x]).copy()
-            y = 'y'
-            df['y0'] = y_range[0]
-            df['y1'] = y_range[1]
+            y = Dimension('y')
+            df['y0'] = float(y_range[0])
+            df['y1'] = float(y_range[1])
             yagg = ['y0', 'y1']
             height = 1
         else:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -631,7 +631,7 @@ class spread_aggregate(area_aggregate):
 class spikes_aggregate(AggregationOperation):
     """
     Aggregates Spikes elements by drawing individual line segments
-    over the entire y_range if no value dimension is defined and 
+    over the entire y_range if no value dimension is defined and
     between zero and the y-value if one is defined.
     """
 
@@ -639,7 +639,7 @@ class spikes_aggregate(AggregationOperation):
         agg_fn = self._get_aggregator(element)
 
         if element.vdims:
-            x, y = element.dimensions()
+            x, y = element.dimensions()[:2]
             if not self.p.y_range:
                 y0, y1 = element.range(1)
                 if y0 >= 0:
@@ -650,9 +650,12 @@ class spikes_aggregate(AggregationOperation):
                     default = (y0, y1)
             else:
                 default = None
+
+            rename_dict = {'x': x.name, 'y': y.name}
         else:
             x, y = element.kdims[0], None
             default = (0, 1)
+            rename_dict = {'x': x.name}
         info = self._get_sampling(element, x, y, ndim=1, default=default)
         (x_range, y_range), (xs, ys), (width, height), (xtype, ytype) = info
         ((x0, x1), (y0, y1)), (xs, ys) = self._dt_transform(x_range, y_range, xs, ys, xtype, ytype)
@@ -685,7 +688,7 @@ class spikes_aggregate(AggregationOperation):
         cvs = ds.Canvas(plot_width=width, plot_height=height,
                         x_range=x_range, y_range=y_range)
 
-        agg = cvs.line(df, x.name, yagg, agg_fn, axis=1)
+        agg = cvs.line(df, x.name, yagg, agg_fn, axis=1).rename(rename_dict)
         if xtype == "datetime":
             agg[x.name] = (agg[x.name]/1e3).astype('datetime64[us]')
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -647,7 +647,7 @@ class spikes_aggregate(AggregationOperation):
 
         spike_length = 0.5 if self.p.spike_length is None else self.p.spike_length
         if element.vdims and self.p.spike_length is None:
-            x, y = element.dimensions()
+            x, y = element.dimensions()[:2]
             rename_dict = {'x': x.name, 'y':y.name}
             if not self.p.y_range:
                 y0, y1 = element.range(1)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -722,6 +722,11 @@ class SpikesPlot(ColorbarPlot):
         data = {}
         pos = self.position
         opts = self.lookup_options(element, 'plot').options
+
+        if len(element.dimensions()) > 1 and 'spike_length' not in opts:
+            self.param.warning("Height mapping Spikes using the first vdim is "
+                               "now deprecated. Use Segments.common_baseline "
+                               "classmethod instead.")
         if len(element) == 0 or self.static_source:
             data = {'x': [], 'y0': [], 'y1': []}
         else:

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -721,12 +721,8 @@ class SpikesPlot(ColorbarPlot):
 
         data = {}
         pos = self.position
-        opts = self.lookup_options(element, 'plot').options
 
-        if len(element.dimensions()) > 1 and 'spike_length' not in opts:
-            self.param.warning("Height mapping Spikes using the first vdim is "
-                               "now deprecated. Use Segments.common_baseline "
-                               "classmethod instead.")
+        opts = self.lookup_options(element, 'plot').options
         if len(element) == 0 or self.static_source:
             data = {'x': [], 'y0': [], 'y1': []}
         else:

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -10,7 +10,7 @@ from bokeh.transform import jitter
 
 from ...plotting.bokeh.selection import BokehOverlaySelectionDisplay
 from ...selection import NoOpSelectionDisplay
-from ...core.data import Dataset
+from ...core.data import Dataset, Dimension
 from ...core.dimension import dimension_name
 from ...core.util import (
     OrderedDict, max_range, basestring, dimension_sanitizer,
@@ -676,14 +676,29 @@ class SpikesPlot(ColorbarPlot):
 
     selection_display = BokehOverlaySelectionDisplay()
 
+    def _get_axis_dims(self, element):
+        if 'spike_length' in self.lookup_options(element, 'plot').options:
+            return  [element.dimensions()[0], None, None]
+        return super(SpikesPlot, self)._get_axis_dims(element)
+
     def get_extents(self, element, ranges, range_type='combined'):
-        if len(element.dimensions()) > 1:
+        opts = self.lookup_options(element, 'plot').options
+        if len(element.dimensions()) > 1 and 'spike_length' not in opts:
             ydim = element.get_dimension(1)
             s0, s1 = ranges[ydim.name]['soft']
             s0 = min(s0, 0) if isfinite(s0) else 0
             s1 = max(s1, 0) if isfinite(s1) else 0
             ranges[ydim.name]['soft'] = (s0, s1)
-        l, b, r, t = super(SpikesPlot, self).get_extents(element, ranges, range_type)
+        proxy_dim = None
+        if 'spike_length' in opts:
+            proxy_dim = Dimension('proxy_dim')
+            proxy_range = (self.position, self.position + opts['spike_length'])
+            ranges['proxy_dim'] = {'data':    proxy_range,
+                                  'hard':     (np.nan, np.nan),
+                                  'soft':     (np.nan, np.nan),
+                                  'combined': proxy_range}
+        l, b, r, t = super(SpikesPlot, self).get_extents(element, ranges, range_type,
+                                                         ydim=proxy_dim)
         if len(element.dimensions()) == 1 and range_type != 'hard':
             if self.batched:
                 bs, ts = [], []
@@ -706,12 +721,13 @@ class SpikesPlot(ColorbarPlot):
 
         data = {}
         pos = self.position
+        opts = self.lookup_options(element, 'plot').options
         if len(element) == 0 or self.static_source:
             data = {'x': [], 'y0': [], 'y1': []}
         else:
             data['x'] = element.dimension_values(0)
             data['y0'] = np.full(len(element), pos)
-            if len(dims) > 1:
+            if len(dims) > 1 and 'spike_length' not in opts:
                 data['y1'] = element.dimension_values(1)+pos
             else:
                 data['y1'] = data['y0']+self.spike_length

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -1139,14 +1139,31 @@ class SpikesPlot(PathPlot, ColorbarPlot):
         ax.add_collection(line_segments)
         return {'artist': line_segments}
 
+    def _get_axis_dims(self, element):
+        if 'spike_length' in self.lookup_options(element, 'plot').options:
+            return  [element.dimensions()[0], None, None]
+        return super(SpikesPlot, self)._get_axis_dims(element)
+
     def get_extents(self, element, ranges, range_type='combined'):
+        opts = self.lookup_options(element, 'plot').options
         if len(element.dimensions()) > 1:
             ydim = element.get_dimension(1)
             s0, s1 = ranges[ydim.name]['soft']
             s0 = min(s0, 0) if isfinite(s0) else 0
             s1 = max(s1, 0) if isfinite(s1) else 0
             ranges[ydim.name]['soft'] = (s0, s1)
-        l, b, r, t = super(SpikesPlot, self).get_extents(element, ranges, range_type)
+
+        proxy_dim = None
+        if 'spike_length' in opts:
+            proxy_dim = Dimension('proxy_dim')
+            proxy_range = (self.position, self.position + opts['spike_length'])
+            ranges['proxy_dim'] = {'data':    proxy_range,
+                                  'hard':     (np.nan, np.nan),
+                                  'soft':     (np.nan, np.nan),
+                                  'combined': proxy_range}
+
+        l, b, r, t = super(SpikesPlot, self).get_extents(element, ranges, range_type,
+                                                         ydim=proxy_dim)
         if len(element.dimensions()) == 1 and range_type != 'hard':
             if self.batched:
                 bs, ts = [], []
@@ -1167,9 +1184,10 @@ class SpikesPlot(PathPlot, ColorbarPlot):
     def get_data(self, element, ranges, style):
         dimensions = element.dimensions(label=True)
         ndims = len(dimensions)
+        opts = self.lookup_options(element, 'plot').options
 
         pos = self.position
-        if ndims > 1:
+        if ndims > 1 and 'spike_length' not in opts:
             data = element.columns([0, 1])
             xs, ys = data[dimensions[0]], data[dimensions[1]]
             data = [[(x, pos), (x, pos+y)] for x, y in zip(xs, ys)]

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -1222,7 +1222,7 @@ class SpikesPlot(PathPlot, ColorbarPlot):
             style['array'] = element.dimension_values(cdim)
             self._norm_kwargs(element, ranges, style, cdim)
 
-        if 'spike_length' in self.lookup_options(element, 'plot').options:
+        if 'spike_length' in opts:
             axis_dims =  (element.dimensions()[0], None)
         elif len(element.dimensions()) == 1:
             axis_dims =  (element.dimensions()[0], None)

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -1139,11 +1139,6 @@ class SpikesPlot(PathPlot, ColorbarPlot):
         ax.add_collection(line_segments)
         return {'artist': line_segments}
 
-    def _get_axis_dims(self, element):
-        if 'spike_length' in self.lookup_options(element, 'plot').options:
-            return  [element.dimensions()[0], None, None]
-        return super(SpikesPlot, self)._get_axis_dims(element)
-
     def get_extents(self, element, ranges, range_type='combined'):
         opts = self.lookup_options(element, 'plot').options
         if len(element.dimensions()) > 1:
@@ -1227,9 +1222,16 @@ class SpikesPlot(PathPlot, ColorbarPlot):
             style['array'] = element.dimension_values(cdim)
             self._norm_kwargs(element, ranges, style, cdim)
 
+        if 'spike_length' in self.lookup_options(element, 'plot').options:
+            axis_dims =  (element.dimensions()[0], None)
+        elif len(element.dimensions()) == 1:
+            axis_dims =  (element.dimensions()[0], None)
+        else:
+            axis_dims =  (element.dimensions()[0], element.dimensions()[1])
         with abbreviated_exception():
             style = self._apply_transforms(element, ranges, style)
-        return (clean_spikes,), style, {'dimensions': dims}
+
+        return (clean_spikes,), style, {'dimensions': axis_dims}
 
 
     def update_handles(self, key, axis, element, ranges, style):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -23,7 +23,7 @@ from ..core import util, traversal
 from ..core.element import Element, Element3D
 from ..core.overlay import Overlay, CompositeOverlay
 from ..core.layout import Empty, NdLayout, Layout
-from ..core.options import Store, Compositor, SkipRendering
+from ..core.options import Store, Compositor, SkipRendering, lookup_options
 from ..core.overlay import NdOverlay
 from ..core.spaces import HoloMap, DynamicMap
 from ..core.util import stream_parameters, isfinite
@@ -262,22 +262,7 @@ class Plot(param.Parameterized):
 
     @classmethod
     def lookup_options(cls, obj, group):
-        plot_class = None
-        try:
-            plot_class = Store.renderers[cls.backend].plotting_class(obj)
-            style_opts = plot_class.style_opts
-        except SkipRendering:
-            style_opts = None
-
-        node = Store.lookup_options(cls.backend, obj, group)
-        if group == 'style' and style_opts is not None:
-            return node.filtered(style_opts)
-        elif group == 'plot' and plot_class:
-            return node.filtered(list(plot_class.params().keys()))
-        else:
-            return node
-
-
+        return lookup_options(obj, group, cls.backend)
 
 class PlotSelector(object):
     """

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -196,21 +196,21 @@ class DatashaderAggregateTests(ComparisonTestCase):
 
     def test_spikes_aggregate_count(self):
         spikes = Spikes([1, 2, 3])
-        agg = rasterize(spikes, width=5, dynamic=False)
+        agg = rasterize(spikes, width=5, dynamic=False, expand=False)
         expected = Image(np.array([[2, 0, 2, 0, 2]]), vdims='count',
                          xdensity=2.5, ydensity=1, bounds=(1, 0, 3, 0.5))
         self.assertEqual(agg, expected)
 
     def test_spikes_aggregate_count_dask(self):
         spikes = Spikes([1, 2, 3], datatype=['dask'])
-        agg = rasterize(spikes, width=5, dynamic=False)
+        agg = rasterize(spikes, width=5, dynamic=False, expand=False)
         expected = Image(np.array([[2, 0, 2, 0, 2]]), vdims='count',
                          xdensity=2.5, ydensity=1, bounds=(1, 0, 3, 0.5))
         self.assertEqual(agg, expected)
 
     def test_spikes_aggregate_dt_count(self):
         spikes = Spikes([dt.datetime(2016, 1, 1),  dt.datetime(2016, 1, 2), dt.datetime(2016, 1, 3)])
-        agg = rasterize(spikes, width=5, dynamic=False)
+        agg = rasterize(spikes, width=5, dynamic=False, expand=False)
         bounds = (np.datetime64('2016-01-01T00:00:00.000000'), 0,
                   np.datetime64('2016-01-03T00:00:00.000000'), 0.5)
         expected = Image(np.array([[2, 0, 2, 0, 2]]), vdims='count', bounds=bounds)
@@ -219,7 +219,7 @@ class DatashaderAggregateTests(ComparisonTestCase):
     def test_spikes_aggregate_dt_count_dask(self):
         spikes = Spikes([dt.datetime(2016, 1, 1),  dt.datetime(2016, 1, 2), dt.datetime(2016, 1, 3)],
                         datatype=['dask'])
-        agg = rasterize(spikes, width=5, dynamic=False)
+        agg = rasterize(spikes, width=5, dynamic=False, expand=False)
         bounds = (np.datetime64('2016-01-01T00:00:00.000000'), 0,
                   np.datetime64('2016-01-03T00:00:00.000000'), 0.5)
         expected = Image(np.array([[2, 0, 2, 0, 2]]), vdims='count', bounds=bounds)

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -198,14 +198,14 @@ class DatashaderAggregateTests(ComparisonTestCase):
         spikes = Spikes([1, 2, 3])
         agg = rasterize(spikes, width=5, dynamic=False)
         expected = Image(np.array([[2, 0, 2, 0, 2]]), vdims='count',
-                         xdensity=2.5, ydensity=1, bounds=(1, 0, 3, 1))
+                         xdensity=2.5, ydensity=1, bounds=(1, 0, 3, 0.5))
         self.assertEqual(agg, expected)
 
     def test_spikes_aggregate_count_dask(self):
         spikes = Spikes([1, 2, 3], datatype=['dask'])
         agg = rasterize(spikes, width=5, dynamic=False)
         expected = Image(np.array([[2, 0, 2, 0, 2]]), vdims='count',
-                         xdensity=2.5, ydensity=1, bounds=(1, 0, 3, 1))
+                         xdensity=2.5, ydensity=1, bounds=(1, 0, 3, 0.5))
         self.assertEqual(agg, expected)
 
     def test_spikes_aggregate_dt_count(self):

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -212,7 +212,7 @@ class DatashaderAggregateTests(ComparisonTestCase):
         spikes = Spikes([dt.datetime(2016, 1, 1),  dt.datetime(2016, 1, 2), dt.datetime(2016, 1, 3)])
         agg = rasterize(spikes, width=5, dynamic=False)
         bounds = (np.datetime64('2016-01-01T00:00:00.000000'), 0,
-                  np.datetime64('2016-01-03T00:00:00.000000'), 1)
+                  np.datetime64('2016-01-03T00:00:00.000000'), 0.5)
         expected = Image(np.array([[2, 0, 2, 0, 2]]), vdims='count', bounds=bounds)
         self.assertEqual(agg, expected)
 
@@ -221,7 +221,7 @@ class DatashaderAggregateTests(ComparisonTestCase):
                         datatype=['dask'])
         agg = rasterize(spikes, width=5, dynamic=False)
         bounds = (np.datetime64('2016-01-01T00:00:00.000000'), 0,
-                  np.datetime64('2016-01-03T00:00:00.000000'), 1)
+                  np.datetime64('2016-01-03T00:00:00.000000'), 0.5)
         expected = Image(np.array([[2, 0, 2, 0, 2]]), vdims='count', bounds=bounds)
         self.assertEqual(agg, expected)
 

--- a/holoviews/tests/plotting/bokeh/testspikesplot.py
+++ b/holoviews/tests/plotting/bokeh/testspikesplot.py
@@ -127,6 +127,21 @@ class TestSpikesPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         self.assertEqual(cds.data['x'].astype('datetime64'), np.array([1483228800000000000]))
+        self.assertEqual(cds.data['y0'], np.array([0]))
+        self.assertEqual(cds.data['y1'], np.array([1]))
+
+        self.assertEqual(cds.data['x_dt_strings'], ['2017-01-01 00:00:00'])
+        hover = plot.handles['hover']
+        self.assertEqual(hover.tooltips, [('x', '@{x_dt_strings}'), ('y', '@{y}')])
+
+    def test_spikes_datetime_kdim_hover_spike_length_override(self):
+        points = Spikes([(dt.datetime(2017, 1, 1), 1)], 'x', 'y').options(
+            tools=['hover'], spike_length=0.75)
+        plot = bokeh_renderer.get_plot(points)
+        cds = plot.handles['cds']
+        self.assertEqual(cds.data['x'].astype('datetime64'), np.array([1483228800000000000]))
+        self.assertEqual(cds.data['y0'], np.array([0]))
+        self.assertEqual(cds.data['y1'], np.array([0.75]))
         self.assertEqual(cds.data['x_dt_strings'], ['2017-01-01 00:00:00'])
         hover = plot.handles['hover']
         self.assertEqual(hover.tooltips, [('x', '@{x_dt_strings}'), ('y', '@{y}')])


### PR DESCRIPTION
Simple PR that addresses the first suggestion mentioned in #4071. 

Specifically, the spike_length plot option (when explicitly supplied) should override the second vdim (if present) in terms of controlling the spike heights. This is necessary if you want extra vdims (e.g for hover information) but don't need the spike heights to represent anything.

The other two suggestions are also nice but I think they ought to be addressed in separate PRs.