### PR TITLE
Implement index based selection in linked brushing

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -35,6 +35,8 @@ class TextPlot(ElementPlot, AnnotationPlot):
     style_opts = text_properties+['color', 'angle', 'visible']
     _plot_methods = dict(single='text', batched='text')
 
+    selection_display = None
+    
     def get_data(self, element, ranges, style):
         mapping = dict(x='x', y='y', text='text')
         if self.static_source:
@@ -143,6 +145,8 @@ class LineAnnotationPlot(ElementPlot, AnnotationPlot):
     _allow_implicit_categories = False
     _plot_methods = dict(single='Span')
 
+    selection_display = None
+
     def get_data(self, element, ranges, style):
         data, mapping = {}, {}
         dim = 'width' if isinstance(element, HLine) else 'height'
@@ -185,6 +189,8 @@ class BoxAnnotationPlot(ElementPlot, AnnotationPlot):
     _allow_implicit_categories = False
     _plot_methods = dict(single='BoxAnnotation')
 
+    selection_display = None
+
     def get_data(self, element, ranges, style):
         data, mapping = {}, {}
         kwd_dim1 = 'left' if isinstance(element, VSpan) else 'bottom'
@@ -214,6 +220,8 @@ class SlopePlot(ElementPlot, AnnotationPlot):
     style_opts = line_properties + ['level']
 
     _plot_methods = dict(single='Slope')
+
+    selection_display = None
 
     def get_data(self, element, ranges, style):
         data, mapping = {}, {}
@@ -249,6 +257,8 @@ class SplinePlot(ElementPlot, AnnotationPlot):
     style_opts = line_properties + ['visible']
     _plot_methods = dict(single='bezier')
 
+    selection_display = None
+
     def get_data(self, element, ranges, style):
         if self.invert_axes:
             data_attrs = ['y0', 'x0', 'cy0', 'cx0', 'cy1', 'cx1', 'y1', 'x1']
@@ -282,6 +292,8 @@ class ArrowPlot(CompositeElementPlot, AnnotationPlot):
     _style_groups = {'arrow': 'arrow', 'text': 'text'}
 
     _draw_order = ['arrow_1', 'text_1']
+
+    selection_display = None
 
     def get_data(self, element, ranges, style):
         plot = self.state
@@ -415,6 +427,8 @@ class DivPlot(BokehPlot, GenericElementPlot, AnnotationPlot):
         other plotting handles can be accessed via plot.handles.""")
 
     _stream_data = False
+
+    selection_display = None
 
     def __init__(self, element, plot=None, **params):
         super(DivPlot, self).__init__(element, **params)

--- a/holoviews/plotting/bokeh/tiles.py
+++ b/holoviews/plotting/bokeh/tiles.py
@@ -14,6 +14,8 @@ class TilePlot(ElementPlot):
 
     style_opts = ['alpha', 'render_parents', 'level', 'smoothing', 'min_zoom', 'max_zoom']
 
+    selection_display = None
+
     def get_extents(self, element, ranges, range_type='combined'):
         extents = super(TilePlot, self).get_extents(element, ranges, range_type)
         if (not self.overlaid and all(e is None or not np.isfinite(e) for e in extents)

--- a/holoviews/plotting/plotly/callbacks.py
+++ b/holoviews/plotting/plotly/callbacks.py
@@ -43,15 +43,30 @@ class PlotlyCallback(object):
         self.plot = plot
         self.streams = streams
         self.source = source
+        self.last_event = None
 
     @classmethod
     def update_streams_from_property_update(cls, property_value, fig_dict):
         event_data = cls.get_event_data_from_property_update(property_value, fig_dict)
+        streams = []
         for trace_uid, stream_data in event_data.items():
             if trace_uid in cls.instances:
                 cb = cls.instances[trace_uid]
+                try:
+                    unchanged = stream_data == cb.last_event
+                except Exception:
+                    unchanged = False
+                if unchanged:
+                    continue
+                cb.last_event = stream_data
                 for stream in cb.streams:
-                    stream.event(**stream_data)
+                    stream.update(**stream_data)
+                    streams.append(stream)
+
+        try:
+            Stream.trigger(streams)
+        except Exception as e:
+            raise e
 
     @classmethod
     def get_event_data_from_property_update(cls, property_value, fig_dict):
@@ -91,7 +106,6 @@ class BoundsCallback(PlotlyCallback):
 
     @classmethod
     def get_event_data_from_property_update(cls, selected_data, fig_dict):
-
         traces = fig_dict.get('data', [])
 
         if not selected_data or 'range' not in selected_data:

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -108,7 +108,8 @@ class _base_link_selections(param.ParameterizedFunction):
         """
         # Create stream that produces element that displays region of selection
         selection_expr_seq = SelectionExprSequence(
-            hvobj, mode=self.selection_mode, include_region=self.show_regions
+            hvobj, mode=self.selection_mode, include_region=self.show_regions,
+            index_cols=self.index_cols
         )
         self._selection_expr_streams[hvobj] = selection_expr_seq
         self._cross_filter_stream.append_input_stream(self._selection_expr_streams[hvobj])

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1050,7 +1050,11 @@ class SelectionExprSequence(Derived):
     ):
         self.mode = mode
         self.include_region = include_region
