### PR TITLE
Normalizing PIL integer data to unit range

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -635,6 +635,7 @@ class RGB(Image):
 
         with open(filename, 'rb') as f:
             data = np.array(Image.open(f))
+            data = data / 255.
 
         if array:
             return data


### PR DESCRIPTION
This is needed for compatibility with the old matplotlib approach.