### PR TITLE
Add new Derived stream class

### DIFF
--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -166,7 +166,7 @@ class _base_link_selections(param.ParameterizedFunction):
         """
         raise NotImplementedError()
 
-    def _expr_stream_updated(self, hvobj, selection_expr, bbox, region_element):
+    def _expr_stream_updated(self, hvobj, selection_expr, bbox, region_element, **kwargs):
         """
         Called when one of the registered HoloViews objects produces a new
         selection expression.  Subclasses should override this method, and
@@ -291,7 +291,7 @@ class link_selections(_base_link_selections):
         """
         return None if self.selected_color is None else _color_to_cmap(self.selected_color)
 
-    def _expr_stream_updated(self, hvobj, selection_expr, bbox, region_element):
+    def _expr_stream_updated(self, hvobj, selection_expr, bbox, region_element, **kwargs):
         if selection_expr:
             if self.cross_filter_mode == "overwrite":
                 # clear other regions and selections

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -786,7 +786,7 @@ class Derived(Stream):
     a result that is a pure function of the input stream values.
     """
     trigger_index = param.Integer(
-        None, allow_None=True,
+        None, allow_None=True, constant=True,
         doc="""Index into input_streams of most recently updated stream"""
     )
 

--- a/holoviews/tests/testselection.py
+++ b/holoviews/tests/testselection.py
@@ -87,7 +87,7 @@ class TestLinkSelections(ComparisonTestCase):
         self.check_overlay_points_like(selected, lnk_sel, self.data)
 
         # Perform selection of second and third point
-        boundsxy = lnk_sel._selection_expr_streams[0]._source_streams[0]
+        boundsxy = lnk_sel._selection_expr_streams[0].input_streams[0]
         self.assertIsInstance(boundsxy, hv.streams.SelectionXY)
         boundsxy.event(bounds=(0, 1, 5, 5))
         unselected, selected, region, region2 = linked[()].values()
@@ -136,7 +136,7 @@ class TestLinkSelections(ComparisonTestCase):
         )
 
         # Select first and third point
-        boundsxy = lnk_sel._selection_expr_streams[0]._source_streams[0]
+        boundsxy = lnk_sel._selection_expr_streams[0].input_streams[0]
         boundsxy.event(bounds=(0, 0, 4, 2))
         current_obj = linked[()]
 
@@ -181,7 +181,7 @@ class TestLinkSelections(ComparisonTestCase):
         self.check_overlay_points_like(current_obj.ErrorBars.II, lnk_sel, self.data)
 
         # Select first and third point
-        boundsxy = lnk_sel._selection_expr_streams[0]._source_streams[0]
+        boundsxy = lnk_sel._selection_expr_streams[0].input_streams[0]
         boundsxy.event(bounds=(0, 0, 4, 2))
 
         current_obj = linked[()]
@@ -228,7 +228,7 @@ class TestLinkSelections(ComparisonTestCase):
         )
 
         # Perform selection of second and third point
-        boundsxy = lnk_sel._selection_expr_streams[0]._source_streams[0]
+        boundsxy = lnk_sel._selection_expr_streams[0].input_streams[0]
         self.assertIsInstance(boundsxy, SelectionXY)
         boundsxy.event(bounds=(0, 1, 5, 5))
         current_obj = linked[()]
@@ -265,7 +265,7 @@ class TestLinkSelections(ComparisonTestCase):
         linked = lnk_sel(points)
 
         # Perform selection of first and (future) third point
-        boundsxy = lnk_sel._selection_expr_streams[0]._source_streams[0]
+        boundsxy = lnk_sel._selection_expr_streams[0].input_streams[0]
         self.assertIsInstance(boundsxy, hv.streams.SelectionXY)
         boundsxy.event(bounds=(0, 0, 4, 2))
         current_obj = linked[()]
@@ -350,7 +350,7 @@ class TestLinkSelections(ComparisonTestCase):
         self.assertEqual(region_hist.data, [None, None])
 
         # (1) Perform selection on points of points [1, 2]
