### PR TITLE
Add single value numpy array to HLine and VLine input

### DIFF
--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -95,6 +95,8 @@ class VLine(Annotation):
     __pos_params = ['x']
 
     def __init__(self, x, **params):
+        if isinstance(x, np.ndarray) and x.size == 1:
+            x = np.atleast_1d(x)[0]
         super(VLine, self).__init__(x, x=x, **params)
 
     def dimension_values(self, dimension, expanded=True, flat=True):
@@ -128,6 +130,8 @@ class HLine(Annotation):
     __pos_params = ['y']
 
     def __init__(self, y, **params):
+        if isinstance(y, np.ndarray) and y.size == 1:
+            y = np.atleast_1d(y)[0]
         super(HLine, self).__init__(y, y=y, **params)
 
     def dimension_values(self, dimension, expanded=True, flat=True):

--- a/holoviews/tests/element/testannotations.py
+++ b/holoviews/tests/element/testannotations.py
@@ -42,18 +42,18 @@ class AnnotationTests(ComparisonTestCase):
         self.assertEqual(hline.range(1), (0, 0))
 
     def test_vline_dimension_values(self):
-        hline = VLine(0)
-        self.assertEqual(hline.range(0), (0, 0))
-        self.assertTrue(all(not np.isfinite(v) for v in hline.range(1)))
+        vline = VLine(0)
+        self.assertEqual(vline.range(0), (0, 0))
+        self.assertTrue(all(not np.isfinite(v) for v in vline.range(1)))
 
         # Testing numpy inputs
-        hline = VLine(np.array([0]))
-        self.assertEqual(hline.range(0), (0, 0))
-        self.assertTrue(all(not np.isfinite(v) for v in hline.range(1)))
+        vline = VLine(np.array([0]))
+        self.assertEqual(vline.range(0), (0, 0))
+        self.assertTrue(all(not np.isfinite(v) for v in vline.range(1)))
 
-        hline = VLine(np.array(0))
-        self.assertEqual(hline.range(0), (0, 0))
-        self.assertTrue(all(not np.isfinite(v) for v in hline.range(1)))
+        vline = VLine(np.array(0))
+        self.assertEqual(vline.range(0), (0, 0))
+        self.assertTrue(all(not np.isfinite(v) for v in vline.range(1)))
 
     def test_arrow_redim_range_aux(self):
         annotations = Arrow(0, 0)

--- a/holoviews/tests/element/testannotations.py
+++ b/holoviews/tests/element/testannotations.py
@@ -32,8 +32,26 @@ class AnnotationTests(ComparisonTestCase):
         self.assertTrue(all(not np.isfinite(v) for v in hline.range(0)))
         self.assertEqual(hline.range(1), (0, 0))
 
+        # Testing numpy inputs
+        hline = HLine(np.array([0]))
+        self.assertTrue(all(not np.isfinite(v) for v in hline.range(0)))
+        self.assertEqual(hline.range(1), (0, 0))
+
+        hline = HLine(np.array(0))
+        self.assertTrue(all(not np.isfinite(v) for v in hline.range(0)))
+        self.assertEqual(hline.range(1), (0, 0))
+
     def test_vline_dimension_values(self):
         hline = VLine(0)
+        self.assertEqual(hline.range(0), (0, 0))
+        self.assertTrue(all(not np.isfinite(v) for v in hline.range(1)))
+
+        # Testing numpy inputs
+        hline = VLine(np.array([0]))
+        self.assertEqual(hline.range(0), (0, 0))
+        self.assertTrue(all(not np.isfinite(v) for v in hline.range(1)))
+
+        hline = VLine(np.array(0))
         self.assertEqual(hline.range(0), (0, 0))
         self.assertTrue(all(not np.isfinite(v) for v in hline.range(1)))
 


### PR DESCRIPTION
This PR adds the ability to give a numpy array with a single value in it to HLine and VLine. 

Furthermore I renamed hline to vline in `test_vline_dimension_values`.