### PR TITLE
Allow other layers in annotator.compose

### DIFF
--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -11,7 +11,7 @@ from panel.pane import PaneBase
 from panel.layout import Row, Tabs
 from panel.util import param_name
 
-from .core import DynamicMap, Element, Layout, Overlay, Store
+from .core import DynamicMap, HoloMap, ViewableElement, Element, Layout, Overlay, Store
 from .core.util import isscalar
 from .element import Rectangles, Path, Polygons, Points, Table, Curve
 from .plotting.links import VertexTableLink, DataLink, RectanglesTableLink, SelectionLink
@@ -115,7 +115,7 @@ class annotate(param.ParameterizedFunction):
             elif isinstance(annotator, annotate):
                 layers.append(annotator.plot)
                 tables += [t[0].object for t in annotator.editor]
-            elif isinstance(annotator, Element):
+            elif isinstance(annotator, (HoloMap, ViewableElement)):
                 layers.append(annotator)
             else:
                 raise ValueError("Cannot compose %s type with annotators." %


### PR DESCRIPTION
Allows adding HoloMap and DynamicMap layers in the background/foreground:

```python
import holoviews as hv
import numpy as np
import geoviews as gv
import panel as pn

hv.extension('bokeh')

select = pn.widgets.Select(options=gv.tile_sources.tile_sources)
show_labels = pn.widgets.Checkbox(name='Show labels', value=True)

@pn.depends(tiles=select, show_labels=show_labels)
def tiles(tiles, show_labels):
    alpha = 1 if show_labels else 0
    return tiles() * gv.tile_sources.StamenLabels().opts(alpha=alpha)

tile_dmap = hv.DynamicMap(tiles)
rectangle = gv.Rectangles([]).opts(global_extent=True, responsive=False, width=500, height=500)

annotator = hv.annotate.instance()
layout = annotator(rectangle, name='Map Annotator', annotations=['Label'])

pn.Column(
    '# Map Annotator',
    pn.Row(select, show_labels),
    hv.annotate.compose(tile_dmap, layout),
)
```

![ezgif-6-224417363e90](https://user-images.githubusercontent.com/1550771/72573786-13335500-38c7-11ea-82b6-b4f28c2ea1e0.gif)
