### PR TITLE
Improve TriMesh wiremesh rendering

### DIFF
--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -11,7 +11,7 @@ from ..core.operation import Operation
 from .chart import Points
 from .path import Path
 from .util import (split_path, pd, circular_layout, connect_edges,
-                   connect_edges_pd, quadratic_bezier)
+                   connect_edges_pd, quadratic_bezier, connect_tri_edges_pd)
 
 
 class RedimGraph(Redim):
@@ -586,13 +586,13 @@ class TriMesh(Graph):
             self._edgepaths = edgepaths
             return edgepaths
 
-        simplices = self.array([0, 1, 2]).astype(np.int32)
-        pts = self.nodes.array([0, 1]).astype(float)
-        pts = pts[simplices]
-        paths = np.pad(pts[:, [0, 1, 2, 0], :],
-                       pad_width=((0, 0), (0, 1), (0, 0)),
-                       mode='constant',
-                       constant_values=np.nan).reshape(-1, 2)[:-1]
+        df = connect_tri_edges_pd(self)
+        pts = df.values.reshape((len(df), 3, 2))
+        paths = np.pad(
+            pts[:, [0, 1, 2, 0], :].astype(float),
+            pad_width=((0, 0), (0, 1), (0, 0)),
+            mode='constant', constant_values=np.nan
+        ).reshape(-1, 2)
         edgepaths = self.edge_type([paths], kdims=self.nodes.kdims[:2],
                                    datatype=['multitabular'])
         self._edgepaths = edgepaths

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -592,7 +592,7 @@ class TriMesh(Graph):
             pts[:, [0, 1, 2, 0], :].astype(float),
             pad_width=((0, 0), (0, 1), (0, 0)),
             mode='constant', constant_values=np.nan
-        ).reshape(-1, 2)
+        ).reshape(-1, 2)[:-1]
         edgepaths = self.edge_type([paths], kdims=self.nodes.kdims[:2],
                                    datatype=['multitabular'])
         self._edgepaths = edgepaths

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -358,7 +358,7 @@ argument to specify a selection specification""")
     def dimensions(self, selection='all', label=False):
         dimensions = super(Graph, self).dimensions(selection, label)
         if selection == 'ranges':
-            if self._nodes:
+            if self._nodes is not None:
                 node_dims = self.nodes.dimensions(selection, label)
             else:
                 node_dims = self.node_type.kdims+self.node_type.vdims

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -296,6 +296,30 @@ def connect_edges_pd(graph):
     return edge_segments
 
 
+def connect_tri_edges_pd(trimesh):
+    """
+    Given a TriMesh element containing abstract edges compute edge
+    segments directly connecting the source and target nodes. This
+    operation depends on pandas and is a lot faster than the pure
+    NumPy equivalent.
+    """
+    edges = trimesh.dframe().copy()
+    edges.index.name = 'trimesh_edge_index'
+    edges = edges.reset_index()
+    nodes = trimesh.nodes.dframe().copy()
+    nodes.index.name = 'node_index'
+    v1, v2, v3 = trimesh.kdims
+    x, y, idx = trimesh.nodes.kdims[:3]
+
+    df = pd.merge(edges, nodes, left_on=[v1.name], right_on=[idx.name])
+    df = df.rename(columns={x.name: 'x0', y.name: 'y0'})
+    df = pd.merge(df, nodes, left_on=[v2.name], right_on=[idx.name])
+    df = df.rename(columns={x.name: 'x1', y.name: 'y1'})
+    df = pd.merge(df, nodes, left_on=[v3.name], right_on=[idx.name])
+    df = df.rename(columns={x.name: 'x2', y.name: 'y2'})
+    return df.sort_values('trimesh_edge_index').drop(['trimesh_edge_index'], axis=1)
+
+
 def connect_edges(graph):
     """
     Given a Graph element containing abstract edges compute edge

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -317,7 +317,8 @@ def connect_tri_edges_pd(trimesh):
     df = df.rename(columns={x.name: 'x1', y.name: 'y1'})
     df = pd.merge(df, nodes, left_on=[v3.name], right_on=[idx.name])
     df = df.rename(columns={x.name: 'x2', y.name: 'y2'})
-    return df.sort_values('trimesh_edge_index').drop(['trimesh_edge_index'], axis=1)
+    df = df.sort_values('trimesh_edge_index').drop(['trimesh_edge_index'], axis=1)
+    return df[['x0', 'y0', 'x1', 'y1', 'x2', 'y2']]
 
 
 def connect_edges(graph):


### PR DESCRIPTION
Switches to rendering datashaded TriMesh wireframe using Canvas.line(axis=1) and also allows rendering trimeshes where the vertex indices are not straightforward integer indices into the node array.