### PR TITLE
Require matplotlib-base in conda recipe

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -30,13 +30,15 @@ requirements:
     - {{ dep }}
     {% endfor %}
     {% for dep in sdata['extras_require']['recommended'] %}
+    {% if "matplotlib" not in dep %}
     - {{ dep }}
+    {% endif %}
+    - matplotlib-base>=2.2
     {% endfor %}
 
 test:
   requires:
     - nose
-    - matplotlib<=3.0
   imports:
     - holoviews
   commands:


### PR DESCRIPTION
Fixes #4263 