### PR TITLE
Dask/cudf histogram fixes

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -717,7 +717,7 @@ class histogram(Operation):
         if is_cupy:
             import cupy
             full_cupy_support = LooseVersion(cupy.__version__) > '8.0'
-            if not full_cupy_support and (normed or self.p.weight_dimension):
+            if not full_cupy_support and (normed or self.p.weight_dimension): 
                 data = cupy.asnumpy(data)
                 is_cupy = False
         if is_dask_array(data):
@@ -783,7 +783,7 @@ class histogram(Operation):
                 if normed == 'height':
                     hist /= hist.max()
             else:
-                hist, edges = histogram(data, density=False, weights=weights, bins=edges)
+                hist, edges = histogram(data, normed=normed, weights=weights, bins=edges)
                 if self.p.weight_dimension and self.p.mean_weighted:
                     hist_mean, _ = histogram(data, density=False, bins=self.p.num_bins)
                     hist /= hist_mean
@@ -792,7 +792,7 @@ class histogram(Operation):
             hist = np.zeros(nbins)
 
         if is_cupy_array(hist):
-            edges = cupy.asnumpy(edges)
+            edges = cupy.asnumpy(edges) 
             hist = cupy.asnumpy(hist)
 
         hist[np.isnan(hist)] = 0

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -717,7 +717,7 @@ class histogram(Operation):
         if is_cupy:
             import cupy
             full_cupy_support = LooseVersion(cupy.__version__) > '8.0'
-            if not full_cupy_support and (normed or self.p.weight_dimension): 
+            if not full_cupy_support and (normed or self.p.weight_dimension):
                 data = cupy.asnumpy(data)
                 is_cupy = False
         if is_dask_array(data):
@@ -783,7 +783,7 @@ class histogram(Operation):
                 if normed == 'height':
                     hist /= hist.max()
             else:
-                hist, edges = histogram(data, normed=normed, weights=weights, bins=edges)
+                hist, edges = histogram(data, density=False, weights=weights, bins=edges)
                 if self.p.weight_dimension and self.p.mean_weighted:
                     hist_mean, _ = histogram(data, density=False, bins=self.p.num_bins)
                     hist /= hist_mean
@@ -792,7 +792,7 @@ class histogram(Operation):
             hist = np.zeros(nbins)
 
         if is_cupy_array(hist):
-            edges = cupy.asnumpy(edges) 
+            edges = cupy.asnumpy(edges)
             hist = cupy.asnumpy(hist)
 
         hist[np.isnan(hist)] = 0

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import param
+import numpy as np
 
 from .selection import PlotlyOverlaySelectionDisplay
 from ...core import util
@@ -309,8 +310,8 @@ class HistogramPlot(ElementPlot):
     def get_data(self, element, ranges, style, **kwargs):
         xdim = element.kdims[0]
         ydim = element.vdims[0]
-        values = element.interface.coords(element, ydim)
-        edges = element.interface.coords(element, xdim)
+        values = np.asarray(element.interface.coords(element, ydim))
+        edges = np.asarray(element.interface.coords(element, xdim))
         if len(edges) < 2:
             binwidth = 0
         else:


### PR DESCRIPTION
This PR has two small fixes for displaying histograms using dask and cudf.

 - First, the plotly histogram plot was passing Dask arrays into the Plotly Figure dictionary which plotly.py doesn't handle.
 - Second, the histogram operation code was still using the deprecated `normed` argument in one place. Numpy still supports this with a runtime deprecation warning, but cupy doesn't. The replacement is the `density` kwarg, which we were already using several places in the same function so I don't think backward compatibility should be affected at all. Also, the `normed` kwarg has been deprecated in numpy for a long time now (since 1.6.0)

Do these make sense @philippjfr ?