### PR TITLE
Dataset propagation improvements

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -281,6 +281,7 @@ class Dataset(Element):
         )
         self._in_method = False
         input_data = data
+        dataset_provided = 'dataset' in kwargs
         input_dataset = kwargs.pop('dataset', None)
         input_pipeline = kwargs.pop(
             'pipeline', None
@@ -320,7 +321,7 @@ class Dataset(Element):
         self._dataset = None
         if input_dataset is not None:
             self._dataset = input_dataset.clone(dataset=None, pipeline=None)
-        elif isinstance(input_data, Dataset):
+        elif isinstance(input_data, Dataset) and not dataset_provided:
             self._dataset = input_data._dataset
         elif type(self) is Dataset:
             self._dataset = self

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -130,8 +130,8 @@ class Operation(param.ParameterizedFunction):
         for hook in self._postprocess_hooks:
             ret = hook(self, ret, **kwargs)
 
-        if (self._propagate_dataset and
-                isinstance(ret, Dataset) and isinstance(element, Dataset)):
+        if (self._propagate_dataset and isinstance(ret, Dataset)
+                and isinstance(element, Dataset)):
             ret._dataset = element.dataset.clone()
             ret._pipeline = element_pipeline.instance(
                 operations=element_pipeline.operations + [

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -70,6 +70,10 @@ class Operation(param.ParameterizedFunction):
     _postprocess_hooks = []
     _allow_extra_keywords=False
 
+    # Flag indicating whether to automatically propagate the .dataset property from
+    # the input of the operation to the result
+    _propagate_dataset = True
+
     @classmethod
     def search(cls, element, pattern):
         """
@@ -126,7 +130,8 @@ class Operation(param.ParameterizedFunction):
         for hook in self._postprocess_hooks:
             ret = hook(self, ret, **kwargs)
 
-        if isinstance(ret, Dataset) and isinstance(element, Dataset):
+        if (self._propagate_dataset and
+                isinstance(ret, Dataset) and isinstance(element, Dataset)):
             ret._dataset = element.dataset.clone()
             ret._pipeline = element_pipeline.instance(
                 operations=element_pipeline.operations + [

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -171,6 +171,11 @@ class CloneTestCase(DatasetPropertyTestCase):
         self.assertEqual(ds_clone.dataset, self.ds2)
         self.assertEqual(len(ds_clone.pipeline.operations), 1)
 
+    def test_clone_dataset_kwarg_none(self):
+        # Setting dataset=None prevents propagation of dataset to cloned object
+        ds_clone = self.ds.clone(dataset=None)
+        self.assertIs(ds_clone, ds_clone.dataset)
+
 
 class ReindexTestCase(DatasetPropertyTestCase):
     def test_reindex_dataset(self):

--- a/holoviews/tests/core/testdatasetproperty.py
+++ b/holoviews/tests/core/testdatasetproperty.py
@@ -11,7 +11,7 @@ except:
 from holoviews import Dataset, Curve, Dimension, Scatter, Distribution
 from holoviews.core import Apply, Redim
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.operation import histogram
+from holoviews.operation import histogram, function
 
 try:
     from holoviews.operation.datashader import dynspread, datashade, rasterize
@@ -826,3 +826,21 @@ class AccessorTestCase(DatasetPropertyTestCase):
         self.assertEqual(
             curve.pipeline(self.ds2), curve2
         )
+
+
+class OperationTestCase(DatasetPropertyTestCase):
+    def test_propagate_dataset(self):
+        op = function.instance(
+            fn=lambda ds: ds.iloc[:5].clone(dataset=None, pipeline=None)
+        )
+        new_ds = op(self.ds)
+        self.assertEqual(new_ds.dataset, self.ds)
+
+    def test_do_not_propagate_dataset(self):
+        op = function.instance(
+            fn=lambda ds: ds.iloc[:5].clone(dataset=None, pipeline=None)
+        )
+        # Disable dataset propagation
+        op._propagate_dataset = False
+        new_ds = op(self.ds)
+        self.assertEqual(new_ds.dataset, new_ds)


### PR DESCRIPTION
https://github.com/holoviz/holoviews/pull/4137/commits/c5adc794e3ecc04ebc6721b0765ef4520938a59e: Cloning a `Dataset` object  with `ds.clone(dataset=None)` should not propagate the `dataset` property to the cloned  object.  That was the behavior initially, but was changed (I think unintentionally) in 83da274a080e99553f531eb591c3983746c12acf. @philippjfr, does this patch look alright?

Added a simple test to lock in the behavior for the future.


https://github.com/holoviz/holoviews/pull/4137/commits/c65395b6fbcc8865f096798e1b5902bc77d99f6f:  Add `Operation._propagate_dataset` class flag to control whether to automatically propagate dataset/pipeline through an operation.

For context, these are both small fixes/improvements needed to get the glaciers demo working with `link_selections`.