### PR TITLE
Fix range calculation in framewise/axiswise configuration

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1447,10 +1447,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         Resets RangeXY streams if norm option is set to framewise
         """
-        if self.overlaid:
+        # Temporarily reverts this fix (see https://github.com/holoviz/holoviews/issues/4396)
+        # This fix caused PlotSize change events to rerender
+        # rasterized/datashaded with the full extents which was wrong
+        if self.overlaid or True:
             return
         for el, callbacks in self.traverse(lambda x: (x.current_frame, x.callbacks)):
-            if el is None:
+            if el is None:W
                 continue
             for callback in callbacks:
                 norm = self.lookup_options(el, 'norm').options
@@ -1466,6 +1469,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         self._reset_ranges()
         reused = isinstance(self.hmap, DynamicMap) and (self.overlaid or self.batched)
+        self.prev_frame =  self.current_frame
         if not reused and element is None:
             element = self._get_frame(key)
         elif element is not None:
@@ -2367,6 +2371,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
         """
         self._reset_ranges()
         reused = isinstance(self.hmap, DynamicMap) and self.overlaid
+        self.prev_frame =  self.current_frame
         if not reused and element is None:
             element = self._get_frame(key)
         elif element is not None:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1453,7 +1453,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if self.overlaid or True:
             return
         for el, callbacks in self.traverse(lambda x: (x.current_frame, x.callbacks)):
-            if el is None:W
+            if el is None:
                 continue
             for callback in callbacks:
                 norm = self.lookup_options(el, 'norm').options

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1447,7 +1447,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         Resets RangeXY streams if norm option is set to framewise
         """
-        # Temporarily reverts this fix (see https://github.com/holoviz/holoviews/issues/4396)
+        # Skipping conditional to temporarily revert fix (see https://github.com/holoviz/holoviews/issues/4396)
         # This fix caused PlotSize change events to rerender
         # rasterized/datashaded with the full extents which was wrong
         if self.overlaid or True:

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -453,6 +453,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         using the last available frame.
         """
         reused = isinstance(self.hmap, DynamicMap) and self.overlaid
+        self.prev_frame =  self.current_frame
         if not reused and element is None:
             element = self._get_frame(key)
         elif element is not None:
@@ -1127,6 +1128,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
     def update_frame(self, key, ranges=None, element=None):
         axis = self.handles['axis']
         reused = isinstance(self.hmap, DynamicMap) and self.overlaid
+        self.prev_frame =  self.current_frame
         if element is None and not reused:
             element = self._get_frame(key)
         elif element is not None:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -635,7 +635,7 @@ class DimensionedPlot(Plot):
             if (not (axiswise and not isinstance(obj, HoloMap)) or
                 (not framewise and isinstance(obj, HoloMap))):
                 self._compute_group_range(group, elements, ranges, framewise,
-                                          robust, self.top_level)
+                                          axiswise, robust, self.top_level)
         self.ranges.update(ranges)
         return ranges
 
@@ -689,7 +689,7 @@ class DimensionedPlot(Plot):
 
 
     @classmethod
-    def _compute_group_range(cls, group, elements, ranges, framewise, robust, top_level):
+    def _compute_group_range(cls, group, elements, ranges, framewise, axiswise, robust, top_level):
         # Iterate over all elements in a normalization group
         # and accumulate their ranges into the supplied dictionary.
         elements = [el for el in elements if el is not None]
@@ -849,7 +849,7 @@ class DimensionedPlot(Plot):
                         pass
                 dranges['factors'] = util.unique_array(expanded)
             dim_ranges.append((gdim, dranges))
-        if prev_ranges and not (framewise and top_level):
+        if prev_ranges and not (framewise and (top_level or axiswise)):
             for d, dranges in dim_ranges:
                 for g, drange in dranges.items():
                     prange = prev_ranges.get(d, {}).get(g, None)

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -134,8 +134,11 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
 
 
     def generate_plot(self, key, ranges, element=None, is_geo=False):
+        self.prev_frame =  self.current_frame
         if element is None:
             element = self._get_frame(key)
