### PR TITLE
Updated Large Data

### DIFF
--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -331,7 +331,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.Layout([rasterize(hv.Points(df), vdim_prefix='').redim.nodata(Count=n).opts(**ropts).relabel(\"nodata=\"+str(n))\n",
+    "hv.Layout([rasterize(hv.Points(df), vdim_prefix='').redim.nodata(Count=n)\\\n",
+    "           .opts(**ropts, cnorm=\"eq_hist\").relabel(\"nodata=\"+str(n))\n",
     "           for n in [0, None]])"
    ]
   },
@@ -350,7 +351,7 @@
     "\n",
     "Dynamic spreading is typically more useful for interactive plotting, because it adjusts depending on how close the datapoints are to each other on screen. As of Datashader 0.12, both types of spreading are supported for both `rasterize()` and `shade()`, but previous Datashader versions only support spreading on the RGB output of `shade()`.\n",
     "\n",
-    "As long as you have Datashader 0.12 or later, you can compare the results in the two zoomed-in plots below, then zoom out to see that the plots are the same when points are clustered together to form a distribution:"
+    "As long as you have Datashader 0.12 or later, you can compare the results when you zoom the two plots below; when you zoom in far enough you should be able to see that the in the two zoomed-in plots below, then zoom out to see that the plots are the same when points are clustered together to form a distribution. (If running a live notebook; remove the semicolon so that you see the live output rather than the saved GIF.)"
    ]
   },
   {
@@ -359,8 +360,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(rasterize(points) + dynspread(rasterize(points)))\\\n",
-    ".opts(opts.Image(cnorm='eq_hist', xlim=(0.1,0.2), ylim=(0.1,0.2)))"
+    "pts = rasterize(points).opts(cnorm='eq_hist')\n",
+    "\n",
+    "pts + dynspread(pts);"
    ]
   },
   {

--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -182,9 +182,68 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Setting options\n",
+    "\n",
+    "By their nature, the datashading operations accept one HoloViews Element type and return a different Element type. Regardless of what type they are given, `rasterize()` returns an `hv.Image`, while `shade()` and `datashade()` return an `hv.RGB`. It is important to keep this transformation in mind, because HoloViews options that you set on your original Element type are not normally transferred to your new Element:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "points2 = decimate(points, dynamic=False, max_samples=3000)\n",
+    "points2.opts(color=\"green\", size=6, marker=\"s\")\n",
+    "\n",
+    "points2 + rasterize(points2).relabel(\"Rasterized\") + datashade(points2).relabel(\"Datashaded\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see the datashaded plot represents each point as a single pixel, many of which are very difficult to see, and that the color, size, and marker shape that you set on the Points element will not be applied to the rasterized or datashaded plot. \n",
+    "\n",
+    "If you want to use Datashader to recreate the options from the original plot, you can usually do so, but you will have to use the various Datashader-specific features explained in the sections below along with HoloViews options for `hv.Image` or `hv.RGB`. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "points2 + \\\n",
+    "spread(rasterize(points2), px=4, shape='square').opts(cmap=[\"green\"]).relabel(\"Rasterized\") +\\\n",
+    "spread(datashade(points2, cmap=[\"green\"]), px=4, shape='square').relabel(\"Datashaded\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that by forcing the single-color colormap `[\"green\"]`, Datashader's support for avoiding overplotting has been lost. In most cases you will want to map to a proper colormap rather than a single color, to better reveal the underlying distribution:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "decimate(points2) + \\\n",
+    "spread(rasterize(points2), px=4, shape='square').opts(cmap=\"Greens\").relabel(\"Rasterized\") +\\\n",
+    "spread(datashade(points2, cmap=\"green\"), px=4, shape='square').relabel(\"Datashaded\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Colormapping\n",
     "\n",
-    "The above plots show a limited range of data, but when you use very large real-world datasets, there is often structure at many spatial scales, which requires special attention to colormapping options. This example dataset from the [Datashader documentation](https://datashader.org/getting_started/Pipeline.html) illustrates the issues, with data clustering at five different spatial scales:"
+    "As you can see above, the choice of colormap and the various colormapping options can be very important for datashaded plots. One issue often seen in large, real-world datasets is that there is structure at many spatial scales, which requires special attention to colormapping options. This example dataset from the [Datashader documentation](https://datashader.org/getting_started/Pipeline.html) illustrates the issues, with data clustering at five different spatial scales:"
    ]
   },
   {
@@ -282,9 +341,9 @@
    "source": [
     "## Spreading\n",
     "\n",
-    "The Datashader examples above treat points and lines as infinitesimal in width, such that a given point or small bit of line segment appears in at most one pixel. This approach ensures that the overall distribution of the points will be mathematically well founded -- each pixel will scale in value directly by the number of points that fall into it, or by the lines that cross it. As a consequence, Datashader does not currently provide support for a marker size or a line width, which both effectively default to one pixel.\n",
+    "By default, Datashader treats points and lines as infinitesimal in width, such that a given point or small bit of line segment appears in at most one pixel. This approach ensures that the overall distribution of the points will be mathematically well founded -- each pixel will scale in value directly by the number of points that fall into it, or by the lines that cross it. As a consequence, Datashader does not currently provide support for a marker size or a line width, which both effectively default to one pixel.\n",
     "\n",
-    "However, many monitors are sufficiently high resolution that a single-pixel point or line can be difficult to see---one pixel may not be visible at all on its own, and even if it is visible it is often difficult to see its color. To compensate for this, HoloViews provides access to Datashader's raster-based \"spreading\", which makes isolated nonzero cells \"spread\" into adjacent ones for visibility.  There are two varieties of spreading supported:\n",
+    "However, many monitors are sufficiently high resolution that a single-pixel point or line can be difficult to see---one pixel may not be visible at all on its own, and even if it is visible it is often difficult to see its color. To compensate for this, HoloViews provides access to Datashader's raster-based \"spreading\" (a generalization of image dilation and convolution), which makes isolated nonzero cells \"spread\" into adjacent ones for visibility.  There are two varieties of spreading supported:\n",
     "\n",
     "1. ``spread``: fixed spreading of a certain number of cells (pixels), which is useful if you want to be sure how much spreading is done regardless of the properties of the data.\n",
     "2. ``dynspread``: spreads up to a maximum size as long as it does not exceed a specified fraction of adjacency between cells (pixels).\n",
@@ -626,7 +685,7 @@
     "shadeable  = [hv.Rectangles((np.arange(100)-0.4, s, np.arange(100)+0.4, e, s>e), vdims='sign').opts(rect_opts)]\n",
     "\n",
     "def nop(x,**k):      return x\n",
-    "def spread4(e, **k): return spread(rasterize(e, **k), px=4).opts(cnorm='eq_hist') \n",
+    "def spread4(e, **k): return spread(rasterize(e, **k), px=4).opts(cnorm='eq_hist', padding=0.1) \n",
     "def plot(e, operation=nop):\n",
     "    return operation(e.relabel(e.__class__.name), **ds_opts.get(e.__class__, {})).opts(**eopts)"
    ]

--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -255,15 +255,15 @@
    "outputs": [],
    "source": [
     "hv.Layout([rasterize(hv.Points(df)).opts(**ropts).opts(cnorm='linear').opts(**o)\n",
-    "           for o in [dict(cnorm='log'), \n",
-    "                     dict(cnorm='log', clim=(0, 10000))]])"
+    "           for o in [dict(cnorm='log', axiswise=True), \n",
+    "                     dict(cnorm='log', axiswise=True, clim=(0, 10000))]])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, pixels with a count of zero are transparent, letting the plot background show through so that the data can be used in overlays. If you want zero to map to the lowest colormap color instead to make a dense, fully filled-in image, you can pass `nodata=None`:"
+    "By default, pixels with a count of zero are transparent, letting the plot background show through so that the data can be used in overlays. If you want zero to map to the lowest colormap color instead to make a dense, fully filled-in image, you can use `redim.nodata` to set the `Dimension.nodata` parameter to None:"
    ]
   },
   {
@@ -272,7 +272,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.Layout([rasterize(hv.Points(df)).opts(**ropts).opts(nodata=n).relabel(\"nodata=\"+str(n))\n",
+    "hv.Layout([rasterize(hv.Points(df), vdim_prefix='').redim.nodata(Count=n).opts(**ropts).relabel(\"nodata=\"+str(n))\n",
     "           for n in [0, None]])"
    ]
   },

--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -304,7 +304,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since datashader only sends the data currently in view to the plotting backend, the default behavior is to rescale the colormap to the range of the visible data as the zoom level changes. This behavior may not be desirable when working with images; to instead use a fixed colormap range, the `clim` parameter can be passed to the `bokeh` backend via the `opts()` method. Note that this approach works with `rasterize()` where the colormapping is done by the `bokeh` backend. With `datashade()`, the colormapping is done with the `shade()` function which takes a `clims` parameter directly instead of passing additional parameters to the backend via `opts()`."
+    "Since datashader only sends the data currently in view to the plotting backend, the default behavior is to rescale the colormap to the range of the visible data as the zoom level changes. This behavior may not be desirable when working with images; to instead use a fixed colormap range, the `clim` parameter can be passed to the `bokeh` backend via the `opts()` method. Note that this approach works with `rasterize()` where the colormapping is done by the `bokeh` backend. With `datashade()`, the colormapping is done with the `shade()` function which takes a `clims` parameter directly instead of passing additional parameters to the backend via `opts()`. For example (removing the semicolon in a live notebook to see the output):"
    ]
   },
   {
@@ -313,15 +313,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.Layout([rasterize(hv.Points(df)).opts(**ropts).opts(cnorm='linear').opts(**o)\n",
-    "           for o in [dict(cnorm='log', axiswise=True), \n",
-    "                     dict(cnorm='log', axiswise=True, clim=(0, 10000))]])"
+    "pts1 = rasterize(hv.Points(df)).opts(**ropts).opts(tools=[], cnorm='log', axiswise=True)\n",
+    "pts2 = rasterize(hv.Points(df)).opts(**ropts).opts(tools=[], cnorm='log', axiswise=True)\n",
+    "\n",
+    "pts1 + pts2.opts(clim=(0, 10000));"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<img src=\"http://assets.holoviews.org/gifs/guides/user_guide/Large_Data/rasterize_clim_example.gif\"></img>\n",
+    "\n",
     "By default, pixels with a count of zero are transparent, letting the plot background show through so that the data can be used in overlays. If you want zero to map to the lowest colormap color instead to make a dense, fully filled-in image, you can use `redim.nodata` to set the `Dimension.nodata` parameter to None:"
    ]
   },
@@ -370,7 +373,6 @@
    "metadata": {},
    "source": [
     "<img src=\"http://assets.holoviews.org/gifs/guides/user_guide/Large_Data/dynspread.gif\"></img>\n",
-    "\n",
     "\n",
     "Both plots show the same data, and look identical when zoomed out, but when zoomed in enough you should be able to see the individual data points on the right while the ones on the left are barely visible.  The dynspread parameters typically need some hand tuning, as the only purpose of such spreading is to make things visible on a particular monitor for a particular observer; the underlying mathematical operations in Datashader do not normally need parameters to be adjusted.\n",
     "\n",

--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -26,12 +26,8 @@
     "import holoviews as hv\n",
     "\n",
     "from holoviews import opts\n",
-    "\n",
-    "from holoviews.operation.datashader import datashade, shade, dynspread, rasterize\n",
+    "from holoviews.operation.datashader import datashade, shade, dynspread, spread, rasterize\n",
     "from holoviews.operation import decimate\n",
-    "\n",
-    "from colorcet import kbc\n",
-    "kbc_r=kbc[::-1]\n",
     "\n",
     "hv.extension('bokeh','matplotlib')\n",
     "\n",
@@ -78,7 +74,7 @@
    "source": [
     "# Principles of datashading\n",
     "\n",
-    "Because HoloViews elements are fundamentally data containers, not visualizations, you can very quickly declare elements such as ``Points`` or ``Path`` containing datasets that may be as large as the full memory available on your machine (or even larger if using Dask dataframes). So even for very large datasets, you can easily  specify a data structure that you can work with for making selections, sampling, aggregations, and so on. However, as soon as you try to visualize it directly with either the Matplotlib or Bokeh plotting extensions, the rendering process may be prohibitively expensive.\n",
+    "Because HoloViews elements are fundamentally data containers, not visualizations, you can very quickly declare elements such as ``Points`` or ``Path`` containing datasets that may be as large as the full memory available on your machine (or even larger if using Dask dataframes). So even for very large datasets, you can easily  specify a data structure that you can work with for making selections, sampling, aggregations, and so on. However, as soon as you try to visualize it directly with either the Matplotlib, Plotly, or Bokeh plotting extensions, the rendering process may be prohibitively expensive.\n",
     "\n",
     "Let's start with a simple example that's easy to visualize in any plotting library:"
    ]
@@ -140,7 +136,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Decimating a plot in this way can be useful, but it discards most of the data, yet still suffers from overplotting. If you have Datashader installed, you can instead use Datashader operations like `rasterize()` to create a dynamic Datashader-based Bokeh plot. The middle plot above shows the result of using `rasterize()` to create a dynamic Datashader-based plot out of an Element with arbitrarily large data. In the rasterized version, the data is binned into a fixed-size 2D array automatically on every zoom or pan event, revealing all the data available at that zoom level and avoiding issues with overplotting by dynamically rescaling the colors used. Each pixel is colored by how many datapoints fall in that pixel, faithfully revealing the data's distribution in a easy-to-display plot. The same process is used for the line-based data in the Paths plot.\n",
+    "Decimating a plot in this way can be useful, but it discards most of the data, yet still suffers from overplotting. If you have Datashader installed, you can instead use Datashader operations like `rasterize()` to create a dynamic Datashader-based Bokeh plot. The middle plot above shows the result of using `rasterize()` to create a dynamic Datashader-based plot out of an Element with arbitrarily large data. In the rasterized version, the data is binned into a fixed-size 2D array automatically on every zoom or pan event, revealing all the data available at that zoom level and avoiding issues with overplotting by dynamically rescaling the colors used. Each pixel is colored by how many datapoints fall in that pixel, faithfully revealing the data's distribution in a easy-to-display plot. The same process is used for the line-based data in the Paths plot, where darker colors represent path intersections.\n",
     "\n",
     "These two Datashader-based plots are similar to the native Bokeh plots above, but instead of making a static Bokeh plot that embeds points or line segments directly into the browser, HoloViews sets up a Bokeh plot with dynamic callbacks instructing Datashader to rasterize the data into a fixed-size array (effectivey a 2D histogram) instead. The dynamic re-rendering provides an interactive user experience, even though the data itself is never provided directly to the browser. Of course, because the full data is not in the browser, a static export of this page (e.g. on holoviews.org or on anaconda.org) will only show the initially rendered version, and will not update with new rasterized arrays when zooming as it will when there is a live Python process available.\n",
     "\n",
@@ -151,7 +147,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# `rasterize()`, `shade()`, and `datashade()`\n",
+    "# HoloViews operations for datashading\n",
+    "\n",
+    "HoloViews provides several operations for calling Datashader on HoloViews elements, including `rasterize()`, `shade()`, and `datashade()`.\n",
     "\n",
     "`rasterize()` uses Datashader to render the data into what is by default a 2D histogram, where every array cell counts the data points falling into that pixel. Bokeh then colormaps that array, turning each cell into a pixel in an image. \n",
     "\n",
@@ -164,20 +162,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rasterize(points).opts(width=350, cmap=kbc_r, colorbar=True, tools=[\"hover\"]).hist() + \\\n",
-    "shade(rasterize(points), cmap=kbc_r, normalization=\"linear\") + \\\n",
-    "datashade(points, cmap=kbc_r, normalization=\"linear\")"
+    "ropts = dict(colorbar=True, tools=[\"hover\"], width=350)\n",
+    "\n",
+    "rasterize(      points).opts(cmap=\"kbc_r\", cnorm=\"linear\").relabel('rasterize()').opts(**ropts).hist() + \\\n",
+    "shade(rasterize(points),     cmap=\"kbc_r\", cnorm=\"linear\").relabel(\"shade(rasterize())\") + \\\n",
+    "datashade(      points,      cmap=\"kbc_r\", cnorm=\"linear\").relabel(\"datashade()\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In all three of the above plots, `rasterize()` is being called to aggregate the data (a large set of x,y locations) into a rectangular grid, with each grid cell counting up the number of points that fall into it.  In the plot on the left, only `rasterize()` is done, and the resulting numeric array of counts is passed to Bokeh for colormapping. That way hover and colorbars can be supported (as shown), and Bokeh can then provide dynamic (client-side, browser-based) colormapping tools in JavaScript, allowing users to have dynamic control over  even static HTML plots.  For instance, in this case, users can use the Box Select tool and select a range of the histogram shown, dynamically remapping the colors used in the plot to cover the selected range.\n",
+    "In all three of the above plots, `rasterize()` is being called to aggregate the data (a large set of x,y locations) into a rectangular grid, with each grid cell counting up the number of points that fall into it.  In the first plot, only `rasterize()` is done, and the resulting numeric array of counts is passed to Bokeh for colormapping. That way hover and colorbars can be supported (as shown), and Bokeh can then provide dynamic (client-side, browser-based) colormapping tools in JavaScript, allowing users to have dynamic control over even static HTML plots.  For instance, in this case, users can use the Box Select tool and select a range of the histogram shown, dynamically remapping the colors used in the plot to cover the selected range.\n",
     "\n",
-    "The other two plots should be identical in appearance, but with the numerical array output of `rasterize()` mapped into RGB colors by Datashader itself, in Python (\"server-side\"), which allows some special Datashader computations described below. Here we've instructed Datashader to use the same colormap used by bokeh, so that the plots look similar, but as you can see the `rasterize()` colormap is determined by a HoloViews plot option, while the `shade` and `datashade` colormap is determined by an argument to those operations. See ``hv.help(rasterize)``,  ``hv.help(shade)``, and ``hv.help(datashade)`` for options that can be selected, and the [Datashader web site](http://datashader.org) for all the details. HoloViews also provides lower-level `aggregate()` and `regrid()` operations that implement `rasterize()` and give more control over how the data is aggregated, but these are not needed for typical usage.\n",
+    "The other two plots should be identical in appearance, but with the numerical array output of `rasterize()` mapped into RGB colors by Datashader itself, in Python (\"server-side\"), which allows some special Datashader computations described below but prevents other Bokeh-based features like hover and colorbars from being used. Here we've instructed Datashader to use the same colormap used by bokeh, so that the plots look similar, but as you can see the `rasterize()` colormap is determined by a HoloViews plot option, while the `shade` and `datashade` colormap is determined by an argument to those operations. See ``hv.help(rasterize)``,  ``hv.help(shade)``, and ``hv.help(datashade)`` for options that can be selected, and the [Datashader web site](http://datashader.org) for all the details. HoloViews also provides lower-level `aggregate()` and `regrid()` operations that implement `rasterize()` and give more control over how the data is aggregated, but these are not needed for typical usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Colormapping\n",
     "\n",
-    "Since datashader only sends the data currently in view to the plotting backend, the default behavior is to rescale colormap to the range of the visible data as the zoom level changes. This behavior may not be desirable when working with images; to instead use a fixed colormap range, the `clim` parameter can be passed to the `bokeh` backend via the `opts()` method. Note that this approach works with `rasterize()` where the colormapping is done by the `bokeh` backend. With `datashade()`, the colormapping is done with the `shade()` function which takes a `clims` parameter directly instead of passing additional parameters to the backend via `opts()`."
+    "The above plots show a limited range of data, but when you use very large real-world datasets, there is often structure at many spatial scales, which requires special attention to colormapping options. This example dataset from the [Datashader documentation](https://datashader.org/getting_started/Pipeline.html) illustrates the issues, with data clustering at five different spatial scales:"
    ]
   },
   {
@@ -186,31 +193,87 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n = 10_000\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
     "\n",
-    "# Strong signal on top\n",
-    "rs = np.random.RandomState(101010)\n",
-    "x = rs.pareto(n, n)\n",
-    "y = x + rs.standard_normal(n)\n",
-    "img1, *_ = np.histogram2d(x, y, bins=60)\n",
+    "num=10000\n",
+    "np.random.seed(1)\n",
     "\n",
-    "# Weak signal in the middle\n",
-    "x2 = rs.standard_normal(n)\n",
-    "y2 = 5 * x + 10 * rs.standard_normal(n)\n",
-    "img2, *_ = np.histogram2d(x2, y2, bins=60)\n",
+    "dists = {cat: pd.DataFrame(dict([('x',np.random.normal(x,s,num)), \n",
+    "                                 ('y',np.random.normal(y,s,num)), \n",
+    "                                 ('val',val), \n",
+    "                                 ('cat',cat)]))      \n",
+    "         for x,  y,  s,  val, cat in \n",
+    "         [(  2,  2, 0.03, 10, \"d1\"), \n",
+    "          (  2, -2, 0.10, 20, \"d2\"), \n",
+    "          ( -2, -2, 0.50, 30, \"d3\"), \n",
+    "          ( -2,  2, 1.00, 40, \"d4\"), \n",
+    "          (  0,  0, 3.00, 50, \"d5\")] }\n",
     "\n",
-    "img = img1 + img2\n",
-    "hv_img = hv.Image(img).opts(active_tools=['wheel_zoom'])\n",
-    "auto_scale_grid = rasterize(hv_img).opts(title='Automatic color range rescaling')\n",
-    "fixed_scale_grid = rasterize(hv_img).opts(title='Fixed color range', clim=(img.min(), img.max()))\n",
-    "auto_scale_grid + fixed_scale_grid; # Output supressed and gif shown below instead"
+    "df = pd.concat(dists,ignore_index=True)\n",
+    "df[\"cat\"]=df[\"cat\"].astype(\"category\")\n",
+    "df"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"http://assets.holoviews.org/gifs/guides/user_guide/Large_Data/rasterize_color_range.gif\"></img>"
+    "Each of the five categories has 10000 points, but distributed over different spatial areas. Bokeh supports three colormap normalization options, which each behave differently:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ropts = dict(tools=[\"hover\"], height=380, width=330, colorbar=True, colorbar_position=\"bottom\")\n",
+    "\n",
+    "hv.Layout([rasterize(hv.Points(df)).opts(**ropts).opts(cnorm=n).relabel(n)\n",
+    "           for n in [\"linear\", \"log\", \"eq_hist\"]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, the `linear` map is easy to interpret, but nearly all of the pixels are drawn in the lightest blue, because the highest-count pixel (around a count of 6000) is much larger in value than the typical pixels. The other two plots show the full structure (five concentrations of data points, including one in the background), with `log` using a standard logarithmic transformation of the count data before colormapping, and `eq_hist` using a histogram-equalization technique (see the [Datashader docs](https://datashader.org/getting_started/Pipeline.html) to reveal structure without any assumptions about the incoming distribution (but with an irregularly spaced colormap that makes the numeric values difficult to reason about). In practice, it is generally a good idea to use `eq_hist` when exploring a large dataset initially, so that you will see any structure present, then switch to `log` or `linear` to share the plots with a simpler-to-explain colormap. All three of these options are supported by the various backends (including Bokeh version 2.2.3 or later)  and by `shade()` and `datashade()` except that `eq_hist` is not yet available for the Plotly backend."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since datashader only sends the data currently in view to the plotting backend, the default behavior is to rescale the colormap to the range of the visible data as the zoom level changes. This behavior may not be desirable when working with images; to instead use a fixed colormap range, the `clim` parameter can be passed to the `bokeh` backend via the `opts()` method. Note that this approach works with `rasterize()` where the colormapping is done by the `bokeh` backend. With `datashade()`, the colormapping is done with the `shade()` function which takes a `clims` parameter directly instead of passing additional parameters to the backend via `opts()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.Layout([rasterize(hv.Points(df)).opts(**ropts).opts(cnorm='linear').opts(**o)\n",
+    "           for o in [dict(cnorm='log'), \n",
+    "                     dict(cnorm='log', clim=(0, 10000))]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, pixels with a count of zero are transparent, letting the plot background show through so that the data can be used in overlays. If you want zero to map to the lowest colormap color instead to make a dense, fully filled-in image, you can pass `nodata=None`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.Layout([rasterize(hv.Points(df)).opts(**ropts).opts(nodata=n).relabel(\"nodata=\"+str(n))\n",
+    "           for n in [0, None]])"
    ]
   },
   {
@@ -219,16 +282,16 @@
    "source": [
     "## Spreading\n",
     "\n",
-    "The Datashader examples above treat points and lines as infinitesimal in width, such that a given point or small bit of line segment appears in at most one pixel. This approach ensures that the overall distribution of the points will be mathematically well founded -- each pixel will scale in value directly by the number of points that fall into it, or by the lines that cross it.\n",
+    "The Datashader examples above treat points and lines as infinitesimal in width, such that a given point or small bit of line segment appears in at most one pixel. This approach ensures that the overall distribution of the points will be mathematically well founded -- each pixel will scale in value directly by the number of points that fall into it, or by the lines that cross it. As a consequence, Datashader does not currently provide support for a marker size or a line width, which both effectively default to one pixel.\n",
     "\n",
-    "However, many monitors are sufficiently high resolution that the resulting point or line can be difficult to see---a single pixel may not actually be visible on its own, and its color may likely be very difficult to make out.  To compensate for this, HoloViews provides access to Datashader's raster-based \"spreading\", which makes isolated nonzero cells \"spread\" into adjacent ones for visibility.  There are two varieties of spreading supported:\n",
+    "However, many monitors are sufficiently high resolution that a single-pixel point or line can be difficult to see---one pixel may not be visible at all on its own, and even if it is visible it is often difficult to see its color. To compensate for this, HoloViews provides access to Datashader's raster-based \"spreading\", which makes isolated nonzero cells \"spread\" into adjacent ones for visibility.  There are two varieties of spreading supported:\n",
     "\n",
     "1. ``spread``: fixed spreading of a certain number of cells (pixels), which is useful if you want to be sure how much spreading is done regardless of the properties of the data.\n",
     "2. ``dynspread``: spreads up to a maximum size as long as it does not exceed a specified fraction of adjacency between cells (pixels).\n",
     "\n",
-    "Dynamic spreading is typically more useful for interactive plotting, because it adjusts depending on how close the datapoints are to each other on screen. As of Datashader 0.11.2, both types of spreading are supported for both `rasterize()` and `shade()`, but previous Datashader versions only support spreading on the RGB output of `shade()`.\n",
+    "Dynamic spreading is typically more useful for interactive plotting, because it adjusts depending on how close the datapoints are to each other on screen. As of Datashader 0.12, both types of spreading are supported for both `rasterize()` and `shade()`, but previous Datashader versions only support spreading on the RGB output of `shade()`.\n",
     "\n",
-    "You can compare the results in the two zoomed-in plots below, then zoom out to see that the plots are the same when points are clustered together to form a distribution:"
+    "As long as you have Datashader 0.12 or later, you can compare the results in the two zoomed-in plots below, then zoom out to see that the plots are the same when points are clustered together to form a distribution:"
    ]
   },
   {
@@ -392,9 +455,9 @@
     "outliers = rolling_outlier_std(curve, rolling_window=50, sigma=2)\n",
     "\n",
     "ds_curve = rasterize(curve).opts(cmap=[\"blue\"])\n",
-    "spread = dynspread(datashade(smoothed, cmap=[\"red\"], width=800),max_px=1) \n",
+    "curvespread = dynspread(datashade(smoothed, cmap=[\"red\"], width=800),max_px=1) \n",
     "\n",
-    "(ds_curve * spread * outliers).opts(\n",
+    "(ds_curve * curvespread * outliers).opts(\n",
     "    opts.Scatter(line_color=\"black\", fill_color=\"red\", size=10, tools=['hover', 'box_select'], width=800))"
    ]
   },
@@ -404,48 +467,7 @@
    "source": [
     "The result of all these operations can be laid out, overlaid, selected, and sampled just like any other HoloViews element, letting you work naturally with even very large datasets.\n",
     "\n",
-    "Note that the above plot will look blocky in a static export (such as on anaconda.org), because the exported version is generated without taking the size of the actual plot (using default height and width for Datashader) into account, whereas the live notebook automatically regenerates the plot to match the visible area on the page. \n",
-    "\n",
-    "# Hover info and colorbars\n",
-    "\n",
-    "Prior to HoloViews 1.14 there was a tradeoff between using `datashade` and `rasterize`:\n",
-    "\n",
-    "* `datashade` would apply histogram equalization by default and map missing values to zero alpha pixels (i.e. turn missing data transparent). The downside was that the RGB output could not support colorbars or Bokeh hover.\n",
-    "\n",
-    "* `rasterize` could support client-side color mapping including colorbars and hover information displaying the true aggregated values but could not support histogram equalization or easily map missing values to transparency.\n",
-    "\n",
-    "As of version HoloViews 1.14, for non-categorical data `rasterize` can be made strictly superior to `datashade` by setting `cnorm`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "palette = hv.plotting.util.process_cmap('viridis', 256)\n",
-    "\n",
-    "rasterized = rasterize(points).opts(\n",
-    "    cnorm='eq_hist', colorbar=True, tools=['hover'], frame_width=350, cmap=palette\n",
-    ")\n",
-    "datashaded = datashade(points, normalization='eq_hist', cmap=palette).opts(frame_width=350)\n",
-    "\n",
-    "datashaded.opts(title='datashade') + rasterized.opts(title='rasterized equivalent')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now the `rasterize` version is better than the `datashade` equivalent in nearly every respect:\n",
-    "\n",
-    "* The Bokeh hover tool and colorbars are now supported.\n",
-    "* The data in the `Image` elements returned by `rasterize` are now useful aggregates ('Counts' by default) instead of meaningless RGB values.\n",
-    "* Although slightly longer to specify, the `rasterize` options make the histogram equalization and transparent values explicit.\n",
-    "\n",
-    "The `nodata` and `cnorm` options works across all backends except for the Plotly backend, where `cnorm` is currently not supported. To use `cnorm='eq_hist'` as in the above example, you will need Bokeh version 2.2.3 or greater.\n",
-    "\n",
-    "If you can satisfy these version requirements, the `rasterize` operation is now encouraged over the `datashade` operation in all supported cases. Cases not yet supported include Datashader's rarely used `cbrt` (cube root) colormapping option, along with its [categorical color mixing](https://datashader.org/getting_started/Pipeline.html#Transformation) support (for which `shade()` or `datashade()` is still needed, and thus hover and colorbars will not be supported)."
+    "Note that the above plot will look blocky in a static export (such as on anaconda.org), because the exported version is generated without taking the size of the actual plot (using default height and width for Datashader) into account, whereas the live notebook automatically regenerates the plot to match the visible area on the page. "
    ]
   },
   {
@@ -489,11 +511,11 @@
     "\n",
     "- datashadable annotations: [`hv.Arrow`](../reference/elements/bokeh/Arrow.ipynb), [`hv.Bounds`](../reference/elements/bokeh/Bounds.ipynb), [`hv.Box`](../reference/elements/bokeh/Box.ipynb), [`hv.Ellipse`](../reference/elements/bokeh/Ellipse.ipynb) (actually do work with datashade currently, but not officially supported because they are not vectorized and thus unlikely to have enough items to be worth datashading)\n",
     "- other annotations: [`hv.Arrow`](../reference/elements/bokeh/Arrow.ipynb), [`hv.HLine`](../reference/elements/bokeh/HLine.ipynb), [`hv.VLine`](../reference/elements/bokeh/VLine.ipynb), [`hv.Text`](../reference/elements/bokeh/Text.ipynb)\n",
-    "- kdes: [`hv.Distribution`](../reference/elements/bokeh/Distribution.ipynb), [`hv.Bivariate`](../reference/elements/bokeh/Bivariate.ipynb)\n",
+    "- kdes: [`hv.Distribution`](../reference/elements/bokeh/Distribution.ipynb), [`hv.Bivariate`](../reference/elements/bokeh/Bivariate.ipynb) (already aggregated)\n",
     "- categorical/symbolic: [`hv.BoxWhisker`](../reference/elements/bokeh/BoxWhisker.ipynb), [`hv.Bars`](../reference/elements/bokeh/Bars.ipynb), [`hv.ErrorBars`](../reference/elements/bokeh/ErrorBars.ipynb)\n",
     "- tables: [`hv.Table`](../reference/elements/bokeh/Table.ipynb), [`hv.ItemTable`](../reference/elements/bokeh/ItemTable.ipynb)\n",
     "\n",
-    "Examples of each supported Element type:"
+    "Let's make some examples of each supported Element type. First, some dummy data:"
    ]
   },
   {
@@ -502,17 +524,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.output(backend='matplotlib')\n",
-    "\n",
     "from bokeh.sampledata.unemployment import data as unemployment\n",
     "from bokeh.sampledata.us_counties import data as counties\n",
-    "\n",
-    "opts.defaults(opts.Image(aspect=1, axiswise=True, xaxis='bare', yaxis='bare'),\n",
-    "              opts.RGB(aspect=1, axiswise=True, xaxis='bare', yaxis='bare'),\n",
-    "              opts.HSV(aspect=1, axiswise=True, xaxis='bare', yaxis='bare'),\n",
-    "              opts.Layout(vspace=0.1, hspace=0.1, sublabel_format='', fig_size=48))\n",
-    "\n",
-    "el_opts = dict(aspect=1, axiswise=True, xaxis='bare', yaxis='bare')\n",
     "\n",
     "np.random.seed(12)\n",
     "N=100\n",
@@ -534,52 +547,110 @@
     "Z = np.sqrt(X**2 + Y**2)\n",
     "\n",
     "rect_colors = {True: 'red', False: 'green'}\n",
-    "rect_opts = opts.Rectangles(lw=0, color=hv.dim('sign').categorize(rect_colors))\n",
     "s = np.random.randn(100).cumsum()\n",
-    "e = s + np.random.randn(100)\n",
-    "\n",
-    "opts2 = dict(filled=True, edge_color='z')\n",
-    "tri = hv.TriMesh.from_vertices(hv.Points(np.random.randn(N,3), vdims='z')).opts(**opts2)\n",
-    "(tri + tri.edgepaths + datashade(tri, aggregator=ds.mean('z')) + datashade(tri.edgepaths)).cols(2)\n",
-    "\n",
-    "shadeable  = [elemtype(pts) for elemtype in [hv.Curve, hv.Scatter]]\n",
-    "shadeable += [hv.Path(counties[(1, 1)], ['lons', 'lats']), hv.Points(counties[(1, 1)], ['lons', 'lats'])]\n",
-    "shadeable += [hv.Spikes(np.random.randn(10000))]\n",
-    "shadeable += [hv.Segments((np.arange(100), s, np.arange(100), e))]\n",
-    "shadeable += [hv.Rectangles((np.arange(100)-0.4, s, np.arange(100)+0.4, e, s>e), vdims='sign').opts(rect_opts)]\n",
-    "shadeable += [hv.Area(np.random.randn(10000).cumsum())]\n",
-    "shadeable += [hv.Spread((np.arange(10000), np.random.randn(10000).cumsum(), np.random.randn(10000)*10))]\n",
-    "shadeable += [hv.Image((x,y,z))]\n",
-    "shadeable += [hv.QuadMesh((Qx,Qy,Z))]\n",
-    "shadeable += [hv.Graph(((np.zeros(N), np.arange(N)),))]\n",
-    "shadeable += [tri.edgepaths]\n",
-    "shadeable += [tri]\n",
-    "shadeable += [hv.operation.contours(hv.Image((x,y,z)), levels=10)]\n",
-    "try:\n",
-    "    import spatialpandas # Needed for datashader polygon support\n",
-    "    shadeable += [hv.Polygons([dict(county, unemployment=unemployment[k]) for k, county in counties.items()\n",
-    "                               if county['state'] == 'tx'], ['lons', 'lats'], ['unemployment']).opts(color='unemployment')]\n",
-    "except: pass\n",
-    "\n",
-    "rasterizable = [hv.RGB(np.dstack([r,g,b])), hv.HSV(np.dstack([g,b,r]))]\n",
-    "\n",
-    "ds_opts = {\n",
-    "    hv.Path: dict(aggregator='any'),\n",
-    "    hv.Points: dict(aggregator='any'),\n",
-    "    hv.Segments: dict(aggregator='any'),\n",
-    "    hv.Rectangles: dict(aggregator=ds.count_cat('sign'), color_key=rect_colors)\n",
-    "}\n",
-    "\n",
-    "hv.Layout([dynspread(datashade(e.relabel(e.__class__.name), **ds_opts.get(e.__class__, {}))).opts(**el_opts) for e in shadeable] + \n",
-    "          [          rasterize(e.relabel(e.__class__.name)).opts(**el_opts)  for e in rasterizable]).opts(shared_axes=False).cols(6)"
+    "e = s + np.random.randn(100)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we called `datashade()` on each Element type, letting Datashader do the full process of rasterization and shading, except that for `RGB` and `HSV` we only called `rasterize()` or else the results would have been converted into a monochrome image.\n",
+    "Next, some options:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.output(backend='matplotlib')\n",
     "\n",
+    "opts.defaults(opts.Layout(vspace=0.1, hspace=0.1, sublabel_format='', fig_size=48))\n",
+    "eopts = dict(aspect=1, axiswise=True, xaxis='bare', yaxis='bare', xticks=False, yticks=False)\n",
+    "opts2 = dict(filled=True, edge_color='z')\n",
+    "rect_opts = opts.Rectangles(lw=0, color=hv.dim('sign').categorize(rect_colors))\n",
+    "\n",
+    "ds_opts = {\n",
+    "    hv.Path:       dict(aggregator='any'),\n",
+    "    hv.Scatter:    dict(aggregator='any'),\n",
+    "    hv.Points:     dict(aggregator='any'),\n",
+    "    hv.Segments:   dict(aggregator='any'),\n",
+    "    hv.Rectangles: dict(aggregator=ds.count_cat('sign'), color_key=rect_colors)\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, some Elements that support datashading, in categories depending on whether they work best with `spread(rasterize())`, with plain `rasterize()`, or require `datashade()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spreadable  = [e(pts) for e in [hv.Curve, hv.Scatter]]\n",
+    "spreadable += [e(counties[(1, 1)], ['lons', 'lats']) for e in [hv.Path, hv.Points]]\n",
+    "spreadable += [hv.Segments((np.arange(100), s, np.arange(100), e))]\n",
+    "spreadable += [hv.Graph(((np.zeros(N), np.arange(N)),))]\n",
+    "spreadable += [hv.operation.contours(hv.Image((x,y,z)), levels=10)]\n",
+    "\n",
+    "tri = hv.TriMesh.from_vertices(hv.Points(np.random.randn(N,3), vdims='z')).opts(**opts2)\n",
+    "spreadable   += [tri.edgepaths]\n",
+    "\n",
+    "rasterizable  = [tri]\n",
+    "rasterizable += [hv.Area(np.random.randn(10000).cumsum())]\n",
+    "rasterizable += [hv.Spread((np.arange(10000), np.random.randn(10000).cumsum(), np.random.randn(10000)*10))]\n",
+    "rasterizable += [hv.Spikes(np.random.randn(1000))]\n",
+    "rasterizable += [hv.QuadMesh((Qx,Qy,Z))]\n",
+    "\n",
+    "polys = hv.Polygons([dict(county, unemployment=unemployment[k]) \n",
+    "                     for k, county in counties.items()\n",
+    "                     if county['state'] == 'tx'], \n",
+    "                    ['lons', 'lats'], ['unemployment']).opts(color='unemployment')\n",
+    "try:\n",
+    "    import spatialpandas # Needed for datashader polygon support\n",
+    "    rasterizable += [polys]\n",
+    "except: pass\n",
+    "\n",
+    "rasterizable += [hv.Image((x,y,z))]\n",
+    "rasterizable += [hv.RGB(np.dstack([r,g,b])), hv.HSV(np.dstack([g,b,r]))]\n",
+    "\n",
+    "shadeable  = [hv.Rectangles((np.arange(100)-0.4, s, np.arange(100)+0.4, e, s>e), vdims='sign').opts(rect_opts)]\n",
+    "\n",
+    "def nop(x,**k):      return x\n",
+    "def spread4(e, **k): return spread(rasterize(e, **k), px=4).opts(cnorm='eq_hist') \n",
+    "def plot(e, operation=nop):\n",
+    "    return operation(e.relabel(e.__class__.name), **ds_opts.get(e.__class__, {})).opts(**eopts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now view these with Datashader via `spread(rasterize())`, `rasterize()`, or `datashade`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.Layout(\n",
+    "    [plot(e, spread4)   for e in spreadable] + \\\n",
+    "    [plot(e, rasterize) for e in rasterizable] + \\\n",
+    "    [plot(e, datashade) for e in shadeable]).cols(6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For comparison, you can see the corresponding non-datashaded plots (as long as you leave N lower than 10000 unless you have a long time to wait!):"
    ]
   },
@@ -589,42 +660,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.Layout([e.relabel(e.__class__.name).opts(**el_opts) for e in shadeable + rasterizable]).cols(6)"
+    "hv.Layout([plot(e) for e in spreadable + rasterizable + shadeable]).cols(6)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These two examples use Matplotlib, but if they were switched to Bokeh and you had a live server, they would support dynamic re-rendering on zoom and pan so that you could explore the full range of data available (e.g. even very large raster images, networks, paths, point clouds, or meshes).\n",
-    "\n",
-    "\n",
-    "# Container types supported for datashading\n",
-    "\n",
-    "In the above examples `datashade()` was called directly on each Element, but it can also be called on Containers, in which case each Element in the Container will be datashaded separately (for all Container types other than a Layout):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hv.output(dpi=80, size=100)\n",
-    "\n",
-    "curves = {'+':hv.Curve(pts), '-':hv.Curve([(x, -1.0*y) for x, y in pts])}\n",
-    "\n",
-    "supported = [hv.HoloMap(curves,'sign'), hv.Overlay(list(curves.values())), hv.NdOverlay(curves), hv.GridSpace(hv.NdOverlay(curves))]\n",
-    "hv.Layout([rasterize(e.relabel(e.__class__.name)) for e in supported]).cols(4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dynspread(rasterize(hv.NdLayout(curves,'sign')))"
+    "The previous two sets of examples use Matplotlib, but if they were switched to Bokeh and you had a live server, they would support dynamic re-rendering on zoom and pan so that you could explore the full range of data available (e.g. even very large raster images, networks, paths, point clouds, or meshes)."
    ]
   },
   {
@@ -634,6 +677,44 @@
    "outputs": [],
    "source": [
     "hv.output(backend='bokeh') # restore bokeh backend in case cells will run out of order"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Container types supported for datashading\n",
+    "\n",
+    "In the above examples `datashade()` or `rasterize` was called directly on each Element, but these operations can also be called on Containers, in which case each Element in the Container will be datashaded separately (for all Container types other than a Layout):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "curves = {'+':hv.Curve(pts), '-':hv.Curve([(x, -1.0*y) for x, y in pts])}\n",
+    "spread(rasterize(hv.HoloMap(curves,'sign')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "containers = [hv.Overlay(list(curves.values())), hv.NdOverlay(curves), hv.GridSpace(hv.NdOverlay(curves))]\n",
+    "hv.Layout([rasterize(e.relabel(e.__class__.name)) for e in containers]).cols(4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spread(rasterize(hv.NdLayout(curves,'sign')))"
    ]
   },
   {

--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -308,6 +308,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<img src=\"http://assets.holoviews.org/gifs/guides/user_guide/Large_Data/dynspread.gif\"></img>\n",
+    "\n",
+    "\n",
     "Both plots show the same data, and look identical when zoomed out, but when zoomed in enough you should be able to see the individual data points on the right while the ones on the left are barely visible.  The dynspread parameters typically need some hand tuning, as the only purpose of such spreading is to make things visible on a particular monitor for a particular observer; the underlying mathematical operations in Datashader do not normally need parameters to be adjusted.\n",
     "\n",
     "The same operation works similarly for line segments:"


### PR DESCRIPTION
As mentioned in https://github.com/holoviz/holoviews/pull/4567, the Large Data notebook still needed a bit of work. I've done that in this PR, but there are a few problems:

- [x] 1. For `decimate(points) + rasterize(points) + rasterize(paths)`, even if I leave off `+ rasterize(paths)`, the colormapping behavior of `rasterize(points)` differs when `decimate(points)` is included. Without `decimate(points)`, the behavior looks reasonable, with colors rescaling to cover the full colormap at each zoom level. With `decimate(points)` in the layout, zooming makes the rasterized data get very light. Why should `decimate` affect a rasterized plot in any way?
- [x] 2. The example in Colormapping using `clim` does not currently show what it purports to show; both plots shown behave the same on zoom and pan; the one with clim defined doesn't do anything different. This is a new example, but I couldn't get the previous Image-based example to work with rasterize() either, even when I forced the z axis to have a different Dimension name, so I don't think it's specific to this example. I don't actually know how to change the x_y Count dimension names, but I assume that won't help since it didn't in the original example. It could still be me doing something wrong, though. In the old example, the colormap rescaled properly on each individual plot, just not when in a layout. On this version, the colormap seems fixed regardless of viewport, which is confusing me. Once it works, it would presumably need a GIF to illustrate it.
- [x] 3. The `xlim=(0.1,0.2), ylim=(0.1,0.2)))` example also presumably needs a gif, as the static website export will otherwise be broken.
- [x] 4. The nodata=None illustration is not working; both plots are identical. Again, am I doing something wrong?
- [x] 5. I haven't tested Large_Data with released versions of Bokeh; does it work reasonably when the new colorbar ticking is not available?
- [x] 6. Is it really `clim` on Bokeh and `clims` on the mpl backend and on shade()? Damn.
- [x] 7. The padding settings don't look right, in the comparison between datashaded and native (mpl) hv plots. Shouldn't there be padding for datashaded non-gridded types, just as for the corresponding non-datashaded non-gridded types (Path, Points, etc.)? 
- [x] 8. And shouldn't padding be 0 for non-datashaded Contour plots? The gap looks bad in regular hv plots; the datashaded ones look much better. In any case, can we make the padding behave the same whether or not we use rasterize?

![image](https://user-images.githubusercontent.com/1695496/100838857-d584df80-3438-11eb-8fad-ba3d39699ff9.png)
![image](https://user-images.githubusercontent.com/1695496/100838877-df0e4780-3438-11eb-81d9-eb91e30b5848.png)
