### PR TITLE
Fix XArrayInterface.aggregate handling of **kwargs

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -389,7 +389,7 @@ class XArrayInterface(GridInterface):
     @classmethod
     def aggregate(cls, dataset, dimensions, function, **kwargs):
         reduce_dims = [d.name for d in dataset.kdims if d not in dimensions]
-        return dataset.data.reduce(function, dim=reduce_dims), []
+        return dataset.data.reduce(function, dim=reduce_dims, **kwargs), []
 
 
     @classmethod


### PR DESCRIPTION
The `aggregate` method of a `holoviews.Dataset` object that was prepared from a `xarray.DataArray` does not pass extra keyword arguments to the aggregation function.

Adding `**kwargs` to the underlying call to xarray's `reduce()` function in the `XArrayInterface.aggregate()` method fixed the issue for me.