### PR TITLE
Compatibility with bokeh 2.2 for CDSCallback

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1169,7 +1169,7 @@ class CDSCallback(Callback):
             if isinstance(values, dict):
                 shape = values.pop('shape', None)
                 dtype = values.pop('dtype', None)
-                dim = values.pop('dimension', None)
+                values.pop('dimension', None)
                 items = sorted([(int(k), v) for k, v in values.items()])
                 values = [v for k, v in items]
                 if dtype is not None:

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1169,6 +1169,7 @@ class CDSCallback(Callback):
             if isinstance(values, dict):
                 shape = values.pop('shape', None)
                 dtype = values.pop('dtype', None)
+                dim = values.pop('dimension', None)
                 items = sorted([(int(k), v) for k, v in values.items()])
                 values = [v for k, v in items]
                 if dtype is not None:


### PR DESCRIPTION
Bokeh 2.2 added a dimension field to JS NdArrays which is messing with the CDSCallback.