### PR TITLE
Disable linking axes of different types

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -40,7 +40,7 @@ from .util import (
     TOOL_TYPES, bokeh_version, date_to_integer, decode_bytes, get_tab_title,
     glyph_order, py2js_tickformatter, recursive_model_update,
     theme_attr_json, cds_column_replace, hold_policy, match_dim_specs,
-    compute_layout_properties, wrap_formatter)
+    compute_layout_properties, wrap_formatter, match_ax_type)
 
 
 
@@ -282,7 +282,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 data[dim] = [v for _ in range(len(list(data.values())[0]))]
 
 
-    def _merge_ranges(self, plots, xspecs, yspecs):
+    def _merge_ranges(self, plots, xspecs, yspecs, xtype, ytype):
         """
         Given a list of other plots return axes that are shared
         with another plot by matching the dimensions specs stored
@@ -293,14 +293,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if plot is None:
                 continue
             if hasattr(plot, 'x_range') and plot.x_range.tags and xspecs is not None:
-                if match_dim_specs(plot.x_range.tags[0], xspecs):
+                if match_dim_specs(plot.x_range.tags[0], xspecs) and match_ax_type(plot.x_range, xtype):
                     plot_ranges['x_range'] = plot.x_range
-                if match_dim_specs(plot.x_range.tags[0], yspecs):
+                if match_dim_specs(plot.x_range.tags[0], yspecs) and match_ax_type(plot.x_range, ytype):
                     plot_ranges['y_range'] = plot.x_range
             if hasattr(plot, 'y_range') and plot.y_range.tags and yspecs is not None:
-                if match_dim_specs(plot.y_range.tags[0], yspecs):
+                if match_dim_specs(plot.y_range.tags[0], yspecs) and match_ax_type(plot.y_range, ytype):
                     plot_ranges['y_range'] = plot.y_range
-                if match_dim_specs(plot.y_range.tags[0], xspecs):
+                if match_dim_specs(plot.y_range.tags[0], xspecs) and match_ax_type(plot.y_range, xtype):
                     plot_ranges['x_range'] = plot.y_range
         return plot_ranges
 
@@ -342,12 +342,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             yspecs = tuple((yd.name, yd.label, yd.unit) for yd in ydims)
         else:
             yspecs = None
-
-        plot_ranges = {}
-        # Try finding shared ranges in other plots in the same Layout
-        norm_opts = self.lookup_options(el, 'norm').options
-        if plots and self.shared_axes and not norm_opts.get('axiswise', False):
-            plot_ranges = self._merge_ranges(plots, xspecs, yspecs)
 
         # Get the Element that determines the range and get_extents
         range_el = el if self.batched and not isinstance(self, OverlayPlot) else element
@@ -394,6 +388,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     or ytype in util.datetime_types):
                     y_axis_type = 'datetime'
 
+        plot_ranges = {}
+        # Try finding shared ranges in other plots in the same Layout
+        norm_opts = self.lookup_options(el, 'norm').options
+        if plots and self.shared_axes and not norm_opts.get('axiswise', False):
+            plot_ranges = self._merge_ranges(plots, xspecs, yspecs, x_axis_type, y_axis_type)
+                    
         # Declare shared axes
         if 'x_range' in plot_ranges:
             self._shared['x'] = True

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -293,14 +293,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if plot is None:
                 continue
             if hasattr(plot, 'x_range') and plot.x_range.tags and xspecs is not None:
-                if match_dim_specs(plot.x_range.tags[0], xspecs) and match_ax_type(plot.x_range, xtype):
+                if match_dim_specs(plot.x_range.tags[0], xspecs) and match_ax_type(plot.xaxis, xtype):
                     plot_ranges['x_range'] = plot.x_range
-                if match_dim_specs(plot.x_range.tags[0], yspecs) and match_ax_type(plot.x_range, ytype):
+                if match_dim_specs(plot.x_range.tags[0], yspecs) and match_ax_type(plot.xaxis, ytype):
                     plot_ranges['y_range'] = plot.x_range
             if hasattr(plot, 'y_range') and plot.y_range.tags and yspecs is not None:
-                if match_dim_specs(plot.y_range.tags[0], yspecs) and match_ax_type(plot.y_range, ytype):
+                if match_dim_specs(plot.y_range.tags[0], yspecs) and match_ax_type(plot.yaxis, ytype):
                     plot_ranges['y_range'] = plot.y_range
-                if match_dim_specs(plot.y_range.tags[0], xspecs) and match_ax_type(plot.y_range, xtype):
+                if match_dim_specs(plot.y_range.tags[0], xspecs) and match_ax_type(plot.yaxis, xtype):
                     plot_ranges['x_range'] = plot.y_range
         return plot_ranges
 
@@ -393,7 +393,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         norm_opts = self.lookup_options(el, 'norm').options
         if plots and self.shared_axes and not norm_opts.get('axiswise', False):
             plot_ranges = self._merge_ranges(plots, xspecs, yspecs, x_axis_type, y_axis_type)
-                    
+
         # Declare shared axes
         if 'x_range' in plot_ranges:
             self._shared['x'] = True

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -39,7 +39,9 @@ from ...core.ndmapping import NdMapping
 from ...core.overlay import Overlay
 from ...core.util import (
     LooseVersion, _getargspec, basestring, callable_name, cftime_types,
-    cftime_to_timestamp, pd, unique_array, isnumeric, arraylike_types)
+    cftime_to_timestamp, pd, unique_array, isnumeric, arraylike_types,
+    datetime_types
+)
 from ...core.spaces import get_nested_dmaps, DynamicMap
 from ..util import dim_axis_label
 
@@ -911,6 +913,18 @@ def match_dim_specs(specs1, specs2):
                 continue
             if s1 != s2:
                 return False
+    return True
+
+
+def match_ax_type(range_model, range_type):
+    """
+    Ensure the range_type matches the Range model being matched.
+    """
+    print(range_model, range_type)
+    if isinstance(range_type, FactorRange):
+        return range_type == 'categorical'
+    elif isinstance(range_model.start, datetime_types):
+        return range_type == 'datetime'
     return True
 
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -44,8 +44,7 @@ from ...core.ndmapping import NdMapping
 from ...core.overlay import Overlay
 from ...core.util import (
     LooseVersion, _getargspec, basestring, callable_name, cftime_types,
-    cftime_to_timestamp, pd, unique_array, isnumeric, arraylike_types,
-    datetime_types
+    cftime_to_timestamp, pd, unique_array, isnumeric, arraylike_types
 )
 from ...core.spaces import get_nested_dmaps, DynamicMap
 from ..util import dim_axis_label

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -19,8 +19,13 @@ from bokeh.core.properties import value
 from bokeh.core.validation import silence
 from bokeh.layouts import WidgetBox, Row, Column
 from bokeh.models import tools
-from bokeh.models import Model, ToolbarBox, FactorRange, Range1d, Plot, Spacer, CustomJS, GridBox
-from bokeh.models.formatters import FuncTickFormatter, TickFormatter, PrintfTickFormatter
+from bokeh.models import (
+    Model, ToolbarBox, FactorRange, Range1d, Plot, Spacer, CustomJS,
+    GridBox, DatetimeAxis, CategoricalAxis
+)
+from bokeh.models.formatters import (
+    FuncTickFormatter, TickFormatter, PrintfTickFormatter
+)
 from bokeh.models.widgets import DataTable, Tabs, Div
 from bokeh.plotting import Figure
 from bokeh.themes.theme import Theme
@@ -916,16 +921,16 @@ def match_dim_specs(specs1, specs2):
     return True
 
 
-def match_ax_type(range_model, range_type):
+def match_ax_type(ax, range_type):
     """
