### PR TITLE
small correction in docs on colormaps

### DIFF
--- a/examples/user_guide/Colormaps.ipynb
+++ b/examples/user_guide/Colormaps.ipynb
@@ -408,7 +408,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You could also consider filtering on the actual values in the colormap, perhaps to ensure that the specific background color you are using is not present in the colormap.  For this you can use the `hv.plotting.process_cmap` function to look up the actual colormap values by name and provider."
+    "You could also consider filtering on the actual values in the colormap, perhaps to ensure that the specific background color you are using is not present in the colormap.  For this you can use the `hv.plotting.util.process_cmap` function to look up the actual colormap values by name and provider."
    ]
   }
  ],


### PR DESCRIPTION
Using holoviews 1.12.7 I found the path to the process_cmap function to be different from what the docs mention. Here's a small correction.