### PR TITLE
Fix various issues related to data interfaces

### DIFF
--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -75,7 +75,7 @@ class DaskInterface(PandasInterface):
         return dataset.clone(dataset.data.compute())
 
     @classmethod
-    def persiste(cls, dataset):
+    def persist(cls, dataset):
         return dataset.clone(dataset.data.persist())
 
     @classmethod

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -472,7 +472,7 @@ class SelectionDisplay(object):
                     selection = dataset.iloc[mask]
                 elif isinstance(element, (Curve, Spread)) and hasattr(dataset.interface, 'mask'):
                     if mask is None:
-                        mask = selection_expr.apply(dataset, compute=False, strict=False)
+                        mask = selection_expr.apply(dataset, keep_index=True, strict=False)
                     selection = dataset.clone(dataset.interface.mask(dataset, ~mask))
                 else:
                     if mask is None:


### PR DESCRIPTION
- `DaskInterface.persiste`was a typo
- The fix for masking on linked selections ensures that cuDFs don't error due to dropping to an array type rather than keeping the series type.