### PR TITLE
Tab completion via __signature__

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -257,21 +257,6 @@ class notebook_extension(extension):
         publish_display_data(data={'text/html': html})
 
 
-    @param.parameterized.bothmethod
-    def tab_completion_docstring(self_or_cls):
-        """
-        Generates a docstring that can be used to enable tab-completion
-        of resources.
-        """
-        elements = ['%s=Boolean' %k for k in list(Store.renderers.keys())]
-        for name, p in self_or_cls.param.objects().items():
-            param_type = p.__class__.__name__
-            elements.append("%s=%s" % (name, param_type))
-
-        return "params(%s)" % ', '.join(['holoviews=Boolean'] + elements)
-
-
-notebook_extension.__doc__ = notebook_extension.tab_completion_docstring()
 notebook_extension.add_delete_action(Renderer._delete_plot)
 
 

--- a/holoviews/tests/core/testoptions.py
+++ b/holoviews/tests/core/testoptions.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pickle
 from unittest import SkipTest
 
@@ -901,6 +902,8 @@ class TestCrossBackendOptions(ComparisonTestCase):
         return img
 
     def test_builder_backend_switch(self):
+        if sys.version_info.major == 3:
+            raise SkipTest('Python 3 tab completes via __signature__ not __doc__')
         Store.options(val=self.store_mpl, backend='matplotlib')
         Store.options(val=self.store_bokeh, backend='bokeh')
         Store.set_current_backend('bokeh')

--- a/holoviews/tests/core/testoptions.py
+++ b/holoviews/tests/core/testoptions.py
@@ -919,6 +919,23 @@ class TestCrossBackendOptions(ComparisonTestCase):
         self.assertEqual('color' in dockeys, True)
         self.assertEqual('linewidth' in dockeys, True)
 
+    def test_builder_backend_switch_signature(self):
+        if sys.version_info.major == 2:
+            raise SkipTest('Python 2 tab completes via __doc__ not __signature__')
+        Store.options(val=self.store_mpl, backend='matplotlib')
+        Store.options(val=self.store_bokeh, backend='bokeh')
+        Store.set_current_backend('bokeh')
+        self.assertEqual(opts.Curve.__signature__ is not None, True)
+        sigkeys = opts.Curve.__signature__.parameters
+        self.assertEqual('color' in sigkeys, True)
+        self.assertEqual('line_width' in sigkeys, True)
+        Store.set_current_backend('matplotlib')
+        self.assertEqual(opts.Curve.__signature__ is not None, True)
+        sigkeys = opts.Curve.__signature__.parameters
+        self.assertEqual('color' in sigkeys, True)
+        self.assertEqual('linewidth' in sigkeys, True)
+
+
     def test_builder_cross_backend_validation(self):
         Store.options(val=self.store_mpl, backend='matplotlib')
         Store.options(val=self.store_bokeh, backend='bokeh')

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -493,10 +493,10 @@ class opts(param.ParameterizedFunction):
         if sys.version_info.major == 2:
             builder.__doc__ = '{element}({kws})'.format(element=element, kws=kws)
         else:
