### PR TITLE
fix bug when the default value of Dimension is 0

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -951,7 +951,7 @@ class DynamicMap(HoloMap):
         for kdim in self.kdims:
             if str(kdim) in stream_params:
                 key.append(None)
-            elif kdim.default:
+            elif kdim.default is not None:
                 key.append(kdim.default)
             elif kdim.values:
                 if all(util.isnumeric(v) for v in kdim.values):


### PR DESCRIPTION
fix #4536

Use the default value of Dimension if it is not None.