### PR TITLE
Multi-dimensional dim transforms on data sets

### DIFF
--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -221,6 +221,14 @@ class Apply(object):
         See :py:meth:`Dimensioned.opts` and :py:meth:`Apply.__call__`
         for more information.
         """
+        from ..util.transform import dim
+        from ..streams import Params
+        params = {}
+        for arg in kwargs.values():
+            if isinstance(arg, dim):
+                params.update(arg.params)
+        streams = Params.from_params(params, watch_only=True)
+        kwargs['streams'] = kwargs.get('streams', []) + streams
         kwargs['_method_args'] = args
         return self.__call__('opts', **kwargs)
 
@@ -258,24 +266,16 @@ class Apply(object):
         See :py:meth:`Dataset.transform` and :py:meth:`Apply.__call__`
         for more information.
         """
+        from ..util.transform import dim
         from ..streams import Params
-        streams = []
         params = {}
         for _, arg in list(args)+list(kwargs.items()):
-            for op in arg.ops:
-                op_args = list(op['args'])+list(op['kwargs'].items())
-                for op_arg in op_args:
-                    if 'panel' in sys.modules:
-                        from panel.widgets.base import Widget
-                        if isinstance(op_arg, Widget):
-                            op_arg = op_arg.param.value
-                    if (isinstance(op_arg, param.Parameter) and
-                        isinstance(op_arg.owner, param.Parameterized)):
-                        params[op_arg.name+str(id(op))] = op_arg
-        streams += Params.from_params(params, watch_only=True)
+            if isinstance(arg, dim):
+                params.update(arg.params)
+        streams = Params.from_params(params, watch_only=True)
+        kwargs['streams'] = kwargs.get('streams', []) + streams
         kwargs['_method_args'] = args
         kwargs['per_element'] = True
-        kwargs['streams'] = streams
         return self.__call__('transform', **kwargs)
 
 

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -205,16 +205,25 @@ class Apply(object):
                     mapped.append((k, new_val))
             return self._obj.clone(mapped, link=link_inputs)
 
-
     def aggregate(self, dimensions=None, function=None, spreadfn=None, **kwargs):
         """Applies a aggregate function to all ViewableElements.
 
-        See :py:meth:`Dimensioned.opts` and :py:meth:`Apply.__call__`
+        See :py:meth:`Dimensioned.aggregate` and :py:meth:`Apply.__call__`
         for more information.
         """
         kwargs['_method_args'] = (dimensions, function, spreadfn)
         kwargs['per_element'] = True
         return self.__call__('aggregate', **kwargs)
+
+    def transform(self, *args, drop=False, drop_duplicate_data=True, **kwargs):
+        """Applies transforms to all Datasets.
+
+        See :py:meth:`Dataset.transform` and :py:meth:`Apply.__call__`
+        for more information.
+        """
+        kwargs['_method_args'] = args
+        return self._call__('transform', drop=drop, drop_duplicate_data=drop_duplicate_data,
+                            spec=Dataset, **kwargs)
 
     def opts(self, *args, **kwargs):
         """Applies options to all ViewableElement objects.

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -252,7 +252,7 @@ class Apply(object):
         """
         return self.__call__('select', **kwargs)
 
-    def transform(self, *args, drop=False, **kwargs):
+    def transform(self, *args, **kwargs):
         """Applies transforms to all Datasets.
 
         See :py:meth:`Dataset.transform` and :py:meth:`Apply.__call__`

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -215,16 +215,6 @@ class Apply(object):
         kwargs['per_element'] = True
         return self.__call__('aggregate', **kwargs)
 
-    def transform(self, *args, drop=False, drop_duplicate_data=True, **kwargs):
-        """Applies transforms to all Datasets.
-
-        See :py:meth:`Dataset.transform` and :py:meth:`Apply.__call__`
-        for more information.
-        """
-        kwargs['_method_args'] = args
-        return self._call__('transform', drop=drop, drop_duplicate_data=drop_duplicate_data,
-                            spec=Dataset, **kwargs)
-
     def opts(self, *args, **kwargs):
         """Applies options to all ViewableElement objects.
 
@@ -262,6 +252,15 @@ class Apply(object):
         """
         return self.__call__('select', **kwargs)
 
+    def transform(self, *args, drop=False, **kwargs):
+        """Applies transforms to all Datasets.
+
+        See :py:meth:`Dataset.transform` and :py:meth:`Apply.__call__`
+        for more information.
+        """
+        kwargs['_method_args'] = args
+        kwargs['per_element'] = True
+        return self.__call__('transform', drop=drop, **kwargs)
 
 @add_metaclass(AccessorPipelineMeta)
 class Redim(object):

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -260,7 +260,7 @@ class Apply(object):
         """
         kwargs['_method_args'] = args
         kwargs['per_element'] = True
-        return self.__call__('transform', drop=drop, **kwargs)
+        return self.__call__('transform', **kwargs)
 
 @add_metaclass(AccessorPipelineMeta)
 class Redim(object):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -464,13 +464,13 @@ class Dataset(Element):
         if vdim:
             dims = self.vdims[:]
             if dim_pos is None:
-                dim_pos = len(self.kdims)
+                dim_pos = len(self.vdims) + len(self.kdims)
             dims.insert(dim_pos, dimension)
             dimensions = dict(vdims=dims)
         else:
             dims = self.kdims[:]
             if dim_pos is None:
-                dim_pos = len(self.vdims)
+                dim_pos = len(self.kdims)
             dims.insert(dim_pos, dimension)
             dimensions = dict(kdims=dims)
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -950,14 +950,14 @@ argument to specify a selection specification""")
         for signature, transform in transforms.items():
             applied = transform.apply(self, compute=False, keep_index=True)
             if len(signature) == 1:
-                new_data[s[0]] = applied
+                new_data[signature[0]] = applied
             else:
                 for s, vals in zip(signature, applied):
                     new_data[s] = vals
 
         new_dims = []
         for d in new_data:
-            if self.get_dimension(s) is None:
+            if self.get_dimension(d) is None:
                 new_dims.append(d)
 
         if drop:

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -961,8 +961,9 @@ argument to specify a selection specification""")
             if self.get_dimension(d) is None:
                 new_dims.append(d)
 
-        if self.interface.datatype in ('image', 'array'):
-            ds = self.clone(datatype=[dt for dt in self.datatype if dt != self.interface.datatype])
+        ds = self
+        if ds.interface.datatype in ('image', 'array'):
+            ds = ds.clone(datatype=[dt for dt in ds.datatype if dt != ds.interface.datatype])
 
         if drop:
             kdims = [ds.get_dimension(d) for d in new_data if d in ds.kdims]

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -997,6 +997,8 @@ argument to specify a selection specification""")
                 for dim_name, dim_transform in kwargs.items()
             ])
         elif dim_transform is not None:
+            if isinstance(signature, (str, Dimension)):
+                signature = [signature]
             if len(signature)==1:
                 new_dimensions = OrderedDict([
                     (signature[0], dim_transform.apply(self))

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -979,7 +979,9 @@ argument to specify a selection specification""")
         else:
             new_data = OrderedDict([(dimension_name(d), values) for d, values in new_data.items()])
             data = ds.interface.assign(ds, new_data)
-            return ds.clone(data, vdims=ds.vdims+new_dims)
+            data, drop = data if isinstance(data, tuple) else (data, [])
+            kdims = [kd for kd in self.kdims if kd.name not in drop]
+            return ds.clone(data, kdims=kdims, vdims=ds.vdims+new_dims)
 
     def __len__(self):
         "Number of values in the Dataset."

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -282,6 +282,10 @@ class Dataset(Element):
     _kdim_reductions = {}
 
     def __new__(cls, data, kdims=None, vdims=None, **kwargs):
+        """
+        Allows casting a DynamicMap to an Element class like hv.Curve, by applying the
+        class to each underlying element.
+        """
         if isinstance(data, DynamicMap):
             return data.apply(cls, per_element=True, kdims=kdims, vdims=vdims, **kwargs)
         else:
