### PR TITLE
Drop lasso and index selection streams from Selection1DExpr elements

### DIFF
--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -347,6 +347,8 @@ class Selection1DExpr(Selection2DExpr):
 
     _inverted_expr = False
 
+    _selection_streams = (SelectionXY,)
+
     def _empty_region(self):
         invert_axes = self.opts.get('plot').kwargs.get('invert_axes', False)
         if ((invert_axes and not self._inverted_expr) or (not invert_axes and self._inverted_expr)):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -408,8 +408,9 @@ class Stream(param.Parameterized):
         """
         Update the stream parameters and trigger an event.
         """
-        self.update(**kwargs)
-        self.trigger([self])
+        updated = self.update(**kwargs)
+        if updated:
+            self.trigger([self])
 
     def update(self, **kwargs):
         """
@@ -422,8 +423,11 @@ class Stream(param.Parameterized):
         """
         self._set_stream_parameters(**kwargs)
         transformed = self.transform()
-        if transformed:
+        if transformed is None:
+            return False
+        else:
             self._set_stream_parameters(**transformed)
+            return True
 
     def __repr__(self):
         cls_name = self.__class__.__name__
@@ -989,7 +993,6 @@ class SelectionExpr(Derived):
     def transform_function(cls, stream_values, constants):
         hvobj = constants["source"]
         include_region = constants["include_region"]
-
         if hvobj is None:
             # source is None
             return dict(selection_expr=None, bbox=None, region_element=None,)

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -1138,7 +1138,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream.input_streams), 3)
+        self.assertEqual(len(expr_stream.input_streams), 1)
         self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)
@@ -1170,7 +1170,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream.input_streams), 3)
+        self.assertEqual(len(expr_stream.input_streams), 1)
         self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)
@@ -1203,7 +1203,7 @@ class TestExprSelectionStream(ComparisonTestCase):
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
-        self.assertEqual(len(expr_stream.input_streams), 3)
+        self.assertEqual(len(expr_stream.input_streams), 1)
         self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
         self.assertIsNone(expr_stream.bbox)
         self.assertIsNone(expr_stream.selection_expr)

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -8,7 +8,7 @@ import param
 
 from holoviews.core.spaces import DynamicMap
 from holoviews.core.util import LooseVersion, pd
-from holoviews.element import Points, Scatter, Curve, Histogram
+from holoviews.element import Points, Scatter, Curve, Histogram, Polygons
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import * # noqa (Test all available streams)
 from holoviews.util import Dynamic, extension
@@ -1226,6 +1226,60 @@ class TestExprSelectionStream(ComparisonTestCase):
             repr((dim('x')>=2.5)&(dim('x')<=8))
         )
         self.assertEqual(expr_stream.bbox, {'x': (2.5, 8)})
+
+
+    def test_selection_expr_stream_polygon_index_cols(self):
+        # Create SelectionExpr on element
+        poly = Polygons([
+            [(0, 0, 'a'), (2, 0, 'a'), (1, 1, 'a')],
+            [(2, 0, 'b'), (4, 0, 'b'), (3, 1, 'b')],
+            [(1, 1, 'c'), (3, 1, 'c'), (2, 2, 'c')]
+        ], vdims=['cat'])
+
+        events = []
+        expr_stream = SelectionExpr(poly, index_cols=['cat'])
+        expr_stream.add_subscriber(lambda **kwargs: events.append(kwargs))
+
+        # Check stream properties
+        self.assertEqual(len(expr_stream.input_streams), 3)
+        self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
+        self.assertIsInstance(expr_stream.input_streams[1], Lasso)
+        self.assertIsInstance(expr_stream.input_streams[2], Selection1D)
+        self.assertIsNone(expr_stream.bbox)
+        self.assertIsNone(expr_stream.selection_expr)
+
+        expr_stream.input_streams[2].event(index=[0, 1])
+        self.assertEqual(
+            repr(expr_stream.selection_expr),
+            repr(dim('cat').isin(['a', 'b']))
+        )
+        self.assertEqual(expr_stream.bbox, None)
+        self.assertEqual(len(events), 1)
+
+        # Ensure bounds event does not trigger another update
+        expr_stream.input_streams[0].event(bounds=(0, 0, 4, 1))
+        self.assertEqual(
+            repr(expr_stream.selection_expr),
+            repr(dim('cat').isin(['a', 'b']))
+        )
+        self.assertEqual(len(events), 1)
+
+        # Ensure geometry event does trigger another update
+        expr_stream.input_streams[1].event(geometry=np.array([(0, 0), (4, 0), (4, 2), (0, 2)]))
+        self.assertEqual(
+            repr(expr_stream.selection_expr),
+            repr(dim('cat').isin(['a', 'b', 'c']))
+        )
+        self.assertEqual(len(events), 2)
+
+        # Ensure index event does trigger another update
+        expr_stream.input_streams[2].event(index=[1, 2])
+        self.assertEqual(
+            repr(expr_stream.selection_expr),
+            repr(dim('cat').isin(['b', 'c']))
+        )
+        self.assertEqual(expr_stream.bbox, None)
+        self.assertEqual(len(events), 3)
 
     def test_selection_expr_stream_dynamic_map(self):
         for element_type in [Scatter, Points]:


### PR DESCRIPTION
Elements which only support selection on one axis do not require Lasso and Selection1D (i.e. index selection) streams.