### PR TITLE
Easily access only non-default options

### DIFF
--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -495,12 +495,13 @@ class Opts(object):
         self._obj = obj
 
 
-    def get(self, group=None, backend=None):
+    def get(self, group=None, backend=None, defaults=True):
         """Returns the corresponding Options object.
 
         Args:
             group: The options group. Flattens across groups if None.
             backend: Current backend if None otherwise chosen backend.
+            defaults: Whether to include default option values
 
         Returns:
             Options object associated with the object containing the
@@ -511,7 +512,8 @@ class Opts(object):
         groups = Options._option_groups if group is None else [group]
         backend = backend if backend else Store.current_backend
         for group in groups:
-            optsobj = Store.lookup_options(backend, self._obj, group)
+            optsobj = Store.lookup_options(backend, self._obj, group,
+                                           defaults=defaults)
             keywords = dict(keywords, **optsobj.kwargs)
         return Options(**keywords)
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1257,10 +1257,10 @@ class Store(object):
         if obj.id in cls._custom_options[backend]:
             return cls._custom_options[backend][obj.id].closest(
                 obj, group, defaults, backend=backend)
-        elif defaults:
-            return cls._options[backend].closest(obj, group, defaults, backend=backend)
+        elif not defaults:
+            return Options()
         else:
-            return OptionTree(groups=cls._options[backend].groups)
+            return cls._options[backend].closest(obj, group, defaults, backend=backend)
 
     @classmethod
     def lookup(cls, backend, obj):


### PR DESCRIPTION
Added `defaults` option to `Element.opts.get` and fixed weird handling of `Store.lookup_options` with defaults=False when no custom options have been set.