### PR TITLE
Warning if __new__ implicitly casts to DynamicMap

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -288,7 +288,7 @@ class Dataset(Element):
         """
         if isinstance(data, DynamicMap):
             class_name = cls.__name__
-            msg = "Implicitly casting {class_name} to DynamicMap. Please use .apply({class_name}) instead."
+            msg = "Cannot construct a {class_name} from the supplied object of type DynamicMap.  Implicitly creating a DynamicMap of {class_name} objects, but instead please explicitly call  .apply({class_name}) on the supplied DynamicMap."
             cls.warning(cls, msg.format(class_name=class_name))
             return data.apply(cls, per_element=True, kdims=kdims, vdims=vdims, **kwargs)
         else:

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -295,7 +295,8 @@ class Dataset(Element):
             extras = ', '.join([el for el in [repr_kdims, repr_vdims, repr_kwargs]
                                if el is not None])
             extras = ', ' + extras if extras else ''
-            apply_args= '{class_name}{extras}'.format(class_name=class_name, extras=extras)
+            apply_args= 'hv.{class_name}{extras}'.format(class_name=class_name,
+                                                         extras=extras)
             msg = "Cannot construct a {class_name} from the supplied object of type DynamicMap. Implicitly creating a DynamicMap of {class_name} objects, but instead please explicitly call  .apply({apply_args}) on the supplied DynamicMap."
             cls.warning(cls, msg.format(class_name=class_name, apply_args=apply_args))
             return data.apply(cls, per_element=True, kdims=kdims, vdims=vdims, **kwargs)

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -298,7 +298,7 @@ class Dataset(Element):
             apply_args= 'hv.{class_name}{extras}'.format(class_name=class_name,
                                                          extras=extras)
             msg = "Cannot construct a {class_name} from the supplied object of type DynamicMap. Implicitly creating a DynamicMap of {class_name} objects, but instead please explicitly call .apply({apply_args}) on the supplied DynamicMap."
-            cls.warning(cls, msg.format(class_name=class_name, apply_args=apply_args))
+            cls.param.warning(cls, msg.format(class_name=class_name, apply_args=apply_args))
             return data.apply(cls, per_element=True, kdims=kdims, vdims=vdims, **kwargs)
         else:
             return super(Dataset, cls).__new__(cls)

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -297,7 +297,7 @@ class Dataset(Element):
             extras = ', ' + extras if extras else ''
             apply_args= 'hv.{class_name}{extras}'.format(class_name=class_name,
                                                          extras=extras)
-            msg = "Cannot construct a {class_name} from the supplied object of type DynamicMap. Implicitly creating a DynamicMap of {class_name} objects, but instead please explicitly call  .apply({apply_args}) on the supplied DynamicMap."
+            msg = "Cannot construct a {class_name} from the supplied object of type DynamicMap. Implicitly creating a DynamicMap of {class_name} objects, but instead please explicitly call .apply({apply_args}) on the supplied DynamicMap."
             cls.warning(cls, msg.format(class_name=class_name, apply_args=apply_args))
             return data.apply(cls, per_element=True, kdims=kdims, vdims=vdims, **kwargs)
         else:

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -287,6 +287,9 @@ class Dataset(Element):
         class to each underlying element.
         """
         if isinstance(data, DynamicMap):
+            class_name = cls.__name__
+            msg = "Implicitly casting {class_name} to DynamicMap. Please use .apply({class_name}) instead."
+            cls.warning(cls, msg.format(class_name=class_name))
             return data.apply(cls, per_element=True, kdims=kdims, vdims=vdims, **kwargs)
         else:
             return super(Dataset, cls).__new__(cls)

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -288,8 +288,16 @@ class Dataset(Element):
         """
         if isinstance(data, DynamicMap):
             class_name = cls.__name__
-            msg = "Cannot construct a {class_name} from the supplied object of type DynamicMap.  Implicitly creating a DynamicMap of {class_name} objects, but instead please explicitly call  .apply({class_name}) on the supplied DynamicMap."
-            cls.warning(cls, msg.format(class_name=class_name))
+            repr_kdims = 'kdims=%r' % kdims if kdims else None
+            repr_vdims = 'vdims=%r' % vdims if vdims else None
+            repr_kwargs = (', '.join('%s=%r' % (k,v) for k,v in kwargs.items())
+                           if kwargs else None)
+            extras = ', '.join([el for el in [repr_kdims, repr_vdims, repr_kwargs]
+                               if el is not None])
+            extras = ', ' + extras if extras else ''
+            apply_args= '{class_name}{extras}'.format(class_name=class_name, extras=extras)
+            msg = "Cannot construct a {class_name} from the supplied object of type DynamicMap. Implicitly creating a DynamicMap of {class_name} objects, but instead please explicitly call  .apply({apply_args}) on the supplied DynamicMap."
+            cls.warning(cls, msg.format(class_name=class_name, apply_args=apply_args))
             return data.apply(cls, per_element=True, kdims=kdims, vdims=vdims, **kwargs)
         else:
             return super(Dataset, cls).__new__(cls)


### PR DESCRIPTION
This PR implements the warning discussed with @jbednar and @philippjfr. The idea is to make the intuitive thing work while alerting the user that some magic is happening in the background. In a sense, this functionality is very similar to how we approach `.collate`.

![image](https://user-images.githubusercontent.com/890576/77003966-4d06f300-692c-11ea-87c2-6a4cf8745d24.png)

Currently work in progress: we can discuss how to improve the warning message and I will format better suggestions for using `.apply` when `kdims`, `vdims` and `kwargs` are not empty.