### PR TITLE
Supporting streams parameter as a dictionary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,4 +109,4 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          coveralls
+          coveralls --service=github

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -19,7 +19,7 @@ from .layout import Layout, AdjointLayout, NdLayout, Empty
 from .ndmapping import UniformNdMapping, NdMapping, item_check
 from .overlay import Overlay, CompositeOverlay, NdOverlay, Overlayable
 from .options import Store, StoreOptions
-from ..streams import Stream, Params, LinkedStream, streams_list_from_dict
+from ..streams import Stream, Params, streams_list_from_dict
 
 
 
@@ -947,7 +947,7 @@ class DynamicMap(HoloMap):
                 stream.source = self
             if isinstance(stream, Params):
                 for p in stream.parameters:
-                    if isinstance(p.owner, LinkedStream) and p.owner.source is None:
+                    if isinstance(p.owner, Stream) and p.owner.source is None:
                         p.owner.source = self
 
         self.periodic = periodic(self)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -19,7 +19,7 @@ from .layout import Layout, AdjointLayout, NdLayout, Empty
 from .ndmapping import UniformNdMapping, NdMapping, item_check
 from .overlay import Overlay, CompositeOverlay, NdOverlay, Overlayable
 from .options import Store, StoreOptions
-from ..streams import Stream, streams_list_from_dict
+from ..streams import Stream, Params, LinkedStream, streams_list_from_dict
 
 
 
@@ -945,6 +945,11 @@ class DynamicMap(HoloMap):
         for stream in self.streams:
             if stream.source is None:
                 stream.source = self
+            if isinstance(stream, Params):
+                for p in stream.parameters:
+                    if isinstance(p.owner, LinkedStream) and p.owner.source is None:
+                        p.owner.source = self
+
         self.periodic = periodic(self)
 
     @property

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -882,13 +882,13 @@ class DynamicMap(HoloMap):
         directly, otherwise it will be automatically wrapped in one.""")
 
     streams = param.List(default=[], constant=True, doc="""
-       List of Stream instances to associate with the DynamicMap or a
-       dictionary mapping parameters or panel widgets to callback
-       argument names. In the list case, the set of parameter values
-       across these streams will be supplied as keyword arguments to the
-       callback when the events are received, updating the streams. When
-       a dictionary is supplied, it will be automatically converted to
-       the equivalent list format.""" )
+       List of Stream instances to associate with the DynamicMap. The
+       set of parameter values across these streams will be supplied as
+       keyword arguments to the callback when the events are received,
+       updating the streams. Can also be supplied as a dictionary that
+       maps parameters or panel widgets to callback argument names that
+       will then be automatically converted to the equivalent list
+       format.""")
 
     cache_size = param.Integer(default=500, doc="""
        The number of entries to cache for fast access. This is an LRU

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -881,7 +881,7 @@ class DynamicMap(HoloMap):
         If the callable is an instance of Callable it will be used
         directly, otherwise it will be automatically wrapped in one.""")
 