@@ -456,7 +460,7 @@ class Dataset(Element):
 
         Args:
             dimension: Dimension or dimension spec to add
-            dim_pos (int) Integer index to insert dimension at
+            dim_pos (int): Integer index to insert dimension at
             dim_val (scalar or ndarray): Dimension value(s) to add
             vdim: Disabled, this type does not have value dimensions
             **kwargs: Keyword arguments passed to the cloned element
@@ -803,7 +807,7 @@ argument to specify a selection specification""")
         """Aggregates data on the supplied dimensions.
 
         Aggregates over the supplied key dimensions with the defined
-        function or dim_transform specified as tuple of the transformed
+        function or dim_transform specified as a tuple of the transformed
         dimension name and dim transform.
 
         Args:

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -446,13 +446,13 @@ class Dataset(Element):
 
         Requires the dimension name or object, the desired position in
         the key dimensions and a key value scalar or array of values,
-        matching the length o shape of the Dataset.
+        matching the length or shape of the Dataset.
 
         Args:
             dimension: Dimension or dimension spec to add
-            dim_pos (int) Integer index to insert dimension at
+            dim_pos (int, None) Integer index to insert dimension at. Default: last
             dim_val (scalar or ndarray): Dimension value(s) to add
-            vdim: Disabled, this type does not have value dimensions
+            vdim: (bool) Whether to insert as vdim, otherwise as kdim
             **kwargs: Keyword arguments passed to the cloned element
 
         Returns:
@@ -466,11 +466,14 @@ class Dataset(Element):
 
         if vdim:
             dims = self.vdims[:]
+            if dim_pos is None:
+                dim_pos = len(self.kdims)
             dims.insert(dim_pos, dimension)
             dimensions = dict(vdims=dims)
-            dim_pos += self.ndims
         else:
             dims = self.kdims[:]
+            if dim_pos is None:
+                dim_pos = len(self.vdims)
             dims.insert(dim_pos, dimension)
             dimensions = dict(kdims=dims)
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -987,6 +987,8 @@ argument to specify a selection specification""")
                 vdim=True,
             )
 
+        # dropping dimensions will also take care of potentially arising
+        # duplicate data points
         if drop:
             new_dim_names = [Dimension(d).name for d in new_dimensions.keys()]
             ds_new = ds_new.drop_dimensions(

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -937,19 +937,25 @@ argument to specify a selection specification""")
             args: Specify the output arguments and transforms as a
                   tuple of dimension specs and dim transforms
             drop (bool): Whether to drop all variables not part of the transform
+            keep_index (bool): Whether to keep indexes
+                  Whether to apply transform on datastructure with
+                  index, e.g. pandas.Series or xarray.DataArray
             kwargs: Specify new dimensions in the form new_dim=dim_transform
 
         Returns:
             Transformed dataset with new dimensions
         """
         drop = kwargs.pop('drop', False)
+        keep_index = kwargs.pop('keep_index', False)
         transforms = OrderedDict()
         for s, transform in list(args)+list(kwargs.items()):
             transforms[util.wrap_tuple(s)] = transform
 
         new_data = OrderedDict()
         for signature, transform in transforms.items():
-            applied = transform.apply(self, compute=False, keep_index=True)
+            applied = transform.apply(
+                self, compute=False, keep_index=keep_index
+            )
             if len(signature) == 1:
                 new_data[signature[0]] = applied
             else:

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -860,7 +860,7 @@ argument to specify a selection specification""")
         elif not isinstance(dimensions, list): dimensions = [dimensions]
         if function is None:
             # Handle dim transforms
-            faceted = self.clone().groupby(dimensions)
+            faceted = self.clone(new_type=Dataset).groupby(dimensions)
             drop_args = dict(drop=True, drop_duplicate_data=True)
             if dim_transform is None:
                 # If both function and dim_transform are None,
@@ -873,7 +873,7 @@ argument to specify a selection specification""")
                         dim_transform=dim_transform, signature=dim_transform_signature,
                         **drop_args,
                     )
-                    .collapse()
+                    .collapse().clone(new_type=type(self))
                 )
         else:
             # Handle functions

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -927,14 +927,21 @@ argument to specify a selection specification""")
         return self.interface.groupby(self, dim_names, container_type,
                                       group_type, **kwargs)
 
-    def transform(self, output_signature=None, dim_transform=None, **kwargs):
+    def transform(
+        self,
+        output_signature=None,
+        dim_transform=None,
+        drop=False,
+        **kwargs
+    ):
         """
         Transforms the Dataset according to a dimension transform.
 
         Args:
-            kwargs: Specify new dimensions in the form new_dim=dim_transform to assign the output directly
             output_signature: Specify output arguments as a list of strings
             dim_transform: a holoviews.util.transform.dim object
+            drop (bool): Whether to drop all variables not part of output
+            kwargs: Specify new dimensions in the form new_dim=dim_transform
 
         Returns:
             Transformed dataset with new dimensions
@@ -966,6 +973,14 @@ argument to specify a selection specification""")
                 dim_val=dim_val,
                 vdim=True,
             )
+
+        if drop:
+            new_dim_names = [Dimension(d).name for d in new_dimensions.keys()]
+            ds_new = ds_new.drop_dimensions(
+                [d for d in ds_new.dimensions()
+                 if d.name not in new_dim_names]
+            )
+
         return ds_new
 
     def __len__(self):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -988,12 +988,13 @@ argument to specify a selection specification""")
             )
 
         # dropping dimensions will also take care of potentially arising
-        # duplicate data points
+        # duplicate data points if drop_duplicate_data is True
         if drop:
             new_dim_names = [Dimension(d).name for d in new_dimensions.keys()]
             ds_new = ds_new.drop_dimensions(
                 [d for d in ds_new.dimensions()
-                 if d.name not in new_dim_names]
+                 if d.name not in new_dim_names],
+                drop_duplicate_data=drop_duplicate_data,
             )
 
         return ds_new

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -484,6 +484,22 @@ class Dataset(Element):
             data = self.interface.add_dimension(self, dimension, dim_pos, dim_val, vdim)
         return self.clone(data, **dimensions)
 
+    def drop_dimensions(self, dimensions):
+        dimensions = [Dimension(drop_dim) for drop_dim in dimensions]
+        keep_kdims = [
+            keep_dim
+            for keep_dim in self.kdims
+            if not keep_dim in dimensions
+        ]
+        keep_vdims = [
+            keep_dim
+            for keep_dim in self.vdims
+            if not keep_dim in dimensions
+        ]
+        # if the backend requires handling of e.g. dependent variables, we can
+        # modify keep_*dims in each interface's implementation
+        data, keep_kdims, keep_vdims = self.interface.drop_dimensions(self, dimensions, keep_kdims, keep_vdims)
+        return self.clone(data=data, kdims=keep_kdims, vdims=keep_vdims)
 
     def select(self, selection_expr=None, selection_specs=None, **selection):
         """Applies selection by dimension name

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -965,14 +965,14 @@ argument to specify a selection specification""")
                 for dim_name, dim_transform in kwargs.items()
             ])
         elif dim_transform is not None:
-            # ineffectively repeating the same dim transform for now
             if len(output_signature)==1:
                 new_dimensions = OrderedDict([
                     (output_signature[0], dim_transform.apply(self))
                 ])
             else:
+                dim_transform_output = dim_transform.apply(self)
                 new_dimensions = OrderedDict([
-                    (dim_name, dim_transform.apply(self)[k])
+                    (dim_name, dim_transform_output[k])
                     for k, dim_name in enumerate(output_signature)
                 ])
         else:

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -942,7 +942,7 @@ argument to specify a selection specification""")
         Returns:
             Transformed dataset with new dimensions
         """
-        drop = kwargs.pop('drop')
+        drop = kwargs.pop('drop', False)
         transforms = OrderedDict()
         for s, transform in list(args)+list(kwargs.items()):
             transforms[util.wrap_tuple(s)] = transform
@@ -961,15 +961,18 @@ argument to specify a selection specification""")
             if self.get_dimension(d) is None:
                 new_dims.append(d)
 
