### PR TITLE
Fixes for index based linked selections

### DIFF
--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -26,15 +26,18 @@ class SelectionIndexExpr(object):
 
     def _get_index_selection(self, index, index_cols):
         self._index_skip = True
+        if not index:
+            return None, None, None
+        ds = self.clone(kdims=index_cols)
         if len(index_cols) == 1:
             index_dim = index_cols[0]
-            vals = dim(index_dim).apply(self.iloc[index], expanded=False)
+            vals = dim(index_dim).apply(ds.iloc[index], expanded=False)
             expr = dim(index_dim).isin(list(util.unique_iterator(vals)))
         else:
             get_shape = dim(self.dataset.get_dimension(index_cols[0]), np.shape)
             index_cols = [dim(self.dataset.get_dimension(c), np.ravel) for c in index_cols]
             vals = dim(index_cols[0], util.unique_zip, *index_cols[1:]).apply(
-                self.iloc[index], expanded=True, flat=True
+                ds.iloc[index], expanded=True, flat=True
             )
             contains = dim(index_cols[0], util.lzip, *index_cols[1:]).isin(vals, object=True)
             expr = dim(contains, np.reshape, get_shape)

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -32,6 +32,8 @@ class SelectionIndexExpr(object):
         if len(index_cols) == 1:
             index_dim = index_cols[0]
             vals = dim(index_dim).apply(ds.iloc[index], expanded=False)
+            if vals.dtype.kind == 'O' and all(isinstance(v, np.ndarray) for v in vals):
+                vals = [v for arr in vals for v in util.unique_iterator(arr)]
             expr = dim(index_dim).isin(list(util.unique_iterator(vals)))
         else:
             get_shape = dim(self.dataset.get_dimension(index_cols[0]), np.shape)

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -5,7 +5,7 @@ elements.
 
 import numpy as np
 
-from ..core import util, NdOverlay
+from ..core import Dataset, NdOverlay, util
 from ..streams import SelectionXY, Selection1D, Lasso
 from ..util.transform import dim
 from .annotation import HSpan, VSpan
@@ -28,7 +28,7 @@ class SelectionIndexExpr(object):
         self._index_skip = True
         if not index:
             return None, None, None
-        ds = self.clone(kdims=index_cols)
+        ds = self.clone(kdims=index_cols, new_type=Dataset)
         if len(index_cols) == 1:
             index_dim = index_cols[0]
             vals = dim(index_dim).apply(ds.iloc[index], expanded=False)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require["recommended"] = extras_require["notebook"] + [
 extras_require["examples"] = extras_require["recommended"] + [
     "networkx",
     "pillow",
-    "xarray >=0.10.4",
+    "xarray >=0.10.4,<0.17.0",
     "plotly >=4.0",
     'dash >=1.16',
     "streamz >=0.5.0",


### PR DESCRIPTION
Fixes two issues with index based linked selections:

1. Ensures empty selection is not applied
2. Ensures that index cols are present on the selected element

Example:

```python
import hvplot.pandas
from holoviews.selection import link_selections
from bokeh.sampledata.autompg import autompg

scatter = autompg.hvplot.scatter('weight', 'accel')
table = autompg.hvplot.table()

link_selections(scatter + table, index_cols=['name', 'yr'])
```

<img width="1285" alt="Screen Shot 2021-01-03 at 1 36 57 PM" src="https://user-images.githubusercontent.com/1550771/103478701-c80c9d80-4dc8-11eb-8856-c9e319ed909d.png">
