### PR TITLE
Allow clashing param stream names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ env:
     - MOZ_HEADLESS=1
 
 stages:
+  - name: tests
+    if: tag =~ ^v(\d+|\.)+([a-z]|rc)?\d?$
   - name: extra_tests
     if: type = cron
   - name: conda_dev_package
@@ -57,7 +59,7 @@ jobs:
     ########## Test Stage ##########
 
     - &default
-      stage: env_setup
+      stage: tests
       env: DESC="Python 3.6 tests" HV_REQUIREMENTS="unit_tests" PYTHON_VERSION=3.6
       before_install:
         - pip install pyctdev && doit miniconda_install && pip uninstall -y doit pyctdev
@@ -72,7 +74,7 @@ jobs:
         - doit env_capture
         - hash -r
       script:
-        - doit test_flakes
+        - doit test_all_recommended
       after_success: coveralls
       after_failure: sleep 10
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1677,24 +1677,22 @@ def stream_parameters(streams, no_duplicates=True, exclude=['name']):
     from ..streams import Params
     param_groups = []
     for s in streams:
+        if isinstance(s, Params):
+            continue
         if not s.contents and isinstance(s.hashkey, dict):
             param_groups.append(list(s.hashkey))
         else:
             param_groups.append(list(s.contents))
-    names = [name for group in param_groups for name in group]
+    names = [name for group in param_groups for name in group
+             if name != '_memoize_key']
 
     if no_duplicates:
         clashes = sorted(set([n for n in names if names.count(n) > 1]))
         clash_streams = []
-        filtered_clashes = []
         for s in streams:
-            if isinstance(s, Params):
-                continue
-            filtered_clashes.extend(clashes)
             for c in clashes:
                 if c in s.contents or (not s.contents and isinstance(s.hashkey, dict) and c in s.hashkey):
                     clash_streams.append(s)
-        clashes = [c for c in filtered_clashes if c != '_memoize_key']
         if clashes:
             clashing = ', '.join([repr(c) for c in clash_streams[:-1]])
             raise Exception('The supplied stream objects %s and %s '

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras_require['examples'] = extras_require['recommended'] + [
     'plotly >=4.0',
     'dash >=1.16',
     'streamz >=0.5.0',
-    'datashader',
+    'datashader ==0.11.1',
     'ffmpeg',
     'cftime',
     'netcdf4',


### PR DESCRIPTION
There are many scenarios where you might depend on multiple Parameterized methods with the same dependencies. This allows such scenarios by allowing Params stream contents to clash in general. Since they are fully qualified I don't see any harm in doing this.