-        self.history_stream = History(SelectionExpr(source, **params))
+        sel_expr = SelectionExpr(
+            source, index_cols=params.pop('index_cols'),
+            **params
+        )
+        self.history_stream = History(sel_expr)
         input_streams = [self.history_stream]
 
         super(SelectionExprSequence, self).__init__(

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -959,9 +959,12 @@ class SelectionExpr(Derived):
         else:
             element_type = source
         if element_type:
-            input_streams = [
-                stream(source=source) for stream in element_type._selection_streams
-            ]
+            input_streams = []
+            for stream in element_type._selection_streams:
+                kwargs = dict(source=source)
+                if isinstance(stream, Selection1D):
+                    kwargs['index'] = None
+                input_streams.append(stream(**kwargs))
             return input_streams
         else:
             return []
@@ -973,6 +976,14 @@ class SelectionExpr(Derived):
             "index_cols": self._index_cols,
             "include_region": self.include_region,
         }
+
+    def transform(self):
+        # Skip index streams if no index_cols are provided
+        for stream in self.input_streams:
+            if (isinstance(stream, Selection1D) and stream._triggering
+                and not self._index_cols):
+                return
+        return super(SelectionExpr, self).transform()
 
     @classmethod
     def transform_function(cls, stream_values, constants):
@@ -996,8 +1007,12 @@ class SelectionExpr(Derived):
         region_element = None
         for stream_value in stream_values:
             params = dict(stream_value, index_cols=constants["index_cols"])
-            selection_expr, bbox, region_element = \
-                element._get_selection_expr_for_stream_value(**params)
+            selection = element._get_selection_expr_for_stream_value(**params)
+            if selection is None:
+                return
+
+            selection_expr, bbox, region_element = selection
+                
             if selection_expr is not None:
                 break
 
@@ -1416,7 +1431,7 @@ class Selection1D(LinkedStream):
     A stream representing a 1D selection of objects by their index.
     """
 
-    index = param.List(default=[], constant=True, doc="""
+    index = param.List(default=[], allow_None=True, constant=True, doc="""
         Indices into a 1D datastructure.""")
 
 

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -1054,9 +1054,10 @@ class TestExprSelectionStream(ComparisonTestCase):
             expr_stream = SelectionExpr(element)
 
             # Check stream properties
-            self.assertEqual(len(expr_stream.input_streams), 2)
+            self.assertEqual(len(expr_stream.input_streams), 3)
             self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
             self.assertIsInstance(expr_stream.input_streams[1], Lasso)
+            self.assertIsInstance(expr_stream.input_streams[2], Selection1D)
             self.assertIsNone(expr_stream.bbox)
             self.assertIsNone(expr_stream.selection_expr)
 
@@ -1080,9 +1081,10 @@ class TestExprSelectionStream(ComparisonTestCase):
             expr_stream = SelectionExpr(element)
 
             # Check stream properties
-            self.assertEqual(len(expr_stream.input_streams), 2)
+            self.assertEqual(len(expr_stream.input_streams), 3)
             self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
             self.assertIsInstance(expr_stream.input_streams[1], Lasso)
+            self.assertIsInstance(expr_stream.input_streams[2], Selection1D)
             self.assertIsNone(expr_stream.bbox)
             self.assertIsNone(expr_stream.selection_expr)
 
@@ -1110,9 +1112,10 @@ class TestExprSelectionStream(ComparisonTestCase):
             expr_stream = SelectionExpr(element)
 
             # Check stream properties
-            self.assertEqual(len(expr_stream.input_streams), 2)
+            self.assertEqual(len(expr_stream.input_streams), 3)
             self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
             self.assertIsInstance(expr_stream.input_streams[1], Lasso)
+            self.assertIsInstance(expr_stream.input_streams[2], Selection1D)
             self.assertIsNone(expr_stream.bbox)
             self.assertIsNone(expr_stream.selection_expr)
 
@@ -1135,7 +1138,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream.input_streams), 2)
+        self.assertEqual(len(expr_stream.input_streams), 3)
         self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)
@@ -1167,7 +1170,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream.input_streams), 2)
+        self.assertEqual(len(expr_stream.input_streams), 3)
         self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)
@@ -1200,7 +1203,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream.input_streams), 2)
+        self.assertEqual(len(expr_stream.input_streams), 3)
         self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)
@@ -1231,7 +1234,7 @@ class TestExprSelectionStream(ComparisonTestCase):
             expr_stream = SelectionExpr(dmap)
 
             # Check stream properties
-            self.assertEqual(len(expr_stream.input_streams), 2)
+            self.assertEqual(len(expr_stream.input_streams), 3)
             self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
             self.assertIsNone(expr_stream.bbox)
             self.assertIsNone(expr_stream.selection_expr)


### PR DESCRIPTION
There appears to have been a regression where `index_cols` was no longer being passed through so that didn't work at all (have to add some tests here). However additionally this also adds support for using the tap tool alongside the lasso and box select tools when `index_cols` are provided.

Implements https://github.com/holoviz/holoviews/issues/4642

ToDo:

- [ ] Write tests for index_cols examples
- [x] Solve problem of both the Selection1D and Lasso/BoundsXY stream triggering on box/lasso select. If we already have the index computed in JS we don't have to do the reverse mapping, from box/lasso -> index selection in Python but currently it's doing both. This also has the benefit that you'll be able to do lasso select without spatialpandas/geopandas as long as you specify `index_cols`.

@jonmmease please review