### PR TITLE
Added selected parameter to Bokeh PathPlot

### DIFF
--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -20,6 +20,10 @@ from .util import bokeh_version, multi_polygons_data
 
 class PathPlot(LegendPlot, ColorbarPlot):
 
+    selected = param.List(default=None, doc="""
+        The current selection as a list of integers corresponding
+        to the selected items.""")
+
     show_legend = param.Boolean(default=False, doc="""
         Whether to show legend for the plot.""")
 


### PR DESCRIPTION
Looks like `PathPlot` was forgotten when the `selected` parameter was added to the Bokeh backend. This PR aims addresses this small oversight.