### PR TITLE
Updated spreading operation to support aggregate arrays

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1511,10 +1511,11 @@ class SpreadingOperation(LinkableOperation):
     to make sparse plots more visible.
     """
 
-    how = param.ObjectSelector(default='source',
-            objects=['source', 'over', 'saturate', 'add'], doc="""
+    how = param.ObjectSelector(default=None,
+            objects=[None, 'source', 'over', 'saturate', 'add', 'max', 'min'], doc="""
         The name of the compositing operator to use when combining
-        pixels.""")
+        pixels. Default of None uses 'over' operator for RGB elements
+        and 'add' operator for aggregate arrays.""")
 
     shape = param.ObjectSelector(default='circle', objects=['circle', 'square'],
                                  doc="""


### PR DESCRIPTION
Minor changes to the spreading operation in order to support aggregate arrays (https://github.com/holoviz/datashader/pull/771). This change does have some important implications:

1. This won't be compatible with datashader releases prior to the PR references above. I could do a version check to turn `None` into an operator accepted by earlier datashader versions (maybe even use 'source'?)
2. The value of `None` maps to 'over' for RGBs and 'add' for arrays in datashader. This breaks backwards compatibility as the current default is 'source'. 

If I implement the version check idea to support older datashader, then the incompatibility would be for newer datashader versions only (where aggregate spreading is supported). I don't know if that makes things more or less confusing overall...