### PR TITLE
Control sort from .overlay/.layout

### DIFF
--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -298,8 +298,9 @@ class MultiDimensionalMapping(Dimensioned):
         group_type = group_type if group_type else type(self)
         dimensions = [self.get_dimension(d, strict=True) for d in dimensions]
         with item_check(False):
+            sort = kwargs.pop('sort', True)
             return util.ndmapping_groupby(self, dimensions, container_type,
-                                          group_type, sort=True, **kwargs)
+                                          group_type, sort=sort, **kwargs)
 
 
     def add_dimension(self, dimension, dim_pos, dim_val, vdim=False, **kwargs):
@@ -486,7 +487,6 @@ class MultiDimensionalMapping(Dimensioned):
                 if d.value_format:
                     dmin, dmax = d.value_format(dmin), d.value_format(dmax)
                 info_str += '\t %s: %s...%s \n' % (d.pprint_label, dmin, dmax)
-        print(info_str)
 
 
     def update(self, other):

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -96,8 +96,7 @@ class MultiDimensionalMapping(Dimensioned):
 
     def __init__(self, initial_items=None, kdims=None, **params):
         if isinstance(initial_items, MultiDimensionalMapping):
-            params = dict(util.get_param_values(initial_items),
-                          **dict({'sort': self.sort}, **params))
+            params = dict(util.get_param_values(initial_items), **dict(params))
         if kdims is not None:
             params['kdims'] = kdims
         super(MultiDimensionalMapping, self).__init__(OrderedDict(), **dict(params))

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -298,7 +298,7 @@ class MultiDimensionalMapping(Dimensioned):
         group_type = group_type if group_type else type(self)
         dimensions = [self.get_dimension(d, strict=True) for d in dimensions]
         with item_check(False):
-            sort = kwargs.pop('sort', True)
+            sort = kwargs.pop('sort', self.sort)
             return util.ndmapping_groupby(self, dimensions, container_type,
                                           group_type, sort=sort, **kwargs)
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1768,14 +1768,16 @@ class ndmapping_groupby(param.ParameterizedFunction):
         multi_index = pd.MultiIndex.from_tuples(ndmapping.keys(), names=all_dims)
         df = pd.DataFrame(list(map(wrap_tuple, ndmapping.values())), index=multi_index)
 
-        kwargs = dict(dict(get_param_values(ndmapping), kdims=idims), **kwargs)
+        # TODO: Look at sort here
+        kwargs = dict(dict(get_param_values(ndmapping), kdims=idims), sort=sort, **kwargs)
         groups = ((wrap_tuple(k), group_type(OrderedDict(unpack_group(group, getter)), **kwargs))
                    for k, group in df.groupby(level=[d.name for d in dimensions]))
 
         if sort:
             selects = list(get_unique_keys(ndmapping, dimensions))
             groups = sorted(groups, key=lambda x: selects.index(x[0]))
-        return container_type(groups, kdims=dimensions)
+
+        return container_type(groups, kdims=dimensions, sort=sort)
 
     @param.parameterized.bothmethod
     def groupby_python(self_or_cls, ndmapping, dimensions, container_type,

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1771,7 +1771,7 @@ class ndmapping_groupby(param.ParameterizedFunction):
         # TODO: Look at sort here
         kwargs = dict(dict(get_param_values(ndmapping), kdims=idims), sort=sort, **kwargs)
         groups = ((wrap_tuple(k), group_type(OrderedDict(unpack_group(group, getter)), **kwargs))
-                   for k, group in df.groupby(level=[d.name for d in dimensions]))
+                   for k, group in df.groupby(level=[d.name for d in dimensions], sort=sort))
 
         if sort:
             selects = list(get_unique_keys(ndmapping, dimensions))

--- a/holoviews/tests/core/testndmapping.py
+++ b/holoviews/tests/core/testndmapping.py
@@ -133,9 +133,9 @@ class NdIndexableMappingTest(ComparisonTestCase):
     def test_idxmapping_groupby_unsorted(self):
         data = [(('B', 2), 1), (('C', 2), 2), (('A', 1), 3)]
         grouped = NdMapping(data, sort=False, kdims=['X', 'Y']).groupby('Y')
-        self.assertEquals(grouped.keys(), [1, 2])
-        self.assertEquals(grouped.values()[0].keys(), ['A'])
-        self.assertEquals(grouped.last.keys(), ['B', 'C'])
+        self.assertEquals(grouped.keys(), [2, 1])
+        self.assertEquals(grouped.values()[0].keys(), ['B', 'C'])
+        self.assertEquals(grouped.last.keys(), ['A'])
 
     def test_idxmapping_reindex(self):
         data = [((0, 0.5), 'a'), ((1, 0.5), 'b')]


### PR DESCRIPTION
Currently, the elements of a kdim subjected to `.overlay` or `.layout` are sorted by default.

This PR is to explore how to let a user disable sorting through these methods.
The proposed API is
```
obj.overlay('kdim', sort=False')
```