### PR TITLE
Allow overlay on a dynamicmap nested in a dynamicmap

### DIFF
--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -216,16 +216,17 @@ def split_dmap_overlay(obj, depth=0):
     """
     layers = []
     if isinstance(obj, DynamicMap):
-        if issubclass(obj.type, NdOverlay) and not depth:
-            for v in obj.last.values():
-                layers.append(obj)
-        elif issubclass(obj.type, Overlay):
-            if obj.callback.inputs and is_dynamic_overlay(obj):
-                for inp in obj.callback.inputs:
-                    layers += split_dmap_overlay(inp, depth+1)
-            else:
+        if obj.type is not None:
+            if issubclass(obj.type, NdOverlay) and not depth:
                 for v in obj.last.values():
                     layers.append(obj)
+            elif issubclass(obj.type, Overlay):
+                if obj.callback.inputs and is_dynamic_overlay(obj):
+                    for inp in obj.callback.inputs:
+                        layers += split_dmap_overlay(inp, depth+1)
+                else:
+                    for v in obj.last.values():
+                        layers.append(obj)
         else:
             layers.append(obj)
         return layers
@@ -699,7 +700,7 @@ def _list_cmaps(provider=None, records=False):
             from colorcet import palette_n, glasbey_hv
             cet_maps = palette_n.copy()
             cet_maps['glasbey_hv'] = glasbey_hv # Add special hv-specific map
-            cmaps += info('colorcet', cet_maps) 
+            cmaps += info('colorcet', cet_maps)
             cmaps += info('colorcet', [p+'_r' for p in cet_maps])
         except:
             pass


### PR DESCRIPTION
This came up on gitter. The following:

```python
import xarray as xr
import hvplot.xarray

dz = xr.tutorial.open_dataset('air_temperature')
dz2 = xr.concat([dz.assign_coords({'group': "exp1"}), dz.assign_coords({'group': "exp2"})], 'group')
dz2.hvplot('lon', 'lat', frame_width=200, coastline=True).layout('group')
```

 was failing with the error:
```python-traceback

~/holoviews/holoviews/plotting/util.py in split_dmap_overlay(obj, depth)
    217     layers = []
    218     if isinstance(obj, DynamicMap):
--> 219         if issubclass(obj.type, NdOverlay) and not depth:
    220             for v in obj.last.values():
    221                 layers.append(obj)

TypeError: issubclass() arg 1 must be a class

:NdLayout   [group]
   :DynamicMap   [time]
      :Overlay
         .Image.I     :Image   [lon,lat]   (air)
         .Coastline.I :Feature   [Longitude,Latitude]
```

With this PR, overlaying on a dynamicmap inside a dynamicmap now works.