### PR TITLE
Allow Tiles the data argument to be None.

### DIFF
--- a/holoviews/element/tiles.py
+++ b/holoviews/element/tiles.py
@@ -37,14 +37,14 @@ class Tiles(Element2D):
 
     group = param.String(default='Tiles', constant=True)
 
-    def __init__(self, data, kdims=None, vdims=None, **params):
+    def __init__(self, data=None, kdims=None, vdims=None, **params):
         try:
             from bokeh.models import MercatorTileSource
         except:
             MercatorTileSource = None
         if MercatorTileSource and isinstance(data, MercatorTileSource):
             data = data.url
-        elif not isinstance(data, util.basestring):
+        elif data is not None and not isinstance(data, util.basestring):
             raise TypeError('%s data should be a tile service URL not a %s type.'
                             % (type(self).__name__, type(data).__name__) )
         super(Tiles, self).__init__(data, kdims=kdims, vdims=vdims, **params)

--- a/holoviews/plotting/bokeh/tiles.py
+++ b/holoviews/plotting/bokeh/tiles.py
@@ -30,7 +30,9 @@ class TilePlot(ElementPlot):
         if not isinstance(element.data, util.basestring):
             SkipRendering("WMTS element data must be a URL string, "
                           "bokeh cannot render %r" % element.data)
-        if '{Q}' in element.data:
+        if element.data is None:
+            raise ValueError("Tile source URL may not be None with the bokeh backend")
+        elif '{Q}' in element.data:
             tile_source = QUADKEYTileSource
         elif all(kw in element.data for kw in ('{XMIN}', '{XMAX}', '{YMIN}', '{YMAX}')):
             tile_source = BBoxTileSource

--- a/holoviews/tests/plotting/plotly/testtiles.py
+++ b/holoviews/tests/plotting/plotly/testtiles.py
@@ -54,7 +54,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         self.assertEqual(len(layers), 0)
 
     def test_styled_mapbox_tiles(self):
-        tiles = Tiles("").opts(mapboxstyle="dark", accesstoken="token-str").redim.range(
+        tiles = Tiles().opts(mapboxstyle="dark", accesstoken="token-str").redim.range(
             x=self.x_range, y=self.y_range
         )
 


### PR DESCRIPTION
This way, the plotly backend can call `Tiles()` without a dummy empty string when using mapbox.

The bokeh backend updated to raise an explicit error message if a URL data is not provided.