### PR TITLE
Fix bug matching elements to subplots in DynamicMap

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -35,7 +35,7 @@ from ...element import Annotation, Graph, VectorField, Path, Contours, Tiles
 from ...streams import Stream, Buffer, RangeXY, PlotSize
 from ...util.transform import dim
 from ..plot import GenericElementPlot, GenericOverlayPlot
-from ..util import dynamic_update, process_cmap, color_intervals, dim_range_key
+from ..util import process_cmap, color_intervals, dim_range_key
 from .callbacks import PlotSizeCallback
 from .plot import BokehPlot
 from .styles import (
@@ -2365,7 +2365,6 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
 
         # Determine which stream (if any) triggered the update
         triggering = [stream for stream in self.streams if stream._triggering]
-
         for k, subplot in self.subplots.items():
             el = None
 
@@ -2376,7 +2375,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                     el = element
                 # If not batched get the Element matching the subplot
                 elif element is not None:
-                    idx, spec, exact = dynamic_update(self, subplot, k, element, items)
+                    idx, spec, exact = self._match_subplot(k, subplot, items, element)
                     if idx is not None:
                         _, el = items.pop(idx)
                         if not exact:

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -20,7 +20,7 @@ from ...element import Graph, Path
 from ...streams import Stream
 from ...util.transform import dim
 from ..plot import GenericElementPlot, GenericOverlayPlot
-from ..util import dynamic_update, process_cmap, color_intervals, dim_range_key
+from ..util import process_cmap, color_intervals, dim_range_key
 from .plot import MPLPlot, mpl_rc_context
 from .util import mpl_version, validate, wrap_formatter
 
@@ -1131,7 +1131,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
         for k, subplot in self.subplots.items():
             el = None if empty else element.get(k, None)
             if isinstance(self.hmap, DynamicMap) and not empty:
-                idx, spec, exact = dynamic_update(self, subplot, k, element, items)
+                idx, spec, exact = self._match_subplot(k, subplot, items, element)
                 if idx is not None:
                     _, el = items.pop(idx)
                     if not exact:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -36,11 +36,13 @@ from ..core.util import stream_parameters, isfinite
 from ..element import Table, Graph, Contours
 from ..streams import Stream, RangeXY, RangeX, RangeY
 from ..util.transform import dim
-from .util import (get_dynamic_mode, initialize_unbounded, dim_axis_label,
-                   attach_streams, traverse_setter, get_nested_streams,
-                   compute_overlayable_zorders, get_nested_plot_frame,
-                   split_dmap_overlay, get_axis_padding, get_range,
-                   get_minimum_span, get_plot_frame, scale_fontsize)
+from .util import (
+    get_dynamic_mode, initialize_unbounded, dim_axis_label,
+    attach_streams, traverse_setter, get_nested_streams,
+    compute_overlayable_zorders, get_nested_plot_frame,
+    split_dmap_overlay, get_axis_padding, get_range, get_minimum_span,
+    get_plot_frame, scale_fontsize, dynamic_update
+)
 
 
 class Plot(param.Parameterized):
@@ -1653,6 +1655,25 @@ class GenericOverlayPlot(GenericElementPlot):
                         zorder=zorder, root=self.root, **passed_handles)
         return plottype(obj, **plotopts)
 
+
+    def _match_subplot(self, k, subplot, items, element):
+        found = False
+        temp_items = list(items)
+        while not found:
+            idx, spec, exact = dynamic_update(self, subplot, k, element, temp_items)
+            if idx is not None:
+                if not exact:
+                    exact_matches = [
+                        dynamic_update(self, subplot, k, element, items)
+                        for k in self.subplots
+                    ]
+                    exact_matches = [m for m in exact_matches if m[-1]]
+                    if exact_matches:
+                        idx = exact_matches[0][0]
+                        _, el = temp_items.pop(idx)
+                        continue
+            found = True
+        return idx, spec, exact
 
     def _create_dynamic_subplots(self, key, items, ranges, **init_kwargs):
         """

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1664,7 +1664,7 @@ class GenericOverlayPlot(GenericElementPlot):
             if idx is not None:
                 if not exact:
                     exact_matches = [
-                        dynamic_update(self, subplot, k, element, items)
+                        dynamic_update(self, subplot, k, element, temp_items)
                         for k in self.subplots
                     ]
                     exact_matches = [m for m in exact_matches if m[-1]]

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1656,11 +1656,11 @@ class GenericOverlayPlot(GenericElementPlot):
         return plottype(obj, **plotopts)
 
 
-    def _match_subplot(self, k, subplot, items, element):
+    def _match_subplot(self, key, subplot, items, element):
         found = False
         temp_items = list(items)
         while not found:
-            idx, spec, exact = dynamic_update(self, subplot, k, element, temp_items)
+            idx, spec, exact = dynamic_update(self, subplot, key, element, temp_items)
             if idx is not None:
                 if not exact:
                     exact_matches = [

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1673,6 +1673,8 @@ class GenericOverlayPlot(GenericElementPlot):
                         _, el = temp_items.pop(idx)
                         continue
             found = True
+        if idx is not None:
+            idx = items.index(temp_items.pop(idx))
         return idx, spec, exact
 
     def _create_dynamic_subplots(self, key, items, ranges, **init_kwargs):

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -11,7 +11,7 @@ from ...core.spaces import DynamicMap
 from ...streams import Stream
 from ...util.transform import dim
 from ..plot import GenericElementPlot, GenericOverlayPlot
-from ..util import dim_range_key, dynamic_update
+from ..util import dim_range_key
 from .plot import PlotlyPlot
 from .util import (
     STYLE_ALIASES, get_colorscale, merge_figure, legend_trace_types)
@@ -616,7 +616,7 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
         figure = None
         for okey, subplot in self.subplots.items():
             if element is not None and subplot.drawn:
-                idx, spec, exact = dynamic_update(self, subplot, okey, element, items)
+                idx, spec, exact = self._match_subplot(okey, subplot, items, element)
                 if idx is not None:
                     _, el = items.pop(idx)
                 else:

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -651,7 +651,7 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
             # If in Dynamic mode propagate elements to subplots
             if not (isinstance(self.hmap, DynamicMap) and element is not None):
                 continue
-            idx, _, _ = dynamic_update(self, subplot, k, element, items)
+            idx, _, _ = self._match_subplot(k, subplot, items, element)
             if idx is not None:
                 items.pop(idx)
         if isinstance(self.hmap, DynamicMap) and items:


### PR DESCRIPTION
This fixes a longstanding bug in Overlay plots driven by a DynamicMap. The problem was that the code tried to assign subplots to elements that matched their spec, however each subplot would do this greedily so if a better match comes along later in the iteration then the plot would already have been assigned. This PR checks whether an exact match does exist and if it does it uses that instead.