-    streams = param.ClassSelector(default=[], class_=(dict, list), constant=True, doc="""
+    streams = param.List(default=[], constant=True, doc="""
        List of Stream instances to associate with the DynamicMap or a
        dictionary mapping parameters or panel widgets to callback
        argument names. In the list case, the set of parameter values

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -886,7 +886,9 @@ class DynamicMap(HoloMap):
        dictionary mapping parameters or panel widgets to callback
        argument names. In the list case, the set of parameter values
        across these streams will be supplied as keyword arguments to the
-       callback when the events are received, updating the streams.""" )
+       callback when the events are received, updating the streams. When
+       a dictionary is supplied, it will be automatically converted to
+       the equivalent list format.""" )
 
     cache_size = param.Integer(default=500, doc="""
        The number of entries to cache for fast access. This is an LRU

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -55,7 +55,7 @@ def streams_list_from_dict(streams):
         if isinstance(v, param.Parameter) and isinstance(v.owner, param.Parameterized):
             params[k] = v
         else:
-            param.main.param.warning('Cannot handle value %r in streams dictionary' % v)
+            raise TypeError('Cannot handle value %r in streams dictionary' % v)
     return Params.from_params(params)
 
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -52,7 +52,9 @@ def streams_list_from_dict(streams):
         if 'panel' in sys.modules:
             from panel.depends import param_value_if_widget
             v = param_value_if_widget(v)
-        if isinstance(v, param.Parameter) and isinstance(v.owner, param.Parameterized):
+        if (isinstance(v, param.Parameter)
+            and (isinstance(v.owner, param.Parameterized)
+                 or issubclass(v.owner, param.Parameterized))):
             params[k] = v
         else:
             raise TypeError('Cannot handle value %r in streams dictionary' % v)
@@ -726,7 +728,7 @@ class Params(Stream):
         for _, group in groupby(sorted(params.items(), key=key_fn), key_fn):
             group = list(group)
             inst = [p.owner for _, p in group][0]
-            if not isinstance(inst, param.Parameterized):
+            if inst is None:
                 continue
             names = [p.name for _, p in group]
             rename = {p.name: n for n, p in group}

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -52,9 +52,7 @@ def streams_list_from_dict(streams):
         if 'panel' in sys.modules:
             from panel.depends import param_value_if_widget
             v = param_value_if_widget(v)
-        if (isinstance(v, param.Parameter)
-            and (isinstance(v.owner, param.Parameterized)
-                 or issubclass(v.owner, param.Parameterized))):
+        if isinstance(v, param.Parameter) and v.owner is not None:
             params[k] = v
         else:
             raise TypeError('Cannot handle value %r in streams dictionary' % v)

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -4,6 +4,7 @@ generate and respond to events, originating either in Python on the
 server-side or in Javascript in the Jupyter notebook (client-side).
 """
 
+import sys
 import weakref
 from numbers import Number
 from collections import defaultdict
@@ -42,6 +43,20 @@ def triggering_streams(streams):
     finally:
         for stream in streams:
             stream._triggering = False
+
+
+def streams_list_from_dict(streams):
+    "Converts a streams dictionary into a streams list"
+    params = {}
+    for k, v in streams.items():
+        if 'panel' in sys.modules:
+            from panel.depends import param_value_if_widget
+            v = param_value_if_widget(v)
+        if isinstance(v, param.Parameter) and isinstance(v.owner, param.Parameterized):
+            params[k] = v
+        else:
+            param.main.param.warning('Cannot handle value %r in streams dictionary' % v)
+    return Params.from_params(params)
 
 
 class Stream(param.Parameterized):

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -1,8 +1,10 @@
 import uuid
 import time
+import sys
 from collections import deque
 
 import param
+from unittest import SkipTest
 import numpy as np
 from holoviews import Dimension, NdLayout, GridSpace, Layout, NdOverlay
 from holoviews.core.spaces import DynamicMap, HoloMap, Callable
@@ -28,7 +30,8 @@ x,y = np.mgrid[-5:6, -5:6] * 0.1
 def sine_array(phase, freq):
     return np.sin(phase + (freq*x**2+freq*y**2))
 
-
+class TestParameters(param.Parameterized):
+    example = param.Number(default=1)
 
 class DynamicMapConstructor(ComparisonTestCase):
 
@@ -49,6 +52,25 @@ class DynamicMapConstructor(ComparisonTestCase):
 
     def test_simple_constructor_streams(self):
         DynamicMap(lambda x: x, streams=[PointerX()])
+
+    def test_simple_constructor_streams_dict(self):
+        pointerx = PointerX()
+        DynamicMap(lambda x: x, streams=dict(x=pointerx.param.x))
+
+    def test_simple_constructor_streams_dict_panel_widget(self):
+        if 'panel' not in sys.modules:
+            raise SkipTest('Panel not available')
+        import panel
+        DynamicMap(lambda x: x, streams=dict(x=panel.widgets.FloatSlider()))
+
+    def test_simple_constructor_streams_dict_parameter(self):
+        test = TestParameters()
+        DynamicMap(lambda x: x, streams=dict(x=test.param.example))
+
+    def test_simple_constructor_streams_dict_invalid(self):
+        regexp = "Cannot handle value 3 in streams dictionary"
+        with self.assertRaisesRegexp(TypeError, regexp):
+            DynamicMap(lambda x: x, streams=dict(x=3))
 
     def test_simple_constructor_streams_invalid_uninstantiated(self):
         regexp = ("The supplied streams list contains objects "

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -67,6 +67,9 @@ class DynamicMapConstructor(ComparisonTestCase):
         test = TestParameters()
         DynamicMap(lambda x: x, streams=dict(x=test.param.example))
 
+    def test_simple_constructor_streams_dict_class_parameter(self):
+        DynamicMap(lambda x: x, streams=dict(x=TestParameters.param.example))
+
     def test_simple_constructor_streams_dict_invalid(self):
         regexp = "Cannot handle value 3 in streams dictionary"
         with self.assertRaisesRegexp(TypeError, regexp):

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -2,9 +2,9 @@ import uuid
 import time
 import sys
 from collections import deque
+from unittest import SkipTest
 
 import param
-from unittest import SkipTest
 import numpy as np
 from holoviews import Dimension, NdLayout, GridSpace, Layout, NdOverlay
 from holoviews.core.spaces import DynamicMap, HoloMap, Callable

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -1270,10 +1270,10 @@ class TestExprSelectionStream(ComparisonTestCase):
 
     def test_selection_expr_stream_polygon_index_cols(self):
         # Create SelectionExpr on element
-        try:
-            import shapely
+        try: import shapely # noqa
         except:
-            raise SkipTest('Shapely required for polygon selection')
+            try: import spatialpandas # noqa
+            except: raise SkipTest('Shapely required for polygon selection')
         poly = Polygons([
             [(0, 0, 'a'), (2, 0, 'a'), (1, 1, 'a')],
             [(2, 0, 'b'), (4, 0, 'b'), (3, 1, 'b')],

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -1230,6 +1230,10 @@ class TestExprSelectionStream(ComparisonTestCase):
 
     def test_selection_expr_stream_polygon_index_cols(self):
         # Create SelectionExpr on element
+        try:
+            import shapely
+        except:
+            raise SkipTest('Shapely required for polygon selection')
         poly = Polygons([
             [(0, 0, 'a'), (2, 0, 'a'), (1, 1, 'a')],
             [(2, 0, 'b'), (4, 0, 'b'), (3, 1, 'b')],

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -358,6 +358,46 @@ class TestParamMethodStream(ComparisonTestCase):
         inner.x = 10
         self.assertEqual(dmap[()], Points([10]))
 
+
+    def test_param_instance_steams_dict(self):
+        inner = self.inner()
+
+        def test(x):
+            return Points([x])
+
+        dmap = DynamicMap(test, streams=dict(x=inner.param.x))
+
+        inner.x = 10
+        self.assertEqual(dmap[()], Points([10]))
+
+    def test_param_class_steams_dict(self):
+        class ClassParamExample(param.Parameterized):
+            x = param.Number(default=1)
+
+        def test(x):
+            return Points([x])
+
+        dmap = DynamicMap(test, streams=dict(x=ClassParamExample.param.x))
+
+        ClassParamExample.x = 10
+        self.assertEqual(dmap[()], Points([10]))
+
+    def test_panel_param_steams_dict(self):
+        try:
+            import panel
+        except:
+            raise SkipTest('Panel required for widget support in streams dict')
+        widget = panel.widgets.FloatSlider(value=1)
+
+        def test(x):
+            return Points([x])
+
+        dmap = DynamicMap(test, streams=dict(x=widget))
+
+        widget.value = 10
+        self.assertEqual(dmap[()], Points([10]))
+
+
     def test_param_method_depends_no_deps(self):
         inner = self.inner()
         stream = ParamMethod(inner.method_no_deps)


### PR DESCRIPTION
This implements an idea raised in https://github.com/holoviz/holoviews/issues/4781 which is to support dictionary values in the `streams` parameter. This currently works:

<img width=500 src="https://user-images.githubusercontent.com/890576/104490825-fa6f8500-5596-11eb-9b56-77c19c0d1138.png"></img>

### TODO

- [x] Detect parameters from linked streams to set up bokeh callbacks.
- [x]  Support class parameters.
- [x] Unit tests
