### PR TITLE
Passing extra parameters through rasterize operation

### DIFF
--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -68,6 +68,7 @@ class Operation(param.ParameterizedFunction):
     # and processed element
     _preprocess_hooks = []
     _postprocess_hooks = []
+    _allow_extra_keywords=False
 
     @classmethod
     def search(cls, element, pattern):
@@ -150,7 +151,9 @@ class Operation(param.ParameterizedFunction):
         The process_element method allows a single element to be
         operated on given an externally supplied key.
         """
-        self.p = param.ParamOverrides(self, params)
+        # Should have a way to merge into paramoverrides.
+        # self.p = param.ParamOverrides(self, params,
+        #                               allow_extra_keywords=self._allow_extra_keywords)
         return self._apply(element, key)
 
 
@@ -161,7 +164,8 @@ class Operation(param.ParameterizedFunction):
                 params[k] = v()
             elif isinstance(v, param.Parameter) and isinstance(v.owner, param.Parameterized):
                 params[k] = getattr(v.owner, v.name)
-        self.p = param.ParamOverrides(self, params)
+        self.p = param.ParamOverrides(self, params,
+                                      allow_extra_keywords=self._allow_extra_keywords)
         if not self.p.dynamic:
             kwargs['dynamic'] = False
             if isinstance(element, HoloMap):

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -159,7 +159,6 @@ class Operation(param.ParameterizedFunction):
             self.p.update(params)
             self.p._check_params(params)
         else:
-        # Should have a way to merge into paramoverrides.
             self.p = param.ParamOverrides(self, params,
                                           allow_extra_keywords=self._allow_extra_keywords)
         return self._apply(element, key)

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -151,9 +151,17 @@ class Operation(param.ParameterizedFunction):
         The process_element method allows a single element to be
         operated on given an externally supplied key.
         """
+        if hasattr(self, 'p'):
+            if self._allow_extra_keywords:
+                extras = self.p._extract_extra_keywords(params)
+                self.p._extra_keywords.update(extras)
+                params = {k: v for k, v in params.items() if k not in self.p._extra_keywords}
+            self.p.update(params)
+            self.p._check_params(params)
+        else:
         # Should have a way to merge into paramoverrides.
-        # self.p = param.ParamOverrides(self, params,
-        #                               allow_extra_keywords=self._allow_extra_keywords)
+            self.p = param.ParamOverrides(self, params,
+                                          allow_extra_keywords=self._allow_extra_keywords)
         return self._apply(element, key)
 
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -111,8 +111,8 @@ class ResamplingOperation(LinkableOperation):
 
     @bothmethod
     def instance(self_or_cls,**params):
-        inst = super(ResamplingOperation, self_or_cls).instance(**
-                                        {k:v for k,v in params.items() if k in self_or_cls.param})
+        filtered = {k:v for k,v in params.items() if k in self_or_cls.param}
+        inst = super(ResamplingOperation, self_or_cls).instance(**filtered)
         inst._precomputed = {}
         return inst
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1134,7 +1134,7 @@ class rasterize(AggregationOperation):
         all_allowed_kws = set()
         all_supplied_kws = set()
         for predicate, transform in self._transforms:
-            op_params = dict({k: v for k, v in (list(self.p.items())+list(self.p.extra_keywords().items()))
+            op_params = dict({k: v for k, v in self.p.items()
                               if k in transform.param
                               and not (v is None and k == 'aggregator')},
                              dynamic=False)

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1135,16 +1135,14 @@ class rasterize(AggregationOperation):
         all_supplied_kws = set()
         for predicate, transform in self._transforms:
             op_params = dict({k: v for k, v in self.p.items()
-                              if k in transform.param
-                              and not (v is None and k == 'aggregator')},
+                              if not (v is None and k == 'aggregator')},
                              dynamic=False)
             extended_kws = dict(op_params, **self.p.extra_keywords())
             all_supplied_kws |= set(extended_kws)
-            allowed = transform.param.params()
-            all_allowed_kws |= set(allowed)
+            all_allowed_kws |= set(transform.param)
             # Collect union set of consumed. Versus union of available.
             op = transform.instance(**{k:v for k,v in extended_kws.items()
-                                       if k in allowed})
+                                       if k in transform.param})
             op._precomputed = self._precomputed
             element = element.map(op, predicate)
             self._precomputed = op._precomputed

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -225,6 +225,12 @@ class DatashaderAggregateTests(ComparisonTestCase):
         expected = Image(np.array([[2, 0, 2, 0, 2]]), vdims='count', bounds=bounds)
         self.assertEqual(agg, expected)
 
