### PR TITLE
Added inspect_points datashader operation

### DIFF
--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -428,6 +428,18 @@ class SpatialPandasInterface(MultiInterface):
             objs.append(obj)
         return objs
 
+    @classmethod
+    def dframe(cls, dataset, dimensions):
+        if dimensions:
+            return dataset.data[dimensions]
+        else:
+            return dataset.data.copy()
+
+    @classmethod
+    def as_dframe(cls, dataset):
+        return dataset.data
+
+
 
 
 def get_geom_type(gdf, col):

--- a/holoviews/core/data/spatialpandas_dask.py
+++ b/holoviews/core/data/spatialpandas_dask.py
@@ -79,6 +79,12 @@ class DaskSpatialPandasInterface(SpatialPandasInterface):
     @classmethod
     def add_dimension(cls, dataset, dimension, dim_pos, values, vdim):
         return cls.base_interface.add_dimension(dataset, dimension, dim_pos, values, vdim)
-        
+
+    @classmethod
+    def dframe(cls, dataset, dimensions):
+        if dimensions:
+            return dataset.data[dimensions].compute()
+        else:
+            return dataset.data.compute()
 
 Interface.register(DaskSpatialPandasInterface)

--- a/holoviews/core/data/spatialpandas_dask.py
+++ b/holoviews/core/data/spatialpandas_dask.py
@@ -52,7 +52,8 @@ class DaskSpatialPandasInterface(SpatialPandasInterface):
     @classmethod
     def values(cls, dataset, dimension, expanded=True, flat=True, compute=True, keep_index=False):
         if compute and not keep_index:
