### PR TITLE
Added outer and inner label_position options to Sankey plot (#4065)

### DIFF
--- a/holoviews/plotting/bokeh/sankey.py
+++ b/holoviews/plotting/bokeh/sankey.py
@@ -17,9 +17,10 @@ class SankeyPlot(GraphPlot):
     labels = param.ClassSelector(class_=(basestring, dim), doc="""
         The dimension or dimension value transform used to draw labels from.""")
 
-    label_position = param.ObjectSelector(default='right', objects=['left', 'right'],
+    label_position = param.ObjectSelector(default='right',
+                                          objects=['left', 'right', 'outer', 'inner'],
                                           doc="""
-        Whether node labels should be placed to the left or right.""")
+        Whether node labels should be placed to the left, right, outer or inner.""")
 
     show_values = param.Boolean(default=True, doc="""
         Whether to show the values.""")
@@ -51,7 +52,7 @@ class SankeyPlot(GraphPlot):
 
     _style_groups = dict(GraphPlot._style_groups, quad='node', text='label')
 
-    _draw_order = ['graph', 'quad_1', 'text_1']
+    _draw_order = ['graph', 'quad_1', 'text_1', 'text_2']
 
     style_opts = GraphPlot.style_opts + ['edge_fill_alpha', 'nodes_line_color',
                                          'label_text_font_size']
@@ -87,7 +88,7 @@ class SankeyPlot(GraphPlot):
     def _update_glyphs(self, element, ranges, style):
         self._sync_nodes()
         super(SankeyPlot, self)._update_glyphs(element, ranges, style)
-    
+
     def _sync_nodes(self):
         arc_renderer = self.handles['quad_1_glyph_renderer']
         scatter_renderer = self.handles['scatter_1_glyph_renderer']
@@ -148,9 +149,26 @@ class SankeyPlot(GraphPlot):
             text = element.nodes.dimension_values(labels)
             text = [labels.pprint_value(v) for v in text]
 
+        ys = nodes.dimension_values(1)
+
+        nodes = element._sankey['nodes']
+        if nodes:
+            offset = (nodes[0]['x1']-nodes[0]['x0'])/4.
+        else:
+            offset = 0
+
         value_dim = element.vdims[0]
         text_labels = []
-        for i, node in enumerate(element._sankey['nodes']):
+
+        is_outer_inner = self.label_position in ['outer', 'inner']
+
+        # initalize label x-locations
+        if self.label_position in ['right', 'outer']:
+            xs = np.array([node['x1'] for node in nodes]) + offset
+        else: # ['left', 'inner']
+            xs = np.array([node['x0'] for node in nodes]) - offset
+
+        for i, node in enumerate(nodes):
             if len(text):
                 label = text[i]
             else:
@@ -166,19 +184,31 @@ class SankeyPlot(GraphPlot):
             if label:
                 text_labels.append(label)
 
-        ys = nodes.dimension_values(1)
-        nodes = element._sankey['nodes']
-        if nodes:
-            offset = (nodes[0]['x1']-nodes[0]['x0'])/4.
-        else:
-            offset = 0
-        if self.label_position == 'right':
-            xs = np.array([node['x1'] for node in nodes])+offset
-        else:
-            xs = np.array([node['x0'] for node in nodes])-offset
+        align = 'left' if self.label_position in ['right', 'outer'] else 'right'
+
+        # handle labels that have different alignment due to inner/outer
+        if is_outer_inner:
+            xs_2 = xs.copy()
+            text_labels_2 = text_labels.copy()
+            for i, node in enumerate(nodes):
+                if self.label_position == 'outer' and node['x0'] == 0:
+                    text_labels[i] = ''
+                    xs_2[i] = node['x0'] - offset
+                elif self.label_position == 'inner' and node['x0'] == 0:
+                    text_labels[i] = ''
+                    xs_2[i] = node['x1'] + offset
+                else:
+                    text_labels_2[i] = ''
+
+            align_2 = 'right' if align == 'left' else 'left'
+            data['text_2'] = dict(x=xs_2, y=ys,
+                                  text=[str(l) for l in text_labels_2])
+            mapping['text_2'] = dict(text='text', x='x', y='y',
+                                     text_baseline='middle', text_align=align_2)
+
         data['text_1'] = dict(x=xs, y=ys, text=[str(l) for l in text_labels])
-        align = 'left' if self.label_position == 'right' else 'right'
-        mapping['text_1'] = dict(text='text', x='x', y='y', text_baseline='middle', text_align=align)
+        mapping['text_1'] = dict(text='text', x='x', y='y',
+                                 text_baseline='middle', text_align=align)
 
     def _patch_hover(self, element, data):
         """
@@ -197,6 +227,7 @@ class SankeyPlot(GraphPlot):
         data['patches_1'][tgt] = [lookup.get(v, v) for v in tgt_vals]
 
     def get_extents(self, element, ranges, range_type='combined'):
+        """Return the extents of the Sankey box"""
         if range_type == 'extents':
             return element.nodes.extents
         xdim, ydim = element.nodes.kdims[:2]
@@ -205,12 +236,20 @@ class SankeyPlot(GraphPlot):
         y0, y1 = ranges[ydim.name][range_type]
         xdiff = (x1-x0)
         ydiff = (y1-y0)
-        if self.label_position == 'right':
-            x0, x1 = x0-(0.05*xdiff), x1+xpad*xdiff
-        else:
-            x0, x1 = x0-xpad*xdiff, x1+(0.05*xdiff)
+
+        if self.label_position in ['right', 'outer']:
+            x1 = x1 + xpad * xdiff
+        else: # ['left', 'inner']
+            x1 = x1 + (0.05 * xdiff)
+
+        if self.label_position in ['left', 'outer']:
+            x0 = x0 - xpad * xdiff
+        else: # ['right', 'inner']
+            x0 = x0 - (0.05 * xdiff)
+
         x0, x1 = max_range([xdim.range, (x0, x1)])
         y0, y1 = max_range([ydim.range, (y0-(0.05*ydiff), y1+(0.05*ydiff))])
+
         return (x0, y0, x1, y1)
 
     def _postprocess_hover(self, renderer, source):


### PR DESCRIPTION
Fixes issue: #4065

Changes: added outer and inner option for label_position parameter of Sankey plot

Tested by running on three Sankey examples: energy, ABXYZ and Royal Society report.

@maintainers: I need some help how to run unit tests, is there a guide somewhere?

Output:
right:
![image](https://user-images.githubusercontent.com/7702207/70043229-5e680180-15c0-11ea-9b20-464df0a96b37.png)

left:
![image](https://user-images.githubusercontent.com/7702207/70043319-8ce5dc80-15c0-11ea-9cc4-3306d9cada2c.png)

outer:
![image](https://user-images.githubusercontent.com/7702207/70043364-9f601600-15c0-11ea-82b1-83990ee6b589.png)
![image](https://user-images.githubusercontent.com/7702207/70043452-c61e4c80-15c0-11ea-9379-3d51dec9b1ae.png)
![image](https://user-images.githubusercontent.com/7702207/70043596-10073280-15c1-11ea-8a8e-654a196d41dd.png)

inner:
![image](https://user-images.githubusercontent.com/7702207/70043392-ab4bd800-15c0-11ea-8646-00628acefd02.png)