-        points_boundsxy = lnk_sel._selection_expr_streams[0]._source_streams[0]
+        points_boundsxy = lnk_sel._selection_expr_streams[0].input_streams[0]
         self.assertIsInstance(points_boundsxy, SelectionXY)
         points_boundsxy.event(bounds=(1, 1, 4, 4))
 
@@ -378,7 +378,7 @@ class TestLinkSelections(ComparisonTestCase):
             )
 
         # (2) Perform selection on histogram bars [0, 1]
-        hist_boundsxy = lnk_sel._selection_expr_streams[1]._source_streams[0]
+        hist_boundsxy = lnk_sel._selection_expr_streams[1].input_streams[0]
         self.assertIsInstance(hist_boundsxy, SelectionXY)
         hist_boundsxy.event(bounds=(0, 0, 2.5, 2))
 
@@ -414,7 +414,7 @@ class TestLinkSelections(ComparisonTestCase):
         )
 
         # (3) Perform selection on points points [0, 2]
-        points_boundsxy = lnk_sel._selection_expr_streams[0]._source_streams[0]
+        points_boundsxy = lnk_sel._selection_expr_streams[0].input_streams[0]
         self.assertIsInstance(points_boundsxy, SelectionXY)
         points_boundsxy.event(bounds=(0, 0, 4, 2.5))
 
@@ -440,7 +440,7 @@ class TestLinkSelections(ComparisonTestCase):
             self.assertEqual(region_hist.data, [0, 2.5])
 
         # (4) Perform selection of bars [1, 2]
-        hist_boundsxy = lnk_sel._selection_expr_streams[1]._source_streams[0]
+        hist_boundsxy = lnk_sel._selection_expr_streams[1].input_streams[0]
         self.assertIsInstance(hist_boundsxy, SelectionXY)
         hist_boundsxy.event(bounds=(1.5, 0, 3.5, 2))
 

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -878,7 +878,7 @@ class TestBufferDataFrameStream(ComparisonTestCase):
 
 
 class Sum(Derived):
-    v = param.Number()
+    v = param.Number(constant=True)
 
     def __init__(self, val_streams, exclusive=False, base=0):
         self.base = base

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -877,6 +877,88 @@ class TestBufferDataFrameStream(ComparisonTestCase):
         self.assertEqual(buff.data, data.iloc[:0, :].reset_index())
 
 
+class Sum(Derived):
+    v = param.Number()
+
+    def __init__(self, val_streams, base=0):
+        self.base = base
+        super(Sum, self).__init__(input_streams=val_streams)
+
+    @property
+    def constants(self):
+        return dict(base=self.base)
+
+    @classmethod
+    def transform_function(cls, stream_values, trigger_index, constants):
+        v = sum([val["v"] for val in stream_values if val["v"]])
+        return dict(v=v + constants['base'])
+
+Val = Stream.define("Val", v=0.0)
+
+
+class TestDerivedStream(ComparisonTestCase):
+
+    def test_simple_derived_stream(self):
+        # Define input streams
+        v0 = Val(v=1.0)
+        v1 = Val(v=2.0)
+
+        # Build Sum stream
+        s0 = Sum([v0, v1])
+
+        # Check outputs
+        self.assertEqual(s0.v, 3.0)
+        self.assertIsNone(s0.trigger_index)
+
+        # Update v0
+        v0.event(v=7.0)
+        self.assertEqual(s0.v, 9.0)
+        self.assertEqual(s0.trigger_index, 0)
+
+        # Update v1
+        v1.event(v=-8.0)
+        self.assertEqual(s0.v, -1.0)
+        self.assertEqual(s0.trigger_index, 1)
+
+    def test_nested_derived_stream(self):
+        v0 = Val(v=1.0)
+        v1 = Val(v=4.0)
+        v2 = Val(v=7.0)
+
+        # Build nested sum stream
+        s1 = Sum([v0, v1])
+        s0 = Sum([s1, v2])
+
+        # Check initial value
+        self.assertEqual(s0.v, 12.0)
+
+        # Update top-level value
+        v2.event(v=8.0)
+        self.assertEqual(s0.v, 13.0)
+        self.assertEqual(s0.trigger_index, 1)
+
+        # Update nested value
+        v1.event(v=5.0,)
+        self.assertEqual(s0.v, 14.0)
+        self.assertEqual(s0.trigger_index, 0)
+
+    def test_derived_stream_constants(self):
+        v0 = Val(v=1.0)
+        v1 = Val(v=4.0)
+        v2 = Val(v=7.0)
+
+        # Build Sum stream with base value
+        s0 = Sum([v0, v1, v2], base=100)
+
+        # Check initial value
+        self.assertEqual(s0.v, 112.0)
+
+        # Update value
+        v2.event(v=8.0)
+        self.assertEqual(s0.v, 113.0)
+        self.assertEqual(s0.trigger_index, 2)
+
+
 class TestExprSelectionStream(ComparisonTestCase):
 
     def setUp(self):
