### PR TITLE
Expose center as an output option

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -98,6 +98,9 @@ class Renderer(Exporter):
     and the Renderer turns the final plotting state into output.
     """
 
+    center = param.Boolean(default=True, doc="""
+        Whether to center the plot""")
+
     backend = param.String(doc="""
         The full, lowercase name of the rendering backend or third
         part plotting package used e.g 'matplotlib' or 'cairo'.""")
@@ -416,7 +419,7 @@ class Renderer(Exporter):
             widget_type = 'individual'
             widget_location = self_or_cls.widget_location or 'right'
 
-        layout = HoloViewsPane(plot, widget_type=widget_type, center=True,
+        layout = HoloViewsPane(plot, widget_type=widget_type, center=self_or_cls.center,
                                widget_location=widget_location, renderer=self_or_cls)
         interval = int((1./self_or_cls.fps) * 1000)
         for player in layout.layout.select(PlayerBase):

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -142,6 +142,7 @@ class OutputSettings(KeywordSettings):
 
     # Lists: strict options, Set: suggested options, Tuple: numeric bounds.
     allowed = {'backend'       : list_backends(),
+               'center'        : [True, False],
                'fig'           : list_formats('fig'),
                'holomap'       : list_formats('holomap'),
                'widgets'       : ['embed', 'live'],
@@ -162,6 +163,7 @@ class OutputSettings(KeywordSettings):
                                             'min-height', 'outline', 'float']}}
 
     defaults = OrderedDict([('backend'      , None),
+                            ('center'       , True),
                             ('fig'          , None),
                             ('holomap'      , None),
                             ('widgets'      , None),
@@ -180,7 +182,7 @@ class OutputSettings(KeywordSettings):
 
     # Remaining backend specific options renderer options
     render_params = ['fig', 'holomap', 'size', 'fps', 'dpi', 'css',
-                     'widget_mode', 'mode', 'widget_location']
+                     'widget_mode', 'mode', 'widget_location', 'center']
 
     options = OrderedDict()
     _backend_options = defaultdict(dict)


### PR DESCRIPTION
Since we switched to Panel we now allow controlling the `widget_location` using hv.output, this also provides control over whether to `center` the output.