### PR TITLE
Add automatic categorical legend for datashaded plots

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -253,21 +253,26 @@ class AggregationOperation(ResamplingOperation):
         'var':   rd.var,
         'std':   rd.std,
         'min':   rd.min,
-        'max':   rd.max
+        'max':   rd.max,
+        'count_cat': rd.count_cat
     }
 
     @classmethod
     def _get_aggregator(cls, element, agg, add_field=True):
         if isinstance(agg, str):
-            if agg not in self._agg_methods:
-                agg_methods = sorted(self._agg_methods)
+            if agg not in cls._agg_methods:
+                agg_methods = sorted(cls._agg_methods)
                 raise ValueError("Aggregation method '%r' is not known; "
                                  "aggregator must be one of: %r" %
                                  (agg, agg_methods))
-            agg = cls._agg_methods[agg]()
+            if agg == 'count_cat':
+                agg = cls._agg_methods[agg]('__temp__')
+            else:
+                agg = cls._agg_methods[agg]()
 
         elements = element.traverse(lambda x: x, [Element])
-        if add_field and getattr(agg, 'column', False) is None and not isinstance(agg, (rd.count, rd.any)):
+        if (add_field and getattr(agg, 'column', False) in ('__temp__', None) and
+            not isinstance(agg, (rd.count, rd.any))):
             if not elements:
                 raise ValueError('Could not find any elements to apply '
                                  '%s operation to.' % cls.__name__)

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -2087,12 +2087,9 @@ class categorical_legend(Operation):
         hvds = element.dataset
         input_el = element.pipeline.operations[0](hvds)
         agg = rasterize_op._get_aggregator(input_el, rasterize_op.aggregator)
-        if isinstance(agg, ds.count_cat):
-            column = agg.column
-        elif isinstance(agg, ds.by):
-            column = agg.column
-        else:
-            return None
+        if not isinstance(agg, (ds.count_cat, ds.by)):
+            return
+        column = agg.column
         if hasattr(hvds.data, 'dtypes'):
             cats = list(hvds.data.dtypes[column].categories)
             if cats == ['__UNKNOWN_CATEGORIES__']:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -256,21 +256,21 @@ class AggregationOperation(ResamplingOperation):
         'max':   rd.max
     }
 
-    def _get_aggregator(self, element, add_field=True):
-        agg = self.p.aggregator
+    @classmethod
+    def _get_aggregator(cls, element, agg, add_field=True):
         if isinstance(agg, str):
             if agg not in self._agg_methods:
                 agg_methods = sorted(self._agg_methods)
                 raise ValueError("Aggregation method '%r' is not known; "
                                  "aggregator must be one of: %r" %
                                  (agg, agg_methods))
-            agg = self._agg_methods[agg]()
+            agg = cls._agg_methods[agg]()
 
         elements = element.traverse(lambda x: x, [Element])
         if add_field and getattr(agg, 'column', False) is None and not isinstance(agg, (rd.count, rd.any)):
             if not elements:
                 raise ValueError('Could not find any elements to apply '
-                                 '%s operation to.' % type(self).__name__)
+                                 '%s operation to.' % cls.__name__)
             inner_element = elements[0]
             if isinstance(inner_element, TriMesh) and inner_element.nodes.vdims:
                 field = inner_element.nodes.vdims[0].name
@@ -282,7 +282,7 @@ class AggregationOperation(ResamplingOperation):
                 raise ValueError("Could not determine dimension to apply "
                                  "'%s' operation to. Declare the dimension "
                                  "to aggregate as part of the datashader "
-                                 "aggregator." % type(self).__name__)
+                                 "aggregator." % cls.__name__)
             agg = type(agg)(field)
         return agg
 
@@ -466,7 +466,7 @@ class aggregate(LineAggregationOperation):
 
 
     def _process(self, element, key=None):
-        agg_fn = self._get_aggregator(element)
+        agg_fn = self._get_aggregator(element, self.p.aggregator)
         if hasattr(agg_fn, 'cat_column'):
             category = agg_fn.cat_column
         else:
@@ -556,7 +556,7 @@ class overlay_aggregate(aggregate):
                  (isinstance(agg_fn, ds.count_cat) and agg_fn.column in element.kdims)))
 
     def _process(self, element, key=None):