+        if self.interface.datatype in ('image', 'array'):
+            ds = self.clone(datatype=[dt for dt in self.datatype if dt != self.interface.datatype])
+
         if drop:
-            kdims = [self.get_dimension(d) for d in new_data if d in self.kdims]
-            vdims = [self.get_dimension(d) or d for d in new_data if d not in self.kdims]
+            kdims = [ds.get_dimension(d) for d in new_data if d in ds.kdims]
+            vdims = [ds.get_dimension(d) or d for d in new_data if d not in ds.kdims]
             data = OrderedDict([(dimension_name(d), values) for d, values in new_data.items()])
-            return self.clone(data, kdims=kdims, vdims=vdims)
+            return ds.clone(data, kdims=kdims, vdims=vdims)
         else:
             new_data = OrderedDict([(dimension_name(d), values) for d, values in new_data.items()])
-            data = self.interface.assign(self, new_data)
-            return self.clone(data, vdims=self.vdims+new_dims)
+            data = ds.interface.assign(ds, new_data)
+            return ds.clone(data, vdims=ds.vdims+new_dims)
 
     def __len__(self):
         "Number of values in the Dataset."

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -281,6 +281,12 @@ class Dataset(Element):
     _vdim_reductions = {}
     _kdim_reductions = {}
 
+    def __new__(cls, data, kdims=None, vdims=None, **kwargs):
+        if isinstance(data, DynamicMap):
+            return data.apply(cls, per_element=True, kdims=kdims, vdims=vdims, **kwargs)
+        else:
+            return super(Dataset, cls).__new__(cls)
+
     def __init__(self, data, kdims=None, vdims=None, **kwargs):
         from ...operation.element import (
             chain as chain_op, factory

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -484,7 +484,15 @@ class Dataset(Element):
             data = self.interface.add_dimension(self, dimension, dim_pos, dim_val, vdim)
         return self.clone(data, **dimensions)
 
-    def drop_dimensions(self, dimensions):
+    def drop_dimensions(self, dimensions, drop_duplicate_data=True):
+        """
+        Drop dimensions from a Dataset.
+
+        Args:
+            dimensions (list of str or Dimension): Dimensions to be dropped
+            drop_duplicate_data: Whether to remove duplicate data after dropping
+                dimensions
+        """
         dimensions = [Dimension(drop_dim) for drop_dim in dimensions]
         keep_kdims = [
             keep_dim
@@ -498,8 +506,13 @@ class Dataset(Element):
         ]
         # if the backend requires handling of e.g. dependent variables, we can
         # modify keep_*dims in each interface's implementation
-        data, keep_kdims, keep_vdims = self.interface.drop_dimensions(self, dimensions, keep_kdims, keep_vdims)
-        return self.clone(data=data, kdims=keep_kdims, vdims=keep_vdims)
+        data, keep_kdims, keep_vdims = self.interface.drop_dimensions(
+            self, dimensions, keep_kdims, keep_vdims,
+            drop_duplicate_data=drop_duplicate_data,
+        )
+        return self.clone(
+            data=data, kdims=keep_kdims, vdims=keep_vdims,
+        )
 
     def select(self, selection_expr=None, selection_specs=None, **selection):
         """Applies selection by dimension name

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -920,7 +920,7 @@ argument to specify a selection specification""")
         return self.interface.groupby(self, dim_names, container_type,
                                       group_type, **kwargs)
 
-    def transform(self, *args, drop=False, **kwargs):
+    def transform(self, *args, **kwargs):
         """Transforms the Dataset according to a dimension transform.
 
         Transforms may be supplied as tuples consisting of the
@@ -942,6 +942,7 @@ argument to specify a selection specification""")
         Returns:
             Transformed dataset with new dimensions
         """
+        drop = kwargs.pop('drop')
         transforms = OrderedDict()
         for s, transform in list(args)+list(kwargs.items()):
             transforms[util.wrap_tuple(s)] = transform

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -281,7 +281,7 @@ class Dataset(Element):
     _vdim_reductions = {}
     _kdim_reductions = {}
 
-    def __new__(cls, data, kdims=None, vdims=None, **kwargs):
+    def __new__(cls, data=None, kdims=None, vdims=None, **kwargs):
         """
         Allows casting a DynamicMap to an Element class like hv.Curve, by applying the
         class to each underlying element.

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -461,9 +461,6 @@ class Dataset(Element):
         if isinstance(dimension, (util.basestring, tuple)):
             dimension = Dimension(dimension)
 
-        if dimension.name in self.kdims:
-            raise Exception('{dim} dimension already defined'.format(dim=dimension.name))
-
         if vdim:
             dims = self.vdims[:]
             if dim_pos is None:
@@ -479,9 +476,13 @@ class Dataset(Element):
 
         if issubclass(self.interface, ArrayInterface) and np.asarray(dim_val).dtype != self.data.dtype:
             element = self.clone(datatype=[default_datatype])
-            data = element.interface.add_dimension(element, dimension, dim_pos, dim_val, vdim)
         else:
-            data = self.interface.add_dimension(self, dimension, dim_pos, dim_val, vdim)
+            element = self.clone()
+
+        if dimension.name in element.dimensions():
+            # self.param.warning('Overwriting existing "{dim}" dimension'.format(dim=dimension.name))
+            element = element.drop_dimensions([dimension.name])
+        data = element.interface.add_dimension(element, dimension, dim_pos, dim_val, vdim)
         return self.clone(data, **dimensions)
 
     def drop_dimensions(self, dimensions, drop_duplicate_data=True):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -855,6 +855,9 @@ argument to specify a selection specification""")
         """
         if function is not None and dim_transform is not None:
             raise ValueError('Can only specify at most one of function or dim_transform')
+
+        if dimensions is None: dimensions = self.kdims
+        elif not isinstance(dimensions, list): dimensions = [dimensions]
         if function is None:
             # Handle dim transforms
             faceted = self.clone().groupby(dimensions)
