### PR TITLE
Fix handling of custom matplotlib and bokeh colormaps

### DIFF
--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -684,7 +684,10 @@ def _list_cmaps(provider=None, records=False):
     if 'matplotlib' in provider:
         try:
             import matplotlib.cm as cm
-            mpl_cmaps = list(cm.cmaps_listed)+list(cm.datad)
+            if hasattr(cm, '_cmap_registry'):
+                mpl_cmaps = list(cm._cmap_registry)
+            else:
+                mpl_cmaps = list(cm.cmaps_listed)+list(cm.datad)
             cmaps += info('matplotlib', mpl_cmaps)
             cmaps += info('matplotlib', [cmap+'_r' for cmap in mpl_cmaps])
         except:

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -595,7 +595,8 @@ def bokeh_palette_to_palette(cmap, ncolors=None, categorical=False):
         reverse = True
 
     # Some colormaps are inverted compared to matplotlib
-    inverted = (not cmap_categorical and not cmap.capitalize() in palettes.mpl)
+    inverted = (not cmap_categorical and not cmap.capitalize() in palettes.mpl
+                and not cmap.startswith('fire'))
     if inverted:
         reverse=not reverse
     ncolors = ncolors or 256

--- a/holoviews/tests/plotting/testplotutils.py
+++ b/holoviews/tests/plotting/testplotutils.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 
-from unittest import SkipTest
+from unittest import SkipTest, skipIf
 
 import numpy as np
 

--- a/holoviews/tests/plotting/testplotutils.py
+++ b/holoviews/tests/plotting/testplotutils.py
@@ -468,7 +468,7 @@ class TestMPLColormapUtils(ComparisonTestCase):
     def setUp(self):
         try:
             import matplotlib.cm # noqa
-            import holoviews.plotting.mpl
+            import holoviews.plotting.mpl # noqa
         except:
             raise SkipTest("Matplotlib needed to test matplotlib colormap instances")
 

--- a/holoviews/tests/plotting/testplotutils.py
+++ b/holoviews/tests/plotting/testplotutils.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
+import sys
+
 from unittest import SkipTest
 
 import numpy as np
@@ -23,6 +25,9 @@ try:
     bokeh_renderer = Store.renderers['bokeh']
 except:
     bokeh_renderer = None
+
+py2_skip = skipIf(sys.version_info.major == 2, "Not supported in python2")
+
 
 
 class TestOverlayableZorders(ComparisonTestCase):
@@ -539,10 +544,12 @@ class TestBokehPaletteUtils(ComparisonTestCase):
         for cat in categorical:
             self.assertTrue(len(set(bokeh_palette_to_palette(cat))) <= 20)
 
+    @py2_skip
     def test_bokeh_colormap_fire(self):
         colors = process_cmap('fire', 3, provider='bokeh')
         self.assertEqual(colors, ['#000000', '#eb1300', '#ffffff'])
 
+    @py2_skip
     def test_bokeh_colormap_fire_r(self):
         colors = process_cmap('fire_r', 3, provider='bokeh')
         self.assertEqual(colors, ['#ffffff', '#ed1400', '#000000'])

--- a/holoviews/tests/plotting/testplotutils.py
+++ b/holoviews/tests/plotting/testplotutils.py
@@ -528,6 +528,7 @@ class TestBokehPaletteUtils(ComparisonTestCase):
     def setUp(self):
         try:
             import bokeh.palettes # noqa
+            import holoviews.plotting.bokeh # noqa
         except:
             raise SkipTest('Bokeh required to test bokeh palette utilities')
 

--- a/holoviews/tests/plotting/testplotutils.py
+++ b/holoviews/tests/plotting/testplotutils.py
@@ -468,17 +468,26 @@ class TestMPLColormapUtils(ComparisonTestCase):
     def setUp(self):
         try:
             import matplotlib.cm # noqa
+            import holoviews.plotting.mpl
         except:
             raise SkipTest("Matplotlib needed to test matplotlib colormap instances")
 
+    def test_mpl_colormap_fire(self):
+        colors = process_cmap('fire', 3, provider='matplotlib')
+        self.assertEqual(colors, ['#000000', '#ed1400', '#ffffff'])
+
+    def test_mpl_colormap_fire_r(self):
+        colors = process_cmap('fire_r', 3, provider='matplotlib')
+        self.assertEqual(colors, ['#ffffff', '#eb1300', '#000000'])
+
     def test_mpl_colormap_name_palette(self):
-        colors = process_cmap('Greys', 3)
+        colors = process_cmap('Greys', 3, provider='matplotlib')
         self.assertEqual(colors, ['#ffffff', '#959595', '#000000'])
 
     def test_mpl_colormap_instance(self):
         from matplotlib.cm import get_cmap
         cmap = get_cmap('Greys')
-        colors = process_cmap(cmap, 3)
+        colors = process_cmap(cmap, 3, provider='matplotlib')
         self.assertEqual(colors, ['#ffffff', '#959595', '#000000'])
 
     def test_mpl_colormap_categorical(self):
@@ -528,6 +537,14 @@ class TestBokehPaletteUtils(ComparisonTestCase):
                        'pastel2', 'set1', 'set2', 'set3', 'paired')
         for cat in categorical:
             self.assertTrue(len(set(bokeh_palette_to_palette(cat))) <= 20)
+
+    def test_bokeh_colormap_fire(self):
+        colors = process_cmap('fire', 3, provider='bokeh')
+        self.assertEqual(colors, ['#000000', '#eb1300', '#ffffff'])
+
+    def test_bokeh_colormap_fire_r(self):
+        colors = process_cmap('fire_r', 3, provider='bokeh')
+        self.assertEqual(colors, ['#ffffff', '#ed1400', '#000000'])
 
     def test_bokeh_palette_categorical(self):
         colors = bokeh_palette_to_palette('Category20', 3)


### PR DESCRIPTION
Two issues compounded causing our default 'fire' cmap to invert in recent releases. In particular recent versions of matplotlib changed how to look up colormaps and we had to adapt, however in doing so we were no longer picking up custom matplotlib colormaps (such as the fire cmap we were registering), which caused us to fall back to using the bokeh 'fire' palette. The issue there was that we had custom handling to invert non-matplotlib based bokeh palettes, because those are generally stored in reverse order, but since 'fire' in particular was stored in the correct order it was incorrectly inversed.

Fixes #4635 