### PR TITLE
CuDF Series is not iterable

### DIFF
--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -163,7 +163,7 @@ class cuDFInterface(PandasInterface):
         group_kwargs['dataset'] = dataset.dataset
 
         # Find all the keys along supplied dimensions
-        keys = product(*(dataset.data[dimensions[0]].unique() for d in dimensions))
+        keys = product(*(dataset.data[dimensions[0]].unique().values_host for d in dimensions))
 
         # Iterate over the unique entries applying selection masks
         grouped_data = []


### PR DESCRIPTION
@philippjfr This is a fix for https://github.com/holoviz/hvplot/issues/510 (which should probably be copied to this repo)

Summary: `.unique()` returns a CuDF Series, which is not iterable unless copied to host. 

No tests as of yet (looking in to GPU CI options)