### PR TITLE
Support positional stream args in DynamicMap callback

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -276,7 +276,11 @@ class Renderer(Exporter):
         dynamic = any(isinstance(m, DynamicMap) for m in holomaps)
 
         if fmt in ['auto', None]:
-            if any(len(o) > 1 or (isinstance(o, DynamicMap) and unbound_dimensions(o.streams, o.kdims))
+            if any(len(o) > 1 or (isinstance(o, DynamicMap) and
+                                  unbound_dimensions(
+                                      o.streams,
+                                      o.kdims,
+                                      no_duplicates=not o.positional_stream_args))
                    for o in holomaps):
                 fmt = holomap_formats[0] if self.holomap in ['auto', None] else self.holomap
             else:

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -18,6 +18,8 @@ from ..utils import LoggingComparisonTestCase
 from .testdimensioned import CustomBackendTestCase, TestObj
 
 XY = Stream.define('XY', x=0,y=0)
+X = Stream.define('X', x=0)
+Y = Stream.define('Y', y=0)
 
 frequencies =  np.linspace(0.5,2.0,5)
 phases = np.linspace(0, np.pi*2, 5)
@@ -65,12 +67,62 @@ class DynamicMapConstructor(ComparisonTestCase):
         with self.assertRaisesRegexp(KeyError, regexp):
             DynamicMap(lambda x: x, streams=[PointerXY()])
 
+    def test_simple_constructor_positional_stream_args(self):
+        DynamicMap(lambda v: v, streams=[PointerXY()], positional_stream_args=True)
+
     def test_simple_constructor_streams_invalid_mismatch_named(self):
 
         def foo(x): return x
         regexp = "Callable 'foo' missing keywords to accept stream parameters: y"
         with self.assertRaisesRegexp(KeyError, regexp):
             DynamicMap(foo, streams=[PointerXY()])
+
+
+class DynamicMapPositionStreamSrgs(ComparisonTestCase):
+    def test_positional_stream_args_without_streams(self):
+        fn = lambda i: Curve([i, i])
+        dmap = DynamicMap(fn, kdims=['i'], positional_stream_args=True)
+        self.assertEqual(dmap[0], Curve([0, 0]))
+
+    def test_positional_stream_args_with_only_stream(self):
+        fn = lambda s: Curve([s['x'], s['y']])
+        xy_stream = XY(x=1, y=2)
+        dmap = DynamicMap(fn, streams=[xy_stream], positional_stream_args=True)
+        self.assertEqual(dmap[()], Curve([1, 2]))
+
+        # Update stream values
+        xy_stream.event(x=5, y=7)
+        self.assertEqual(dmap[()], Curve([5, 7]))
+
+    def test_positional_stream_args_with_single_kdim_and_stream(self):
+        fn = lambda i, s: Points([i, i]) + Curve([s['x'], s['y']])
+        xy_stream = XY(x=1, y=2)
+        dmap = DynamicMap(
+            fn, kdims=['i'], streams=[xy_stream], positional_stream_args=True
+        )
+        self.assertEqual(dmap[6], Points([6, 6]) + Curve([1, 2]))
+
+        # Update stream values
+        xy_stream.event(x=5, y=7)
+        self.assertEqual(dmap[3], Points([3, 3]) + Curve([5, 7]))
+
+    def test_positional_stream_args_with_multiple_kdims_and_stream(self):
+        fn = lambda i, j, s1, s2: Points([i, j]) + Curve([s1['x'], s2['y']])
+        x_stream = X(x=2)
+        y_stream = Y(y=3)
+
+        dmap = DynamicMap(
+            fn,
+            kdims=['i', 'j'],
+            streams=[x_stream, y_stream],
+            positional_stream_args=True
+        )
+        self.assertEqual(dmap[0, 1], Points([0, 1]) + Curve([2, 3]))
+
+        # Update stream values
+        x_stream.event(x=5)
+        y_stream.event(y=6)
+        self.assertEqual(dmap[3, 4], Points([3, 4]) + Curve([5, 6]))
 
 
 class DynamicMapMethods(ComparisonTestCase):
@@ -389,8 +441,8 @@ class DynamicMapMethods(ComparisonTestCase):
         self.assertEqual(dmaps[1][0], Points([]))
         with self.assertRaises(KeyError):
             dmaps[1][1]
-    
-        
+
+
 
 class DynamicMapOptionsTests(CustomBackendTestCase):
 

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -78,7 +78,7 @@ class DynamicMapConstructor(ComparisonTestCase):
             DynamicMap(foo, streams=[PointerXY()])
 
 
-class DynamicMapPositionStreamSrgs(ComparisonTestCase):
+class DynamicMapPositionalStreamArgs(ComparisonTestCase):
     def test_positional_stream_args_without_streams(self):
         fn = lambda i: Curve([i, i])
         dmap = DynamicMap(fn, kdims=['i'], positional_stream_args=True)

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -124,6 +124,16 @@ class DynamicMapPositionalStreamArgs(ComparisonTestCase):
         y_stream.event(y=6)
         self.assertEqual(dmap[3, 4], Points([3, 4]) + Curve([5, 6]))
 
+    def test_initialize_with_overlapping_stream_params(self):
+        fn = lambda xy0, xy1: \
+             Points([xy0['x'], xy0['y']]) + Curve([xy1['x'], xy1['y']])
+        xy_stream0 = XY(x=1, y=2)
+        xy_stream1 = XY(x=3, y=4)
+        dmap = DynamicMap(
+            fn, streams=[xy_stream0, xy_stream1], positional_stream_args=True
+        )
+        self.assertEqual(dmap[()], Points([1, 2]) + Curve([3, 4]))
+
 
 class DynamicMapMethods(ComparisonTestCase):
 


### PR DESCRIPTION
This PR is a step toward supporting #4433 using a `DynamicMap` transformation.  The idea is described in https://github.com/holoviz/holoviews/issues/4433#issuecomment-663715053.

## Background
The callback function for a `DynamicMap` is currently called by passing the kdim values as positional arguments, followed by stream parameter values as keyword arguments.  For example:

```python
import holoviews as hv
from holoviews.streams import Stream
XY = Stream.define('XY', x=0,y=0)
xy_stream = XY()

def callback_fn(i_value, y, x):
    ...

dmap = hv.DynamicMap(callback_fn, kdims=["i"], streams=[xy_stream])
```
Here the `i_value` argument is the `i` key dimension that is called positionally (named `i_value` to emphasize that it's called by position not by name), and the `x` and `y` arguments are the stream parameters and they are called as keyword arguments.  So here the `x` and `y` argument names must match the param names of the `xy_stream` stream.

This approach is convenient when writing callback functions by hand, when there are only a few stream parameters and the stream parameter names don't conflict. But it's less convenience when building a callback function programmatically that will input many streams with potentially overlapping parameter names. This will be the situation when building the transformation in #4433.

## Description
This PR adds a `positional_stream_args` parameter to the `DynamicMap` class that, when set to `True`, will configure the `DynamicMap` to pass stream values to the callback function positionally.  The stream arguments will follow the kdim arguments (if any), the value of each stream argument is a `dict` containing key-value pairs for each param in the stream, and the order of the stream arguments is determined by the order of the streams in the `streams` parameter list.

Here's an example of what this looks like:

```python
import holoviews as hv
from holoviews.streams import Stream
XY = Stream.define('XY', x=0,y=0)
xy_stream0 = XY()
xy_stream1 = XY()

def callback_fn(i_value, s0, s1):
    x0, y0 = s0['x'], s0['y']
    x1, y1 = s1['x'], s1['y']
    ...

dmap = hv.DynamicMap(
    callback_fn, kdims=["i"], streams=[xy_stream0, yx_stream1], positional_stream_args=True
)
```

When `positional_stream_args=True` there is no possibility of stream parameter name clashes.

Of course, the default is `False` to match the current behavior.

Does this sound reasonable @jlstevens @philippjfr ?
