### PR TITLE
Ensure operations do not recursively accumulate pipelines

### DIFF
--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -129,13 +129,20 @@ class Operation(param.ParameterizedFunction):
 
 
         element_pipeline = getattr(element, '_pipeline', None)
+
+        if hasattr(element, '_in_method'):
+            in_method = element._in_method
+            if not in_method:
+                element._in_method = True
         ret = self._process(element, key)
+        if hasattr(element, '_in_method') and not in_method:
+            element._in_method = in_method
 
         for hook in self._postprocess_hooks:
             ret = hook(self, ret, **kwargs)
 
         if (self._propagate_dataset and isinstance(ret, Dataset)
-            and isinstance(element, Dataset)):
+            and isinstance(element, Dataset) and not in_method):
             ret._dataset = element.dataset.clone()
             ret._pipeline = element_pipeline.instance(
                 operations=element_pipeline.operations + [


### PR DESCRIPTION
Major, major bug causing Operations to recursively accumulate operations in a pipeline which would progressively degrade anything that would then replay that pipeline (e.g. linked selections). On many linked_selections examples this provides a 2x speedup on initial rendering and then a progressively increasing speedup over the buggy version every time the pipeline is replayed, e.g. for a datashaded plot with linked selections applied you would get 10x slowdowns after just a few seconds of zooming around.