@@ -874,8 +877,6 @@ argument to specify a selection specification""")
                 )
         else:
             # Handle functions
-            if dimensions is None: dimensions = self.kdims
-            elif not isinstance(dimensions, list): dimensions = [dimensions]
             kdims = [self.get_dimension(d, strict=True) for d in dimensions]
             if not len(self):
                 if spreadfn:

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -240,6 +240,18 @@ class ArrayInterface(Interface):
 
 
     @classmethod
+    def assign(cls, dataset, new_data):
+        data = dataset.data.copy()
+        for d, arr in new_data.items():
+            if dataset.get_dimension(d) is None:
+                continue
+            idx = dataset.get_dimension_index(d)
+            data[:, idx] = arr
+        new_cols = [arr for d, arr in new_data.items() if dataset.get_dimension(d) is None]
+        return np.column_stack([data]+new_cols)
+
+
+    @classmethod
     def aggregate(cls, dataset, dimensions, function, **kwargs):
         reindexed = dataset.reindex(dimensions)
         grouped = (cls.groupby(reindexed, dimensions, list, 'raw')

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -215,7 +215,7 @@ class DictInterface(Interface):
         columns = defaultdict(list)
         for key, ds in datasets:
             for k, vals in ds.data.items():
-                columns[k].append(vals)
+                columns[k].append(np.atleast_1d(vals))
             for d, k in zip(dimensions, key):
                 columns[d.name].append(np.full(len(ds), k))
 
@@ -268,6 +268,13 @@ class DictInterface(Interface):
                 return util.unique_array(values)
             values = np.asarray(values)
         return values
+
+
+    @classmethod
+    def assign(cls, dataset, new_data):
+        data = OrderedDict(dataset.data)
+        data.update(new_data)
+        return data
 
 
     @classmethod

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -179,7 +179,7 @@ class PandasInterface(Interface):
             kwargs['sort'] = False
         return pd.concat(dataframes, **kwargs)
 
-        
+
     @classmethod
     def concat(cls, datasets, dimensions, vdims):
         dataframes = []
@@ -346,13 +346,8 @@ class PandasInterface(Interface):
         return data
 
     @classmethod
-    def drop_dimensions(cls, dataset, dimensions, keep_kdims=None, keep_vdims=None, drop_duplicate_data=True):
-        data = dataset.data.drop(columns=[
-            d.name for d in dimensions
-        ])
-        if drop_duplicate_data:
-            data = data.loc[~data.duplicated()]
-        return data, keep_kdims, keep_vdims
+    def assign(cls, dataset, new_data):
+        return dataset.data.assign(**new_data)
 
     @classmethod
     def as_dframe(cls, dataset):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -341,8 +341,6 @@ class PandasInterface(Interface):
     @classmethod
     def add_dimension(cls, dataset, dimension, dim_pos, values, vdim):
         data = dataset.data.copy()
-        if vdim:
-            dim_pos += len(dataset.kdims)
         if dimension.name not in data:
             data.insert(dim_pos, dimension.name, values)
         return data

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -346,11 +346,13 @@ class PandasInterface(Interface):
         return data
 
     @classmethod
-    def drop_dimensions(cls, dataset, dimensions, keep_kdims=None, keep_vdims=None):
-        ds_new = dataset.data.drop(columns=[
+    def drop_dimensions(cls, dataset, dimensions, keep_kdims=None, keep_vdims=None, drop_duplicate_data=True):
+        data = dataset.data.drop(columns=[
             d.name for d in dimensions
         ])
-        return ds_new, keep_kdims, keep_vdims
+        if drop_duplicate_data:
+            data = data.loc[~data.duplicated()]
+        return data, keep_kdims, keep_vdims
 
     @classmethod
     def as_dframe(cls, dataset):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -341,6 +341,8 @@ class PandasInterface(Interface):
     @classmethod
     def add_dimension(cls, dataset, dimension, dim_pos, values, vdim):
         data = dataset.data.copy()
+        if vdim:
+            dim_pos += len(dataset.kdims)
         if dimension.name not in data:
             data.insert(dim_pos, dimension.name, values)
         return data

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -345,6 +345,12 @@ class PandasInterface(Interface):
             data.insert(dim_pos, dimension.name, values)
         return data
 
+    @classmethod
+    def drop_dimensions(cls, dataset, dimensions, keep_kdims=None, keep_vdims=None):
+        ds_new = dataset.data.drop(columns=[
+            d.name for d in dimensions
+        ])
+        return ds_new, keep_kdims, keep_vdims
 
     @classmethod
     def as_dframe(cls, dataset):

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -613,7 +613,6 @@ class XArrayInterface(GridInterface):
             coords[k] = (k, v)
         if coords:
             data = data.assign_coords(coords)
-        packed = cls.packed(dataset)
         dims = tuple(kd.name for kd in dataset.kdims[::-1])
         vars = OrderedDict()
         for k, v in new_data.items():

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -382,7 +382,7 @@ class XArrayInterface(GridInterface):
             return data.T.flatten() if flat else data
         else:
             if keep_index:
-                return dataset[dim.name]
+                return dataset.data[dim.name]
             return cls.coords(dataset, dim.name, ordered=True)
 
 
@@ -618,6 +618,7 @@ class XArrayInterface(GridInterface):
                 continue
             elif isinstance(v, xr.DataArray):
                 coords[k] = v.rename(**{v.name: k})
+                continue
             coord_vals = cls.coords(dataset, k)
             if not coord_vals.ndim > 1 and np.all(coord_vals[1:] < coord_vals[:-1]):
                 v = v[::-1]

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -606,7 +606,8 @@ class XArrayInterface(GridInterface):
         coords = {k: v for k, v in new_data.items() if k in dataset.kdims}
         if coords:
             data = data.assign_coords(coords)
-        vars = {k: v for k, v in new_data.items() if k not in dataset.kdims}
+        vars = {k: (tuple(kd.name for kd in dataset.kdims[::-1]), v)
+                for k, v in new_data.items() if k not in dataset.kdims}
         data = data.assign(vars)
         return data
 

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -609,6 +609,9 @@ class XArrayInterface(GridInterface):
     def assign(cls, dataset, new_data):
         import xarray as xr
         data = dataset.data
+        prev_coords = set.intersection(*[
+            set(var.coords) for var in data.data_vars.values()
+        ])
         coords = OrderedDict()
         for k, v in new_data.items():
             if k not in dataset.kdims:
@@ -632,7 +635,9 @@ class XArrayInterface(GridInterface):
                 vars[k] = (dims, cls.canonicalize(dataset, v, data_coords=dims))
         if vars:
             data = data.assign(vars)
-        return data
+        used_coords = set.intersection(*[set(var.coords) for var in data.data_vars.values()])
+        drop_coords = set.symmetric_difference(used_coords, prev_coords)
+        return data.drop(list(drop_coords)), list(drop_coords)
 
 
 Interface.register(XArrayInterface)

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -623,7 +623,7 @@ class XArrayInterface(GridInterface):
                 v = v[::-1]
             coords[k] = (k, v)
         if coords:
-            data = data.assign_coords(coords)
+            data = data.assign_coords(**coords)
         dims = tuple(kd.name for kd in dataset.kdims[::-1])
         vars = OrderedDict()
         for k, v in new_data.items():

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -715,34 +715,6 @@ class LabelledData(param.Parameterized):
         else:
             return map_fn(self) if applies else self
 
-    def transform(self, *args, drop=False, drop_duplicate_data=True, **kwargs):
-        """Transforms the contents according to a dimension transform.
-
-        Applies a dimension transform to each child of this dimensioned container.
-
-        Args:
-            output_signature (list of str): Specify output arguments
-            dim_transform (holoviews.util.transform.dim object)
-            drop (bool): Whether to drop all variables not part of output
-            drop_duplicate_data (bool): Whether to drop duplicate data (if
-                non-output variables are dropped, see argument `bool`)
-            kwargs: Specify new dimensions in the form new_dim=dim_transform
-                to assign the output directly
-
-        Returns:
-            Container where each child has new dimensions
-        """
-        new_self = self.clone()
-        for key, el in self.items():
-            new_self[key] = el.transform(
-                *args,
-                drop=drop,
-                drop_duplicate_data=drop_duplicate_data,
-                **kwargs,
-            )
-
-        return new_self
-
 
     def __getstate__(self):
         "Ensures pickles save options applied to this objects."

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -715,6 +715,26 @@ class LabelledData(param.Parameterized):
         else:
             return map_fn(self) if applies else self
 
+    def transform(self, *args, **kwargs):
+        """ Transforms the contents according to a dimension transform.
+
+        Applies a dimension transform to each child of this dimensioned container.
+
+        Args:
+            output_signature (list of str): Specify output arguments
+            dim_transform (holoviews.util.transform.dim object)
+            kwargs: Specify new dimensions in the form new_dim=dim_transform
+                to assign the output directly
+
+        Returns:
+            Container where each child has new dimensions
+        """
+        new_self = self.clone()
+        for k, e in enumerate(self.traverse(depth=1)):
+            new_self[k] = e.transform(*args, **kwargs)
+
+        return new_self
+
 
     def __getstate__(self):
         "Ensures pickles save options applied to this objects."

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -715,14 +715,17 @@ class LabelledData(param.Parameterized):
         else:
             return map_fn(self) if applies else self
 
-    def transform(self, *args, **kwargs):
-        """ Transforms the contents according to a dimension transform.
+    def transform(self, *args, drop=False, drop_duplicate_data=True, **kwargs):
+        """Transforms the contents according to a dimension transform.
 
         Applies a dimension transform to each child of this dimensioned container.
 
         Args:
             output_signature (list of str): Specify output arguments
             dim_transform (holoviews.util.transform.dim object)
+            drop (bool): Whether to drop all variables not part of output
+            drop_duplicate_data (bool): Whether to drop duplicate data (if
+                non-output variables are dropped, see argument `bool`)
             kwargs: Specify new dimensions in the form new_dim=dim_transform
                 to assign the output directly
 
@@ -730,8 +733,13 @@ class LabelledData(param.Parameterized):
             Container where each child has new dimensions
         """
         new_self = self.clone()