+        else:
+            self.current_frame = element
 
         if is_geo and not self._supports_geo:
             raise ValueError(
@@ -723,8 +726,8 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
         return figure
 
     def update_frame(self, key, ranges=None, element=None, is_geo=False):
-
         reused = isinstance(self.hmap, DynamicMap) and self.overlaid
+        self.prev_frame =  self.current_frame
         if not reused and element is None:
             element = self._get_frame(key)
         elif element is not None:

--- a/holoviews/tests/plotting/bokeh/testcallbacks.py
+++ b/holoviews/tests/plotting/bokeh/testcallbacks.py
@@ -1,5 +1,7 @@
 import datetime as dt
+
 from collections import deque, namedtuple
+from unittest import SkipTest
 
 import numpy as np
 
@@ -475,6 +477,7 @@ class TestServerCallbacks(CallbackTestCase):
         self.assertEqual(stream.y_range, (0.2, 0.8))
 
     def test_rangexy_framewise_reset(self):
+        raise SkipTest('The fix for this was reverted, see #4396')
         stream = RangeXY(x_range=(0, 2), y_range=(0, 1))
         curve = DynamicMap(lambda z, x_range, y_range: Curve([1, 2, z]),
                            kdims=['z'], streams=[stream]).redim.range(z=(0, 3))

--- a/holoviews/tests/plotting/bokeh/testlayoutplot.py
+++ b/holoviews/tests/plotting/bokeh/testlayoutplot.py
@@ -56,7 +56,8 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
         img2 = Image(np.mgrid[0:5, 0:5][0], vdims='z').apply.transform(
             z=transform).opts(framewise=True, axiswise=True)
         plot = bokeh_renderer.get_plot(img1+img2)
-        img1_plot, img2_plot = (sp.subplots['main'] for sp in plot.subplots.values())
+        img1_plot = plot.subplots[(0, 0)].subplots['main']
+        img2_plot = plot.subplots[(0, 1)].subplots['main']
         img1_cmapper = img1_plot.handles['color_mapper']
         img2_cmapper = img2_plot.handles['color_mapper']
         self.assertEqual(img1_cmapper.low, 0)
@@ -77,7 +78,8 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
         img2 = Image(np.mgrid[0:5, 0:5][0], vdims='z2').apply.transform(
             z2=transform).opts(framewise=True)
         plot = bokeh_renderer.get_plot(img1+img2)
-        img1_plot, img2_plot = (sp.subplots['main'] for sp in plot.subplots.values())
+        img1_plot = plot.subplots[(0, 0)].subplots['main']
+        img2_plot = plot.subplots[(0, 1)].subplots['main']
         img1_cmapper = img1_plot.handles['color_mapper']
         img2_cmapper = img2_plot.handles['color_mapper']
         self.assertEqual(img1_cmapper.low, 0)

--- a/holoviews/tests/plotting/bokeh/testlayoutplot.py
+++ b/holoviews/tests/plotting/bokeh/testlayoutplot.py
@@ -54,7 +54,7 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
         stream = Stream.define('zscale', value=1)()
         transform = dim('z')*stream.param.value
         img2 = Image(np.mgrid[0:5, 0:5][0], vdims='z').apply.transform(
-            z=dim('z')*stream.param.value).opts(framewise=True, axiswise=True)
+            z=transform).opts(framewise=True, axiswise=True)
         plot = bokeh_renderer.get_plot(img1+img2)
         img1_plot, img2_plot = (sp.subplots['main'] for sp in plot.subplots.values())
         img1_cmapper = img1_plot.handles['color_mapper']
@@ -75,7 +75,7 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
         stream = Stream.define('zscale', value=1)()
         transform = dim('z2')*stream.param.value
         img2 = Image(np.mgrid[0:5, 0:5][0], vdims='z2').apply.transform(
-            z2=dim('z2')*stream.param.value).opts(framewise=True)
+            z2=transform).opts(framewise=True)
         plot = bokeh_renderer.get_plot(img1+img2)
         img1_plot, img2_plot = (sp.subplots['main'] for sp in plot.subplots.values())
         img1_cmapper = img1_plot.handles['color_mapper']

