### PR TITLE
Improve handling of categorical dtypes on empty arrays

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1834,8 +1834,7 @@ class ColorbarPlot(ElementPlot):
         cmap = colors or style.get(prefix+'cmap', style.get('cmap', 'viridis'))
         nan_colors = {k: rgba_tuple(v) for k, v in self.clipping_colors.items()}
         if isinstance(cmap, dict):
-            if factors is None:
-                factors = list(cmap)
+            factors = list(cmap)
             palette = [cmap.get(f, nan_colors.get('NaN', self._default_nan)) for f in factors]
             if isinstance(eldim, dim):
                 if eldim.dimension in element:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1114,8 +1114,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
             # If color is not valid colorspec add colormapper
             numeric = isinstance(val, util.arraylike_types) and val.dtype.kind in 'uifMmb'
+            colormap = style.get(prefix+'cmap')
             if ('color' in k and isinstance(val, util.arraylike_types) and
-                (numeric or not validate('color', val))):
+                (numeric or not validate('color', val) or isinstance(colormap, dict))):
                 kwargs = {}
                 if val.dtype.kind not in 'ifMu':
                     range_key = dim_range_key(v)

--- a/holoviews/plotting/bokeh/styles.py
+++ b/holoviews/plotting/bokeh/styles.py
@@ -137,7 +137,7 @@ def validate(style, value, scalar=False):
     if isinstance(value, arraylike_types+(list,)):
         if scalar:
             return False
-        return len(value) and all(validator(v) for v in value)
+        return all(validator(v) for v in value)
     return validator(value)
 
 # Utilities

--- a/holoviews/plotting/bokeh/styles.py
+++ b/holoviews/plotting/bokeh/styles.py
@@ -126,7 +126,6 @@ def validate(style, value, scalar=False):
        The style value to validate
     scalar: bool
 
-
     Returns
     -------
     valid: boolean or None
@@ -138,7 +137,7 @@ def validate(style, value, scalar=False):
     if isinstance(value, arraylike_types+(list,)):
         if scalar:
             return False
-        return all(validator(v) for v in value)
+        return len(value) and all(validator(v) for v in value)
     return validator(value)
 
 # Utilities

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -745,6 +745,8 @@ class DimensionedPlot(Plot):
                         drange = values.min(), values.max()
                     elif util.isscalar(values):
                         drange = values, values
+                    elif values.dtype.kind in 'US':
+                        factors = util.unique_array(values)
                     elif len(values) == 0:
                         drange = np.NaN, np.NaN
                     else:
@@ -756,7 +758,7 @@ class DimensionedPlot(Plot):
                             factors = util.unique_array(values)
                     if dim_name not in group_ranges:
                         group_ranges[dim_name] = {'data': [], 'hard': [], 'soft': []}
-    
+
                     if factors is not None:
                         if 'factors' not in group_ranges[dim_name]:
                             group_ranges[dim_name]['factors'] = []
@@ -817,8 +819,10 @@ class DimensionedPlot(Plot):
             dranges = {'data': data_range, 'hard': hard_range,
                        'soft': soft_range, 'combined': combined}
             if 'factors' in values:
-                dranges['factors'] = util.unique_array([
-                    v for fctrs in values['factors'] for v in fctrs])
+                all_factors = values['factors']
+                factor_dtype = all_factors[0].dtype if all_factors else None
+                dranges['factors'] = util.unique_array(np.array([
+                    v for fctrs in all_factors for v in fctrs], dtype=factor_dtype))
             dim_ranges.append((gdim, dranges))
         if prev_ranges and not (framewise and top_level):
             for d, dranges in dim_ranges:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -826,7 +826,7 @@ class DimensionedPlot(Plot):
                 if dtype is not None:
                     try:
                         # Try to keep the same dtype
-                        expanded = np.array(expanded, dtype=factor_dtype)
+                        expanded = np.array(expanded, dtype=dtype)
                     except Exception:
                         pass
                 dranges['factors'] = util.unique_array(expanded)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -820,9 +820,16 @@ class DimensionedPlot(Plot):
                        'soft': soft_range, 'combined': combined}
             if 'factors' in values:
                 all_factors = values['factors']
-                factor_dtype = all_factors[0].dtype if all_factors else None
-                dranges['factors'] = util.unique_array(np.array([
-                    v for fctrs in all_factors for v in fctrs], dtype=factor_dtype))
+                factor_dtypes = {fs.dtype for fs in all_factors} if all_factors else []
+                dtype = list(factor_dtypes)[0] if len(factor_dtypes) == 1 else None
+                expanded = [v for fctrs in all_factors for v in fctrs]
+                if dtype is not None:
+                    try:
+                        # Try to keep the same dtype
+                        expanded = np.array(expanded, dtype=factor_dtype)
+                    except Exception:
+                        pass
+                dranges['factors'] = util.unique_array(expanded)
             dim_ranges.append((gdim, dranges))
         if prev_ranges and not (framewise and top_level):
             for d, dranges in dim_ranges:


### PR DESCRIPTION
An empty array of string types was not treated correctly for categorical colormapping for various reasons:

- The dtype was dropped in the range calculation
- An explicit colormapping is treated as ground truth for factors and forces categorical colormapping