### PR TITLE
Simplified packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,15 +2,12 @@ include README.rst
 include LICENSE.txt
 include CHANGELOG.md
 include holoviews/.version
-
-recursive-include tests *
-
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]
-
-recursive-include doc Makefile make.bat *.conf *.css *.html *.ico *.ipynb *.js *.json *.npy *.png *.py *.rst *.svg
-prune doc/builder
-prune doc/nbpublisher
-recursive-include doc/test_data README.rst
-
-recursive-include examples *.csv *.gz *.ipynb *.md *.npz *.png
+include holoviews/ipython/*.html
+include holoviews/plotting/mpl/*.mplstyle
+include holoviews/tests/ipython/notebooks/*.ipynb
+global-exclude *.py[co]
+global-exclude __pycache__
+global-exclude *~
+global-exclude *.ipynb_checkpoints/*
+graft examples
+graft holoviews/examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "param >=1.7.0",
+    "pyct >=0.4.4",
+    "setuptools >=30.3.0",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-import sys, os
+import json
+import os
+import sys
 import shutil
-from collections import defaultdict
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
 
+from setuptools import setup, find_packages
+
+import pyct.build
 
 setup_args = {}
 install_requires = ['param>=1.8.0,<2.0', 'numpy>=1.0', 'pyviz_comms>=0.7.2', 'panel>=0.7.0']
@@ -51,51 +51,23 @@ extras_require['nbtests'] = extras_require['recommended'] + [
 extras_require['doc'] = extras_require['examples'] + [
     'nbsite>0.5.2', 'sphinx', 'sphinx_holoviz_theme', 'mpl_sample_data', 'awscli']
 
-extras_require['build'] = ['param >=1.7.0', 'setuptools']
+extras_require['build'] = ['param >=1.7.0', 'setuptools >=30.3.0', 'pyct >=0.4.4']
 
 # Everything including cyordereddict (optimization) and nosetests
 extras_require['all'] = list(set(extras_require['unit_tests']) | set(extras_require['nbtests']))
 
-
-def embed_version(basepath, ref='v0.2.2'):
-    """
-    Autover is purely a build time dependency in all cases (conda and
-    pip) except for when you use pip's remote git support [git+url] as
-    1) you need a dynamically changing version and 2) the environment
-    starts off clean with zero dependencies installed.
-    This function acts as a fallback to make Version available until
-    PEP518 is commonly supported by pip to express build dependencies.
-    """
-    import io, zipfile, importlib
-    try:    from urllib.request import urlopen
-    except: from urllib import urlopen
-    try:
-        url = 'https://github.com/ioam/autover/archive/{ref}.zip'
-        response = urlopen(url.format(ref=ref))
-        zf = zipfile.ZipFile(io.BytesIO(response.read()))
-        ref = ref[1:] if ref.startswith('v') else ref
-        embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-        with open(os.path.join(basepath, 'version.py'), 'wb') as f:
-            f.write(embed_version)
-        return importlib.import_module("version")
-    except:
-        return None
 
 def get_setup_version(reponame):
     """
     Helper to get the current version from either git describe or the
     .version file (if available).
     """
-    import json
     basepath = os.path.split(__file__)[0]
     version_file_path = os.path.join(basepath, reponame, '.version')
     try:
         from param import version
-
-        # Ensure that param.version has Version object
-        assert hasattr(version, 'Version')
     except:
-        version = embed_version(basepath)
+        version = None
     if version is not None:
         return version.Version.setup_version(basepath, reponame, archive_commit="$Format:%h$")
     else:
@@ -122,33 +94,8 @@ setup_args.update(dict(
         'console_scripts': [
             'holoviews = holoviews.util.command:main'
         ]},
-    packages=["holoviews",
-              "holoviews.core",
-              "holoviews.core.data",
-              "holoviews.element",
-              "holoviews.ipython",
-              "holoviews.util",
-              "holoviews.operation",
-              "holoviews.plotting",
-              "holoviews.plotting.mpl",
-              "holoviews.plotting.bokeh",
-              "holoviews.plotting.plotly",
-              "holoviews.tests",
-              "holoviews.tests.core",
-              "holoviews.tests.core.data",
-              "holoviews.tests.element",
-              "holoviews.tests.ipython",
-              "holoviews.tests.ipython.notebooks",
-              "holoviews.tests.operation",
-              "holoviews.tests.plotting",
-              "holoviews.tests.plotting.bokeh",
-              "holoviews.tests.plotting.matplotlib",
-              "holoviews.tests.plotting.plotly",
-              "holoviews.tests.util"],
-    package_data={'holoviews': ['.version'],
-                  'holoviews.ipython': ['*.html'],
-                  'holoviews.plotting.mpl': ['*.mplstyle'],
-                  'holoviews.tests.ipython.notebooks': ['*.ipynb']},
+    packages=find_packages(),
+    include_package_data=True,
     classifiers=[
         "License :: OSI Approved :: BSD License",
         "Development Status :: 5 - Production/Stable",
@@ -164,81 +111,13 @@ setup_args.update(dict(
         "Topic :: Software Development :: Libraries"]
 ))
 
-def check_pseudo_package(path):
-    """
-    Verifies that a fake subpackage path for assets (notebooks, svgs,
-    pngs etc) both exists and is populated with files.
-    """
-    if not os.path.isdir(path):
-        raise Exception("Please make sure pseudo-package %s exists." % path)
-    else:
-        assets = os.listdir(path)
-        if len(assets) == 0:
-            raise Exception("Please make sure pseudo-package %s is populated." % path)
-
-
-excludes = ['DS_Store', '.log', 'ipynb_checkpoints']
-packages = []
-extensions = defaultdict(list)
-
-def walker(top, names):
-    """
-    Walks a directory and records all packages and file extensions.
-    """
-    global packages, extensions
-    if any(exc in top for exc in excludes):
-        return
-    package = top[top.rfind('holoviews'):].replace(os.path.sep, '.')
-    packages.append(package)
-    for name in names:
-        ext = '.'.join(name.split('.')[1:])
-        ext_str = '*.%s' % ext
-        if ext and ext not in excludes and ext_str not in extensions[package]:
-            extensions[package].append(ext_str)
-
-
-# Note: This function should be identical to util.examples
-# (unfortunate and unavoidable duplication)
-def examples(path='holoviews-examples', verbose=False, force=False, root=__file__):
-    """
-    Copies the notebooks to the supplied path.
-    """
-    filepath = os.path.abspath(os.path.dirname(root))
-    example_dir = os.path.join(filepath, './examples')
-    if not os.path.exists(example_dir):
-        example_dir = os.path.join(filepath, '../examples')
-    if os.path.exists(path):
-        if not force:
-            print('%s directory already exists, either delete it or set the force flag' % path)
-            return
-        shutil.rmtree(path)
-    ignore = shutil.ignore_patterns('.ipynb_checkpoints', '*.pyc', '*~')
-    tree_root = os.path.abspath(example_dir)
-    if os.path.isdir(tree_root):
-        shutil.copytree(tree_root, path, ignore=ignore, symlinks=True)
-    else:
-        print('Cannot find %s' % tree_root)
-
-
-
-def package_assets(example_path):
-    """
-    Generates pseudo-packages for the examples directory.
-    """
-    examples(example_path, force=True, root=__file__)
-    for root, dirs, files in os.walk(example_path):
-        walker(root, dirs+files)
-    setup_args['packages'] += packages
-    for p, exts in extensions.items():
-        if exts:
-            setup_args['package_data'][p] = exts
-
 
 if __name__ == "__main__":
     example_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 'holoviews/examples')
-    if 'develop' not in sys.argv:
-        package_assets(example_path)
+
+    if 'develop' not in sys.argv and 'egg_info' not in sys.argv:
+        pyct.build.examples(example_path, __file__, force=True)
 
     if 'install' in sys.argv:
         header = "HOLOVIEWS INSTALLATION INFORMATION"


### PR DESCRIPTION
* Get's rid of the hacky package bundling and uses the MANIFEST in the way we use across projects.
* Uses setuptools `find_packages` which reduces the risk of forgetting to add a newly added subpackage (which has happened a few times)
 * Adds pyproject.toml to ensure that `pip install -e .` works consistently (and should allow GitHub to extract the necessary information from the setup.py)
* Gets rid of param embed_version, we don't use that in any other package and no one has ever complained

I'm also hoping that this will finally allow GitHub to extract the information it needs from the setup.py to add the `Used By` button at the top of the repo.