--- a/holoviews/tests/plotting/bokeh/testlayoutplot.py
+++ b/holoviews/tests/plotting/bokeh/testlayoutplot.py
@@ -8,6 +8,7 @@ from holoviews.core import (HoloMap, GridSpace, Layout, Empty, Dataset,
 from holoviews.element import Curve, Image, Points, Histogram, Scatter
 from holoviews.streams import Stream
 from holoviews.util import render, opts
+from holoviews.util.transform import dim
 
 try:
     from bokeh.layouts import Column, Row
@@ -47,6 +48,48 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(img2_cmapper.low, 0)
         self.assertEqual(img1_cmapper.high, 40)
         self.assertEqual(img2_cmapper.high, 40)
+
+    def test_layout_framewise_matching_norm_update(self):
+        img1 = Image(np.mgrid[0:5, 0:5][0], vdims='z').opts(framewise=True, axiswise=True)
+        stream = Stream.define('zscale', value=1)()
+        transform = dim('z')*stream.param.value
+        img2 = Image(np.mgrid[0:5, 0:5][0], vdims='z').apply.transform(
+            z=dim('z')*stream.param.value).opts(framewise=True, axiswise=True)
+        plot = bokeh_renderer.get_plot(img1+img2)
+        img1_plot, img2_plot = (sp.subplots['main'] for sp in plot.subplots.values())
+        img1_cmapper = img1_plot.handles['color_mapper']
+        img2_cmapper = img2_plot.handles['color_mapper']
+        self.assertEqual(img1_cmapper.low, 0)
+        self.assertEqual(img2_cmapper.low, 0)
+        self.assertEqual(img1_cmapper.high, 4)
+        self.assertEqual(img2_cmapper.high, 4)
+        stream.update(value=10)
+        self.assertEqual(img1_cmapper.high, 4)
+        self.assertEqual(img2_cmapper.high, 40)
+        stream.update(value=2)
+        self.assertEqual(img1_cmapper.high, 4)
+        self.assertEqual(img2_cmapper.high, 8)
+
+    def test_layout_framewise_nonmatching_norm_update(self):
+        img1 = Image(np.mgrid[0:5, 0:5][0], vdims='z').opts(framewise=True)
+        stream = Stream.define('zscale', value=1)()
+        transform = dim('z2')*stream.param.value
+        img2 = Image(np.mgrid[0:5, 0:5][0], vdims='z2').apply.transform(
+            z2=dim('z2')*stream.param.value).opts(framewise=True)
+        plot = bokeh_renderer.get_plot(img1+img2)
+        img1_plot, img2_plot = (sp.subplots['main'] for sp in plot.subplots.values())
+        img1_cmapper = img1_plot.handles['color_mapper']
+        img2_cmapper = img2_plot.handles['color_mapper']
+        self.assertEqual(img1_cmapper.low, 0)
+        self.assertEqual(img2_cmapper.low, 0)
+        self.assertEqual(img1_cmapper.high, 4)
+        self.assertEqual(img2_cmapper.high, 4)
+        stream.update(value=10)
+        self.assertEqual(img1_cmapper.high, 4)
+        self.assertEqual(img2_cmapper.high, 40)
+        stream.update(value=2)
+        self.assertEqual(img1_cmapper.high, 4)
+        self.assertEqual(img2_cmapper.high, 8)
 
     def test_layout_title(self):
         hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})


### PR DESCRIPTION
This fixes a bug related to range calculations but only partially. The problematic situation is that when a stream triggers an update we only recompute the particular subplot(s) that are driven by that stream. This messes with range calculations because those work across plots and we have no way to update the overall range without triggering the range calculation at the top level plot. 

This PR fixes the situation where both axiswise and framewise are set because in that situation we do not have to recompute across all plots. However `framewise=True, axiswise=False` is still a problem and the only idea I have to address the problem is for top level plots to pass all the individual ranges from each element down to each subplot so that they can recompute the overall ranges by simply updating the ranges of the elements that are being updated. That is definitely more effort though.