-            meta = np.array([], dtype=cls.dtype(dataset, dimension))
+            dtype = cls.dtype(dataset, dimension)
+            meta = np.array([], dtype=dtype.base)
             return dataset.data.map_partitions(
                 cls.partition_values, meta=meta, dataset=dataset,
                 dimension=dimension, expanded=expanded, flat=flat

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -411,9 +411,10 @@ class XArrayInterface(GridInterface):
         Given a dataset object and data in the appropriate format for
         the interface, return a simple scalar.
         """
-        if (not cls.packed(dataset) and len(data.data_vars) == 1 and
-            len(data[dataset.vdims[0].name].shape) == 0):
-            return data[dataset.vdims[0].name].item()
+        if not cls.packed(dataset) and len(data.data_vars) == 1:
+            array = data[dataset.vdims[0].name].squeeze()
+            if len(array.shape) == 0:
+                return array.item()
         return data
 
 

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -56,7 +56,9 @@ class Path(SelectionPolyExpr, Geometry):
 
     group = param.String(default="Path", constant=True)
 
-    datatype = param.ObjectSelector(default=['multitabular', 'spatialpandas'])
+    datatype = param.ObjectSelector(default=[
+        'multitabular', 'spatialpandas', 'dask_spatialpandas']
+    )
 
     def __init__(self, data, kdims=None, vdims=None, **params):
         if isinstance(data, tuple) and len(data) == 2:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1885,7 +1885,8 @@ class inspect_points(Operation):
 
     @classmethod
     def _mask_dataframe(cls, raster, x, y, xdelta, ydelta):
-        "Mask the dataframe with size around x and y"
+        "Mask the dataframe around the specified x and y position with
+        the given x and y deltas"
         ds = raster.dataset
         x0, x1, y0, y1 = x-xdelta, x+xdelta, y-ydelta, y+ydelta
         if 'spatialpandas' in ds.interface.datatype:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1794,8 +1794,8 @@ class inspect_base(Operation):
 
     hits = param.DataFrame(default=pd.DataFrame(), allow_None=True)
 
-    max_hits = param.Integer(default=1, doc="""
-       Maximum number of points to display within the mask of size
+    max_elements = param.Integer(default=1, doc="""
+       Maximum number of elements to display within the mask of size
        pixels. Points are prioritized by distance from the cursor
        point. This means that the default value of one shows the single
        closest sample to the cursor. Note that this limit is not applies
@@ -1836,7 +1836,7 @@ class inspect_base(Operation):
 
         self.hits = result
         df = self.p.transform(result)
-        return self._element(raster, df.iloc[:self.p.max_hits])
+        return self._element(raster, df.iloc[:self.p.max_elements])
 
     @classmethod
     def _distance_args(cls, element, x_range, y_range,  pixels):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1790,8 +1790,8 @@ class inspect_points(Operation):
         if ((self.p.value_bounds and not (self.p.value_bounds[0] < val < self.p.value_bounds[1])) or
             val == self.p.null_value):
             empty_df = self._empty_df(raster.dataset)
+            df = self.p.points_transformer(empty_df)
             self.hits = self.p.hits_transformer(empty_df)
-            df = self.p.points_transformer(self.hits)
             vdims = self._vdims(raster, df)
             return Points(df, kdims=raster.kdims, vdims=vdims)
 
@@ -1800,8 +1800,8 @@ class inspect_points(Operation):
         mask_size = self._distance_args(raster, x_range, y_range, self.pixels)
         masked = self._mask_dataframe(raster, self.p.x, self.p.y, mask_size)
         dist_sorted = self._sort_by_distance(raster, masked, self.p.x, self.p.y)
+        df = self.p.points_transformer(dist_sorted)
         self.hits = self.p.hits_transformer(dist_sorted)
-        df = self.p.points_transformer(self.hits)
         vdims = self._vdims(raster, df)
         return Points(df, kdims=raster.kdims, vdims=vdims).iloc[:self.p.point_count]
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1842,18 +1842,14 @@ class inspect_points(Operation):
         if ((self.p.value_bounds and
              not (self.p.value_bounds[0] < val < self.p.value_bounds[1]))
              or val == self.p.null_value):
-            empty_df = self._empty_df(raster.dataset)
-            df = self.p.points_transformer(self.p.transformer(empty_df))
-            self.hits = self.p.hits_transformer(self.p.transformer(empty_df))
-            vdims = self._vdims(raster, df)
-            return Points(df, kdims=raster.kdims, vdims=vdims)
-
-        masked = self._mask_dataframe(raster, x, y, xdelta, ydelta)
-        dist_sorted = self._sort_by_distance(raster, masked, x, y)
-        df = self.p.points_transformer(self.p.transformer(dist_sorted))
-        self.hits = self.p.hits_transformer(self.p.transformer(dist_sorted))
-        vdims = self._vdims(raster, df)
-        return Points(df, kdims=raster.kdims, vdims=vdims).iloc[:self.p.max_points]
+            result = self._empty_df(raster.dataset)
+        else:
+            masked = self._mask_dataframe(raster, x, y, xdelta, ydelta)
+            result = self._sort_by_distance(raster, masked, x, y).iloc[:self.p.max_points]
+        transformed = self.p.transformer(result)
+        self.hits = self.p.hits_transformer(transformed)
+        df = self.p.points_transformer(transformed)
+        return Points(df, kdims=raster.kdims, vdims=self._vdims(raster, df))
 
     @property
     def mask(self):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1799,7 +1799,7 @@ class inspect_points(Operation):
         masked = self._mask_dataframe(raster, self.p.x, self.p.y, mask_size)
         dist_sorted = self._sort_by_distance(raster, masked, self.p.x, self.p.y)
         self.hits = self.p.hits_transformer(dist_sorted)
-        return Points(self.p.points_transformer(self.hits), vdims=self.p.vdims).iloc[:self.p.point_count]
+        return Points(self.p.points_transformer(self.hits), kdims=raster.kdims).iloc[:self.p.point_count]
 
     @classmethod
     def _empty_df(cls, dataset):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1790,7 +1790,7 @@ class inspect_points(Operation):
         if ((self.p.value_bounds and not (self.p.value_bounds[0] < val < self.p.value_bounds[1])) or
             val == self.p.null_value):
             df = self._empty_df(raster.dataset)
-            self.hits = self.p.hits_transformer(None)
+            self.hits = self.p.hits_transformer(df)
             return Points(self.points_transformer(self.hits), kdims=raster.kdims)
 
         x_range, y_range = raster.range(0), raster.range(1)

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1912,7 +1912,7 @@ class inspect_poly(inspect_base):
 
     @classmethod
     def _element(cls, raster, df):
-        return hv.Polygons(df, kdims=raster.kdims, vdims=cls._vdims(raster, df)).opts(
+        return Polygons(df, kdims=raster.kdims, vdims=cls._vdims(raster, df)).opts(
             color_index=None)
 
     @classmethod

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1775,7 +1775,7 @@ class inspect_points(Operation):
     y = param.Number(default=0)
 
     def _process(self, raster, key=None):
-        no_match = Points(self.p.hits_transformer(None), extents=raster.extents)
+        no_match = Points(self.p.hits_transformer(None))
         try: val = raster[self.p.x,self.p.y]
         except: val = self.p.null_value # Exception at the edges
         interface = raster.dataset.interface.datatype
@@ -1798,7 +1798,6 @@ class inspect_points(Operation):
                      else [col for col in self.hits.columns
                            if col not in ['x','y']])
             point = Points(self.hits, vdims=vdims).iloc[:self.p.point_count]
-            point.extents=raster.extents
             return point
         self.hits = self.p.hits_transformer(None)
         return no_match

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1770,14 +1770,14 @@ class inspect_mask(Operation):
 
 class inspect_points(Operation):
     """
-    Given datashaded aggregate (Image) output, return a single
-    (hoverable) point at the sample closest to the cursor.
+    Given datashaded aggregate (Image) output, return a set of
+    (hoverable) points sampled from those near the cursor.
     """
 
     pixels = param.Integer(default=3, doc="""
        Number of pixels in data space around the cursor point to search
        for hits in. The hit within this box mask that is closest to the
-       cursors position is displayed.""")
+       cursor's position is displayed.""")
 
     null_value = param.Number(default=0, doc="""
        Value of raster which indicates no hits. For instance zero for
@@ -1805,7 +1805,7 @@ class inspect_points(Operation):
        customization of the hits parameter and points output
        respectively. Useful when no distinction is needed between the
        hits_transformer and the points_transformer or when these later
-       transformers share the same initial code (e.g common merges and
+       transformers share the same initial code (e.g. common merges and
        joins with other sources of data)""")
 
     hits_transformer = param.Callable(default=identity, doc="""
@@ -1820,8 +1820,8 @@ class inspect_points(Operation):
 
     points_transformer = param.Callable(default=identity, doc="""
       Function that transforms the hits dataframe after applying the
-      transformer and before it it pass to the Points. Can be used to
-      customize the value dimensions e.g to implement custom hover
+      transformer and before it is passed to the Points. Can be used to
+      customize the value dimensions e.g. to implement custom hover
       behavior.""")
 
     # Stream values and overrides

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1729,7 +1729,7 @@ class directly_connect_edges(_connect_edges, connect_edges):
 
 def identity(x): return x
 
-class inspect_points(LinkableOperation):
+class inspect_points(Operation):
     """
     Given datashaded aggregate (Image) output, return a single
     (hoverable) point at the sample closest to the cursor.
@@ -1770,7 +1770,6 @@ class inspect_points(LinkableOperation):
        is also what is passed to the Points object.""")
 
     # Stream values and overrides
-    link_inputs = param.Boolean(default=True)
     streams = param.List(default=[PointerXY])
     x = param.Number(default=0)
     y = param.Number(default=0)

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1794,12 +1794,12 @@ class inspect_base(Operation):
 
     hits = param.DataFrame(default=pd.DataFrame(), allow_None=True)
 
-    max_elements = param.Integer(default=1, doc="""
-       Maximum number of elements to display within the mask of size
-       pixels. Points are prioritized by distance from the cursor
-       point. This means that the default value of one shows the single
-       closest sample to the cursor. Note that this limit is not applies
-       to the hits parameter.""")
+    max_indicators = param.Integer(default=1, doc="""
+       Maximum number of indicator elements to display within the mask
+       of size pixels. Points are prioritized by distance from the
+       cursor point. This means that the default value of one shows the
+       single closest sample to the cursor. Note that this limit is not
+       applies to the hits parameter.""")
 
     transform = param.Callable(default=identity, doc="""
       Function that transforms the hits dataframe before it is passed to
@@ -1836,7 +1836,7 @@ class inspect_base(Operation):
 
         self.hits = result
         df = self.p.transform(result)
-        return self._element(raster, df.iloc[:self.p.max_elements])
+        return self._element(raster, df.iloc[:self.p.max_indicators])
 
     @classmethod
     def _distance_args(cls, element, x_range, y_range,  pixels):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -756,7 +756,7 @@ class geom_aggregate(AggregationOperation):
             df[y0d.name] = df[y0d.name].astype('datetime64[us]').astype('int64')
             df[y1d.name] = df[y1d.name].astype('datetime64[us]').astype('int64')
 
-        if isinstance(agg_fn, ds.count_cat):
+        if isinstance(agg_fn, ds.count_cat) and df[agg_fn.column].dtype.name != 'category':
             df[agg_fn.column] = df[agg_fn.column].astype('category')
 
         params = self._get_agg_params(element, x0d, y0d, agg_fn, (x0, y0, x1, y1))
@@ -1374,7 +1374,7 @@ class geometry_rasterize(AggregationOperation):
         if self.p.precompute:
             self._precomputed[element._plot_id] = (data, col)
 
-        if isinstance(agg_fn, ds.count_cat):
+        if isinstance(agg_fn, ds.count_cat) and data[agg_fn.column].dtype.name != 'category':
             data[agg_fn.column] = data[agg_fn.column].astype('category')
 
         if isinstance(element, Polygons):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1782,7 +1782,7 @@ class inspect_points(Operation):
         if isinstance(raster, RGB):
             raster = raster[..., raster.vdims[-1]]
         x_range, y_range = raster.range(0), raster.range(1)
-        xdelta, ydelta = self._distance_args(raster, x_range, y_range, self.pixels)
+        xdelta, ydelta = self._distance_args(raster, x_range, y_range, self.p.pixels)
         x, y = self.p.x, self.p.y
         val = raster[x-xdelta:x+xdelta, y-ydelta:y+ydelta].reduce(function=np.nansum)
         if np.isnan(val):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1899,22 +1899,14 @@ class inspect_points(Operation):
         return ds.select(**query).dframe()
 
     @classmethod
-    def _get_xs_ys(cls, raster, df):
-        "Returns the x and y arrays or series for the given dataframe"
-        ds = raster.dataset
-        if 'spatialpandas' in ds.interface.datatype:
-            geom = ds.interface.geo_column(ds.data)
-            return df[geom].array.x, df[geom].array.y
-        xdim, ydim = raster.kdims
-        return df[xdim].values, df[ydim].values
-
-    @classmethod
     def _sort_by_distance(cls, raster, df, x, y):
         """
         Returns a dataframe of hits within a given mask around a given
         spatial location, sorted by distance from that location.
         """
-        xs, ys = cls._get_xs_ys(raster, df)
+        ds = raster.dataset.clone(df)
+        print("BOO")
+        xs, ys = (ds.dimension_values(kd) for kd in raster.kdims)
         dx, dy = xs - x, ys - y
         distances = pd.Series(dx*dx + dy*dy)
         return df.iloc[distances.argsort().values]

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1793,7 +1793,7 @@ class inspect_points(Operation):
 
     hits = param.DataFrame(default=pd.DataFrame(), allow_None=True)
 
-    point_count = param.Integer(default=1, doc="""
+    max_points = param.Integer(default=1, doc="""
        Maximum number of points to display within the mask of size
        pixels. Points are prioritized by distance from the cursor
        point. This means that the default value of one shows the single
@@ -1853,7 +1853,7 @@ class inspect_points(Operation):
         df = self.p.points_transformer(self.p.transformer(dist_sorted))
         self.hits = self.p.hits_transformer(self.p.transformer(dist_sorted))
         vdims = self._vdims(raster, df)
-        return Points(df, kdims=raster.kdims, vdims=vdims).iloc[:self.p.point_count]
+        return Points(df, kdims=raster.kdims, vdims=vdims).iloc[:self.p.max_points]
 
     @property
     def mask(self):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1885,8 +1885,10 @@ class inspect_points(Operation):
 
     @classmethod
     def _mask_dataframe(cls, raster, x, y, xdelta, ydelta):
-        "Mask the dataframe around the specified x and y position with
-        the given x and y deltas"
+        """
+        Mask the dataframe around the specified x and y position with
+        the given x and y deltas
+        """
         ds = raster.dataset
         x0, x1, y0, y1 = x-xdelta, x+xdelta, y-ydelta, y+ydelta
         if 'spatialpandas' in ds.interface.datatype:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1815,7 +1815,7 @@ class inspect_points(Operation):
     @classmethod
     def _empty_df(cls, dataset):
         if 'dask' in dataset.interface.datatype:
-            return dataset.data.partitions[0].head(0)
+            return dataset.data._meta.iloc[:0]
         elif dataset.interface.datatype in ['pandas', 'geopandas', 'spatialpandas']:
             return dataset.data.head(0)
         return dataset.iloc[:0].dframe()

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1735,11 +1735,8 @@ class inspect_points(LinkableOperation):
 
     pixels = param.Integer(default=3, doc="""
        Number of pixels in data space around the cursor point to search
-       for hits in (with mask_shape). The hit in this mask that is
-       closest to the cursors position is displayed.""")
-
-    mask_shape = param.ObjectSelector(default='square', objects=['square'], doc="""
-       Not implemented.""")
+       for hits in. The hit within this box mask that is closest to the
+       cursors position is displayed.""")
 
     null_value = param.Number(default=0, doc="""
        Value of raster which indicates no hits. For instance zero for

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1749,6 +1749,12 @@ class inspect_points(LinkableOperation):
        a value of (1,1000) would make sure no more than a thousand
        samples will be searched.""")
 
+
+    point_count = param.Integer(default=1, doc="""
+       Maximum number of points to display within the mask of size
+       pixels. Points are prioritized by distance from the cursor
+       point. This means that the default value of one shows the single
+       closest sample to the cursor.""")
     # Stream values and overrides
     link_inputs = param.Boolean(default=True)
     streams = param.List(default=[PointerXY])
@@ -1774,7 +1780,7 @@ class inspect_points(LinkableOperation):
                                           mask_size, interface)
             dist_sorted = self._sort_by_distance(masked, self.p.x, self.p.y,
                                                  raster.kdims, interface)
-            point = Points(dist_sorted).iloc[:1]
+            point = Points(dist_sorted).iloc[:self.p.point_count]
             point.extents=raster.extents
             return point
         return no_match

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1795,8 +1795,10 @@ class inspect_points(LinkableOperation):
             dist_sorted = self._sort_by_distance(masked, self.p.x, self.p.y,
                                                  raster.kdims, interface)
             self.hits = self.p.hits_transformer(dist_sorted)
-            point = Points(self.hits , vdims=list(col for col in self.hits.columns
-                                    if col not in ['x','y'])).iloc[:self.p.point_count]
+            vdims=  ([] if (self.p.hits_transformer is identity)
+                     else [col for col in self.hits.columns
+                           if col not in ['x','y']])
+            point = Points(self.hits, vdims=vdims).iloc[:self.p.point_count]
             point.extents=raster.extents
             return point
         self.hits = self.p.hits_transformer(None)

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1905,7 +1905,6 @@ class inspect_points(Operation):
         spatial location, sorted by distance from that location.
         """
         ds = raster.dataset.clone(df)
-        print("BOO")
         xs, ys = (ds.dimension_values(kd) for kd in raster.kdims)
         dx, dy = xs - x, ys - y
         distances = pd.Series(dx*dx + dy*dy)

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -17,7 +17,7 @@ try:
     from holoviews.core.util import pd
     from holoviews.operation.datashader import (
         aggregate, regrid, ds_version, stack, directly_connect_edges,
-        shade, spread, rasterize, AggregationOperation
+        shade, spread, rasterize, inspect_points, AggregationOperation
     )
 except:
     raise SkipTest('Datashader not available')
@@ -1097,3 +1097,32 @@ class GraphBundlingTests(ComparisonTestCase):
     def test_directly_connect_paths(self):
         direct = directly_connect_edges(self.graph)._split_edgepaths
         self.assertEqual(direct, self.graph.edgepaths)
+
+class InspectorTests(ComparisonTestCase):
+    """
+    Tests for inspector operations
+    """
+    def setUp(self):
+        points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
+        self.img = rasterize(points, dynamic=False,
+                             x_range=(0, 1), y_range=(0, 1), width=4, height=4)
+
+    def test_points_inspection_1px_mask(self):
+        points = inspect_points(self.img, max_indicators=3, dynamic=False, pixels=1, x=-0.1, y=-0.1)
+        self.assertEqual(points.dimension_values('x'), np.array([]))
+        self.assertEqual(points.dimension_values('y'), np.array([]))
+
+    def test_points_inspection_2px_mask(self):
+        points = inspect_points(self.img, max_indicators=3, dynamic=False, pixels=2, x=-0.1, y=-0.1)
+        self.assertEqual(points.dimension_values('x'), np.array([0.2]))
+        self.assertEqual(points.dimension_values('y'), np.array([0.3]))
+
+    def test_points_inspection_4px_mask(self):
+        points = inspect_points(self.img, max_indicators=3, dynamic=False, pixels=4, x=-0.1, y=-0.1)
+        self.assertEqual(points.dimension_values('x'), np.array([0.2, 0.4]))
+        self.assertEqual(points.dimension_values('y'), np.array([0.3, 0.7]))
+
+    def test_points_inspection_5px_mask(self):
+        points = inspect_points(self.img, max_indicators=3, dynamic=False, pixels=5, x=-0.1, y=-0.1)
+        self.assertEqual(points.dimension_values('x'), np.array([0.2, 0.4, 0]))
+        self.assertEqual(points.dimension_values('y'), np.array([0.3, 0.7, 0.99]))

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ extras_require["examples"] = extras_require["recommended"] + [
     "ffmpeg",
     "cftime",
     "netcdf4",
-    "dask<=2020.12.0",
+    "dask",
     "scipy",
     "shapely",
     "scikit-image"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     "pyviz_comms >=0.7.3",
     "panel >=0.8.0",
     "colorcet",
-    "pandas",
+    "pandas<=1.2.0",
 ]
 
 extras_require = {}

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     "pyviz_comms >=0.7.3",
     "panel >=0.8.0",
     "colorcet",
-    "pandas<=1.2.0",
+    "pandas",
 ]
 
 extras_require = {}
@@ -42,7 +42,7 @@ extras_require["examples"] = extras_require["recommended"] + [
     "ffmpeg",
     "cftime",
     "netcdf4",
-    "dask",
+    "dask<=2020.12.0",
     "scipy",
     "shapely",
     "scikit-image"


### PR DESCRIPTION
WIP.

Here is the example code

```python
import numpy as np
from spatialpandas.geometry import PointArray
from spatialpandas import GeoDataFrame
from holoviews.operation.datashader import rasterize, dynspread, inspect_sample
import holoviews as hv
hv.extension('bokeh')

def gaussian_df(specs=(1.5,0,1.0),num=10000):
    np.random.seed(1)
    xs, ys = np.random.normal(specs[0],specs[2],num), np.random.normal(specs[1],specs[2],num)
    return xs,ys

xs, ys = gaussian_df()
sdf = GeoDataFrame({'geometry':PointArray((xs, ys)),'id':list(range(len(xs)))})
rasterized = dynspread(rasterize(hv.Points(sdf)))
rasterized * inspect_sample(rasterized).opts(color='red', tools=['hover'], size=6)
```
![github1](https://user-images.githubusercontent.com/890576/105103986-14b5d100-5a77-11eb-8be2-d4f969a4d3e0.gif)

Getting tap behavior is as easy as adding `streams=[hv.streams.Tap]` to the operation:

![github1](https://user-images.githubusercontent.com/890576/105104121-4cbd1400-5a77-11eb-99db-d235dcefa84e.gif)

## TODO

- [x] Make sure vdims of original data are preserved for hover information
- [x] Find out why the initial render looks blank until a small zoom in/out occurs
- [x] Handle normal dataframes (getting the x/y from the raster kdims), geopandas, and spatially indexed spatialpandas dataframes.
- [x] Tests
- [ ] Documentation
