### PR TITLE
Configurable throttling schemes on ServerCallback

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -324,7 +324,7 @@ class ServerCallback(MessageCallback):
 
     adaptive_window = 3
 
-    throttle_timeout = 50
+    throttle_timeout = 100
 
     throttling_scheme = 'adaptive'
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -15,7 +15,6 @@ from bokeh.models import (
     FreehandDrawTool, PointDrawTool
 )
 from panel.io.state import state
-from panel.callbacks import PeriodicCallback
 from pyviz_comms import JS_CALLBACK
 from tornado import gen
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -19,6 +19,7 @@ import param
 from panel.config import config
 from panel.io.notebook import push
 from panel.io.state import state
+from panel.io.server import unlocked
 from pyviz_comms import JupyterComm
 
 from ..selection import NoOpSelectionDisplay
@@ -232,6 +233,7 @@ class Plot(param.Parameterized):
                         for d, k in zip(self.dimensions, key))
             stream_key = util.wrap_tuple_streams(key, self.dimensions, self.streams)
 
+
             self._trigger_refresh(stream_key)
             if self.top_level:
                 self.push()
@@ -248,7 +250,8 @@ class Plot(param.Parameterized):
         "Triggers update to a plot on a refresh event"
         # Update if not top-level, batched or an ElementPlot
         if not self.top_level or isinstance(self, GenericElementPlot):
-            self.update(key)
+            with unlocked():
+                self.update(key)
 
 
     def push(self):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import pyct.build
 
 setup_args = {}
 install_requires = ['param>=1.9.3,<2.0', 'numpy>=1.0', 'pyviz_comms>=0.7.3',
-                    'panel>=0.7.0', 'pandas']
+                    'panel>=0.8.0', 'pandas']
 
 extras_require = {}
 


### PR DESCRIPTION
The throttling scheme used by `LinkedStream` callbacks on bokeh server has never really worked very robustly. This latest attempt fixes the existing throttle mode and adds two additional modes so that now we support the following throttling modes:

- adaptive (default): The callback adapts the throttling timeout depending on the rolling mean of the time taken to process each message.
- throttle: Uses the fixed `throttle_timeout` as the minimum amount of time between events.
- debounce: Processes the message only when no new event has been received within the `throttle_timeout` duration.

I would like to come up with a good way to expose these options.

- [x] Also fixes https://github.com/holoviz/holoviews/issues/4371 by ensuring server updates are processed immediately as long as the Document can be unlocked