-        for k, e in enumerate(self.traverse(depth=1)):
-            new_self[k] = e.transform(*args, **kwargs)
+        for key, el in self.items():
+            new_self[key] = el.transform(
+                *args,
+                drop=drop,
+                drop_duplicate_data=drop_duplicate_data,
+                **kwargs,
+            )
 
         return new_self
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -630,7 +630,7 @@ class LabelledData(param.Parameterized):
         return identifier_match
 
 
-    def traverse(self, fn=None, specs=None, full_breadth=True):
+    def traverse(self, fn=None, specs=None, full_breadth=True, depth=None):
         """Traverses object returning matching items
 
         Traverses the set of children of the object, collecting the
@@ -646,6 +646,8 @@ class LabelledData(param.Parameterized):
             full_breadth: Whether to traverse all objects
                 Whether to traverse the full set of objects on each
                 container or only the first.
+            depth (1 or None): Whether to traverse only the first level,
+                (excluding the parent level), or all
 
         Returns:
             list: List of objects that matched
@@ -668,8 +670,13 @@ class LabelledData(param.Parameterized):
             for el in self:
                 if el is None:
                     continue
-                accumulator += el.traverse(fn, specs, full_breadth)
+                if depth is None:
+                    accumulator += el.traverse(fn, specs, full_breadth)
+                elif depth == 1:
+                    accumulator.append(el)
                 if not full_breadth: break
+        if depth == 1:
+            accumulator = accumulator[1:]
         return accumulator
 
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -629,14 +629,11 @@ class LabelledData(param.Parameterized):
         identifier_match = match_fn(identifier_specification[:len(split_spec)]) == self_spec
         return identifier_match
 
-
-    def traverse(self, fn=None, specs=None, full_breadth=True, depth=None):
+    def traverse(self, fn=None, specs=None, full_breadth=True):
         """Traverses object returning matching items
-
         Traverses the set of children of the object, collecting the
         all objects matching the defined specs. Each object can be
         processed with the supplied function.
-
         Args:
             fn (function, optional): Function applied to matched objects
             specs: List of specs to match
@@ -646,9 +643,6 @@ class LabelledData(param.Parameterized):
             full_breadth: Whether to traverse all objects
                 Whether to traverse the full set of objects on each
                 container or only the first.
-            depth (1 or None): Whether to traverse only the first level,
-                (excluding the parent level), or all
-
         Returns:
             list: List of objects that matched
         """
@@ -670,13 +664,8 @@ class LabelledData(param.Parameterized):
             for el in self:
                 if el is None:
                     continue
-                if depth is None:
-                    accumulator += el.traverse(fn, specs, full_breadth)
-                elif depth == 1:
-                    accumulator.append(el)
+                accumulator += el.traverse(fn, specs, full_breadth)
                 if not full_breadth: break
-        if depth == 1:
-            accumulator = accumulator[1:]
         return accumulator
 
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1514,7 +1514,7 @@ def resolve_dependent_value(value):
        value: A value which will be resolved
 
     Returns:
-       A new dictionary with where any parameter dependencies have been
+       A new dictionary where any parameter dependencies have been
        resolved.
     """
     if 'panel' in sys.modules:

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -369,6 +369,9 @@ class BaseShape(Path):
 
     __abstract = True
 
+    def __new__(cls, *args, **kwargs):
+        return super(Dataset, cls).__new__(cls)
+
     def __init__(self, **params):
         super(BaseShape, self).__init__([], **params)
         self.interface = MultiInterface

--- a/holoviews/plotting/bokeh/hex_tiles.py
+++ b/holoviews/plotting/bokeh/hex_tiles.py
@@ -28,15 +28,11 @@ class hex_binning(Operation):
     useable.
     """
 
-    aggregator = param.ClassSelector(default=np.size, class_=(dim, types.FunctionType),
-    doc="""
-    Aggregation function or dimension transform used to compute bin values.
-    Defaults to np.size to count the number of values in each bin.""")
-
-    aggregator_signature = param.List(default=None, class_=str, doc="""
-    Names for output variables of aggregator. Can be referenced in dim
-    transforms on the element. Only respected when aggregator is itself a dim
-    transform.""")
+    aggregator = param.ClassSelector(
+        default=np.size, class_=(dim, types.FunctionType, tuple), doc="""
+        Aggregation function or dimension transform used to compute
+        bin values. Defaults to np.size to count the number of values
+        in each bin.""")
 
     gridsize = param.ClassSelector(default=50, class_=(int, tuple))
 
@@ -90,19 +86,9 @@ class hex_binning(Operation):
         xd, yd = (element.get_dimension(i) for i in indexes)
         xd, yd = xd.clone(range=(x0, x1)), yd.clone(range=(y0, y1))
         kdims = [yd, xd] if self.p.invert_axes else [xd, yd]
-        if isinstance(aggregator, dim_transform):
-            signature = self.p.aggregator_signature
-            if signature is None:
-                signature = vdims[:1]
-            agg_args = dict(
-                dim_transform=aggregator,
-                dim_transform_signature=signature,
-            )
-        else:
-            agg_args = dict(function=aggregator)
         agg = (
             element.clone(data, kdims=kdims, vdims=vdims)
-            .aggregate(**agg_args)
+            .aggregate(function=aggregator)
         )
         if self.p.min_count is not None and self.p.min_count > 1:
             agg = agg[:, :, self.p.min_count:]
@@ -118,15 +104,10 @@ Compositor.register(compositor)
 
 class HexTilesPlot(ColorbarPlot):
 
-    aggregator = param.ClassSelector(default=np.size, class_=(dim, types.FunctionType),
+    aggregator = param.ClassSelector(default=np.size, class_=(dim, types.FunctionType, tuple),
     doc="""
     Aggregation function or dimension transform used to compute bin values.
     Defaults to np.size to count the number of values in each bin.""")
-
-    aggregator_signature = param.List(default=None, class_=str, doc="""
-    Names for output variables of aggregator. Can be referenced in dim
-    transforms on the element. Only respected when aggregator is itself a dim
-    transform.""")
 
     gridsize = param.ClassSelector(default=50, class_=(int, tuple), doc="""
       Number of hexagonal bins along x- and y-axes. Defaults to uniform

--- a/holoviews/plotting/bokeh/hex_tiles.py
+++ b/holoviews/plotting/bokeh/hex_tiles.py
@@ -203,7 +203,8 @@ class HexTilesPlot(ColorbarPlot):
         style['aspect_scale'] = scale
         scale_dim = element.get_dimension(self.size_index)
         scale = style.get('scale')
-        if scale_dim and ((isinstance(scale, basestring) and scale in element) or isinstance(scale, dim)):
+        if (scale_dim and ((isinstance(scale, basestring) and scale in element) or
+                           isinstance(scale, dim_transform))):
             self.param.warning("Cannot declare style mapping for 'scale' option "
                                "and declare a size_index; ignoring the size_index.")
             scale_dim = None

--- a/holoviews/plotting/bokeh/hex_tiles.py
+++ b/holoviews/plotting/bokeh/hex_tiles.py
@@ -9,12 +9,11 @@ try:
 except:
     cartesian_to_axial = None
 
-from ...util.transform import dim as dim_transform
 from ...core import Dimension, Operation
 from ...core.options import Compositor
 from ...core.util import basestring, isfinite
 from ...element import HexTiles
