### PR TITLE
Increased tolerance for aspect divergence

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -794,8 +794,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
                 desired_xspan = yspan*(ratio/frame_aspect)
                 desired_yspan = xspan/(ratio/frame_aspect)
-                if ((np.allclose(desired_xspan, xspan, rtol=0.01) and
-                     np.allclose(desired_yspan, yspan, rtol=0.01)) or
+                if ((np.allclose(desired_xspan, xspan, rtol=0.05) and
+                     np.allclose(desired_yspan, yspan, rtol=0.05)) or
                     not (util.isfinite(xspan) and util.isfinite(yspan))):
                     pass
                 elif desired_yspan >= yspan:


### PR DESCRIPTION
Currently to enforce a `data_aspect` it is sometimes necessary to adjust the axis ranges. This works fine generally but if the tolerance for aspect divergence is too small it can be the case that adjusting the axis ranges causes the ticks to increase or decrease in size which in turn changes the aspect and can trigger a loop of events. By increasing the allowable tolerance for aspect divergence we can avoid these bouncing loops.

Fixes https://github.com/holoviz/geoviews/issues/111