-    Ensure the range_type matches the Range model being matched.
+    Ensure the range_type matches the axis model being matched.
     """
-    print(range_model, range_type)
-    if isinstance(range_type, FactorRange):
+    if isinstance(ax[0], CategoricalAxis):
         return range_type == 'categorical'
-    elif isinstance(range_model.start, datetime_types):
+    elif isinstance(ax[0], DatetimeAxis):
         return range_type == 'datetime'
-    return True
+    else:
+        return range_type in ('auto', 'log')
 
 
 def wrap_formatter(formatter, axis):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -573,7 +573,7 @@ class DimensionedPlot(Plot):
         if obj is None or not self.normalize or all_table:
             return OrderedDict()
         # Get inherited ranges
-        ranges = self.ranges if ranges is None else dict(ranges)
+        ranges = self.ranges if ranges is None else {k: dict(v) for k, v in ranges.items()}
 
         # Get element identifiers from current object and resolve
         # with selected normalization options
@@ -589,9 +589,7 @@ class DimensionedPlot(Plot):
             # Skip if ranges are cached or already computed by a
             # higher-level container object.
             framewise = framewise or self.dynamic or len(elements) == 1
-            if group in ranges and (not framewise or ranges is not self.ranges):
-                continue
-            elif not framewise: # Traverse to get all elements
+            if not framewise: # Traverse to get all elements
                 elements = obj.traverse(return_fn, [group])
             elif key is not None: # Traverse to get elements for each frame
                 frame = self._get_frame(key)
@@ -683,6 +681,8 @@ class DimensionedPlot(Plot):
                                 drange = (np.nanmin(values), np.nanmax(values))
                         except:
                             factors = util.unique_array(values)
+                    if dim_name in ranges.get(group, {}):
+                        continue
                     if dim_name not in group_ranges:
                         group_ranges[dim_name] = {'data': [], 'hard': [], 'soft': []}
                     if factors is not None:
@@ -694,6 +694,9 @@ class DimensionedPlot(Plot):
 
             # Compute dimension normalization
             for el_dim in el.dimensions('ranges'):
+                dim_name = el_dim.name
+                if dim_name in ranges.get(group, {}):
+                    continue
                 if hasattr(el, 'interface'):
                     if isinstance(el, Graph) and el_dim in el.nodes.dimensions():
                         dtype = el.nodes.interface.dtype(el.nodes, el_dim)
@@ -713,15 +716,15 @@ class DimensionedPlot(Plot):
                 else:
                     data_range = el.range(el_dim, dimension_range=False)
 
-                if el_dim.name not in group_ranges:
-                    group_ranges[el_dim.name] = {'data': [], 'hard': [], 'soft': []}
-                group_ranges[el_dim.name]['data'].append(data_range)
-                group_ranges[el_dim.name]['hard'].append(el_dim.range)
-                group_ranges[el_dim.name]['soft'].append(el_dim.soft_range)
+                if dim_name not in group_ranges:
+                    group_ranges[dim_name] = {'data': [], 'hard': [], 'soft': []}
+                group_ranges[dim_name]['data'].append(data_range)
+                group_ranges[dim_name]['hard'].append(el_dim.range)
+                group_ranges[dim_name]['soft'].append(el_dim.soft_range)
                 if (any(isinstance(r, util.basestring) for r in data_range) or
                     el_dim.type is not None and issubclass(el_dim.type, util.basestring)):
-                    if 'factors' not in group_ranges[el_dim.name]:
-                        group_ranges[el_dim.name]['factors'] = []
+                    if 'factors' not in group_ranges[dim_name]:
+                        group_ranges[dim_name]['factors'] = []
                     if el_dim.values not in ([], None):
                         values = el_dim.values
                     elif el_dim in el:
@@ -736,10 +739,23 @@ class DimensionedPlot(Plot):
                         all(isinstance(v, (np.ndarray)) for v in values)):
                         values = np.concatenate(values)
                     factors = util.unique_array(values)
-                    group_ranges[el_dim.name]['factors'].append(factors)
+                    group_ranges[dim_name]['factors'].append(factors)
+
+        group_dim_ranges = defaultdict(dict)
+        for gdim, values in group_ranges.items():
+            matching = True
+            for t, rs in values.items():
+                if t == 'factors':
+                    continue
+                matching &= (
+                    len({'date' if isinstance(v, util.datetime_types) else 'number'
+                         for rng in rs for v in rng if util.isfinite(v)}) < 2
+                )
+            if matching:
+                group_dim_ranges[gdim] = values
 
         dim_ranges = []
-        for gdim, values in group_ranges.items():
+        for gdim, values in group_dim_ranges.items():
             hard_range = util.max_range(values['hard'], combined=False)
             soft_range = util.max_range(values['soft'])
             data_range = util.max_range(values['data'])
@@ -751,7 +767,10 @@ class DimensionedPlot(Plot):
                 dranges['factors'] = util.unique_array([
                     v for fctrs in values['factors'] for v in fctrs])
             dim_ranges.append((gdim, dranges))
-        ranges[group] = OrderedDict(dim_ranges)
+        if group not in ranges:
+            ranges[group] = OrderedDict(dim_ranges)
+        else:
+            ranges[group].update(OrderedDict(dim_ranges))
 
 
     @classmethod

--- a/holoviews/tests/plotting/bokeh/testlayoutplot.py
+++ b/holoviews/tests/plotting/bokeh/testlayoutplot.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import re
 
 import numpy as np
@@ -337,3 +338,21 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(cp1.handles['y_range'].end, 3)
         self.assertEqual(cp2.handles['y_range'].start, 10)
         self.assertEqual(cp2.handles['y_range'].end, 30)
+
+    def test_layout_categorical_numeric_type_axes_not_linked(self):
+        curve1 = Curve([1, 2, 3])
+        curve2 = Curve([('A', 0), ('B', 1), ('C', 2)])
+        layout = curve1 + curve2
+        plot = bokeh_renderer.get_plot(layout)
+        cp1, cp2 = plot.subplots[(0, 0)].subplots['main'], plot.subplots[(0, 1)].subplots['main']
+        self.assertIsNot(cp1.handles['x_range'], cp2.handles['x_range'])
+        self.assertIs(cp1.handles['y_range'], cp2.handles['y_range'])
+
+    def test_layout_datetime_numeric_type_axes_not_linked(self):
+        curve1 = Curve([1, 2, 3])
+        curve2 = Curve([(dt.datetime(2020, 1, 1), 0), (dt.datetime(2020, 1, 2), 1), (dt.datetime(2020, 1, 3), 2)])
+        layout = curve1 + curve2
+        plot = bokeh_renderer.get_plot(layout)
+        cp1, cp2 = plot.subplots[(0, 0)].subplots['main'], plot.subplots[(0, 1)].subplots['main']
+        self.assertIsNot(cp1.handles['x_range'], cp2.handles['x_range'])
+        self.assertIs(cp1.handles['y_range'], cp2.handles['y_range'])


### PR DESCRIPTION
Previously axes which had values of different types would still share their ranges (causing errors) or linked their axes (causing a lot of weirdness). For now this PR disables the linking and skips computing the shared ranges. The correct solution would be to compute the ranges by type, i.e. datetime and numeric would get stored and shared separately which would allow axes to still share ranges if their types match, e.g. if there are two numeric and one datetime axes the numeric axes would at least still match. 

Fixes https://github.com/holoviz/holoviews/issues/3845