### PR TITLE
Sankey: toggle node sorting in ascending breadth.

### DIFF
--- a/holoviews/element/sankey.py
+++ b/holoviews/element/sankey.py
@@ -33,6 +33,9 @@ class _layout_sankey(Operation):
     iterations = param.Integer(default=32, doc="""
         Number of iterations to run the layout algorithm.""")
 
+    node_sort = param.Boolean(default=True, doc="""
+        Sort nodes in ascending breadth.""")
+
     def _process(self, element, key=None):
         nodes, edges, graph = self.layout(element, **self.p)
         params = get_param_values(element)
@@ -251,7 +254,8 @@ class _layout_sankey(Operation):
         def resolveCollisions():
             for nodes in node_map.values():
                 y = y0
-                nodes.sort(key=cmp_to_key(self.ascendingBreadth))
+                if self.p.node_sort:
+                    nodes.sort(key=cmp_to_key(self.ascendingBreadth))
                 for node in nodes:
                     dy = y-node['y0']
                     if dy > 0:

--- a/holoviews/plotting/bokeh/sankey.py
+++ b/holoviews/plotting/bokeh/sankey.py
@@ -36,6 +36,9 @@ class SankeyPlot(GraphPlot):
     iterations = param.Integer(default=32, doc="""
         Number of iterations to run the layout algorithm.""")
 
+    node_sort = param.Boolean(default=True, doc="""
+        Sort nodes in ascending breadth.""")
+
     # Deprecated options
 
     color_index = param.ClassSelector(default=2, class_=(basestring, int),

--- a/holoviews/plotting/mpl/sankey.py
+++ b/holoviews/plotting/mpl/sankey.py
@@ -32,6 +32,9 @@ class SankeyPlot(GraphPlot):
     iterations = param.Integer(default=32, doc="""
         Number of iterations to run the layout algorithm.""")
 
+    node_sort = param.Boolean(default=True, doc="""
+        Sort nodes in ascending breadth.""")
+
     # Deprecated options
 
     color_index = param.ClassSelector(default=2, class_=(basestring, int),


### PR DESCRIPTION
```python
import pandas as pd
import holoviews as hv

hv.extension("bokeh")

sankey = hv.Sankey(
    pd.DataFrame(
        [
            ["B", "X", 2],
            ["A", "X", 5],
            ["A", "Y", 7],
            ["A", "Z", 6],
            ["B", "Y", 9],
            ["B", "Z", 4],
            ["Y", "F", 4],
            ["Y", "C", 12],
            ["Z", "C", 5],
            ["Z", "F", 5],
            ["X", "F", 7],
        ],
        columns=["source", "target", "value"],
    )
)
sankey.opts(
    width=600,
    height=300,
    edge_color="target",
    node_color="source",
    color_index=0,
    node_sort=True,  #default
```
sorted:
![sorted](https://user-images.githubusercontent.com/1495173/69717339-2a966300-110c-11ea-97f2-2771a34f0eba.png)
not sorted:
![not_sorted](https://user-images.githubusercontent.com/1495173/69717336-2a966300-110c-11ea-9352-85fc9a412ebd.png)

This is important when comparing Sankey plots for the same dataset while filtering several options. If the sorting is handled by the order of the dataframe passed to Sankey (hence by the user) then nodes not getting sorted allows a straightforward comparison of the plots.