### PR TITLE
Add flag to declare Operations that should be applied per element

### DIFF
--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -70,6 +70,9 @@ class Operation(param.ParameterizedFunction):
     _postprocess_hooks = []
     _allow_extra_keywords=False
 
+    # Whether to apply operation per element (will be enabled by default in 2.0)
+    _per_element = False
+
     # Flag indicating whether to automatically propagate the .dataset property from
     # the input of the operation to the result
     _propagate_dataset = True
@@ -184,10 +187,12 @@ class Operation(param.ParameterizedFunction):
                 # Backwards compatibility for key argument
                 return element.clone([(k, self._apply(el, key=k))
                                       for k, el in element.items()])
-            elif isinstance(element, ViewableElement):
+            elif ((self._per_element and isinstance(element, Element)) or
+                  (not self._per_element and isinstance(element, ViewableElement))):
                 return self._apply(element)
         elif 'streams' not in kwargs:
             kwargs['streams'] = self.p.streams
+        kwargs['per_element'] = self._per_element
         return element.apply(self, **kwargs)
 
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1509,6 +1509,8 @@ class SpreadingOperation(LinkableOperation):
                                  doc="""
         The shape to spread by. Options are 'circle' [default] or 'square'.""")
 
+    _per_element = True
+
     @classmethod
     def uint8_to_uint32(cls, img):
         shape = img.shape

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -344,6 +344,8 @@ class threshold(Operation):
     group = param.String(default='Threshold', doc="""
        The group assigned to the thresholded output.""")
 
+    _per_element = True
+
     def _process(self, matrix, key=None):
 
         if not isinstance(matrix, Image):
@@ -370,6 +372,8 @@ class gradient(Operation):
 
     group = param.String(default='Gradient', doc="""
     The group assigned to the output gradient matrix.""")
+
+    _per_element = True
 
     def _process(self, matrix, key=None):
 
@@ -425,6 +429,8 @@ class convolve(Operation):
         convolution in lbrt (left, bottom, right, top) format. By
         default, no slicing is applied.""")
 
+    _per_element = True
+
     def _process(self, overlay, key=None):
         if len(overlay) != 2:
             raise Exception("Overlay must contain at least to items.")
@@ -474,6 +480,8 @@ class contours(Operation):
 
     overlaid = param.Boolean(default=False, doc="""
         Whether to overlay the contour on the supplied Element.""")
+
+    _per_element = True
 
     def _process(self, element, key=None):
         try:
@@ -773,6 +781,8 @@ class decimate(Operation):
        The x_range as a tuple of min and max y-value. Auto-ranges
        if set to None.""")
 
+    _per_element = True
+
     def _process_layer(self, element, key=None):
         if not isinstance(element, Dataset):
             raise ValueError("Cannot downsample non-Dataset types.")
@@ -806,6 +816,8 @@ class interpolate_curve(Operation):
                                                   'steps-post', 'linear'],
                                          default='steps-mid', doc="""
        Controls the transition point of the step along the x-axis.""")
+
+    _per_element = True
 
     @classmethod
     def pts_to_prestep(cls, x, values):

--- a/holoviews/operation/stats.py
+++ b/holoviews/operation/stats.py
@@ -56,6 +56,8 @@ class univariate_kde(Operation):
     groupby = param.ClassSelector(default=None, class_=(basestring, Dimension), doc="""
       Defines a dimension to group the Histogram returning an NdOverlay of Histograms.""")
 
+    _per_element = True
+
     def _process(self, element, key=None):
         if self.p.groupby:
             if not isinstance(element, Dataset):
@@ -165,6 +167,8 @@ class bivariate_kde(Operation):
     y_range  = param.NumericTuple(default=None, length=2, doc="""
        The x_range as a tuple of min and max y-value. Auto-ranges
        if set to None.""")
+
+    _per_element = True
 
     def _process(self, element, key=None):
         try:


### PR DESCRIPTION
This adds a `_per_element` flag to the Operation baseclass and enables that flag for select subclasses. In 2.0 we can consider flipping that switch and applying it by default as suggested by https://github.com/holoviz/holoviews/issues/1107