### PR TITLE
Fixes for coloring on adjoined Histograms

### DIFF
--- a/examples/reference/elements/bokeh/Scatter.ipynb
+++ b/examples/reference/elements/bokeh/Scatter.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "scatter = hv.Scatter(data, vdims=['y', 'z', 'size'])\n",
     "scatter = scatter.opts(color='z', size=dim('size')*20)\n",
-    "scatter + scatter[0.3:0.7, 0.3:0.7].hist('z')"
+    "scatter + scatter[0.3:0.7, 0.3:0.7].hist()"
    ]
   },
   {

--- a/examples/reference/elements/matplotlib/Scatter.ipynb
+++ b/examples/reference/elements/matplotlib/Scatter.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "scatter = hv.Scatter(data, vdims=['y', 'z', 'size'])\n",
     "scatter = scatter.opts(color='z', s=dim('size')*100)\n",
-    "scatter + scatter[0.3:0.7, 0.3:0.7].hist('z')"
+    "scatter + scatter[0.3:0.7, 0.3:0.7].hist()"
    ]
   },
   {

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -483,15 +483,20 @@ class SideHistogramPlot(HistogramPlot):
                       if d is not None]
         dimension = color_dims[0] if color_dims else None
         cmapper = self._get_colormapper(dimension, element, {}, {})
-        if cmapper and dimension in element.dimensions():
+        if cmapper:
+            cvals = None
             if isinstance(dimension, dim):
-                dim_name = dimension.dimension.name
-                data[dim_name] = [] if self.static_source else dimension.apply(element)
+                if dimension.applies(element):
+                    dim_name = dimension.dimension.name
+                    cvals = [] if self.static_source else dimension.apply(element)
             else:
-                dim_name = dimension.name
-                data[dim_name] = [] if self.static_source else element.dimension_values(dimension)
-            mapping['fill_color'] = {'field': dim_name,
-                                     'transform': cmapper}
+                if dimension in element.dimensions():
+                    dim_name = dimension.name
+                    cvals = [] if self.static_source else element.dimension_values(dimension)
+            if cvals is not None:
+                data[dim_name] = cvals
+                mapping['fill_color'] = {'field': dim_name,
+                                         'transform': cmapper}
         return (data, mapping, style)
 
 

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -508,7 +508,7 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
             cdim = None
 
         # Get colormapping options
-        if isinstance(range_item, (HeatMap, Raster)) or cdim and cdim in element:
+        if isinstance(range_item, (HeatMap, Raster)) or (cdim and cdim in element):
             style = self.lookup_options(range_item, 'style')[self.cyclic_index]
             cmap = cm.get_cmap(style.get('cmap'))
             main_range = style.get('clims', main_range)

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -508,7 +508,7 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
             cdim = None
 
         # Get colormapping options
-        if isinstance(range_item, (HeatMap, Raster)) or cdim:
+        if isinstance(range_item, (HeatMap, Raster)) or cdim and cdim in element:
             style = self.lookup_options(range_item, 'style')[self.cyclic_index]
             cmap = cm.get_cmap(style.get('cmap'))
             main_range = style.get('clims', main_range)


### PR DESCRIPTION
Both bokeh and matplotlib did not handle the condition where an adjoined histogram was added to a colormapped plot but the dimension of the histogram does not match the color dimension.