### PR TITLE
Allow PandasInterface constructor with duplicate dimensions

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -91,7 +91,7 @@ class PandasInterface(Interface):
             # Then use defined data type
             kdims = kdims if kdims else kdim_param.default
             vdims = vdims if vdims else vdim_param.default
-            columns = [dimension_name(d) for d in kdims+vdims]
+            columns = list(util.unique_iterator([dimension_name(d) for d in kdims+vdims]))
 
             if isinstance(data, dict) and all(c in data for c in columns):
                 data = cyODict(((d, data[d]) for d in columns))

--- a/holoviews/tests/core/data/testpandasinterface.py
+++ b/holoviews/tests/core/data/testpandasinterface.py
@@ -24,6 +24,10 @@ class BasePandasInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
 
     __test__ = False
 
+    def test_duplicate_dimension_constructor(self):
+        ds = Dataset(([1, 2, 3], [1, 2, 3]), ['A', 'B'], ['A'])
+        self.assertEqual(list(ds.data.columns), ['A', 'B'])
+
     def test_dataset_empty_list_init_dtypes(self):
         dataset = Dataset([], kdims=['x'], vdims=['y'])
         for d in 'xy':


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/4139