### PR TITLE
Remove pytest as an explicit dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,6 @@ extras_require['tests'] = [
     'path.py',
     'matplotlib >=2.2,<3.1',
     'nbsmoke >=0.2.0',
-    'pytest-cov ==2.5.1',
-    'pytest <6.0',
     'nbconvert <6',
     'twine',
     'rfc3986',


### PR DESCRIPTION
pytest is currently an indirect dependency (comes from nbsmoke).

* Using pytest in place of nose is WIP (#4621), so it makes sense to add it back in that PR, but there should be no need to pin pytest.
* Have removed pytest-cov, as I guess it's unused (not totally certain though, and measuring coverage from notebook runs would be good - should add that; #4622). Again, it could come back in #4621 when pytest is used instead of nose.