### PR TITLE
Remove all use of cyordereddict.

### DIFF
--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -1,7 +1,4 @@
-try:
-    from cyordereddict import OrderedDict
-except:
-    from collections import OrderedDict
+from collections import OrderedDict
 
 from . import util
 from .pprint import PrettyPrinter

--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -1,4 +1,7 @@
-from collections import OrderedDict
+try:
+    from cyordereddict import OrderedDict
+except:
+    from collections import OrderedDict
 
 from . import util
 from .pprint import PrettyPrinter

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -9,7 +9,7 @@ import string
 import unicodedata
 import datetime as dt
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from contextlib import contextmanager
 from distutils.version import LooseVersion as _LooseVersion
 from functools import partial
@@ -19,10 +19,6 @@ from types import FunctionType
 import numpy as np
 import param
 
-try:
-    from cyordereddict import OrderedDict
-except:
-    from collections import OrderedDict
 
 # Python3 compatibility
 if sys.version_info.major >= 3:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -19,7 +19,10 @@ from types import FunctionType
 import numpy as np
 import param
 
-from collections import OrderedDict
+try:
+    from cyordereddict import OrderedDict
+except:
+    from collections import OrderedDict
 
 # Python3 compatibility
 if sys.version_info.major >= 3:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -19,10 +19,7 @@ from types import FunctionType
 import numpy as np
 import param
 
-try:
-    from cyordereddict import OrderedDict
-except:
-    from collections import OrderedDict
+from collections import OrderedDict
 
 # Python3 compatibility
 if sys.version_info.major >= 3:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ if sys.version_info.major > 2:
 
 # Extra third-party libraries
 extras_require["extras"] = extras_require["examples"] + [
-    "cyordereddict",
     "pscript ==0.7.1",
 ]
 
@@ -93,7 +92,6 @@ extras_require["nbtests"] = extras_require["recommended"] + [
     "deepdiff",
     "nbconvert ==5.3.1",
     "jsonschema ==2.6.0",
-    "cyordereddict",
     "ipython ==5.4.1",
 ]
 
@@ -116,11 +114,10 @@ extras_require["build"] = [
     "python <3.8",
 ]
 
-# Everything including cyordereddict (optimization) and nosetests
+# Everything for examples and nosetests
 extras_require["all"] = list(
     set(extras_require["unit_tests"]) | set(extras_require["nbtests"])
 )
-
 
 def get_setup_version(reponame):
     """

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ def get_setup_version(reponame):
     version_file_path = os.path.join(basepath, reponame, ".version")
     try:
         from param import version
-    except:
+    except ImportError:
         version = None
     if version is not None:
         return version.Version.setup_version(


### PR DESCRIPTION
It is obsolete and even its upstream declares that the OrderedDict in the standard library is superior to it (since 3.5).