### PR TITLE
Allow calling annotator on Overlay

### DIFF
--- a/examples/user_guide/Annotators.ipynb
+++ b/examples/user_guide/Annotators.ipynb
@@ -53,10 +53,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "points = hv.Points([(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)]).opts(size=10)\n",
+    "points = hv.Points([(0.0, 0.0), (1.0, 1.0), (200000.0, 2000000.0)]).opts(size=10, min_height=500)\n",
     "\n",
     "annotator = hv.annotate.instance()\n",
-    "layout = annotator(points, annotations=['Label'], name=\"Point Annotations\")\n",
+    "layout = annotator(hv.element.tiles.Wikipedia() * points, annotations=['Label'], name=\"Point Annotations\")\n",
     "\n",
     "print(layout)"
    ]
@@ -199,7 +199,7 @@
     "\n",
     "curve_annotator = hv.annotate.instance()\n",
     "\n",
-    "curve_annotator(curve, annotations={'Label': str})"
+    "curve_annotator(curve.opts(width=800, height=400, responsive=False), annotations={'Label': str})"
    ]
   },
   {
@@ -243,7 +243,7 @@
     "\n",
     "box_annotator = hv.annotate.instance()\n",
     "\n",
-    "box_annotator(boxes, annotations=['Label'])"
+    "box_annotator(boxes.opts(width=800, height=400, responsive=False), annotations=['Label'])"
    ]
   },
   {
@@ -295,7 +295,7 @@
     "\n",
     "path_annotator = hv.annotate.instance()\n",
     "\n",
-    "path_annotator(path, annotations=['Label'], vertex_annotations=['Value'])"
+    "path_annotator(path.opts(width=800, height=400, responsive=False), annotations=['Label'], vertex_annotations=['Value'])"
    ]
   },
   {
@@ -320,7 +320,28 @@
    "source": [
     "## Composing Annotators\n",
     "\n",
-    "If you want to work with multiple annotators in the same plot, you can recompose and rearrange the components returned by each `annotate` helper, but doing so can get confusing. To simplify working with multiple annotators at the same time, the `annotate` helper provides a special classmethod that allows composing multiple annotators and other elements, e.g. making a set of tiles into a combined layout consisting of all the components:"
+    "Often we will want to add some annotations on top of one or more other elements which provide context, e.g. when annotating an image with a set of `Points`. As long as only one annotation layer is required you can pass an overlay of multiple elements to the `annotate` operation and it will automatically associate the annotator with the layer that supports annotation. Note however that this will error if multiple elements that support annotation are provided. Below we will annotate a two-photon microscopy image with a set of Points, e.g. to mark the location of each cell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = hv.Image(np.load('../assets/twophoton.npz')['Calcium'][..., 0])\n",
+    "cells = hv.Points([]).opts(width=500, height=500, responsive=False, padding=0)\n",
+    "\n",
+    "hv.annotate(img * cells, annotations=['Label'], name=\"Cell Annotator\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multiple Annotators\n",
+    "\n",
+    "If you want to work with multiple annotators in the same plot, you can recompose and rearrange the components returned by each `annotate` helper manually, but doing so can get confusing. To simplify working with multiple annotators at the same time, the `annotate` helper provides a special classmethod that allows composing multiple annotators and other elements, e.g. making a set of tiles into a combined layout consisting of all the components:"
    ]
   },
   {

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -121,7 +121,7 @@ class annotate(param.ParameterizedFunction):
                 raise ValueError("Cannot compose %s type with annotators." %
                                  type(annotator).__name__)
         tables = Overlay(tables, group='Annotator')
-        return (Overlay(layers).collate() + tables).opts(sizing_mode='stretch_width')
+        return (Overlay(layers).collate() + tables)
 
     def __call__(self, element, **params):
         overlay = element if isinstance(element, Overlay) else [element]
@@ -143,7 +143,7 @@ class annotate(param.ParameterizedFunction):
                 annotator_type = sorted(matches)[0][1]
                 self.annotator = annotator_type(element, **params)
                 tables = Overlay([t[0].object for t in self.annotator.editor], group='Annotator')
-                layout = (self.annotator.plot + tables).opts(sizing_mode='stretch_width')
+                layout = (self.annotator.plot + tables)
                 layers.append(layout)
             else:
                 layers.append(element)

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -134,18 +134,19 @@ class annotate(param.ParameterizedFunction):
                 if isinstance(element, eltype):
                     matches.append((getmro(type(element)).index(eltype), atype))
             if matches:
-                if annotator_type is None:
+                if annotator_type is not None:
                     msg = ('An annotate call may only annotate a single element. '
                            'If you want to annotate multiple elements call annotate '
                            'on each one separately and then use the annotate.compose '
                            'method to combine them into a single layout.')
                     raise ValueError(msg)
-                else:
-                    annotator_type = sorted(matches)[0][1]
-                    self.annotator = annotator_type(element, **params)
-                    tables = Overlay([t[0].object for t in self.annotator.editor], group='Annotator')
-                    layout = (self.annotator.plot + tables).opts(sizing_mode='stretch_width')
-                    layers.append(layout)
+                annotator_type = sorted(matches)[0][1]
+                self.annotator = annotator_type(element, **params)
+                tables = Overlay([t[0].object for t in self.annotator.editor], group='Annotator')
+                layout = (self.annotator.plot + tables).opts(sizing_mode='stretch_width')
+                layers.append(layout)
+            else:
+                layers.append(element)
 
         if annotator_type is None:
             obj = overlay if isinstance(overlay, Overlay) else element

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1018,9 +1018,10 @@ class PointDrawCallback(GlyphDrawCallback):
             kwargs['custom_tooltip'] = stream.tooltip
         if stream.styles:
             self._create_style_callback(plot.handles['cds'], plot.handles['glyph'], 'x')
-        point_tool = PointDrawTool(drag=all(s.drag for s in self.streams),
-                                   empty_value=stream.empty_value,
-                                   renderers=renderers, **kwargs)
+        point_tool = PointDrawTool(
+            add=all(s.add for s in self.streams),
+            drag=all(s.drag for s in self.streams),
+            empty_value=stream.empty_value, renderers=renderers, **kwargs)
         self.plot.state.tools.append(point_tool)
         source = self.plot.handles['source']
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -893,7 +893,8 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                 nsubplots = len(subplots)
 
                 modes = {sp.sizing_mode for sp in subplots
-                         if sp not in (None, 'auto', 'fixed')}
+                         if sp.sizing_mode not in (None, 'auto', 'fixed')}
+                sizing_mode = self.sizing_mode
                 if modes:
                     responsive_width = any(s in m for m in modes for s in ('width', 'both'))
                     responsive_height = any(s in m for m in modes for s in ('height', 'both'))
