### PR TITLE
Dash updates / fixes

### DIFF
--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -247,7 +247,10 @@ def decode_store_data(store_data):
     return pickle.loads(base64.b64decode(store_data["pickled"]))
 
 
-def to_dash(app, hvobjs, reset_button=False, graph_class=dcc.Graph):
+def to_dash(
+        app, hvobjs, reset_button=False, graph_class=dcc.Graph,
+        button_class=html.Button
+):
     """
     Build Dash components and callbacks from a collection of HoloViews objects
 
@@ -259,7 +262,8 @@ def to_dash(app, hvobjs, reset_button=False, graph_class=dcc.Graph):
             objects to their initial values. Defaults to False.
         graph_class: Class to use when creating Graph components, one of dcc.Graph
             (default) or ddk.Graph.
-
+        button_class: Class to use when creating reset button component.
+            E.g. html.Button (default) or dbc.Button
     Returns:
         DashComponents named tuple with properties:
             - graphs: List of graph components (with type matching the input
@@ -428,7 +432,7 @@ def to_dash(app, hvobjs, reset_button=False, graph_class=dcc.Graph):
     # Add reset button
     if reset_button:
         reset_id = 'reset-' + str(uuid.uuid4())
-        reset_button = html.Button(id=reset_id, children="Reset")
+        reset_button = button_class(id=reset_id, children="Reset")
         inputs.append(Input(
             component_id=reset_id, component_property='n_clicks'
         ))

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -68,6 +68,7 @@ def plot_to_figure(plot, reset_nclicks=0):
     # Remove figure width height, let container decide
     fig_dict['layout'].pop('width', None)
     fig_dict['layout'].pop('height', None)
+    fig_dict['layout'].pop('autosize', None)
 
     # Pass to figure constructor to expand magic underscore notation
     return go.Figure(fig_dict)


### PR DESCRIPTION
A few misc. fixes / updates to Dash logic:
 - Support `responsive` argument to change whether the figure width/height from HoloViews is hard-coded or whether the figures grow to fill their containers (the default)
 - Support customizing the dash Button component for compatibility third-party components.
 - Don't regenerate figures in response to Dash events that don't change any of the stream values. This avoids regenerating all figures when switching the active toolbar tool.