### PR TITLE
Better debouncing of bokeh server callbacks

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -143,11 +143,11 @@ class Plot(param.Parameterized):
                 if not plot.root:
                     continue
                 for cb in getattr(plot, 'callbacks', []):
-                    if hasattr(pane, '_on_error') and cb.comm:
+                    if hasattr(pane, '_on_error') and getattr(cb, 'comm', None):
                         cb.comm._on_error = partial(pane._on_error, plot.root.ref['id'])
         elif self.root:
             for cb in getattr(self, 'callbacks', []):
-                if hasattr(pane, '_on_error') and cb.comm:
+                if hasattr(pane, '_on_error') and getattr(cb, 'comm', None):
                     cb.comm._on_error = partial(pane._on_error, self.root.ref['id'])
 
     @property


### PR DESCRIPTION
This PR fixes issues with debouncing bokeh callbacks on the server, ensuring that events are triggered at most every 50 milliseconds (currently configurable on `ServerCallback.debounce`).