### PR TITLE
Fix for AttributeError in _compute_group_range for linked plots

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -870,13 +870,15 @@ class DimensionedPlot(Plot):
             prev_ids = prev_frame.traverse(lambda o: id(o))
             for d, dranges in dim_ranges:
                 values = prev_ranges.get(d, {}).get('values', None)
-                ids = values.get('id')
-                if values is None:
+
+                if values is None or 'id' not in values:
                     for g, drange in dranges.items():
                         if d not in prev_ranges:
                             prev_ranges[d] = {}
                         prev_ranges[d][g] = drange
                     continue
+
+                ids = values.get('id')
 
                 # Filter out ranges of updated elements and append new ranges
                 merged = {}


### PR DESCRIPTION
After an update, previously working code produced `AttributeError: 'tuple' object has no attribute 'get'` exceptions.

Code to reproduce:
```python
import numpy as np
import holoviews as hv
from holoviews.selection import link_selections
import panel as pn

hv.extension('bokeh')

data = np.random.random((1000, 100))
scatter = hv.Scatter(data)
link = link_selections.instance()
example = link(scatter + scatter)

pn.serve(example)
``` 

In the plot, select a region in one of the linked plots, then the following exception will occur. It will also directly occur, if the plots are datashaded:
``` 
Traceback (most recent call last):
  File "site-packages/tornado/ioloop.py", line 741, in _run_callback
    ret = callback()
  File "site-packages/tornado/ioloop.py", line 765, in _discard_future_result
    future.result()
  File "site-packages/bokeh/server/session.py", line 71, in _needs_document_lock_wrapper
    result = await result
  File "site-packages/tornado/gen.py", line 216, in wrapper
    result = ctx_run(func, *args, **kwargs)
  File "holoviews/holoviews/plotting/bokeh/callbacks.py", line 466, in process_on_event
    self.on_msg(msg)
  File "holoviews/holoviews/plotting/bokeh/callbacks.py", line 163, in on_msg
    raise e
  File "holoviews/holoviews/plotting/bokeh/callbacks.py", line 155, in on_msg
    Stream.trigger(streams)
  File "holoviews/holoviews/streams.py", line 171, in trigger
    subscriber(**dict(union))
  File "holoviews/holoviews/streams.py", line 834, in perform_update
    self.event()
  File "holoviews/holoviews/streams.py", line 415, in event
    self.trigger([self])
  File "holoviews/holoviews/streams.py", line 171, in trigger
    subscriber(**dict(union))
  File "holoviews/holoviews/streams.py", line 919, in perform_update
    self.event()
  File "holoviews/holoviews/streams.py", line 415, in event
    self.trigger([self])
  File "holoviews/holoviews/streams.py", line 171, in trigger
    subscriber(**dict(union))
  File "holoviews/holoviews/streams.py", line 834, in perform_update
    self.event()
  File "holoviews/holoviews/streams.py", line 415, in event
    self.trigger([self])
  File "holoviews/holoviews/streams.py", line 171, in trigger
    subscriber(**dict(union))
  File "holoviews/holoviews/plotting/plot.py", line 244, in refresh
    raise e
  File "holoviews/holoviews/plotting/plot.py", line 240, in refresh
    self._trigger_refresh(stream_key)
  File "holoviews/holoviews/plotting/plot.py", line 257, in _trigger_refresh
    self.update(key)
  File "holoviews/holoviews/plotting/plot.py", line 981, in update
    item = self.__getitem__(key)
  File "holoviews/holoviews/plotting/plot.py", line 446, in __getitem__
    self.update_frame(frame)
  File "holoviews/holoviews/plotting/bokeh/element.py", line 2388, in update_frame
    ranges = self.compute_ranges(range_obj, key, ranges)
  File "holoviews/holoviews/plotting/plot.py", line 638, in compute_ranges
    self._compute_group_range(group, elements, ranges, framewise,
  File "holoviews/holoviews/plotting/plot.py", line 873, in _compute_group_range
    ids = values.get('id')
AttributeError: 'tuple' object has no attribute 'get'
``` 

Even without working myself thru the whole code, the offending line looks slightly misplaced:
https://github.com/holoviz/holoviews/blob/39738bc078959c6fc58f940ae0f905ae962a568d/holoviews/plotting/plot.py#L873
Accessing `values` here looks misplaced, which might be `None`, and an `if`-statement taking care of the case that `values` is `None` (which can currently not reached since the access to `.get(...)` would error in case `values` being `None`.

By moving the access past the check, and letting the `if` handle the `tuple` case as well, the problem seems solved and the plots are apparently working as desired, however probably someone with more in-depth knowledge of the `DimensionedPlot._compute_group_range`-function should check if this properly solves the handling.
