### PR TITLE
Add layout opts to control y of suptitle in mpl

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -1100,8 +1100,8 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
         title_obj = None
         title = self._format_title(key)
         if self.show_title and len(self.coords) > 1 and title:
-            title_obj = self.handles['fig'].suptitle(title, **self._fontsize('title'),
-                                                     y=self.suptitle_y)
+            title_obj = self.handles['fig'].suptitle(title, y=self.suptitle_y,
+                                                     **self._fontsize('title'))
             self.handles['title'] = title_obj
             self.handles['bbox_extra_artists'] += [title_obj]
 

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -761,6 +761,9 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
       Specifies the space between vertically adjacent elements in the grid.
       Default value is set conservatively to avoid overlap of subplots.""")
 
+    suptitle_y = param.Number(default=0.98, doc="""
+        The y location of the layout title in figure coordinates.""")
+
     fontsize = param.Parameter(default={'title':16}, allow_None=True)
 
     # Whether to enable fix for non-square figures
@@ -1097,7 +1100,8 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
         title_obj = None
         title = self._format_title(key)
         if self.show_title and len(self.coords) > 1 and title:
-            title_obj = self.handles['fig'].suptitle(title, **self._fontsize('title'))
+            title_obj = self.handles['fig'].suptitle(title, **self._fontsize('title'),
+                                                     y=self.suptitle_y)
             self.handles['title'] = title_obj
             self.handles['bbox_extra_artists'] += [title_obj]
 


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/4380
![image](https://user-images.githubusercontent.com/15331990/79669102-cccbeb80-817e-11ea-9b42-561b1343efee.png)

Defaults to matplotlib's default 0.98
https://matplotlib.org/3.2.1/api/_as_gen/matplotlib.pyplot.suptitle.html
```
import xarray as xr
import hvplot.xarray
import holoviews as hv
hv.extension('matplotlib')
ds = xr.tutorial.open_dataset('air_temperature').isel(time=slice(0, 5))
ds = xr.concat([ds.assign_coords(**{'exp': '1'}), ds.assign_coords(**{'exp': '2'})], 'exp')
ds['air'].attrs =  {}
ds.hvplot('lon', 'lat').layout('time').cols(2)

ds.hvplot('lon', 'lat').layout('time').cols(2).opts(suptitle_y=0.9)
```

The other cropped labels can be fixed with adjusting fig_bounds
`ds.hvplot('lon', 'lat').layout('time').cols(2).opts(suptitle_y=0.9, fig_bounds=(0.1, 0.1, 0.8, 0.8))`
![image](https://user-images.githubusercontent.com/15331990/79669153-26341a80-817f-11ea-8868-5165cd12d978.png)

Without suptitle_y:
`ds.hvplot('lon', 'lat').layout('time').cols(2).opts(fig_bounds=(0.1, 0.1, 0.8, 0.8))`
![image](https://user-images.githubusercontent.com/15331990/79669163-3d730800-817f-11ea-9864-8ab73bb6661a.png)