@@ -905,8 +906,6 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                         sizing_mode = 'stretch_width'
                     elif responsive_height:
                         sizing_mode = 'stretch_height'
-                    else:
-                        sizing_mode = None
 
                 # If tabs enabled lay out AdjointLayout on grid
                 if self.tabs:

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1052,8 +1052,11 @@ class PointDraw(CDSStream):
     """
     Attaches a PointDrawTool and syncs the datasource.
 
+    add: boolean
+        Whether to allow adding new Points
+
     drag: boolean
-        Whether to enable dragging of polygons and paths
+        Whether to enable dragging of Points
 
     empty_value: int/float/string/None
         The value to insert on non-position columns when adding a new polygon
@@ -1070,8 +1073,9 @@ class PointDraw(CDSStream):
         An optional tooltip to override the default
     """
 
-    def __init__(self, empty_value=None, drag=True, num_objects=0, styles={},
-                 tooltip=None, **params):
+    def __init__(self, empty_value=None, add=True, drag=True, num_objects=0,
+                 styles={}, tooltip=None, **params):
+        self.add = add
         self.drag = drag
         self.empty_value = empty_value
         self.num_objects = num_objects

--- a/holoviews/tests/test_annotators.py
+++ b/holoviews/tests/test_annotators.py
@@ -1,6 +1,7 @@
 from holoviews import Overlay
 from holoviews.annotators import annotate, PointAnnotator, PathAnnotator
 from holoviews.element import Points, Path, Table
+from holoviews.element.tiles import Wikipedia, Tiles
 
 from holoviews.tests.plotting.bokeh.testplot import TestBokehPlot
 
@@ -22,6 +23,20 @@ class Test_annotate(TestBokehPlot):
 
         self.assertIsInstance(tables, Overlay)
         self.assertEqual(len(tables), 3)
+
+    def test_annotate_overlay(self):
+        layout = annotate(Wikipedia() * Points([]), annotations=['Label'])
+
+        overlay = layout.DynamicMap.I[()]
+        tables = layout.Annotator.PointAnnotator[()]
+
+        self.assertIsInstance(overlay, Overlay)
+        self.assertEqual(len(overlay), 2)
+        self.assertIsInstance(overlay.get(0), Tiles)
+        self.assertEqual(overlay.get(1), Points([], vdims='Label'))
+
+        self.assertIsInstance(tables, Overlay)
+        self.assertEqual(len(tables), 1)
 
     def test_annotated_property(self):
         annotator = annotate.instance()


### PR DESCRIPTION
Allows calling `annotate` on an Overlay containing one element to annotate and other elements which cannot be annotated. Will error if multiple elements to annotate are supplied.

- [x] Add tests
- [x] Update docs