### PR TITLE
REL+BUG: Fix panel requirement on Python 3.5

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     {% for dep in sdata.get('install_requires',{}) %}
     {% if "python_version<" not in dep %}
     {% set dep_parts = dep.split(';') %}
-    - {{ dep_parts[0] }}
+    - {{ dep_parts[0]|trim }}
     {% endif %}
     {% endfor %}
     {% for dep in sdata['extras_require']['recommended'] %}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,11 +27,11 @@ requirements:
   run:
     - python {{ sdata['python_requires'] }}
     {% for dep in sdata.get('install_requires',{}) %}
-    {% if "panel" not in dep %}
-    - {{ dep }}
+    {% if "python_version<" not in dep %}
+    {% set dep_parts = dep.split(';') %}
+    - {{ dep_parts[0] }}
     {% endif %}
     {% endfor %}
-    - panel >=0.8
     {% for dep in sdata['extras_require']['recommended'] %}
     - {{ dep }}
     {% endfor %}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,9 +29,9 @@ requirements:
     {% for dep in sdata.get('install_requires',{}) %}
     {% if "panel" not in dep %}
     - {{ dep }}
-	{% endif %}
+    {% endif %}
     {% endfor %}
-    - panel >=0.7
+    - panel >=0.8
     {% for dep in sdata['extras_require']['recommended'] %}
     - {{ dep }}
     {% endfor %}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,7 +22,10 @@ requirements:
   build:
     - python {{ sdata['python_requires'] }}
     {% for dep in sdata['extras_require']['build'] %}
-    - {{ dep }}
+    {% if "python_version<" not in dep %}
+    {% set dep_parts = dep.split(';') %}
+    - {{ dep_parts[0]|trim }}
+    {% endif %}
     {% endfor %}
   run:
     - python {{ sdata['python_requires'] }}
@@ -33,7 +36,10 @@ requirements:
     {% endif %}
     {% endfor %}
     {% for dep in sdata['extras_require']['recommended'] %}
-    - {{ dep }}
+    {% if "python_version<" not in dep %}
+    {% set dep_parts = dep.split(';') %}
+    - {{ dep_parts[0]|trim }}
+    {% endif %}
     {% endfor %}
 
 test:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,8 +27,11 @@ requirements:
   run:
     - python {{ sdata['python_requires'] }}
     {% for dep in sdata.get('install_requires',{}) %}
+    {% if "panel" not in dep %}
     - {{ dep }}
+	{% endif %}
     {% endfor %}
+    - panel >=0.7
     {% for dep in sdata['extras_require']['recommended'] %}
     - {{ dep }}
     {% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ import pyct.build
 
 setup_args = {}
 install_requires = ['param>=1.9.3,<2.0', 'numpy>=1.0', 'pyviz_comms>=0.7.3',
-                    'panel>=0.7.0', 'pandas']
+                    "panel>=0.7.0,<0.9.0; python_version<'3.6'",
+                    "panel>=0.7.0; python_version>='3.6'",
+                    'pandas']
 
 extras_require = {}
 


### PR DESCRIPTION
The current release of Holoviews still claims to support Python 3.5.
However, it can not be installed on Python 3.5 with its current installation requirements. The reason for this is an anomaly in the release history of panel. We work around this problem by specifying a maximum version requirement of panel for holoviews when installing on Python 3.5.
More details of the problem are given below.

The new major release of bokeh, v2.0.0, dropped support for Python 3.5. This new python version requirement was specified in its setup.py requirements.
To support the new bokeh API, panel was changed with what was effectively a new major release in v0.9.0. This version of panel is only for bokeh>=2.0.0, and this requirement was specified in its setup.py requirements. However, panel did not change its Python version requirements to >=3.6 until version 0.9.4.
This means that whenever one tries to install the latest available version of panel on Python 3.5, pip will attempt to install version 0.9.3, and then fail because it is not possible to support the bokeh>=2.0.0 requirement on Python 3.5. Consequently, all packages which require panel and continue to support Python 3.5 need to include an extra specification for the panel version on Python <3.6.