### PR TITLE
Fix: double double remove callbacks

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -111,6 +111,8 @@ class MessageCallback(object):
         if self.handle_ids:
             handles = self._init_plot_handles()
             for handle_name in self.models:
+                if not (handle_name in handles):
+                    continue
                 handle = handles[handle_name]
                 cb_hash = (id(handle), id(type(self)))
                 self._callbacks.pop(cb_hash, None)


### PR DESCRIPTION
I have the following hierarchy of widgets:

> @pn.depends
> > GridMatrix
> > > Points
> > >  > hv.streams.Selection1D(source=points_element)

When I update the input widgets to the @pn.depends, the old GridMatrix/Points/Selection1D get torn down a new hierarchy gets built. However, I receive the following unexpected exception during teardown, even when I comment out the add_subscriber call to Selection1D:

```
Sep 16 22:58:46 ip-172-31-55-18 python[102370]: Traceback (most recent call last):
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/tornado/ioloop.py", line 743, in _run_callback
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     ret = callback()
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/tornado/ioloop.py", line 767, in _discard_future_result
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     future.result()
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/bokeh/server/session.py", line 71, in _needs_document_lock_wrapper
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     result = await result
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/tornado/gen.py", line 191, in wrapper
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     result = func(*args, **kwargs)
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/panel/viewable.py", line 516, in _change_coroutine
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     self._change_event(doc)
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/panel/viewable.py", line 526, in _change_event
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     self._process_events(events)
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/panel/viewable.py", line 512, in _process_events
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     self.param.set_param(**self._process_property_change(events))
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/param/parameterized.py", line 1365, in set_param
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     self_._batch_call_watchers()
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/param/parameterized.py", line 1480, in _batch_call_watchers
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     watcher.fn(*events)
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/panel/param.py", line 700, in _replace_pane
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     self._update_inner(new_object)
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/panel/pane/base.py", line 368, in _update_inner
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     self._pane.object = new_object
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/param/parameterized.py", line 296, in _f
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     return f(self, obj, val)
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/param/parameterized.py", line 861, in __set__
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     obj.param._call_watcher(watcher, event)
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/param/parameterized.py", line 1456, in _call_watcher
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     watcher.fn(event)
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/panel/pane/base.py", line 188, in _update_pane
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     self._update_object(ref, doc, root, parent, comm)
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/panel/pane/base.py", line 155, in _update_object
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     new_model = self._get_model(doc, root, parent, comm)
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/panel/pane/holoviews.py", line 256, in _get_model
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     old_plot.cleanup()
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/holoviews/plotting/bokeh/plot.py", line 246, in cleanup
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     callback.cleanup()
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/holoviews/plotting/bokeh/callbacks.py", line 97, in cleanup
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     self.reset()
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:   File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/holoviews/plotting/bokeh/callbacks.py", line 114, in reset
Sep 16 22:58:46 ip-172-31-55-18 python[102370]:     handle = handles[handle_name]
Sep 16 22:58:46 ip-172-31-55-18 python[102370]: KeyError: 'selected'
```

The code in this pull request solves the problem. I have not built a proper conceptual model for _why_ the problem happens . This is an empirical fix. It seems to make my dashboard work. I am hoping that a maintainer familiar with the holoviews event system internals can verify that the fix is appropriate or suggest something better.