### PR TITLE
typo fix, path->poly

### DIFF
--- a/examples/user_guide/Annotators.ipynb
+++ b/examples/user_guide/Annotators.ipynb
@@ -241,9 +241,9 @@
     "point_layout = point_annotator(points, annotations=['Label'])\n",
     "\n",
     "poly_annotator = annotate.instance()\n",
-    "path_layout = path_annotator(hv.Polygons([]), annotations=['Label'])\n",
+    "poly_layout = poly_annotator(hv.Polygons([]), annotations=['Label'])\n",
     "\n",
-    "annotate.compose(hv.element.tiles.Wikipedia(), point_layout, path_layout)"
+    "annotate.compose(hv.element.tiles.Wikipedia(), point_layout, poly_layout)"
    ]
   }
  ],


### PR DESCRIPTION
minor typo fix to the last cell in the notebook. The poly_annotator was labeled as path annotator.