### PR TITLE
Bokeh 2.3 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       DESC: "Python ${{ matrix.python-version }} tests"
       HV_REQUIREMENTS: "unit_tests"
       PYTHON_VERSION: ${{ matrix.python-version }}
-      CHANS_DEV: "-c pyviz/label/dev"
+      CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev"
       CHANS: "-c pyviz"
       MPLBACKEND: "Agg"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1244,6 +1244,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         for glyph_type in ('', 'selection_', 'nonselection_', 'hover_', 'muted_'):
             if renderer:
                 glyph = getattr(renderer, glyph_type+'glyph', None)
+            if glyph == 'auto':
+                base_glyph = renderer.glyph
+                glyph = type(base_glyph)(**base_glyph.properties_with_values())
+                setattr(renderer, glyph_type+'glyph', glyph)
             if not glyph or (not renderer and glyph_type):
                 continue
             filtered = self._filter_properties(merged, glyph_type, allowed_properties)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1244,10 +1244,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         for glyph_type in ('', 'selection_', 'nonselection_', 'hover_', 'muted_'):
             if renderer:
                 glyph = getattr(renderer, glyph_type+'glyph', None)
-            if glyph == 'auto':
-                base_glyph = renderer.glyph
-                glyph = type(base_glyph)(**base_glyph.properties_with_values())
-                setattr(renderer, glyph_type+'glyph', glyph)
+                if glyph == 'auto':
+                    base_glyph = renderer.glyph
+                    glyph = type(base_glyph)(**base_glyph.properties_with_values())
+                    setattr(renderer, glyph_type+'glyph', glyph)
             if not glyph or (not renderer and glyph_type):
                 continue
             filtered = self._filter_properties(merged, glyph_type, allowed_properties)


### PR DESCRIPTION
Fixes for Bokeh 2.3 compatibility:

- Ensure Renderer glyphs set to 'auto' are instantiated 