-from ...util.transform import dim
+from ...util.transform import dim as dim_transform
 from .element import ColorbarPlot
 from .selection import BokehOverlaySelectionDisplay
 from .styles import line_properties, fill_properties
@@ -29,10 +28,10 @@ class hex_binning(Operation):
     """
 
     aggregator = param.ClassSelector(
-        default=np.size, class_=(dim, types.FunctionType, tuple), doc="""
-        Aggregation function or dimension transform used to compute
-        bin values. Defaults to np.size to count the number of values
-        in each bin.""")
+        default=np.size, class_=(types.FunctionType, tuple), doc="""
+      Aggregation function or dimension transform used to compute bin
+      values. Defaults to np.size to count the number of values
+      in each bin.""")
 
     gridsize = param.ClassSelector(default=50, class_=(int, tuple))
 
@@ -104,10 +103,11 @@ Compositor.register(compositor)
 
 class HexTilesPlot(ColorbarPlot):
 
-    aggregator = param.ClassSelector(default=np.size, class_=(dim, types.FunctionType, tuple),
-    doc="""
-    Aggregation function or dimension transform used to compute bin values.
-    Defaults to np.size to count the number of values in each bin.""")
+    aggregator = param.ClassSelector(
+        default=np.size, class_=(types.FunctionType, tuple), doc="""
+      Aggregation function or dimension transform used to compute
+      bin values.  Defaults to np.size to count the number of values
+      in each bin.""")
 
     gridsize = param.ClassSelector(default=50, class_=(int, tuple), doc="""
       Number of hexagonal bins along x- and y-axes. Defaults to uniform

--- a/holoviews/plotting/bokeh/hex_tiles.py
+++ b/holoviews/plotting/bokeh/hex_tiles.py
@@ -33,6 +33,11 @@ class hex_binning(Operation):
     Aggregation function or dimension transform used to compute bin values.
     Defaults to np.size to count the number of values in each bin.""")
 
+    aggregator_signature = param.List(default=None, class_=str, doc="""
+    Names for output variables of aggregator. Can be referenced in dim
+    transforms on the element. Only respected when aggregator is itself a dim
+    transform.""")
+
     gridsize = param.ClassSelector(default=50, class_=(int, tuple))
 
     invert_axes = param.Boolean(default=False)
@@ -86,9 +91,12 @@ class hex_binning(Operation):
         xd, yd = xd.clone(range=(x0, x1)), yd.clone(range=(y0, y1))
         kdims = [yd, xd] if self.p.invert_axes else [xd, yd]
         if isinstance(aggregator, dim_transform):
+            signature = self.p.aggregator_signature
+            if signature is None:
+                signature = vdims[:1]
             agg_args = dict(
                 dim_transform=aggregator,
-                dim_transform_signature=['_Transformed'],
+                dim_transform_signature=signature,
             )
         else:
             agg_args = dict(function=aggregator)
@@ -114,6 +122,11 @@ class HexTilesPlot(ColorbarPlot):
     doc="""
     Aggregation function or dimension transform used to compute bin values.
     Defaults to np.size to count the number of values in each bin.""")
+
+    aggregator_signature = param.List(default=None, class_=str, doc="""
+    Names for output variables of aggregator. Can be referenced in dim
+    transforms on the element. Only respected when aggregator is itself a dim
+    transform.""")
 
     gridsize = param.ClassSelector(default=50, class_=(int, tuple), doc="""
       Number of hexagonal bins along x- and y-axes. Defaults to uniform

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -477,13 +477,14 @@ class OverlaySelectionDisplay(SelectionDisplay):
             dataset = element.dataset
             try:
                 if dataset.interface.gridded:
-                    mask = selection_expr.apply(dataset, expanded=True, flat=False)
+                    mask = selection_expr.apply(dataset, expanded=True, flat=False, strict=True)
                     selection = dataset.clone(dataset.interface.mask(dataset, ~mask))
                 elif isinstance(element, (Curve, Spread)) and hasattr(dataset.interface, 'mask'):
-                    mask = selection_expr.apply(dataset)
+                    mask = selection_expr.apply(dataset, compute=False, strict=True)
                     selection = dataset.clone(dataset.interface.mask(dataset, ~mask))
                 else:
-                    selection = dataset.select(selection_expr=selection_expr)
+                    mask = selection_expr.apply(dataset, compute=False, keep_index=True, strict=True)
+                    selection = dataset.select(selection_mask=mask)
                 element = element.pipeline(selection)
             except KeyError as e:
                 key_error = str(e).replace('"', '').replace('.', '')

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -681,7 +681,7 @@ class Params(Stream):
                 group[0].owner.param.watch(self._watcher, [p.name for p in group])
 
     @classmethod
-    def from_params(cls, params):
+    def from_params(cls, params, **kwargs):
         """Returns Params streams given a dictionary of parameters
 
         Args:
@@ -699,7 +699,7 @@ class Params(Stream):
                 continue
             names = [p.name for _, p in group]
             rename = {p.name: n for n, p in group}
-            streams.append(cls(inst, names, rename=rename))
+            streams.append(cls(inst, names, rename=rename, **kwargs))
         return streams
 
     def _validate_rename(self, mapping):

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -395,7 +395,17 @@ class HomogeneousColumnTests(object):
         df = self.dataset_hm.dframe(['x'])
         self.assertEqual(df, pd.DataFrame({'x': self.xs}, dtype=df.dtypes[0]))
 
+    def test_dataset_transform_replace_hm(self):
+        transformed = self.dataset_hm.transform(y=dim('y')*2)
+        expected = Dataset((self.xs, self.y_ints*2), 'x', 'y')
+        self.assertEqual(transformed, expected)
 
+    def test_dataset_transform_add_hm(self):
+        transformed = self.dataset_hm.transform(y2=dim('y')*2)
+        expected = Dataset((self.xs, self.y_ints, self.y_ints*2), 'x', ['y', 'y2'])
+        self.assertEqual(transformed, expected)
+
+        
 
 class HeterogeneousColumnTests(HomogeneousColumnTests):
     """
@@ -613,7 +623,6 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         grouped = HoloMap([('M', Dataset(group1, kdims=['Age'], vdims=self.vdims)),
                            ('F', Dataset(group2, kdims=['Age'], vdims=self.vdims))],
                           kdims=['Gender'], sort=False)
-        print(grouped.keys())
         self.assertEqual(self.table.groupby(['Gender']), grouped)
 
     def test_dataset_groupby_alias(self):
@@ -839,6 +848,26 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
     def test_dataset_array_ht(self):
         self.assertEqual(self.dataset_ht.array(),
                          np.column_stack([self.xs, self.ys]))
+
+    # Transforms
+
+    def test_dataset_transform_replace_ht(self):
+        transformed = self.table.transform(
+            Age=dim('Age')**2, Weight=dim('Weight')*2, Height=dim('Height')/2.
+        )
+        expected = Dataset({'Gender':self.gender, 'Age':self.age**2,
+                            'Weight':self.weight*2, 'Height':self.height/2.},
+                           kdims=self.kdims, vdims=self.vdims)
+        self.assertEqual(transformed, expected)
+
+    def test_dataset_transform_add_ht(self):
+        transformed = self.table.transform(combined=dim('Age')*dim('Weight'))
+        expected = Dataset({'Gender':self.gender, 'Age':self.age,
+                              'Weight':self.weight, 'Height':self.height,
+                              'combined': self.age*self.weight},
+                             kdims=self.kdims, vdims=self.vdims+['combined'])
+        self.assertEqual(transformed, expected)
+
 
 
 class ScalarColumnTests(object):

--- a/holoviews/tests/core/data/testarrayinterface.py
+++ b/holoviews/tests/core/data/testarrayinterface.py
@@ -1,3 +1,5 @@
+from unittest import SkipTest
+
 import numpy as np
 
 from holoviews.core.data import Dataset
