### PR TITLE
Fix datashader instability by disabling plot padding for Plotly RGB elements.

### DIFF
--- a/holoviews/plotting/plotly/__init__.py
+++ b/holoviews/plotting/plotly/__init__.py
@@ -126,8 +126,9 @@ options.Raster = Options('style', cmap=dflt_cmap)
 options.QuadMesh = Options('style', cmap=dflt_cmap)
 options.HeatMap = Options('style', cmap='RdBu_r')
 
-# RGB
-# Disable padding in RGB elements to prevent datashader artifacts
+# Disable padding for image-like elements
+options.Image = Options("plot", padding=0)
+options.Raster = Options("plot", padding=0)
 options.RGB = Options("plot", padding=0)
 
 # 3D

--- a/holoviews/plotting/plotly/__init__.py
+++ b/holoviews/plotting/plotly/__init__.py
@@ -126,6 +126,10 @@ options.Raster = Options('style', cmap=dflt_cmap)
 options.QuadMesh = Options('style', cmap=dflt_cmap)
 options.HeatMap = Options('style', cmap='RdBu_r')
 
+# RGB
+# Disable padding in RGB elements to prevent datashader artifacts
+options.RGB = Options("plot", padding=0)
+
 # 3D
 options.Scatter3D = Options('style', color=Cycle(), size=6)
 


### PR DESCRIPTION
The introduction of plot padding last release broke the default behavior of using `datashade` with the plotly backend in the notebook.  It resulted in the plot continually zooming out and crashing the kernel.

This  simple (and I think appropriate) fix is to disable padding, by default, for the RGB elements with the plotly backend. Even apart from datashader, I think zero padding is a better default for RGB images as it's a bit awkward for there to be an empty border around them.