-            signature = Signature([Parameter('cls', Parameter.POSITIONAL_ONLY)]
-                                  + ([Parameter('spec', Parameter.KEYWORD_ONLY)]
-                                     + [Parameter(kw, Parameter.KEYWORD_ONLY)
-                                        for kw in sorted_kw_set]))
+            signature = Signature([Parameter('cls', Parameter.POSITIONAL_ONLY),
+                                   Parameter('spec', Parameter.POSITIONAL_OR_KEYWORD)]
+                                  + [Parameter(kw, Parameter.KEYWORD_ONLY)
+                                     for kw in sorted_kw_set])
             builder.__signature__ = signature
         return classmethod(builder)
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -89,6 +89,9 @@ class opts(param.ParameterizedFunction):
        to strict (default), any invalid keywords are simply skipped. If
        strict, invalid keywords prevent the options being applied.""")
 
+    def __init__(self, *args, **kwargs): # Needed for opts specific __signature__
+        super(opts, self).__init__(*args, **kwargs)
+
     def __call__(self, *args, **params):
         if not params and not args:
             return Options()

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -2,7 +2,7 @@ import os, sys, inspect, shutil
 
 from collections import defaultdict
 from types import FunctionType
-from inspect import Parameter, Signature
+
 
 try:
     from pathlib import Path
@@ -493,6 +493,7 @@ class opts(param.ParameterizedFunction):
             kws = ', '.join('{opt}=None'.format(opt=opt) for opt in sorted_kw_set)
             builder.__doc__ = '{element}({kws})'.format(element=element, kws=kws)
         else:
+            from inspect import Parameter, Signature
             signature = Signature([Parameter('spec', Parameter.POSITIONAL_OR_KEYWORD)]
                                   + [Parameter(kw, Parameter.KEYWORD_ONLY)
                                      for kw in sorted_kw_set])
@@ -542,6 +543,7 @@ class opts(param.ParameterizedFunction):
                 'params(strict=Boolean, name=String)','')
             cls.__doc__ = '\n    opts({kws})'.format(kws=kws) + old_doc
         else:
+            from inspect import Parameter, Signature
             signature = Signature([Parameter('args', Parameter.VAR_POSITIONAL)]
                                   + [Parameter(kw, Parameter.KEYWORD_ONLY)
                                      for kw in sorted_kw_set])

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -489,12 +489,11 @@ class opts(param.ParameterizedFunction):
 
         filtered_keywords = [k for k in completions if k not in cls._no_completion]
         sorted_kw_set = sorted(set(filtered_keywords))
-        kws = ', '.join('{opt}=None'.format(opt=opt) for opt in sorted_kw_set)
         if sys.version_info.major == 2:
+            kws = ', '.join('{opt}=None'.format(opt=opt) for opt in sorted_kw_set)
             builder.__doc__ = '{element}({kws})'.format(element=element, kws=kws)
         else:
-            signature = Signature([Parameter('cls', Parameter.POSITIONAL_ONLY),
-                                   Parameter('spec', Parameter.POSITIONAL_OR_KEYWORD)]
+            signature = Signature([Parameter('spec', Parameter.POSITIONAL_OR_KEYWORD)]
                                   + [Parameter(kw, Parameter.KEYWORD_ONLY)
                                      for kw in sorted_kw_set])
             builder.__signature__ = signature

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -638,7 +638,11 @@ class output(param.ParameterizedFunction):
         else:
             Store.output_settings.output(line=line, help_prompt=help_prompt, **options)
 
-output.__doc__ = Store.output_settings._generate_docstring()
+if sys.version_info.major == 2:
+    output.__doc__ = Store.output_settings._generate_docstring(signature=True)
+else:
+    output.__doc__ = Store.output_settings._generate_docstring(signature=False)
+    output.__init__.__signature__ = Store.output_settings._generate_signature()
 
 
 def renderer(name):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -533,9 +533,17 @@ class opts(param.ParameterizedFunction):
                         cls._create_builder(element, keywords))
 
         filtered_keywords = [k for k in all_keywords if k not in cls._no_completion]
-        kws = ', '.join('{opt}=None'.format(opt=opt) for opt in sorted(filtered_keywords))
-        old_doc = cls.__original_docstring__.replace('params(strict=Boolean, name=String)','')
-        cls.__doc__ = '\n    opts({kws})'.format(kws=kws) + old_doc
+        sorted_kw_set = sorted(set(filtered_keywords))
+        if sys.version_info.major == 2:
+            kws = ', '.join('{opt}=None'.format(opt=opt) for opt in sorted_kw_set)
+            old_doc = cls.__original_docstring__.replace(
+                'params(strict=Boolean, name=String)','')
+            cls.__doc__ = '\n    opts({kws})'.format(kws=kws) + old_doc
+        else:
+            signature = Signature([Parameter('args', Parameter.VAR_POSITIONAL)]
+                                  + [Parameter(kw, Parameter.KEYWORD_ONLY)
+                                     for kw in sorted_kw_set])
+            cls.__init__.__signature__ = signature
 
 
 Store._backend_switch_hooks.append(opts._update_backend)

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -1,6 +1,5 @@
 
 from collections import defaultdict
-from inspect import Signature, Parameter
 from ..core import OrderedDict
 from ..core import Store
 from ..core.util import basestring
@@ -243,6 +242,7 @@ class OutputSettings(KeywordSettings):
 
     @classmethod
     def _generate_signature(cls):
+        from inspect import Signature, Parameter
         keywords = ['backend', 'fig', 'holomap', 'widgets', 'fps', 'max_frames',
                     'size', 'dpi', 'filename', 'info', 'css', 'widget_location']
         return Signature([Parameter(kw, Parameter.KEYWORD_ONLY) for kw in keywords])

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -245,7 +245,7 @@ class OutputSettings(KeywordSettings):
     def _generate_signature(cls):
         keywords = ['backend', 'fig', 'holomap', 'widgets', 'fps', 'max_frames',
                     'size', 'dpi', 'filename', 'info', 'css', 'widget_location']
-        return  Signature([Parameter(kw, Parameter.KEYWORD_ONLY) for kw in keywords])
+        return Signature([Parameter(kw, Parameter.KEYWORD_ONLY) for kw in keywords])
 
 
     @classmethod

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -1,5 +1,6 @@
 
 from collections import defaultdict
+from inspect import Signature, Parameter
 from ..core import OrderedDict
 from ..core import Store
 from ..core.util import basestring
@@ -211,7 +212,7 @@ class OutputSettings(KeywordSettings):
     nbagg_counter = 0
 
     @classmethod
-    def _generate_docstring(cls):
+    def _generate_docstring(cls, signature=False):
         intro = ["Helper used to set HoloViews display options.",
                  "Arguments are supplied as a series of keywords in any order:", '']
         backend = "backend      : The backend used by HoloViews"
@@ -234,8 +235,17 @@ class OutputSettings(KeywordSettings):
                         dpi, filename, info, css, widget_location]
         keywords = ['backend', 'fig', 'holomap', 'widgets', 'fps', 'max_frames',
                     'size', 'dpi', 'filename', 'info', 'css', 'widget_location']
-        signature = '\noutput(%s)\n' % ', '.join('%s=None' % kw for kw in keywords)
-        return '\n'.join([signature] + intro + descriptions)
+        if signature:
+            doc_signature = '\noutput(%s)\n' % ', '.join('%s=None' % kw for kw in keywords)
+            return '\n'.join([doc_signature] + intro + descriptions)
+        else:
+            return '\n'.join(intro + descriptions)
+
+    @classmethod
+    def _generate_signature(cls):
+        keywords = ['backend', 'fig', 'holomap', 'widgets', 'fps', 'max_frames',
+                    'size', 'dpi', 'filename', 'info', 'css', 'widget_location']
+        return  Signature([Parameter(kw, Parameter.KEYWORD_ONLY) for kw in keywords])
 
 
     @classmethod


### PR DESCRIPTION
This PR aims to address #4193. 

Note that the docstring approach is used for 2.x only (i.e 2.7 which will be dropped this year) and ``__signature__`` is used for all 3.x. This means things won't work in 3.0, 3.1, 3.2 as ``__signature__`` was introduced in 3.3. I don't believe this matters as holoviews doesn't support those versions anyway.

Currently work in progress:

- [x] Tab completion for `opts`
- [x] Tab completion for the extension.
- [ ] Address other uses of ``__doc__`` for tab completion.

The bigger issue is that most of our parameterized objects used param to implement the tab completion and updating param in a general way is trickier. Thankfully, I think that tab completing options is the critical thing for holoviews and that needs special handling anyway.