-        agg_fn = self._get_aggregator(element)
+        agg_fn = self._get_aggregator(element, self.p.aggregator)
 
         if not self.applies(element, agg_fn, line_width=self.p.line_width):
             raise ValueError(
@@ -654,7 +654,7 @@ class area_aggregate(AggregationOperation):
 
     def _process(self, element, key=None):
         x, y = element.dimensions()[:2]
-        agg_fn = self._get_aggregator(element)
+        agg_fn = self._get_aggregator(element, self.p.aggregator)
 
         default = None
         if not self.p.y_range:
@@ -726,7 +726,7 @@ class spikes_aggregate(LineAggregationOperation):
       The offset of the lower end of each spike.""")
 
     def _process(self, element, key=None):
-        agg_fn = self._get_aggregator(element)
+        agg_fn = self._get_aggregator(element, self.p.aggregator)
         x, y = element.kdims[0], None
 
         spike_length = 0.5 if self.p.spike_length is None else self.p.spike_length
@@ -798,7 +798,7 @@ class geom_aggregate(AggregationOperation):
         raise NotImplementedError
 
     def _process(self, element, key=None):
-        agg_fn = self._get_aggregator(element)
+        agg_fn = self._get_aggregator(element, self.p.aggregator)
         x0d, y0d, x1d, y1d = element.kdims
         info = self._get_sampling(element, [x0d, x1d], [y0d, y1d], ndim=1)
         (x_range, y_range), (xs, ys), (width, height), (xtype, ytype) = info
@@ -994,7 +994,7 @@ class regrid(AggregationOperation):
         # Apply regridding to each value dimension
         regridded = {}
         arrays = self._get_xarrays(element, coords, xtype, ytype)
-        agg_fn = self._get_aggregator(element, add_field=False)
+        agg_fn = self._get_aggregator(element, self.p.aggregator, add_field=False)
         for vd, xarr in arrays.items():
             rarray = cvs.raster(xarr, upsample_method=interp,
                                 downsample_method=agg_fn)
@@ -1021,11 +1021,11 @@ class contours_rasterize(aggregate):
     aggregator = param.ClassSelector(default=ds.mean(),
                                      class_=(ds.reductions.Reduction, str))
 
-    def _get_aggregator(self, element, add_field=True):
-        agg = self.p.aggregator
+    @classmethod
+    def _get_aggregator(cls, element, agg, add_field=True):
         if not element.vdims and agg.column is None and not isinstance(agg, (rd.count, rd.any)):
             return ds.any()
-        return super()._get_aggregator(element, add_field)
+        return super()._get_aggregator(element, agg, add_field)
 
 
 
@@ -1113,9 +1113,12 @@ class trimesh_rasterize(aggregate):
                or not (element.vdims or element.nodes.vdims)):
             wireframe = True
             precompute = False # TriMesh itself caches wireframe
-            agg = self._get_aggregator(element) if isinstance(agg, (ds.any, ds.count)) else ds.any()
+            if isinstance(agg, (ds.any, ds.count)):
+                agg = self._get_aggregator(element, self.p.aggregator)
+            else:
+                agg = ds.any()
         elif getattr(agg, 'column', None) is None:
-            agg = self._get_aggregator(element)
+            agg = self._get_aggregator(element, self.p.aggregator)
 
         if element._plot_id in self._precomputed:
             precomputed = self._precomputed[element._plot_id]
@@ -1174,7 +1177,7 @@ class quadmesh_rasterize(trimesh_rasterize):
         data = element.data
 
         x, y = element.kdims
-        agg_fn = self._get_aggregator(element)
+        agg_fn = self._get_aggregator(element, self.p.aggregator)
         info = self._get_sampling(element, x, y)
         (x_range, y_range), (xs, ys), (width, height), (xtype, ytype) = info
         if xtype == 'datetime':
@@ -1417,15 +1420,15 @@ class geometry_rasterize(LineAggregationOperation):
     aggregator = param.ClassSelector(default=ds.mean(),
                                      class_=(ds.reductions.Reduction, str))
 
-    def _get_aggregator(self, element, add_field=True):
-        agg = self.p.aggregator
+    @classmethod
+    def _get_aggregator(cls, element, agg, add_field=True):
         if (not (element.vdims or isinstance(agg, str)) and
             agg.column is None and not isinstance(agg, (rd.count, rd.any))):
             return ds.count()
-        return super()._get_aggregator(element, add_field)
+        return super()._get_aggregator(element, agg, add_field)
 
     def _process(self, element, key=None):
-        agg_fn = self._get_aggregator(element)
+        agg_fn = self._get_aggregator(element, self.p.aggregator)
         xdim, ydim = element.kdims
         info = self._get_sampling(element, xdim, ydim)
         (x_range, y_range), (xs, ys), (width, height), (xtype, ytype) = info
@@ -2074,21 +2077,16 @@ class categorical_legend(Operation):
 
     def _process(self, element, key=None):
         from ..plotting.util import rgb2hex
-        rasterize_op, shade_op = None, None
-        for op in element.pipeline.operations[::-1]:
-            if isinstance(op, (shade, datashade)):
-                shade_op = op
-            if isinstance(op, (rasterize, datashade)):
-                rasterize_op = op
-            if None not in (shade_op, rasterize_op):
-                break
-        if shade_op is None:
+        rasterize_op = element.pipeline.find(rasterize)
+        if isinstance(rasterize_op, datashade):
+            shade_op = rasterize_op
+        else:
+            shade_op = element.pipeline.find(shade)
+        if None in (shade_op, rasterize_op):
             return None
-        if not hasattr(rasterize_op, 'p'):
-            rasterize_op = rasterize_op.instance()
-            rasterize_op.p = param.ParamOverrides(rasterize_op, {})
         hvds = element.dataset
-        agg = rasterize_op._get_aggregator(element.pipeline.operations[0](hvds))
+        input_el = element.pipeline.operations[0](hvds)
+        agg = rasterize_op._get_aggregator(input_el, rasterize_op.aggregator)
         if isinstance(agg, ds.count_cat):
             column = agg.column
         elif isinstance(agg, ds.by):

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -229,6 +229,20 @@ class chain(Operation):
         else:
             return processed.clone(group=self.p.group)
 
+    def find(self, operation):
+        """
+        Returns the first found occurrence of an operation while
+        performing a backward traversal of the chain pipeline.
+        """
+        found = None
+        for op in self.operations[::-1]:
+            if isinstance(op, operation):
+                found = op
+                break
+            if not op.link_inputs:
+                break
+        return found
+
 
 class transform(Operation):
     """

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -229,7 +229,7 @@ class chain(Operation):
         else:
             return processed.clone(group=self.p.group)
 
-    def find(self, operation):
+    def find(self, operation, skip_nonlinked=True):
         """
         Returns the first found occurrence of an operation while
         performing a backward traversal of the chain pipeline.
@@ -239,7 +239,7 @@ class chain(Operation):
             if isinstance(op, operation):
                 found = op
                 break
-            if not op.link_inputs:
+            if not op.link_inputs and skip_nonlinked:
                 break
         return found
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2205,7 +2205,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
         renderers = []
         for item in legend_items:
             item.renderers[:] = [r for r in item.renderers if r not in renderers]
-            if item in filtered or not item.renderers or not any(r.visible for r in item.renderers):
+            if item in filtered or not item.renderers:
                 continue
             renderers += item.renderers
             filtered.append(item)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2205,7 +2205,8 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
         renderers = []
         for item in legend_items:
             item.renderers[:] = [r for r in item.renderers if r not in renderers]
-            if item in filtered or not item.renderers:
+            if (item in filtered or not item.renderers or
+                not any(r.visible or 'hv_legend' in r.tags for r in item.renderers)):
                 continue
             renderers += item.renderers
             filtered.append(item)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2053,11 +2053,11 @@ class LegendPlot(ElementPlot):
     legend_cols = param.Integer(default=False, doc="""
        Whether to lay out the legend as columns.""")
 
-    legend_specs = {'right': 'right', 'left': 'left', 'top': 'above',
-                    'bottom': 'below'}
-
     legend_opts = param.Dict(default={}, doc="""
         Allows setting specific styling options for the colorbar.""")
+
+    legend_specs = {'right': 'right', 'left': 'left', 'top': 'above',
+                    'bottom': 'below'}
 
     def _process_legend(self, plot=None):
         plot = plot or self.handles['plot']

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -155,7 +155,7 @@ class RGBPlot(LegendPlot):
 
     def _init_glyphs(self, plot, element, ranges, source):
         super(RGBPlot, self)._init_glyphs(plot, element, ranges, source)
-        if 'holoviews.operation.datashader' not in sys.modules:
+        if 'holoviews.operation.datashader' not in sys.modules or not self.show_legend:
             return
         try:
             legend = categorical_legend(element, backend=self.backend)

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
+import sys
+
 import numpy as np
 import param
 
@@ -7,6 +9,7 @@ from bokeh.models import DatetimeAxis, CustomJSHover
 
 from ...core.util import cartesian_product, dimension_sanitizer, isfinite
 from ...element import Raster
+from .chart import PointPlot
 from .element import ElementPlot, ColorbarPlot
 from .selection import BokehOverlaySelectionDisplay
 from .styles import base_properties, fill_properties, line_properties, mpl_to_bokeh
@@ -144,6 +147,17 @@ class RGBPlot(ElementPlot):
         xdim, ydim = element.kdims
         return [(xdim.pprint_label, '$x'), (ydim.pprint_label, '$y'),
                 ('RGBA', '@image')], {}
+
+    def _init_glyphs(self, plot, element, ranges, source):
+        super(RGBPlot, self)._init_glyphs(plot, element, ranges, source)
+        if 'holoviews.operation.datashader' not in sys.modules:
+            return
+        from ...operation.datashader import categorical_legend
+        legend = categorical_legend(element)
+        if legend is None:
+            return
+        legend_plot = PointPlot(legend)
+        legend_plot.initialize_plot(plot=plot)
 
     def get_data(self, element, ranges, style):
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -11,7 +11,7 @@ from ...core.util import cartesian_product, dimension_sanitizer, isfinite
 from ...element import Raster
 from ..util import categorical_legend
 from .chart import PointPlot
-from .element import ElementPlot, ColorbarPlot, LegendPlot
+from .element import ColorbarPlot, LegendPlot
 from .selection import BokehOverlaySelectionDisplay
 from .styles import base_properties, fill_properties, line_properties, mpl_to_bokeh
 from .util import colormesh
@@ -159,11 +159,12 @@ class RGBPlot(LegendPlot):
             return
         try:
             legend = categorical_legend(element, backend=self.backend)
-        except Exception as e:
+        except Exception:
             return
         if legend is None:
             return
-        legend_params = {l: v for l, v in self.param.get_param_values() if k.startswith('legend')}
+        legend_params = {k: v for k, v in self.param.get_param_values()
+                         if k.startswith('legend')}
         self._legend_plot = PointPlot(legend, **legend_params)
         self._legend_plot.initialize_plot(plot=plot)
         self.handles['rgb_color_mapper'] = self._legend_plot.handles['color_color_mapper']

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -167,6 +167,7 @@ class RGBPlot(LegendPlot):
                          if k.startswith('legend')}
         self._legend_plot = PointPlot(legend, keys=[], overlaid=1, **legend_params)
         self._legend_plot.initialize_plot(plot=plot)
+        self._legend_plot.handles['glyph_renderer'].tags.append('hv_legend')
         self.handles['rgb_color_mapper'] = self._legend_plot.handles['color_color_mapper']
 
     def get_data(self, element, ranges, style):

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -165,7 +165,7 @@ class RGBPlot(LegendPlot):
             return
         legend_params = {k: v for k, v in self.param.get_param_values()
                          if k.startswith('legend')}
-        self._legend_plot = PointPlot(legend, **legend_params)
+        self._legend_plot = PointPlot(legend, keys=[], overlaid=1, **legend_params)
         self._legend_plot.initialize_plot(plot=plot)
         self.handles['rgb_color_mapper'] = self._legend_plot.handles['color_color_mapper']
 

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -545,7 +545,7 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
                 offset_line.set_ydata(offset)
 
 
-class PointPlot(ChartPlot, ColorbarPlot):
+class PointPlot(ChartPlot, ColorbarPlot, LegendPlot):
     """
     Note that the 'cmap', 'vmin' and 'vmax' style arguments control
     how point magnitudes are rendered to different colors.

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -494,7 +494,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         legend = plot_kwargs.pop('cat_legend', None)
         with abbreviated_exception():
             handles = self.init_artists(ax, plot_data, plot_kwargs)
-        if legend and 'artist' in handles:
+        if legend and 'artist' in handles and hasattr(handles['artist'], 'legend_elements'):
             legend_handles, _ = handles['artist'].legend_elements()
             leg = ax.legend(legend_handles, legend['factors'],
                             title=legend['title'], **self._legend_opts)
@@ -615,10 +615,10 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                     else:
                         factors = util.unique_array(val)
                     val = util.search_indices(val, factors)
+                    new_style['cat_legend'] = {
+                        'title': v.dimension, 'prop': 'c', 'factors': factors
+                    }
                 k = prefix+'c'
-                title = v.dimension
-                new_style['cat_legend'] = {'title': title, 'prop': 'c', 'factors': factors}
-
             new_style[k] = val
 
         for k, val in list(new_style.items()):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -1070,6 +1070,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
         and set up the legend
         """
         legend_data = []
+        legend_plot = True
         dimensions = overlay.kdims
         title = ', '.join([d.label for d in dimensions])
         for key, subplot in self.subplots.items():
@@ -1078,7 +1079,9 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             title = ', '.join([d.name for d in dimensions])
             handle = subplot.traverse(lambda p: p.handles['artist'],
                                       [lambda p: 'artist' in p.handles])
-            if isinstance(overlay, NdOverlay):
+            if getattr(subplot, '_legend_plot', None) is not None:
+                legend_plot = True
+            elif isinstance(overlay, NdOverlay):
                 label = ','.join([dim.pprint_value(k, print_unit=True)
                                   for k, dim in zip(key, dimensions)])
                 if handle:
@@ -1102,7 +1105,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
                 used_labels.append(label)
         if (not len(set(data.values())) > 0) or not self.show_legend:
             legend = axis.get_legend()
-            if legend:
+            if legend and not (legend_plot or self.show_legend):
                 legend.set_visible(False)
         else:
             leg = axis.legend(list(data.keys()), list(data.values()),

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -1,3 +1,5 @@
+import sys
+
 import param
 import numpy as np
 
@@ -5,7 +7,9 @@ from ...core import CompositeOverlay, Element
 from ...core import traversal
 from ...core.util import match_spec, max_range, unique_iterator
 from ...element.raster import Image, Raster, RGB
-from .element import ElementPlot, ColorbarPlot, OverlayPlot
+from ..util import categorical_legend
+from .chart import PointPlot
+from .element import ElementPlot, ColorbarPlot, LegendPlot, OverlayPlot
 from .plot import MPLPlot, GridPlot, mpl_rc_context
 from .util import LooseVersion, get_raster_array, mpl_version
 
@@ -100,7 +104,7 @@ class RasterPlot(RasterBasePlot, ColorbarPlot):
         return axis_kwargs
 
 
-class RGBPlot(RasterBasePlot):
+class RGBPlot(RasterBasePlot, LegendPlot):
 
     style_opts = ['alpha', 'interpolation', 'visible', 'filterrad']
 
@@ -115,6 +119,21 @@ class RGBPlot(RasterBasePlot):
         style['extent'] = [l, r, b, t]
         style['origin'] = 'upper'
         return [data], style, {'xticks': xticks, 'yticks': yticks}
+
+    def init_artists(self, ax, plot_args, plot_kwargs):
+        handles = super(RGBPlot, self).init_artists(ax, plot_args, plot_kwargs)
+        if 'holoviews.operation.datashader' not in sys.modules:
+            return handles
+        try:
+            legend = categorical_legend(self.current_frame, backend=self.backend)
+        except Exception:
+            return handles
+        if legend is None:
+            return handles
+        legend_params = {k: v for k, v in self.param.get_param_values() if k.startswith('legend')}
+        self._legend_plot = PointPlot(legend, axis=ax, fig=self.state, **legend_params)
+        self._legend_plot.initialize_plot()
+        return handles
 
     def update_handles(self, key, axis, element, ranges, style):
         im = self.handles['artist']

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -131,7 +131,9 @@ class RGBPlot(RasterBasePlot, LegendPlot):
         if legend is None:
             return handles
         legend_params = {k: v for k, v in self.param.get_param_values() if k.startswith('legend')}
-        self._legend_plot = PointPlot(legend, axis=ax, fig=self.state, **legend_params)
+        self._legend_plot = PointPlot(legend, axis=ax, fig=self.state,
+                                      keys=self.keys, dimensions=self.dimensions,
+                                      overlaid=1, **legend_params)
         self._legend_plot.initialize_plot()
         return handles
 

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -122,7 +122,7 @@ class RGBPlot(RasterBasePlot, LegendPlot):
 
     def init_artists(self, ax, plot_args, plot_kwargs):
         handles = super(RGBPlot, self).init_artists(ax, plot_args, plot_kwargs)
-        if 'holoviews.operation.datashader' not in sys.modules:
+        if 'holoviews.operation.datashader' not in sys.modules or not self.show_legend:
             return handles
         try:
             legend = categorical_legend(self.current_frame, backend=self.backend)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1173,7 +1173,7 @@ class GenericElementPlot(DimensionedPlot):
 
     def __init__(self, element, keys=None, ranges=None, dimensions=None,
                  batched=False, overlaid=0, cyclic_index=0, zorder=0, style=None,
-                 overlay_dims={}, stream_sources=[], streams=None, **params):
+                 overlay_dims={}, stream_sources={}, streams=None, **params):
         self.zorder = zorder
         self.cyclic_index = cyclic_index
         self.overlaid = overlaid

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -21,6 +21,7 @@ from ..core.util import (
     closest_match, is_number, isfinite, python2sort, disable_constant,
     arraylike_types
 )
+from ..element import Points
 from ..streams import LinkedStream, Params
 from ..util.transform import dim
 
@@ -884,9 +885,6 @@ register_cmaps('Uniform Categorical', 'colorcet', 'cet', 'light',
     ['glasbey_dark'])
 
 
-
-
-
 def process_cmap(cmap, ncolors=None, provider=None, categorical=False):
     """
     Convert valid colormap specifications to a list of colors.
@@ -1287,3 +1285,45 @@ fire_colors = linear_kryw_0_100_c71 = [\
 # Bokeh palette
 fire = [str('#{0:02x}{1:02x}{2:02x}'.format(int(r*255),int(g*255),int(b*255)))
         for r,g,b in fire_colors]
+
+
+class categorical_legend(Operation):
+
+    backend = param.String()
+
+    def _process(self, element, key=None):
+        import datashader as ds
+        from ..operation.datashader import shade, rasterize, datashade
+        rasterize_op = element.pipeline.find(rasterize, skip_nonlinked=False)
+        if isinstance(rasterize_op, datashade):
+            shade_op = rasterize_op
+        else:
+            shade_op = element.pipeline.find(shade, skip_nonlinked=False)
+        if None in (shade_op, rasterize_op):
+            return None
+        hvds = element.dataset
+        input_el = element.pipeline.operations[0](hvds)
+        agg = rasterize_op._get_aggregator(input_el, rasterize_op.aggregator)
+        if not isinstance(agg, (ds.count_cat, ds.by)):
+            return
+        column = agg.column
+        if hasattr(hvds.data, 'dtypes'):
+            cats = list(hvds.data.dtypes[column].categories)
+            if cats == ['__UNKNOWN_CATEGORIES__']:
+                cats = list(hvds.data[column].cat.as_known().categories)
+        else:
+            cats = list(hvds.dimension_values(column, expanded=False))
+        colors = shade_op.color_key or ds.colors.Sets1to3
+        color_data = [(0, 0, cat) for cat in cats]
+        if isinstance(colors, list):
+            cat_colors = {cat: colors[i] for i, cat in enumerate(cats)}
+        else:
+            cat_colors = {cat: colors[cat] for cat in cats}
+        cmap = {}
+        for cat, color in cat_colors.items():
+            if isinstance(color, tuple):
+                color = rgb2hex([v/256 for v in color[:3]])
+            cmap[cat] = color
+        return Points(color_data, vdims=['category']).opts(
+            cmap=cmap, color='category', show_legend=True,
+            backend=self.p.backend, visible=False)


### PR DESCRIPTION
Inspects the pipeline of an RGB element and discovers the shade and rasterize operations used to generate an RGB to then automatically add a legend.

<img width="1215" alt="Screen Shot 2021-01-28 at 1 04 12 PM" src="https://user-images.githubusercontent.com/1550771/106136282-5e827380-6169-11eb-8e1f-4f84fea2fefb.png">

- [x] Clean up operation and factor out operations to traverse pipeline
- [x] Factor out code to render legend plot and use across all interfaces
- [ ] Update legend when needed
 