@@ -43,3 +45,9 @@ class ArrayDatasetTest(HomogeneousColumnTests, InterfaceTests):
         ds_sorted = Dataset(([2, 2, 1, 1], [2, 1, 2, 1], [0, 2, 1, 3]),
                             kdims=['x', 'y'], vdims=['z'])
         self.assertEqual(ds.sort(reverse=True), ds_sorted)
+
+    def test_dataset_transform_replace_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_transform_add_hm(self):
+        raise SkipTest("Not supported")

--- a/holoviews/tests/core/data/testbinneddatasets.py
+++ b/holoviews/tests/core/data/testbinneddatasets.py
@@ -13,6 +13,7 @@ from holoviews.core.data.interface import DataError
 from holoviews.core.util import OrderedDict
 from holoviews.element import Histogram, QuadMesh
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.util.transform import dim
 
 
 class Binned1DTest(ComparisonTestCase):
@@ -156,7 +157,17 @@ class Binned2DTest(ComparisonTestCase):
                            for i in range(3)}, kdims=['y'])
         self.assertEqual(grouped, holomap)
 
+    def test_qmesh_transform_replace_kdim(self):
+        transformed = self.dataset2d.transform(x=dim('x')*2)
+        expected = QuadMesh((self.xs*2, self.ys, self.zs))
+        self.assertEqual(expected, transformed)
 
+    def test_qmesh_transform_replace_vdim(self):
+        transformed = self.dataset2d.transform(z=dim('z')*2)
+        expected = QuadMesh((self.xs, self.ys, self.zs*2))
+        self.assertEqual(expected, transformed)
+
+        
 
 class Irregular2DBinsTest(ComparisonTestCase):
 
@@ -253,3 +264,13 @@ class Irregular2DBinsTest(ComparisonTestCase):
         hmap = HoloMap({0: Dataset((self.xs, self.ys, zs[0]), ['lon', 'lat'], 'A'),
                         1: Dataset((self.xs, self.ys, zs[1]), ['lon', 'lat'], 'A')}, kdims='z')
         self.assertEqual(grouped, hmap)
+
+    def test_irregular_transform_replace_kdim(self):
+        transformed = Dataset((self.xs, self.ys, self.zs), ['x', 'y'], 'z').transform(x=dim('x')*2)
+        expected = Dataset((self.xs*2, self.ys, self.zs), ['x', 'y'], 'z')
+        self.assertEqual(expected, transformed)
+
+    def test_irregular_transform_replace_vdim(self):
+        transformed = Dataset((self.xs, self.ys, self.zs), ['x', 'y'], 'z').transform(z=dim('z')*2)
+        expected = Dataset((self.xs, self.ys, self.zs*2), ['x', 'y'], 'z')
+        self.assertEqual(expected, transformed)

--- a/holoviews/tests/core/data/testgridinterface.py
+++ b/holoviews/tests/core/data/testgridinterface.py
@@ -8,6 +8,7 @@ import numpy as np
 from holoviews.core.data import Dataset
 from holoviews.core.util import pd, date_range
 from holoviews.element import Image, Curve, RGB, HSV
+from holoviews.util.transform import dim
 
 try:
     import dask.array as da
@@ -314,9 +315,44 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
         expected[mask] = np.nan
         self.assertEqual(masked_array, expected)
 
+    def test_dataset_transform_replace_kdim_on_grid(self):
+        transformed = self.dataset_grid.transform(x=dim('x')*2)
+        expected = self.element(
+            ([0, 2], self.grid_ys, self.grid_zs), ['x', 'y'], ['z']
+        )
+        self.assertEqual(transformed, expected)
+
+    def test_dataset_transform_replace_vdim_on_grid(self):
+        transformed = self.dataset_grid.transform(z=dim('z')*2)
+        expected = self.element(
+            (self.grid_xs, self.grid_ys, self.grid_zs*2), ['x', 'y'], ['z']
+        )
+        self.assertEqual(transformed, expected)
+
+    def test_dataset_transform_replace_vdim_on_grid(self):
+        transformed = self.dataset_grid.transform(z=dim('z')*2)
+        expected = self.element(
+            (self.grid_xs, self.grid_ys, self.grid_zs*2), ['x', 'y'], ['z']
+        )
+        self.assertEqual(transformed, expected)
+
+    def test_dataset_transform_replace_kdim_on_inverted_grid(self):
+        transformed = self.dataset_grid_inv.transform(x=dim('x')*2)
+        expected = self.element(
+            ([2, 0], self.grid_ys[::-1], self.grid_zs), ['x', 'y'], ['z']
+        )
+        self.assertEqual(transformed, expected)
+        
+    def test_dataset_transform_replace_vdim_on_inverted_grid(self):
+        transformed = self.dataset_grid_inv.transform(z=dim('z')*2)
+        expected = self.element(
+            (self.grid_xs[::-1], self.grid_ys[::-1], self.grid_zs*2), ['x', 'y'], ['z']
+        )
+        self.assertEqual(transformed, expected)
+
+
 
 class GridInterfaceTests(BaseGridInterfaceTests):
-
     datatype = 'grid'
     data_type = (OrderedDict, dict)
     element = Dataset
@@ -495,6 +531,7 @@ class DaskGridInterfaceTests(GridInterfaceTests):
         df = self.dataset_hm.dframe()
         self.assertEqual(df.x.values, self.xs)
         self.assertEqual(df.y.values, self.y_ints.compute())
+
 
 
 

--- a/holoviews/tests/core/data/testgridinterface.py
+++ b/holoviews/tests/core/data/testgridinterface.py
@@ -335,7 +335,7 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
             ([2, 0], self.grid_ys[::-1], self.grid_zs), ['x', 'y'], ['z']
         )
         self.assertEqual(transformed, expected)
-        
+
     def test_dataset_transform_replace_vdim_on_inverted_grid(self):
         transformed = self.dataset_grid_inv.transform(z=dim('z')*2)
         expected = self.element(

--- a/holoviews/tests/core/data/testgridinterface.py
+++ b/holoviews/tests/core/data/testgridinterface.py
@@ -329,13 +329,6 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
         )
         self.assertEqual(transformed, expected)
 
-    def test_dataset_transform_replace_vdim_on_grid(self):
-        transformed = self.dataset_grid.transform(z=dim('z')*2)
-        expected = self.element(
-            (self.grid_xs, self.grid_ys, self.grid_zs*2), ['x', 'y'], ['z']
-        )
-        self.assertEqual(transformed, expected)
-
     def test_dataset_transform_replace_kdim_on_inverted_grid(self):
         transformed = self.dataset_grid_inv.transform(x=dim('x')*2)
         expected = self.element(

--- a/holoviews/tests/core/data/testxarrayinterface.py
+++ b/holoviews/tests/core/data/testxarrayinterface.py
@@ -1,4 +1,5 @@
 import datetime as dt
+
 from collections import OrderedDict
 from unittest import SkipTest
 

--- a/holoviews/tests/util/testtransform.py
+++ b/holoviews/tests/util/testtransform.py
@@ -209,11 +209,11 @@ class TestDimTransforms(ComparisonTestCase):
         self.check_apply(expr, self.linear_floats.sum())
 
     def test_std_transform(self):
-        expr = dim('float').std()
+        expr = dim('float').std(ddof=0)
         self.check_apply(expr, self.linear_floats.std(ddof=0))
 
     def test_var_transform(self):
-        expr = dim('float').var()
+        expr = dim('float').var(ddof=0)
         self.check_apply(expr, self.linear_floats.var(ddof=0))
 
     def test_log_transform(self):

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -486,8 +486,11 @@ class dim(object):
         for o in self.ops:
             args = o['args']
             fn = o['fn']
+            kwargs = dict(o['kwargs'])
             fn_name = self._numpy_funcs.get(fn)
             if fn_name and hasattr(data, fn_name):
+                if 'axis' not in kwargs and not isinstance(fn, np.ufunc):
+                    kwargs['axis'] = None
                 fn = fn_name
             fn_args = [] if isinstance(fn, basestring) else [data]
             for arg in args:
@@ -506,7 +509,6 @@ class dim(object):
             eldim = dataset.get_dimension(lookup)
             drange = ranges.get(eldim.name, {})
             drange = drange.get('combined', drange)
-            kwargs = o['kwargs']
             if (((fn is norm) or (o['fn'] is lognorm)) and drange != {} and
                 not ('min' in kwargs and 'max' in kwargs)):
                 data = fn(data, *drange)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -513,7 +513,14 @@ class dim(object):
                 not ('min' in kwargs and 'max' in kwargs)):
                 data = fn(data, *drange)
             elif isinstance(fn, basestring):
