### PR TITLE
Fix binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![BuildStatus](https://travis-ci.org/holoviz/holoviews.svg?branch=master)](https://travis-ci.org/holoviz/holoviews)
 [![Coveralls](https://img.shields.io/coveralls/pyviz/holoviews.svg)](https://coveralls.io/r/pyviz/holoviews)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pyviz/pyviz?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/pyviz/holoviews/master?filepath=examples)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/holoviz/holoviews/master?filepath=examples)
 
 # <img src="https://assets.holoviews.org/logo/holoviews_color_icon_500x500.png" alt="HoloViews logo" height="40px" align="left" /> HoloViews
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![BuildStatus](https://travis-ci.org/holoviz/holoviews.svg?branch=master)](https://travis-ci.org/holoviz/holoviews)
 [![Coveralls](https://img.shields.io/coveralls/pyviz/holoviews.svg)](https://coveralls.io/r/pyviz/holoviews)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pyviz/pyviz?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/holoviz/holoviews/master?filepath=examples)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/holoviz/holoviews/master?urlpath=lab/tree/examples)
 
 # <img src="https://assets.holoviews.org/logo/holoviews_color_icon_500x500.png" alt="HoloViews logo" height="40px" align="left" /> HoloViews
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,32 +4,29 @@ channels:
   - conda-forge
 
 dependencies:
-  - defaults::numpy
-  - defaults::scipy
-  - defaults::matplotlib
-  - notebook
+  - pyviz::holoviews=0.9.*
+  # Install requires
+  - pyviz::param>=1.8.0,<2.0
+  - pyviz::pyviz_comms>=0.7.2
+  - pyviz::panel>=0.7.0
+  - numpy>=1.0
+  - pandas
+  # Notebook dependencies already filled by binder
+  # Recommended installs
+  - matplotlib>=2.1
+  - bokeh>=1.1.0
+  # To run all examples
   - networkx
+  - pillow
+  - xarray>=0.10.4
+  - plotly>=4.0
+  - pyviz::datashader
   - selenium
-  - cyordereddict
   - phantomjs
   - ffmpeg
-  - pillow=5.3.0
-  - pandas=0.24.0
-  - xarray=0.11.0
-  - ipython=5.4.1
-  - jsonschema=2.6.0
-  - nbconvert=5.3.1
-  - netcdf4=1.3.1
-  - pscript==0.7.1
-  - plotly=4.0
-  - bokeh=1.0.4
-  - pyviz::param=1.8.1
-  - pyviz::pyviz_comms=0.7.0
-  - pyviz::datashader
-  # Testing requirements
-  - flake8
-  - nose
-  - path.py
-  - deepdiff
-  - awscli
-  - coveralls
+  - streamz>=0.5.0
+  - cftime
+  - netcdf4
+  - bzip2
+  - dask
+  - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - pyviz::holoviews=0.9.*
+  - pyviz::holoviews=1.13*
   # Install requires
   - pyviz::param>=1.8.0,<2.0
   - pyviz::pyviz_comms>=0.7.2

--- a/postBuild
+++ b/postBuild
@@ -1,2 +1,5 @@
 # Install the bokeh sampledata required for some examples
 bokeh sampledata
+
+# JupyterLab extension
+jupyter labextension install @pyviz/jupyterlab_pyviz

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,2 @@
+# Install the bokeh sampledata required for some examples
+bokeh sampledata


### PR DESCRIPTION
Fixes #4349 

I've basically copied the dependencies mentionned in ``setup.py`` to the ``environment.yml`` (those that seemed useful to run the examples) and pinned the last released version of ``holoviews``. The binder from that branch can be tried here: https://mybinder.org/v2/gh/maximlt/holoviews/maximlt-fix-binder?filepath=examples. It would be nice to have a way to keep the environment.yml file synced with setup.py.

I've tried to run the 5 *getting started* notebooks, they all run fine. I came accross two issues while randomly running some other notebooks:
- A few warnings: ``MatplotlibDeprecationWarning: The datapath rcparam was deprecated in Matplotlib 3.2.1 and will be removed two minor releases later``
- The users will have to download the bokeh sampledata with ``import bokeh.sampledata; bokeh.sampledata.download()``. The error message is pretty clear and helpful so that shouldn't be a big problem.

Please let me know if this can be improved :)

(It'd also be nice to have a binder badge on every notebook page of holoview.org :o)