### PR TITLE
Avoid unnecessary casting after MultiInterface.iloc

### DIFF
--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -498,7 +498,7 @@ class MultiInterface(Interface):
             new_data = []
             for d in geoms:
                 template.data = d
-                new_data.append(template.iloc[:, cols])
+                new_data.append(template.iloc[:, cols].data)
             return new_data
 
         count = 0


### PR DESCRIPTION
If MultiInterface.iloc returns a list of Datasets the Dataset constructor will attempt to unpack these which can cause unnecessary casting or even drop additional data.