### PR TITLE
Allow using dim expressions as accessors

### DIFF
--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -3,7 +3,6 @@ from __future__ import division
 import operator
 import sys
 
-from functools import partial
 from types import BuiltinFunctionType, BuiltinMethodType, FunctionType, MethodType
 
 import numpy as np

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -272,8 +272,8 @@ class dim(object):
         return hash(repr(self))
 
     def __call__(self, *args, **kwargs):
-        if (not self.opts or not isinstance(self.ops[-1]['fn'], basestring) or
-            'accessor' not in self.opts[-1]['kwargs']):
+        if (not self.ops or not isinstance(self.ops[-1]['fn'], basestring) or
+            'accessor' not in self.ops[-1]['kwargs']):
             raise ValueError("Cannot use __call__ method on dim expression "
                              "which is not an accessor. Ensure that you only "
                              "call a dim expression, which was created by "
@@ -647,7 +647,7 @@ class dim(object):
                     if fn_name in dir(np):
                         format_string = '.'.join([self._namespaces['numpy'], format_string])
                 else:
-                    format_string = 'dim(' + prev+', {fn}'
+                    format_string = prev+', {fn}'
                 if accessor:
                     pass
                 elif args:
@@ -657,6 +657,8 @@ class dim(object):
                     if kwargs:
                         format_string += ', {kwargs}'
                 elif kwargs:
+                    if not format_string.endswith('('):
+                        format_string += ', '
                     format_string += '{kwargs}'
             op_repr = format_string.format(fn=fn_name, repr=op_repr,
                                            args=args, kwargs=kwargs)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -445,7 +445,7 @@ class dim(object):
 
     # Other methods
 
-    def applies(self, dataset):
+    def applies(self, dataset, strict=False):
         """
         Determines whether the dim transform can be applied to the
         Dataset, i.e. whether all referenced dimensions can be
@@ -456,9 +456,10 @@ class dim(object):
         if isinstance(self.dimension, dim):
             applies = self.dimension.applies(dataset)
         else:
-            applies = dataset.get_dimension(self.dimension) is not None
+            lookup = self.dimension if strict else self.dimension.name
+            applies = dataset.get_dimension(lookup) is not None
             if isinstance(dataset, Graph) and not applies:
-                applies = dataset.nodes.get_dimension(self.dimension) is not None
+                applies = dataset.nodes.get_dimension(lookup) is not None
         for op in self.ops:
             args = op.get('args')
             if not args:

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -279,7 +279,11 @@ class dim(object):
                              "call a dim expression, which was created by "
                              "accessing an attribute that does not exist "
                              "on an existing dim expression.")
-        new_op = dict(self.ops[-1], args=args, kwargs=kwargs)
+        op = self.ops[-1]
+        if op['fn'] == 'str':
+            new_op = dict(op, fn=astype, args=(str,), kwargs={})
+        else:
+            new_op = dict(op, args=args, kwargs=kwargs)
         return self.clone(self.dimension, self.ops[:-1]+[new_op])
 
     def __getattr__(self, attr):
@@ -439,9 +443,10 @@ class dim(object):
             kwargs = {'min': limits[0], 'max': limits[1]}
         return dim(self, norm, **kwargs)
 
+    @property
     def str(self):
-        "Casts values to strings."
-        return self.astype(str)
+        "Casts values to strings or provides str accessor."
+        return dim(self, 'str', accessor=True)
 
     # Other methods
 
@@ -525,7 +530,7 @@ class dim(object):
 
             if isinstance(fn, basestring):
                 accessor = kwargs.pop('accessor', None)
-                fn_args = [data]
+                fn_args = []
             else:
                 accessor = False
                 fn_args = [data]
@@ -569,7 +574,7 @@ class dim(object):
                 if method is None:
                     mtype = 'attribute' if accessor else 'method'
                     raise AttributeError(
-                        "%r could not be applied to '%r', '%s' %s"
+                        "%r could not be applied to '%r', '%s' %s "
                         "does not exist on %s type."
                         % (self, dataset, fn, mtype, type(data).__name__)
                     )


### PR DESCRIPTION
In a recent PR we added support for `dim` expressions which can call arbitrary functions on the datastructure they will be applied to. This PR generalizes this mechanism to allow not just calling methods but also using accessors on the underlying object, e.g. to use datetime accessors on a pandas Series:

```python
dim_expr = hv.dim('dates').dt.week
ds = hv.Dataset(pd.date_range('2012', '2013'), 'dates', datatype=['dataframe'])
ds.transform(week=dim_expr).data
```

![Screen Shot 2020-03-22 at 8 31 05 PM](https://user-images.githubusercontent.com/1550771/77258625-14448200-6c7c-11ea-9798-54c4b1729733.png)