+    def test_spikes_aggregate_spike_length(self):
+        spikes = Spikes([1, 2, 3])
+        agg = rasterize(spikes, width=5, dynamic=False, expand=False, spike_length=7)
+        expected = Image(np.array([[2, 0, 2, 0, 2]]), vdims='count',
+                         xdensity=2.5, ydensity=1, bounds=(1, 0, 3, 7.0))
+        self.assertEqual(agg, expected)
     def test_spikes_aggregate_with_height_count(self):
         spikes = Spikes([(1, 0.2), (2, 0.8), (3, 0.4)], vdims='y')
         agg = rasterize(spikes, width=5, height=5, y_range=(0, 1), dynamic=False)
@@ -237,6 +243,20 @@ class DatashaderAggregateTests(ComparisonTestCase):
             [0, 0, 1, 0, 0],
             [0, 0, 1, 0, 0]
         ])
+        expected = Image((xs, ys, arr), vdims='count')
+        self.assertEqual(agg, expected)
+
+    def test_spikes_aggregate_with_height_count_override(self):
+        spikes = Spikes([(1, 0.2), (2, 0.8), (3, 0.4)], vdims='y')
+        agg = rasterize(spikes, width=5, height=5, y_range=(0, 1),
+                        spike_length=0.3, dynamic=False)
+        xs = [1.2, 1.6, 2.0, 2.4, 2.8]
+        ys = [0.1, 0.3, 0.5, 0.7, 0.9]
+        arr = np.array([[1, 0, 1, 0, 1],
+                        [1, 0, 1, 0, 1],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0]])
         expected = Image((xs, ys, arr), vdims='count')
         self.assertEqual(agg, expected)
 


### PR DESCRIPTION
This PR is *not* ready right now: the goal is to get a discussion going about how exactly we can dispatch parameters from a generic parameterized function to delegated parameterized functions.

The code path is tricky but here are the key points of what I am trying to achieve together with the various caveats:

1. `Operation` is given the class attribute `_allow_extra_keywords=False` by default. This preserves the current behavior for most operations. Classes that need to dispatch keywords to parameters can override this to `True` (which all classes will then inherit). This sets the corresponding argument in `param.ParamOverrides`.

2. I can't use param to warn here as the warning is determined by the set of parameterized functions that can be dispatched over. It would be nice to generalize but with this approach HoloViews, not param is doing the warning. 

3. This means I have to also silence unknown parameter warnings in the `instance` method which get used when `rasterize` is called. This is why I am filtering with `{k:v for k,v in params.items() if k in self_or_cls.param}`.

4. The `_process` method involves a loop over 'transforms' (rasterizers) and then over the layers of any overlay passed in. I have to filter out unknown parameters but track which one could get used by one of the rasterizers *whether or not there is an element present for it to apply to*. It might be nicer to warn about parameters that don't actually apply to a specific overlay but it is also reasonable to keep `rasterize` general in what it accepts in case the contents of overlays change.

5. The `process_element` method clobbers `self.p` when it gets used with a new `ParamOverrides` which means `.extra_keywords()` doesn't track the extra keywords properly. This is why it is commented out for now: it seems we need a way to merge/update into an existing `ParamOverrides` object.

As you can see this is a little hairier than I hoped and it isn't entirely obvious how this could be abstracted to work at the param level in a nice way. The current code shows an outline of what we might want to do but right now it is more of a pointer to the various problems!