### PR TITLE
Fixed overspecified version statement with regard to Python 2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ addition, thanks to the maintainers @jbednar, @jlstevens and
 @philippjfr for contributing to this release. This version includes a
 large number of new features, enhancements, and bug fixes.
 
-It is important to note that version 1.14.0 will be the last HoloViews
+It is important to note that version 1.14 will be the last HoloViews
 release supporting Python 2.
 
 Major features:

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -23,7 +23,7 @@ thanks to the maintainers @jbednar, @jlstevens and @philippjfr for
 contributing to this release. This version includes a large number of
 new features, enhancements, and bug fixes.
 
-It is important to note that version 1.14.0 will be the last HoloViews
+It is important to note that version 1.14 will be the last HoloViews
 release supporting Python 2.
 
 Major features:


### PR DESCRIPTION
Minor but potentially important fix to the docs.

Reflects a direct fix I made the the HTML file on S3 (https://s3-eu-west-1.amazonaws.com/holoviews.org/releases.html)