### PR TITLE
copy index values to host for iteration

### DIFF
--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -282,8 +282,8 @@ class cuDFInterface(PandasInterface):
             if not hasattr(reindexed, agg):
                 raise ValueError('%s aggregation is not supported on cudf DataFrame.' % agg)
             agg = getattr(reindexed, agg)()
-            data = dict(((col, [v]) for col, v in zip(agg.index, agg.to_array())))
-            df = util.pd.DataFrame(data, columns=list(agg.index))
+            data = dict(((col, [v]) for col, v in zip(agg.index.values_host, agg.to_array())))
+            df = util.pd.DataFrame(data, columns=list(agg.index.values_host))
 
         dropped = []
         for vd in vdims:


### PR DESCRIPTION
cc @philippjfr @jlstevens 

This PR adds some missing `.values_host` calls necessary on cudf indices before iteration. It fixes the following broken tests:

```
FAILED holoviews/tests/core/data/testcudfinterface.py::cuDFInterfaceTests::test_dataset_1D_reduce_hm - AttributeError: 'StringIndex' object has no attribute 'value_host'
FAILED holoviews/tests/core/data/testcudfinterface.py::cuDFInterfaceTests::test_dataset_1D_reduce_hm_alias - AttributeError: 'StringIndex' object has no attribute 'value_host'
FAILED holoviews/tests/core/data/testcudfinterface.py::cuDFInterfaceTests::test_dataset_1D_reduce_ht - AttributeError: 'StringIndex' object has no attribute 'value_host'
FAILED holoviews/tests/core/data/testcudfinterface.py::cuDFInterfaceTests::test_dataset_2D_reduce_hm - AttributeError: 'StringIndex' object has no attribute 'value_host'
FAILED holoviews/tests/core/data/testcudfinterface.py::cuDFInterfaceTests::test_dataset_2D_reduce_ht - AttributeError: 'StringIndex' object has no attribute 'value_host'
```