### PR TITLE
Remove special instructions for IPython 5.0

### DIFF
--- a/examples/user_guide/Installing_and_Configuring.ipynb
+++ b/examples/user_guide/Installing_and_Configuring.ipynb
@@ -51,26 +51,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Jupyter notebook configuration\n",
-    "\n",
-    "In version 5.0 of the Jupyter notebook, limits on data rates were added that unfortunately also prevent image output from showing up in many cases.  For now, the most effective [fix](https://stackoverflow.com/questions/43288550/iopub-data-rate-exceeded-when-viewing-image-in-jupyter-notebook) is to generate a Jupyter config file:\n",
-    "\n",
-    "```\n",
-    "jupyter notebook --generate-config\n",
-    "```\n",
-    "\n",
-    "and then edit the resulting file (most likely, ~/.jupyter/jupyter_notebook_config.py) with code that changes the limit:\n",
-    "\n",
-    "```\n",
-    "c = get_config()\n",
-    "c.NotebookApp.iopub_data_rate_limit=100000000\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## JupyterLab configuration\n",
     "\n",
     "To work with JupyterLab you will also need the HoloViews JupyterLab\n",


### PR DESCRIPTION
The installation section still contained a paragraph on working around a specific issue in the notebook 5.0. That issue was fixed in 5.1 and the notebook is actually on version > 6 now, so it seems that that note is no longer needed.

This particular notebook workaround is confusing and I personally don't like tinkering with the defaults if I can avoid it because I never know how they impact my other projects or how these changes are carried forward in upgrades. Since this issue seems to be relevant only for a very specific notebook version that is now a thing of the past, I suggest to remove that paragraph.
(See links in the removed text to stackoverflow and the related notebook issues that show that the issue was resolved.)