### PR TITLE
Switch to simple Histogram selections

### DIFF
--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -4,7 +4,6 @@ import param
 from ..core import util
 from ..core import Dimension, Dataset, Element2D
 from ..core.data import GridInterface
-from ..streams import SelectionXY
 from .geom import Rectangles, Points, VectorField # noqa: backward compatible import
 from .selection import Selection1DExpr, Selection2DExpr
 

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -159,7 +159,7 @@ class Bars(Chart):
 
 
 
-class Histogram(Chart):
+class Histogram(Selection1DExpr, Chart):
     """
     Histogram is a Chart element representing a number of bins in a 1D
     coordinate system. The key dimension represents the binned values,
@@ -180,11 +180,6 @@ class Histogram(Chart):
 
     _binned = True
 
-    _selection_streams = (SelectionXY,)
-
-    def _empty_region(self):
-        return self.clone([])
-
     def __init__(self, data, edges=None, **params):
         if data is None:
             data = []
@@ -198,103 +193,6 @@ class Histogram(Chart):
             data = data[::-1]
 
         super(Histogram, self).__init__(data, **params)
-
-    def _get_selection_expr_for_stream_value(self, **kwargs):
-        from ..util.transform import dim
-
-        invert_axes = self.opts.get('plot').kwargs.get('invert_axes', False)
-
-        ds = self.dataset
-        if kwargs.get('bounds', None) is None:
-            el = ds.clone([]) if ds.interface.gridded else ds.iloc[:0]
-            return None, None, self.pipeline(el)
-
-        if invert_axes:
-            y0, x0, y1, x1 = kwargs['bounds']
-        else:
-            x0, y0, x1, y1 = kwargs['bounds']
-
-        # Handle invert_xaxis/invert_yaxis
-        if y0 > y1:
-            y0, y1 = y1, y0
-        if x0 > x1:
-            x0, x1 = x1, x0
-
-        xdim = self.kdims[0]
-        ydim = self.vdims[0]
-
-        edges = self.edges
-        centers = self.dimension_values(xdim)
-        heights = self.dimension_values(ydim)
-
-        selected_mask = (
-            (centers >= x0) & (centers <= x1) &
-            (heights >= y0) & (heights <= y1)
-        )
-
-        selected_bins = (np.arange(len(centers))[selected_mask] + 1).tolist()
-        if not selected_bins:
-            el = ds.clone([]) if ds.interface.gridded else ds.iloc[:0]
-            return None, None, self.pipeline(el)
-
-        bbox = {
-            xdim.name: (
-                edges[max(0, min(selected_bins) - 1)],
-                edges[min(len(edges - 1), max(selected_bins))],
-            ),
-        }
-        index_cols = kwargs.get('index_cols')
-        if index_cols:
-            shape = dim(self.dataset.get_dimension(index_cols[0]), np.shape)
-            index_cols = [dim(self.dataset.get_dimension(c), np.ravel) for c in index_cols]
-            sel = self.dataset.clone(datatype=['dataframe', 'dictionary']).select(**bbox)
-            vals = dim(index_cols[0], util.unique_zip, *index_cols[1:]).apply(
-                sel, expanded=True, flat=True
-            )
-            contains = dim(index_cols[0], util.lzip, *index_cols[1:]).isin(vals, object=True)
-            selection_expr = dim(contains, np.reshape, shape)
-            region = None
-        else:
-            selection_expr = dim(xdim).digitize(edges).isin(selected_bins)
-            if selected_bins[-1] == len(centers):
-                # Handle values exactly on the upper boundary
-                selection_expr = selection_expr | (dim(xdim) == edges[-1])
-            if ds.interface.gridded:
-                mask = selection_expr.apply(ds, expanded=True, flat=False)
-                ds = ds.clone(ds.interface.mask(ds, mask))
-            else:
-                ds = ds.select(selection_expr)
-            region = self.pipeline(ds)
-        return selection_expr, bbox, region
-
-    @staticmethod
-    def _merge_regions(region1, region2, operation):
-        if region1 is None:
-            if operation == 'inverse':
-                return region2.clone(data=(
-                    (region2.edges,
-                     np.zeros_like(region2.dimension_values(1)))
-                ))
-            else:
-                return region2
-
-        if operation == 'overwrite':
-            return region2
-        elif operation == 'inverse':
-            y = region1.dimension_values(1).copy()
-            y[region2.dimension_values(1) > 0] = 0
-            return region1.clone(data=(region1.edges, y))
-        elif operation == 'intersect':
-            op = np.min
-        elif operation == 'union':
-            op = np.max
-
-        return region1.clone(data=(
-            region1.edges,
-            op(np.stack([region1.dimension_values(1),
-                         region2.dimension_values(1)], axis=1), axis=1)
-        ))
-
     def __setstate__(self, state):
         """
         Ensures old-style Histogram types without an interface can be unpickled.

--- a/holoviews/plotting/plotly/selection.py
+++ b/holoviews/plotting/plotly/selection.py
@@ -65,6 +65,9 @@ class PlotlyOverlaySelectionDisplay(OverlaySelectionDisplay):
             # Darken unselected color
             if unselected_color:
                 region_color = linear_gradient(unselected_color, "#000000", 9)[3]
