### PR TITLE
Fix mysterious id_offset bug

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1748,7 +1748,9 @@ class StoreOptions(object):
         max_ids = []
         for backend in Store.renderers.keys():
             store_ids = Store.custom_options(backend=backend).keys()
-            max_id = max(store_ids)+1 if len(store_ids) > 0 else 0
+            max_id = max(store_ids, default=0)
+            if store_ids:
+                max_id += 1
             max_ids.append(max_id)
         # If no backends defined (e.g plotting not imported) return zero
         return max(max_ids) if len(max_ids) else 0


### PR DESCRIPTION
Can't explain the bug but this should fix it:

```
  File "C:\Miniconda3\envs\test-environment\lib\site-packages\holoviews\core\options.py", line 1751, in id_offset
    max_id = max(store_ids)+1 if len(store_ids) > 0 else 0
ValueError: max() arg is an empty sequence
```