### PR TITLE
Only mask value dimensions

### DIFF
--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -230,7 +230,7 @@ class DictInterface(Interface):
         for vd in dataset.vdims:
             new_array = np.copy(dataset.data[vd.name])
             new_array[mask] = mask_value
-            masked[k] = new_array
+            masked[vd.name] = new_array
         return masked
 
 

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -226,9 +226,9 @@ class DictInterface(Interface):
 
     @classmethod
     def mask(cls, dataset, mask, mask_value=np.nan):
-        masked = OrderedDict()
-        for k, v in dataset.data.items():
-            new_array = np.copy(dataset.data[k])
+        masked = OrderedDict(dataset.data)
+        for vd in dataset.vdims:
+            new_array = np.copy(dataset.data[vd.name])
             new_array[mask] = mask_value
             masked[k] = new_array
         return masked

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -263,7 +263,8 @@ class PandasInterface(Interface):
     @classmethod
     def mask(cls, dataset, mask, mask_value=np.nan):
         masked = dataset.data.copy()
-        masked[mask] = mask_value
+        cols = [vd.name for vd in dataset.vdims]
+        masked.loc[mask, cols] = mask_value
         return masked
 
 


### PR DESCRIPTION
This ensures that linked selection masking is only applied to value dimensions. Key dimensions will often not support nan masking so this ensures weird type conversions do not happen and in the cuDF case ensures that there are no type errors.