### PR TITLE
Handle log colormapper zero lower bound

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1265,6 +1265,12 @@ def is_number(obj):
     else: return False
 
 
+def is_int(obj, int_like=False):
+    real_int = isinstance(obj, int) or getattr(getattr(obj, 'dtype'), 'kind') in 'ui'
+    if real_int or (int_like and hasattr(obj, 'is_integer') and obj.is_integer()):
+        return True
+    return False
+
 class ProgressIndicator(param.Parameterized):
     """
     Baseclass for any ProgressIndicator that indicates progress

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -884,6 +884,8 @@ def process_cmap(cmap, ncolors=None, provider=None, categorical=False):
 
     if isinstance(cmap, Cycle):
         palette = [rgb2hex(c) if isinstance(c, tuple) else c for c in cmap.values]
+    elif isinstance(cmap, tuple):
+        palette = list(cmap)
     elif isinstance(cmap, list):
         palette = cmap
     elif isinstance(cmap, basestring):


### PR DESCRIPTION
Ensures compatibility with changes to log colormapping and change to tuple palettes in bokeh 2.0.x 

Fixes #4361 
Fixes #4376 
