### PR TITLE
Fix for inward pointing whiskers for some box plots

### DIFF
--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -159,8 +159,8 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         if len(vals):
             q1, q2, q3 = (percentile(vals, q=q) for q in range(25, 100, 25))
             iqr = q3 - q1
-            upper = vals[vals <= q3 + 1.5*iqr].max()
-            lower = vals[vals >= q1 - 1.5*iqr].min()
+            upper = max(vals[vals <= q3 + 1.5*iqr].max(), q3)
+            lower = min(vals[vals >= q1 - 1.5*iqr].min(), q1)
         else:
             q1, q2, q3 = 0, 0, 0
             upper, lower = 0, 0


### PR DESCRIPTION
For the Bokeh rendering of box plots, we have been using this definition of a whisker: the maximal data point less than (1.5 times the interquartile region plus the position of the top of the box). With this definition, we can get some strange results, as shown below.

```python
import holoviews as hv
hv.extension('bokeh')

# Box-whisker with transparent box so we can see inward whisker
hv.BoxWhisker(
    data=[1, 2, 3, 10]
).opts(
    box_fill_alpha=0
)
```

<img width="344" alt="Screen Shot 2020-08-10 at 23 17 12" src="https://user-images.githubusercontent.com/1873517/89867821-9d465200-db66-11ea-8859-727bc646fd48.png">

We see that the top whisker is below the top of the box. This is because we are using the above definition of the whisker position. In the case shown above, the end point of the top whisker is 3, but the top of the box is at 4.75. The description on [Wikipedia](https://en.wikipedia.org/wiki/Box_plot) gives a more precise definition of the whisker:

> From above the upper quartile, a distance of 1.5 times the IQR is measured out and a whisker is drawn up to the largest observed point from the dataset that falls within this distance.

To implement this, we can adjust the `_box_stats()` function in `plotting/bokeh/stats.py` to define the upper and lower whiskers as follows.

```
            upper = max(vals[vals <= q3 + 1.5*iqr].max(), q3)
            lower = min(vals[vals >= q1 - 1.5*iqr].min(), q1)
```
