### PR TITLE
add missing '.html' in doc/reference_manual/index.rst

### DIFF
--- a/doc/reference_manual/index.rst
+++ b/doc/reference_manual/index.rst
@@ -87,4 +87,4 @@ HoloViews subpackages
 .. _plotting.plotly: holoviews.plotting.plotly.html
 .. _selection: holoviews.selection.html
 .. _streams: holoviews.streams.html
-.. _util: holoviews.util
+.. _util: holoviews.util.html


### PR DESCRIPTION
Small fix for https://github.com/holoviz/holoviews/issues/4746