@@ -889,14 +971,14 @@ class TestExprSelectionStream(ComparisonTestCase):
             expr_stream = SelectionExpr(element)
 
             # Check stream properties
-            self.assertEqual(len(expr_stream._source_streams), 2)
-            self.assertIsInstance(expr_stream._source_streams[0], SelectionXY)
-            self.assertIsInstance(expr_stream._source_streams[1], Lasso)
+            self.assertEqual(len(expr_stream.input_streams), 2)
+            self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
+            self.assertIsInstance(expr_stream.input_streams[1], Lasso)
             self.assertIsNone(expr_stream.bbox)
             self.assertIsNone(expr_stream.selection_expr)
 
             # Simulate interactive update by triggering source stream
-            expr_stream._source_streams[0].event(bounds=(1, 1, 3, 4))
+            expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
 
             # Check SelectionExpr values
             self.assertEqual(
@@ -915,14 +997,14 @@ class TestExprSelectionStream(ComparisonTestCase):
             expr_stream = SelectionExpr(element)
 
             # Check stream properties
-            self.assertEqual(len(expr_stream._source_streams), 2)
-            self.assertIsInstance(expr_stream._source_streams[0], SelectionXY)
-            self.assertIsInstance(expr_stream._source_streams[1], Lasso)
+            self.assertEqual(len(expr_stream.input_streams), 2)
+            self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
+            self.assertIsInstance(expr_stream.input_streams[1], Lasso)
             self.assertIsNone(expr_stream.bbox)
             self.assertIsNone(expr_stream.selection_expr)
 
             # Simulate interactive update by triggering source stream
-            expr_stream._source_streams[0].event(bounds=(1, 1, 3, 4))
+            expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
 
             # Check SelectionExpr values
             self.assertEqual(
@@ -945,14 +1027,14 @@ class TestExprSelectionStream(ComparisonTestCase):
             expr_stream = SelectionExpr(element)
 
             # Check stream properties
-            self.assertEqual(len(expr_stream._source_streams), 2)
-            self.assertIsInstance(expr_stream._source_streams[0], SelectionXY)
-            self.assertIsInstance(expr_stream._source_streams[1], Lasso)
+            self.assertEqual(len(expr_stream.input_streams), 2)
+            self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
+            self.assertIsInstance(expr_stream.input_streams[1], Lasso)
             self.assertIsNone(expr_stream.bbox)
             self.assertIsNone(expr_stream.selection_expr)
 
             # Simulate interactive update by triggering source stream
-            expr_stream._source_streams[0].event(bounds=(3, 4, 1, 1))
+            expr_stream.input_streams[0].event(bounds=(3, 4, 1, 1))
 
             # Check SelectionExpr values
             self.assertEqual(
@@ -970,14 +1052,14 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream._source_streams), 2)
-        self.assertIsInstance(expr_stream._source_streams[0], SelectionXY)
+        self.assertEqual(len(expr_stream.input_streams), 2)
+        self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)
 
         # Simulate interactive update by triggering source stream.
         # Select second and forth bar.
