### PR TITLE
Support link_selections on dynamic overlays

### DIFF
--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -164,7 +164,8 @@ class _base_link_selections(param.ParameterizedFunction):
                     self._selection_streams, hvobj, operations,
                     self._selection_expr_streams.get(hvobj, None), cache=self._cache
                 )
-            elif issubclass(hvobj.type, Overlay):
+            elif (issubclass(hvobj.type, Overlay) and
+                  getattr(hvobj.callback, "name", None) == "dynamic_mul"):
                 return Overlay([
                     self._selection_transform(el, operations=operations)
                     for el in callback.inputs

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -164,6 +164,11 @@ class _base_link_selections(param.ParameterizedFunction):
                     self._selection_streams, hvobj, operations,
                     self._selection_expr_streams.get(hvobj, None), cache=self._cache
                 )
+            elif issubclass(hvobj.type, Overlay):
+                return Overlay([
+                    self._selection_transform(el, operations=operations)
+                    for el in callback.inputs
+                ]).collate()
             else:
                 # This is a DynamicMap that we don't know how to recurse into.
                 return hvobj

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1020,7 +1020,7 @@ class SelectionExpr(Derived):
                 return
 
             selection_expr, bbox, region_element = selection
-                
+
             if selection_expr is not None:
                 break
 
@@ -1107,6 +1107,8 @@ class SelectionExprSequence(Derived):
         combined_region_element = None
 
         for selection_contents in stream_values[0]["values"]:
+            if selection_contents is None:
+                continue
             selection_expr = selection_contents['selection_expr']
             if not selection_expr:
                 continue


### PR DESCRIPTION
This PR adds support for performing `link_selections` on DynamicMaps that are the result of performing the `__mul__` operator on one or more DynamicMap layers.

This came up when trying to use `link_selections` and datashader together on top of a `Tiles` element.

e.g.
```python
link_selections(tiles * datashade(...))
```

The result of  `tiles * datashade(...)` is a `DynamicMap` that returns an `Overlay`. Previously we skipped these in `link_selections` because it's not possible to accurately recurse in the general case.

This PR handles only the very common case of DynamicMaps generated by the `__mul__` operator.