-                data = getattr(data, fn)(*args, **kwargs)
+                method = getattr(data, fn, None)
+                if method is None:
+                    raise AttributeError(
+                        "%r could not be applied to '%r', '%s' method "
+                        "does not exist on %s type."
+                        % (self, dataset, fn, type(data).__name__)
+                    )
+                data = method(*args, **kwargs)
             else:
                 data = fn(*args, **kwargs)
         return data
@@ -529,7 +536,7 @@ class dim(object):
             ufunc = isinstance(fn, np.ufunc)
             args = ', '.join([repr(r) for r in o['args']]) if o['args'] else ''
             kwargs = sorted(o['kwargs'].items(), key=operator.itemgetter(0))
-            kwargs = '%s' % ', '.join(['%s=%s' % item for item in kwargs]) if kwargs else ''
+            kwargs = '%s' % ', '.join(['%s=%r' % item for item in kwargs]) if kwargs else ''
             if fn in self._binary_funcs:
                 fn_name = self._binary_funcs[o['fn']]
                 if o['reverse']:

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -486,6 +486,9 @@ class dim(object):
         for o in self.ops:
             args = o['args']
             fn = o['fn']
+            fn_name = self._numy_funcs.get(fn)
+            if fn_name and hasattr(data, fn_name):
+                fn = fn_name
             fn_args = [] if isinstance(fn, basestring) else [data]
             for arg in args:
                 if isinstance(arg, dim):

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -8,7 +8,7 @@ from types import BuiltinFunctionType, BuiltinMethodType, FunctionType, MethodTy
 import numpy as np
 
 from ..core.dimension import Dimension
-from ..core.util import basestring, unique_iterator
+from ..core.util import basestring, resolve_dependent_value, unique_iterator
 
 def _maybe_map(numpy_fn):
     def fn(values, *args, **kwargs):
@@ -504,8 +504,23 @@ class dim(object):
                         keep_index,
                         compute,
                     )
+                arg = resolve_dependent_value(arg)
                 fn_args.append(arg)
+            fn_kwargs = {}
+            for k, v in kwargs.items():
+                if isinstance(v, dim):
+                    v = v.apply(
+                        dataset,
+                        flat,
+                        expanded,
+                        ranges,
+                        all_values,
+                        keep_index,
+                        compute,
+                    )
+                fn_kwargs[k] = resolve_dependent_value(v)
             args = tuple(fn_args[::-1] if o['reverse'] else fn_args)
+            kwargs = dict(fn_kwargs)
             eldim = dataset.get_dimension(lookup)
             drange = ranges.get(eldim.name, {})
             drange = drange.get('combined', drange)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -501,7 +501,7 @@ class dim(object):
                 fn_args.append(arg)
             args = tuple(fn_args[::-1] if o['reverse'] else fn_args)
             eldim = dataset.get_dimension(lookup)
-            drange = ranges.get(dimension_name(lookup), {})
+            drange = ranges.get(eldim.name, {})
             drange = drange.get('combined', drange)
             kwargs = o['kwargs']
             if (((fn is norm) or (o['fn'] is lognorm)) and drange != {} and

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -7,7 +7,7 @@ from types import BuiltinFunctionType, BuiltinMethodType, FunctionType, MethodTy
 
 import numpy as np
 
-from ..core.dimension import Dimension, dimension_name
+from ..core.dimension import Dimension
 from ..core.util import basestring, unique_iterator
 
 def _maybe_map(numpy_fn):
@@ -486,7 +486,7 @@ class dim(object):
         for o in self.ops:
             args = o['args']
             fn = o['fn']
-            fn_name = self._numy_funcs.get(fn)
+            fn_name = self._numpy_funcs.get(fn)
             if fn_name and hasattr(data, fn_name):
                 fn = fn_name
             fn_args = [] if isinstance(fn, basestring) else [data]

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -475,6 +475,7 @@ class dim(object):
            compute: For data types that support lazy evaluation, whether
                the result should be computed before it is returned.
            strict: Whether to strictly check for dimension matches
+               (if False, counts any dimensions with matching names as the same)
 
         Returns:
             values: NumPy array computed by evaluating the expression


### PR DESCRIPTION
Addresses #3932 and https://github.com/holoviz/holoviews/issues/237

Supersedes #3636.

Related to #3790.

In this PR, we have the possibility to apply arbitrary dim transforms with multiple output values to Datasets, taking into account correct insertion of dimensions. The name of the new method used here is `.transform`, which provides two ways of specifying transforms. You either supply tuples of dimensions and dim_transforms as args or as kwargs and the method will apply these transforms and either replace the existing dimensions or add the newly added dimensions as new value dimensions. 

The upside of all of this is that we get complex statistical aggregation for free - see below for an example with hex bins that compute trends within each bin.

List of changes
- [x] Add Dataset.transform
- [x] Implement Interface.assign
- [x] Dataset.aggregate now handles dim transforms
- [x] tests

### Setup

```python
import xarray as xr
from holoviews import Dataset
import numpy as np
import pandas as pd
import holoviews as hv
from holoviews import dim, opts
```

### Multi-dimensional dim transforms and aggregations


```python
df = pd.DataFrame(dict(
    x=np.array(range(7))%2,
    y=np.array(range(7))%3,
    u=np.array(range(7))%4,
    v=np.array(range(7))%5
))
ds = Dataset(df, ['x', 'y'], ['u', 'v'])
nds = ds.groupby(['x'])

# scalar output
tf1 = dim('u', lambda u, v: np.sum(u) + np.sum(v), dim('v'))
# tuple of arrays
tf2 = dim('u', lambda u, v: (u, np.mean(v)), dim('v'))
```

```python
print(ds.data.head())
```

x|y|u|v
---|---|---|---
0|0|0|0
1|1|1|1
0|2|2|2
1|0|3|3
0|1|0|4




```python
print(ds.transform(w=tf1).data)

# same as:
# ds.transform(('w', tf1)).data
```

x|y|u|v|w
---|---|---|---|---
0|0|0|0|20
1|1|1|1|20
0|2|2|2|20
1|0|3|3|20
0|1|0|4|20
1|2|1|0|20
0|0|2|1|20




```python
print(ds.transform((('a', 'b'), tf2), drop=True).data)
```

a|b
---|---
0|1.5714285714285714
1|1.5714285714285714
2|1.5714285714285714
3|1.5714285714285714




```python
print(ds.aggregate('y', w=tf1).data)
```

y|w
---|---
0|9
1|6
2|5


### Example: Complex hex binning operations


```python
hv.extension('bokeh')
xds = xr.tutorial.open_dataset('air_temperature').sel(time=slice(None, '2013-1-5'))
df = xds.to_dataframe().reset_index()

def regression(x1, x2):
    x1 = pd.to_numeric(x1)/1e9/86400.
    p = np.polyfit(x1, x2, 1)
    return p[0], p[1]

tf = dim('time', regression, dim('air'))
ds = hv.Dataset(df, ['lon', 'lat'], ['time', 'air'])

e = hv.HexTiles(ds)
e.opts(gridsize=10, aggregator=(('trend', 'offset'), tf),
       color=dim('trend'),
       scale=dim('offset').norm(),
       colorbar=True, width=600)
```
![image](https://user-images.githubusercontent.com/38992106/67949549-46b2ed00-fbbe-11e9-9d6b-1484d5e03b19.png)