-        expr_stream._source_streams[0].event(bounds=(1.5, 2.5, 4.6, 6))
+        expr_stream.input_streams[0].event(bounds=(1.5, 2.5, 4.6, 6))
         self.assertEqual(
             repr(expr_stream.selection_expr),
             repr((dim('x')>=1.5)&(dim('x')<=4.6))
@@ -987,7 +1069,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         # Select third, forth, and fifth bar.  Make sure there is special
         # handling when last bar is selected to include values exactly on the
         # upper edge in the selection
-        expr_stream._source_streams[0].event(bounds=(2.5, -10, 8, 10))
+        expr_stream.input_streams[0].event(bounds=(2.5, -10, 8, 10))
         self.assertEqual(
             repr(expr_stream.selection_expr),
             repr((dim('x')>=2.5)&(dim('x')<=8))
@@ -1002,14 +1084,14 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream._source_streams), 2)
-        self.assertIsInstance(expr_stream._source_streams[0], SelectionXY)
+        self.assertEqual(len(expr_stream.input_streams), 2)
+        self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)
 
         # Simulate interactive update by triggering source stream.
         # Select second and forth bar.
-        expr_stream._source_streams[0].event(bounds=(2.5, 1.5, 6, 4.6))
+        expr_stream.input_streams[0].event(bounds=(2.5, 1.5, 6, 4.6))
         self.assertEqual(
             repr(expr_stream.selection_expr),
             repr((dim('x')>=1.5)&(dim('x')<=4.6))
@@ -1019,7 +1101,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         # Select third, forth, and fifth bar.  Make sure there is special
         # handling when last bar is selected to include values exactly on the
         # upper edge in the selection
-        expr_stream._source_streams[0].event(bounds=(-10, 2.5, 10, 8))
+        expr_stream.input_streams[0].event(bounds=(-10, 2.5, 10, 8))
         self.assertEqual(
             repr(expr_stream.selection_expr),
             repr((dim('x')>=2.5)&(dim('x')<=8))
@@ -1035,14 +1117,14 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream._source_streams), 2)
-        self.assertIsInstance(expr_stream._source_streams[0], SelectionXY)
+        self.assertEqual(len(expr_stream.input_streams), 2)
+        self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)
 
         # Simulate interactive update by triggering source stream.
         # Select second and forth bar.
-        expr_stream._source_streams[0].event(bounds=(4.6, 6, 1.5, 2.5))
+        expr_stream.input_streams[0].event(bounds=(4.6, 6, 1.5, 2.5))
         self.assertEqual(
             repr(expr_stream.selection_expr),
             repr((dim('x')>=1.5)&(dim('x')<=4.6))
@@ -1052,7 +1134,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         # Select third, forth, and fifth bar.  Make sure there is special
         # handling when last bar is selected to include values exactly on the
         # upper edge in the selection
-        expr_stream._source_streams[0].event(bounds=(8, 10, 2.5, -10))
+        expr_stream.input_streams[0].event(bounds=(8, 10, 2.5, -10))
         self.assertEqual(
             repr(expr_stream.selection_expr),
             repr((dim('x')>=2.5)&(dim('x')<=8))
@@ -1066,13 +1148,13 @@ class TestExprSelectionStream(ComparisonTestCase):
             expr_stream = SelectionExpr(dmap)
 
             # Check stream properties
-            self.assertEqual(len(expr_stream._source_streams), 2)
-            self.assertIsInstance(expr_stream._source_streams[0], SelectionXY)
+            self.assertEqual(len(expr_stream.input_streams), 2)
+            self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
             self.assertIsNone(expr_stream.bbox)
             self.assertIsNone(expr_stream.selection_expr)
 
             # Simulate interactive update by triggering source stream
-            expr_stream._source_streams[0].event(bounds=(1, 1, 3, 4))
+            expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
 
             # Check SelectionExpr values
             self.assertEqual(


### PR DESCRIPTION
closes https://github.com/holoviz/holoviews/issues/4530

This PR introduces a new `Derived` stream class that generalizes the concept of having a `Stream` that produces values based on one or more other input streams.  

The `SelectionExpr` stream had done this in a somewhat ad-hoc way, but with this PR `SelectionExpr` is now a subclass of the new `Derived` stream.

The existing `SelectionExpr` tests pass with minimal updates. I also added a new set of tests for `Derived` streams directly in `holoviews/tests/teststreams.py`.  This is a good place to look at for a simple example of what a `Derived` stream subclass looks like.

Let me know if you have any questions or concerns about the approach or API. Thanks!