### PR TITLE
docs: fix simple typo, inupt -> input

### DIFF
--- a/holoviews/plotting/plotly/util.py
+++ b/holoviews/plotting/plotly/util.py
@@ -896,7 +896,7 @@ def configure_matching_axes_from_dims(fig, matching_prop='_dim'):
 def clean_internal_figure_properties(fig):
     """
     Remove all HoloViews internal properties (those with leading underscores) from the
-    inupt figure.
+    input figure.
 
     Note: This function mutates the input figure
 


### PR DESCRIPTION
There is a small typo in holoviews/plotting/plotly/util.py.

Should read `input` rather than `inupt`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md