### PR TITLE
Add History stream

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -871,7 +871,7 @@ class History(Stream):
         self.input_stream.event()
 
     def clear_history(self):
-        self.values.clear()
+        del self.values[:]
         self.event()
 
     def _register_input_stream(self):
@@ -887,7 +887,7 @@ class History(Stream):
     def __del__(self):
         self.input_stream.source = None
         self.input_stream.clear()
-        self.values.clear()
+        del self.values[:]
 
 
 class SelectionExpr(Derived):

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -1009,14 +1009,14 @@ class TestHistoryStream(ComparisonTestCase):
         self.assertEqual(callback_input, [])
 
         # Perform updates on val stream and make sure history callback is triggered
-        callback_input.clear()
+        del callback_input[:]
         val.event(v=2.0)
         self.assertEqual(
             callback_input[0],
             {"values": [{"v": 1.0}, {"v": 2.0}]}
         )
 
-        callback_input.clear()
+        del callback_input[:]
         val.event(v=3.0)
         self.assertEqual(
             callback_input[0],
@@ -1024,7 +1024,7 @@ class TestHistoryStream(ComparisonTestCase):
         )
 
         # clearing history should trigger callback
-        callback_input.clear()
+        del callback_input[:]
         history.clear_history()
         self.assertEqual(
             callback_input[0],
@@ -1032,7 +1032,7 @@ class TestHistoryStream(ComparisonTestCase):
         )
 
         # Update after clearing
-        callback_input.clear()
+        del callback_input[:]
         val.event(v=4.0)
         self.assertEqual(
             callback_input[0],

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -974,6 +974,72 @@ class TestDerivedStream(ComparisonTestCase):
         self.assertEqual(s0.v, -8.0)
 
 
+class TestHistoryStream(ComparisonTestCase):
+    def test_initial_history_stream_values(self):
+        # Check values list is initialized with initial contents of input stream
+        val = Val(v=1.0)
+        history = History(val)
+        self.assertEqual(history.contents, {"values": [val.contents]})
+
+    def test_history_stream_values_appended(self):
+        val = Val(v=1.0)
+        history = History(val)
+        # Perform a few updates on val stream
+        val.event(v=2.0)
+        val.event(v=3.0)
+        self.assertEqual(
+            history.contents,
+            {"values": [{"v": 1.0}, {"v": 2.0}, {"v": 3.0}]}
+        )
+
+        # clear
+        history.clear_history()
+        self.assertEqual(history.contents, {"values": []})
+
+    def test_history_stream_trigger_callbacks(self):
+        # Construct history stream
+        val = Val(v=1.0)
+        history = History(val)
+
+        # Register callback
+        callback_input = []
+        def cb(**kwargs):
+            callback_input.append(kwargs)
+        history.add_subscriber(cb)
+        self.assertEqual(callback_input, [])
+
+        # Perform updates on val stream and make sure history callback is triggered
+        callback_input.clear()
+        val.event(v=2.0)
+        self.assertEqual(
+            callback_input[0],
+            {"values": [{"v": 1.0}, {"v": 2.0}]}
+        )
+
+        callback_input.clear()
+        val.event(v=3.0)
+        self.assertEqual(
+            callback_input[0],
+            {"values": [{"v": 1.0}, {"v": 2.0}, {"v": 3.0}]}
+        )
+
+        # clearing history should trigger callback
+        callback_input.clear()
+        history.clear_history()
+        self.assertEqual(
+            callback_input[0],
+            {"values": []}
+        )
+
+        # Update after clearing
+        callback_input.clear()
+        val.event(v=4.0)
+        self.assertEqual(
+            callback_input[0],
+            {"values": [{"v": 4.0}]}
+        )
+
+
 class TestExprSelectionStream(ComparisonTestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Overview
This PR adds a `History` stream type. `History` stream instances wrap another stream and collect a history of the values taken on by that stream. This list of states is as the `values` property

## Motivation
A follow-on PR will refactor `link_selections` to be based on `Derived` (https://github.com/holoviz/holoviews/pull/4532) and `History` streams, making it possible for `uncollate` (See https://github.com/holoviz/holoviews/pull/4551) to extract the linked streams from result of `link_selections`.

But, this is a simple and generally useful stream type, so I wanted to split it out into its own PR.

## Example Usage
```python
Val = Stream.define("Val", v=0.0)
history = History(val)
prihnt(history.contents)
```
```
{"values": [{"v": 1.0}]}
```
```python
# Perform a few updates on val stream
val.event(v=2.0)
val.event(v=3.0)
print(history.contents)
```
```
{"values": [{"v": 1.0}, {"v": 2.0}, {"v": 3.0}]}
```
```python
history.clear_history()
print(history.contents)
```
```
{"values": []}
```