+            if "Span" in el1_name:
+                unselected_color = unselected_color or "#e6e9ec"
+                region_color = linear_gradient(unselected_color, "#000000", 9)[1]
             if "line_width" in allowed_keywords:
                 options["line_width"] = 1
         else:

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -970,7 +970,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream._source_streams), 1)
+        self.assertEqual(len(expr_stream._source_streams), 2)
         self.assertIsInstance(expr_stream._source_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)
@@ -980,9 +980,9 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream._source_streams[0].event(bounds=(1.5, 2.5, 4.6, 6))
         self.assertEqual(
             repr(expr_stream.selection_expr),
-            repr(dim('x').digitize(hist.edges).isin([2, 4]))
+            repr((dim('x')>=1.5)&(dim('x')<=4.6))
         )
-        self.assertEqual(expr_stream.bbox, {'x': (1.5, 4.5)})
+        self.assertEqual(expr_stream.bbox, {'x': (1.5, 4.6)})
 
         # Select third, forth, and fifth bar.  Make sure there is special
         # handling when last bar is selected to include values exactly on the
@@ -990,10 +990,9 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream._source_streams[0].event(bounds=(2.5, -10, 8, 10))
         self.assertEqual(
             repr(expr_stream.selection_expr),
-            repr((dim('x').digitize(hist.edges).isin([3, 4, 5])) |
-                 (dim('x') == hist.edges[-1]))
+            repr((dim('x')>=2.5)&(dim('x')<=8))
         )
-        self.assertEqual(expr_stream.bbox, {'x': (2.5, 5.5)})
+        self.assertEqual(expr_stream.bbox, {'x': (2.5, 8)})
 
     def test_selection_expr_stream_hist_invert_axes(self):
         # Create SelectionExpr on element
@@ -1003,7 +1002,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream._source_streams), 1)
+        self.assertEqual(len(expr_stream._source_streams), 2)
         self.assertIsInstance(expr_stream._source_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)
@@ -1013,9 +1012,9 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream._source_streams[0].event(bounds=(2.5, 1.5, 6, 4.6))
         self.assertEqual(
             repr(expr_stream.selection_expr),
-            repr(dim('x').digitize(hist.edges).isin([2, 4]))
+            repr((dim('x')>=1.5)&(dim('x')<=4.6))
         )
-        self.assertEqual(expr_stream.bbox, {'x': (1.5, 4.5)})
+        self.assertEqual(expr_stream.bbox, {'x': (1.5, 4.6)})
 
         # Select third, forth, and fifth bar.  Make sure there is special
         # handling when last bar is selected to include values exactly on the
@@ -1023,10 +1022,9 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream._source_streams[0].event(bounds=(-10, 2.5, 10, 8))
         self.assertEqual(
             repr(expr_stream.selection_expr),
-            repr((dim('x').digitize(hist.edges).isin([3, 4, 5])) |
-                 (dim('x') == hist.edges[-1]))
+            repr((dim('x')>=2.5)&(dim('x')<=8))
         )
-        self.assertEqual(expr_stream.bbox, {'x': (2.5, 5.5)})
+        self.assertEqual(expr_stream.bbox, {'x': (2.5, 8)})
 
     def test_selection_expr_stream_hist_invert_xaxis_yaxis(self):
         # Create SelectionExpr on element
@@ -1037,7 +1035,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream._source_streams), 1)
+        self.assertEqual(len(expr_stream._source_streams), 2)
         self.assertIsInstance(expr_stream._source_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)
@@ -1047,9 +1045,9 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream._source_streams[0].event(bounds=(4.6, 6, 1.5, 2.5))
         self.assertEqual(
             repr(expr_stream.selection_expr),
-            repr(dim('x').digitize(hist.edges).isin([2, 4]))
+            repr((dim('x')>=1.5)&(dim('x')<=4.6))
         )
-        self.assertEqual(expr_stream.bbox, {'x': (1.5, 4.5)})
+        self.assertEqual(expr_stream.bbox, {'x': (1.5, 4.6)})
 
         # Select third, forth, and fifth bar.  Make sure there is special
         # handling when last bar is selected to include values exactly on the
@@ -1057,10 +1055,9 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream._source_streams[0].event(bounds=(8, 10, 2.5, -10))
         self.assertEqual(
             repr(expr_stream.selection_expr),
-            repr((dim('x').digitize(hist.edges).isin([3, 4, 5])) |
-                 (dim('x') == hist.edges[-1]))
+            repr((dim('x')>=2.5)&(dim('x')<=8))
         )
-        self.assertEqual(expr_stream.bbox, {'x': (2.5, 5.5)})
+        self.assertEqual(expr_stream.bbox, {'x': (2.5, 8)})
 
     def test_selection_expr_stream_dynamic_map(self):
         for element_type in [Scatter, Points]:


### PR DESCRIPTION
Switches to simpler Histogram selections because the more complex approach is more expensive and not supported by all Dataset interfaces.