### PR TITLE
Ensure bokeh server events are handled on non-server infrastructure

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -326,8 +326,11 @@ class ServerCallback(MessageCallback):
         """
         self._queue.append((attr, old, new))
         if not self._active and self.plot.document:
-            self.plot.document.add_timeout_callback(self.process_on_change, 50)
-            self._active = True
+            if self.plot.document.session_context:
+                self.plot.document.add_timeout_callback(self.process_on_change, 50)
+                self._active = True
+            else:
+                self.process_on_change()
 
 
     def on_event(self, event):
@@ -337,8 +340,11 @@ class ServerCallback(MessageCallback):
         """
         self._queue.append((event))
         if not self._active and self.plot.document:
-            self.plot.document.add_timeout_callback(self.process_on_event, 50)
-            self._active = True
+            if self.plot.document.session_context:
+                self.plot.document.add_timeout_callback(self.process_on_event, 50)
+                self._active = True
+            else:
+                self.process_on_event()
 
 
     def process_on_event(self):
@@ -360,7 +366,9 @@ class ServerCallback(MessageCallback):
                 model_obj = self.plot_handles.get(self.models[0])
                 msg[attr] = self.resolve_attr_spec(path, event, model_obj)
             self.on_msg(msg)
-        self.plot.document.add_timeout_callback(self.process_on_event, 50)
+
+        if self.plot.document.session_context:
+            self.plot.document.add_timeout_callback(self.process_on_event, 50)
 
 
     def process_on_change(self):
@@ -381,7 +389,9 @@ class ServerCallback(MessageCallback):
             msg[attr] = self.resolve_attr_spec(path, cb_obj)
 
         self.on_msg(msg)
-        self.plot.document.add_timeout_callback(self.process_on_change, 50)
+
+        if self.plot.document.session_context:
+            self.plot.document.add_timeout_callback(self.process_on_change, 50)
 
 
     def set_server_callback(self, handle):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -9,6 +9,7 @@ from bokeh.models import (
     Range1d, DataRange1d, PolyDrawTool, BoxEditTool, PolyEditTool,
     FreehandDrawTool, PointDrawTool
 )
+from panel.callbacks import PeriodicCallback
 from pyviz_comms import JS_CALLBACK
 
 from ...core import OrderedDict
@@ -326,11 +327,11 @@ class ServerCallback(MessageCallback):
         """
         self._queue.append((attr, old, new))
         if not self._active and self.plot.document:
+            self._active = True
             if self.plot.document.session_context:
                 self.plot.document.add_timeout_callback(self.process_on_change, 50)
-                self._active = True
             else:
-                self.process_on_change()
+                PeriodicCallback(callback=self.process_on_change, period=50, count=1).start()
 
 
     def on_event(self, event):
@@ -340,11 +341,11 @@ class ServerCallback(MessageCallback):
         """
         self._queue.append((event))
         if not self._active and self.plot.document:
+            self._active = True
             if self.plot.document.session_context:
                 self.plot.document.add_timeout_callback(self.process_on_event, 50)
-                self._active = True
             else:
-                self.process_on_event()
+                PeriodicCallback(callback=self.process_on_event, period=50, count=1).start()
 
 
     def process_on_event(self):
@@ -369,6 +370,8 @@ class ServerCallback(MessageCallback):
 
         if self.plot.document.session_context:
             self.plot.document.add_timeout_callback(self.process_on_event, 50)
+        else:
+            PeriodicCallback(callback=self.process_on_event, period=50, count=1).start()
 
 
     def process_on_change(self):
@@ -392,6 +395,8 @@ class ServerCallback(MessageCallback):
 
         if self.plot.document.session_context:
             self.plot.document.add_timeout_callback(self.process_on_change, 50)
+        else:
+            PeriodicCallback(callback=self.process_on_change, period=100, count=1).start()
 
 
     def set_server_callback(self, handle):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -14,7 +14,6 @@ from collections import Counter, defaultdict
 import numpy as np
 import param
 
-from panel.callbacks import PeriodicCallback
 from panel.io.notebook import push
 from panel.io.state import state
 
@@ -198,9 +197,7 @@ class Plot(param.Parameterized):
                                      for s in p.streams if s._triggering]
                 if self.document.session_context:
                     self.document.add_next_tick_callback(self.refresh)
-                else:
-                    PeriodicCallback(callback=self.refresh, count=1, period=10).start()
-                return
+                    return
 
         # Ensure that server based tick callbacks maintain stream triggering state
         for s in self._triggering:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -14,6 +14,7 @@ from collections import Counter, defaultdict
 import numpy as np
 import param
 
+from panel.callbacks import PeriodicCallback
 from panel.io.notebook import push
 from panel.io.state import state
 
@@ -197,7 +198,9 @@ class Plot(param.Parameterized):
                                      for s in p.streams if s._triggering]
                 if self.document.session_context:
                     self.document.add_next_tick_callback(self.refresh)
-                    return
+                else:
+                    PeriodicCallback(callback=self.refresh, count=1, period=10).start()
+                return
 
         # Ensure that server based tick callbacks maintain stream triggering state
         for s in self._triggering:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -195,14 +195,14 @@ class Plot(param.Parameterized):
                 # If we do not have the Document lock, schedule refresh as callback
                 self._triggering += [s for p in self.traverse(lambda x: x, [Plot])
                                      for s in p.streams if s._triggering]
-                self.document.add_next_tick_callback(self.refresh)
-                return
+                if self.document.session_context:
+                    self.document.add_next_tick_callback(self.refresh)
+                    return
 
         # Ensure that server based tick callbacks maintain stream triggering state
         for s in self._triggering:
             s._triggering = True
         try:
-
             traverse_setter(self, '_force', True)
             key = self.current_key if self.current_key else self.keys[0]
             dim_streams = [stream for stream in self.streams


### PR DESCRIPTION
When using bokeh server events on non-bokeh server infrastructure (e.g. the new ipywidget support) timeout callbacks are currently not processed. This ensures these events are processed appropriately. With this PR linked streams and other bokeh events are handled correctly when wrapped in jupyter_bokeh.

- [x] Try adding new timeouts to add some throttling