### PR TITLE
rcparam datapath deprecated in mpl 3.2.1

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -34,6 +34,7 @@ def _rc_context(rcparams):
         'savefig.frameon', # deprecated in MPL 3.1, to be removed in 3.3
         'verbose.level', # deprecated in MPL 3.1, to be removed in 3.3
         'verbose.fileo', # deprecated in MPL 3.1, to be removed in 3.3
+        'datapath', # deprecated in MPL 3.2.1, to be removed in 3.3
     ]
     old_rcparams = {k: mpl.rcParams[k] for k in mpl.rcParams.keys()
                     if mpl_version < '3.0' or k not in deprecated}

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -236,10 +236,11 @@ class MPLRenderer(Renderer):
             'savefig.frameon', # deprecated in MPL 3.1, to be removed in 3.3
             'verbose.level', # deprecated in MPL 3.1, to be removed in 3.3
             'verbose.fileo', # deprecated in MPL 3.1, to be removed in 3.3
+            'datapath', # deprecated in MPL 3.2.1, to be removed in 3.3
         ]
         old_rcparams = {k: mpl.rcParams[k] for k in mpl.rcParams.keys()
                         if mpl_version < '3.0' or k not in deprecated}
-    
+
         try:
             cls._rcParams = old_rcparams
             yield


### PR DESCRIPTION
See https://github.com/holoviz/geoviews/issues/452

This whole code to handle deprecated rcparams is now being duplicated in renderer.py and plot.py, should probably factor that out somehow?

https://matplotlib.org/3.2.1/api/prev_api_changes/api_changes_3.2.0.html#the-datapath-rcparam