### PR TITLE
Fix for inplace dtype multiplication issue

### DIFF
--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -468,7 +468,7 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
         """
         edges, hvals, widths, lims, isdatetime = super(SideHistogramPlot, self)._process_hist(hist)
         offset = self.offset * lims[3]
-        hvals *= 1-self.offset
+        hvals = hvals * (1-self.offset)
         hvals += offset
         lims = lims[0:3] + (lims[3] + offset,)
         return edges, hvals, widths, lims, isdatetime


### PR DESCRIPTION
Simple fix to address inplace int/float multiplication issue in `SideHistogram`.