### PR TITLE
Supporting streams dictionaries in operations

### DIFF
--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -216,9 +216,6 @@ class Operation(param.ParameterizedFunction):
         elif 'streams' not in kwargs:
             kwargs['streams'] = self.p.streams
 
-
-        if isinstance(kwargs['streams'], dict):
-            kwargs['streams'] = streams.streams_list_from_dict(kwargs['streams'])
         kwargs['per_element'] = self._per_element
         kwargs['link_dataset'] = self._propagate_dataset
         kwargs['link_inputs'] = self.p.link_inputs

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -11,7 +11,6 @@ from .options import Store
 from .overlay import NdOverlay, Overlay
 from .spaces import Callable, HoloMap
 from . import util, Dataset
-from .. import streams
 
 
 class Operation(param.ParameterizedFunction):
@@ -215,7 +214,6 @@ class Operation(param.ParameterizedFunction):
                 return self._apply(element)
         elif 'streams' not in kwargs:
             kwargs['streams'] = self.p.streams
-
         kwargs['per_element'] = self._per_element
         kwargs['link_dataset'] = self._propagate_dataset
         kwargs['link_inputs'] = self.p.link_inputs

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -11,6 +11,7 @@ from .options import Store
 from .overlay import NdOverlay, Overlay
 from .spaces import Callable, HoloMap
 from . import util, Dataset
+from .. import streams
 
 
 class Operation(param.ParameterizedFunction):
@@ -214,6 +215,10 @@ class Operation(param.ParameterizedFunction):
                 return self._apply(element)
         elif 'streams' not in kwargs:
             kwargs['streams'] = self.p.streams
+
+
+        if isinstance(kwargs['streams'], dict):
+            kwargs['streams'] = streams.streams_list_from_dict(kwargs['streams'])
         kwargs['per_element'] = self._per_element
         kwargs['link_dataset'] = self._propagate_dataset
         kwargs['link_inputs'] = self.p.link_inputs

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -59,7 +59,7 @@ class Operation(param.ParameterizedFunction):
        visualization should update this stream with range changes
        originating from the newly generated axes.""")
 
-    streams = param.List(default=[], doc="""
+    streams = param.ClassSelector(default=[], class_=(dict, list), doc="""
         List of streams that are applied if dynamic=True, allowing
         for dynamic interaction with the plot.""")
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -96,9 +96,9 @@ class ResamplingOperation(LinkableOperation):
         width and height.
     """)
 
-    streams = param.List(default=[PlotSize, RangeXY], doc="""
-        List of streams that are applied if dynamic=True, allowing
-        for dynamic interaction with the plot.""")
+    streams = param.ClassSelector(default=[PlotSize, RangeXY], class_=(dict, list), doc="""
+       List or dictionary of streams that are applied if dynamic=True,
+       allowing for dynamic interaction with the plot.""")
 
     element_type = param.ClassSelector(class_=(Dataset,), instantiate=False,
                                         is_instance=False, default=Image,
@@ -1742,7 +1742,8 @@ class inspect_mask(Operation):
        Size of the mask that should match the pixels parameter used in
        the associated inspection operation.""")
 
-    streams = param.List(default=[PointerXY])
+    streams = param.ClassSelector(default=dict(x=PointerXY.param.x,
+                                               y=PointerXY.param.y), class_=(dict, list))
     x = param.Number(default=0)
     y = param.Number(default=0)
 
@@ -1807,7 +1808,9 @@ class inspect_base(Operation):
       e.g. to implement custom hover behavior.""")
 
     # Stream values and overrides
-    streams = param.List(default=[PointerXY])
+    streams = param.ClassSelector(default=dict(x=PointerXY.param.x,
+                                               y=PointerXY.param.y),
+                                  class_=(dict, list))
     x = param.Number(default=0)
     y = param.Number(default=0)
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1742,8 +1742,7 @@ class inspect_mask(Operation):
        Size of the mask that should match the pixels parameter used in
        the associated inspection operation.""")
 
-    streams = param.ClassSelector(default=dict(x=PointerXY.param.x,
-                                               y=PointerXY.param.y), class_=(dict, list))
+    streams = param.ClassSelector(default=[PointerXY], class_=(dict, list))
     x = param.Number(default=0)
     y = param.Number(default=0)
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -783,6 +783,9 @@ class Params(Stream):
         pass
 
     def update(self, **kwargs):
+        if isinstance(self.parameterized, Stream):
+            self.parameterized.update(**kwargs)
+            return
         for k, v in kwargs.items():
             setattr(self.parameterized, k, v)
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -783,11 +783,21 @@ class Params(Stream):
         pass
 
     def update(self, **kwargs):
-        if isinstance(self.parameterized, Stream):
+        if self._rename:
+            owner_updates = defaultdict(dict)
+            for (owner, pname), rname in self._rename.items():
+                if rname in kwargs:
+                    owner_updates[owner][pname] = kwargs[rname]
+            for owner, updates in owner_updates.items():
+                if isinstance(owner, Stream):
+                    owner.update(**updates)
+                else:
+                    owner.param.set_param(**kwargs)
+        elif isinstance(self.parameterized, Stream):
             self.parameterized.update(**kwargs)
             return
-        for k, v in kwargs.items():
-            setattr(self.parameterized, k, v)
+        else:
+            self.parameterized.param.set_param(**kwargs)
 
     @property
     def contents(self):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -53,14 +53,14 @@ def streams_list_from_dict(streams):
             from panel.depends import param_value_if_widget
             v = param_value_if_widget(v)
         if isinstance(v, param.Parameter) and v.owner is not None:
-            if isinstance(v.owner, Stream):
-                params[k] = v
-            elif issubclass(v.owner, Stream):
+            if issubclass(v.owner, Stream):
                 stream_instance = v.owner()
                 # Nothing is holding onto this instance except via its
                 # parameters
                 pval = getattr(stream_instance.param, v.name)
                 params[k] = pval
+            else:
+                params[k] = v
         else:
             raise TypeError('Cannot handle value %r in streams dictionary' % v)
     return Params.from_params(params)

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -53,7 +53,7 @@ def streams_list_from_dict(streams):
             from panel.depends import param_value_if_widget
             v = param_value_if_widget(v)
         if isinstance(v, param.Parameter) and v.owner is not None:
-            if issubclass(v.owner, Stream):
+            if isinstance(v.owner, type) and issubclass(v.owner, Stream):
                 stream_instance = v.owner()
                 # Nothing is holding onto this instance except via its
                 # parameters

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -53,7 +53,14 @@ def streams_list_from_dict(streams):
             from panel.depends import param_value_if_widget
             v = param_value_if_widget(v)
         if isinstance(v, param.Parameter) and v.owner is not None:
-            params[k] = v
+            if isinstance(v.owner, Stream):
+                params[k] = v
+            elif issubclass(v.owner, Stream):
+                stream_instance = v.owner()
+                # Nothing is holding onto this instance except via its
+                # parameters
+                pval = getattr(stream_instance.param, v.name)
+                params[k] = pval
         else:
             raise TypeError('Cannot handle value %r in streams dictionary' % v)
     return Params.from_params(params)

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -785,7 +785,7 @@ class Params(Stream):
                 if isinstance(owner, Stream):
                     owner.update(**updates)
                 else:
-                    owner.param.set_param(**kwargs)
+                    owner.param.set_param(**updates)
         elif isinstance(self.parameterized, Stream):
             self.parameterized.update(**kwargs)
             return

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -529,6 +529,9 @@ class Buffer(Pipe):
     is allowed while streaming.
     """
 
+    data = param.Parameter(default=None, constant=True, doc="""
+        Arbitrary data being streamed to a DynamicMap callback.""")
+
     def __init__(self, data, length=1000, index=True, following=True, **params):
         if (util.pd and isinstance(data, util.pd.DataFrame)):
             example = data
@@ -799,6 +802,14 @@ class ParamMethod(Params):
     a parameterized class and triggers when one of the parameters
     change.
     """
+
+    parameterized = param.ClassSelector(class_=(param.Parameterized,
+                                                param.parameterized.ParameterizedMetaclass),
+                                        constant=True, allow_None=True, doc="""
+        Parameterized instance to watch for parameter changes.""")
+
+    parameters = param.List([], constant=True, doc="""
+        Parameters on the parameterized to watch.""")
 
     def __init__(self, parameterized, parameters=None, watch=True, **params):
         if not util.is_param_method(parameterized):
@@ -1295,6 +1306,13 @@ class Draw(PointerXY):
     A series of updating x/y-positions when drawing, together with the
     current stroke count
     """
+    x = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the x-axis in data coordinates""")
+
+    y = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the y-axis in data coordinates""")
 
     stroke_count = param.Integer(default=0, constant=True, doc="""
        The current drawing stroke count. Increments every time a new
@@ -1305,32 +1323,74 @@ class SingleTap(PointerXY):
     The x/y-position of a single tap or click in data coordinates.
     """
 
+    x = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the x-axis in data coordinates""")
+
+    y = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the y-axis in data coordinates""")
 
 class Tap(PointerXY):
     """
     The x/y-position of a tap or click in data coordinates.
     """
+    x = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the x-axis in data coordinates""")
+
+    y = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the y-axis in data coordinates""")
 
 
 class DoubleTap(PointerXY):
     """
     The x/y-position of a double-tap or -click in data coordinates.
     """
+    x = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the x-axis in data coordinates""")
+
+    y = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the y-axis in data coordinates""")
 
 class PressUp(PointerXY):
     """
     The x/y position of a mouse pressup event in data coordinates.
     """
+    x = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the x-axis in data coordinates""")
+
+    y = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the y-axis in data coordinates""")
 
 class PanEnd(PointerXY):
     """The x/y position of a the end of a pan event in data coordinates.
     """
+    x = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the x-axis in data coordinates""")
+
+    y = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the y-axis in data coordinates""")
 
 class MouseEnter(PointerXY):
     """
     The x/y-position where the mouse/cursor entered the plot area
     in data coordinates.
     """
+    x = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the x-axis in data coordinates""")
+
+    y = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the y-axis in data coordinates""")
 
 
 class MouseLeave(PointerXY):
@@ -1338,6 +1398,13 @@ class MouseLeave(PointerXY):
     The x/y-position where the mouse/cursor entered the plot area
     in data coordinates.
     """
+    x = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the x-axis in data coordinates""")
+
+    y = param.ClassSelector(class_=pointer_types, default=None,
+                            constant=True, doc="""
+           Pointer position along the y-axis in data coordinates""")
 
 
 class PlotSize(LinkedStream):
@@ -1424,6 +1491,10 @@ class SelectionXY(BoundsXY):
     Unlike a BoundsXY stream, this stream returns range or categorical
     selections.
     """
+
+    bounds = param.Tuple(default=None, constant=True, length=4,
+                         allow_None=True, doc="""
+        Bounds defined as (left, bottom, right, top) tuple.""")
 
     x_selection = param.ClassSelector(class_=(tuple, list), allow_None=True,
                                       constant=True, doc="""
@@ -1516,6 +1587,12 @@ class PointDraw(CDSStream):
         An optional tooltip to override the default
     """
 
+    data = param.Dict(constant=True, doc="""
+        Data synced from Bokeh ColumnDataSource supplied as a
+        dictionary of columns, where each column is a list of values
+        (for point-like data) or list of lists of values (for
+        path-like data).""")
+
     def __init__(self, empty_value=None, add=True, drag=True, num_objects=0,
                  styles={}, tooltip=None, **params):
         self.add = add
@@ -1554,6 +1631,12 @@ class CurveEdit(PointDraw):
         An optional tooltip to override the default
     """
 
+    data = param.Dict(constant=True, doc="""
+        Data synced from Bokeh ColumnDataSource supplied as a
+        dictionary of columns, where each column is a list of values
+        (for point-like data) or list of lists of values (for
+        path-like data).""")
+
     def __init__(self, style={}, tooltip=None, **params):
         self.style = style or {'size': 10}
         self.tooltip = tooltip
@@ -1590,6 +1673,12 @@ class PolyDraw(CDSStream):
         The usual bokeh style options apply, e.g. fill_color,
         line_alpha, size, etc.
     """
+
+    data = param.Dict(constant=True, doc="""
+        Data synced from Bokeh ColumnDataSource supplied as a
+        dictionary of columns, where each column is a list of values
+        (for point-like data) or list of lists of values (for
+        path-like data).""")
 
     def __init__(self, empty_value=None, drag=True, num_objects=0,
                  show_vertices=False, vertex_style={}, styles={},
@@ -1644,6 +1733,12 @@ class FreehandDraw(CDSStream):
         An optional tooltip to override the default
     """
 
+    data = param.Dict(constant=True, doc="""
+        Data synced from Bokeh ColumnDataSource supplied as a
+        dictionary of columns, where each column is a list of values
+        (for point-like data) or list of lists of values (for
+        path-like data).""")
+
     def __init__(self, empty_value=None, num_objects=0, styles={}, tooltip=None, **params):
         self.empty_value = empty_value
         self.num_objects = num_objects
@@ -1691,6 +1786,12 @@ class BoxEdit(CDSStream):
     tooltip: str
         An optional tooltip to override the default
     """
+
+    data = param.Dict(constant=True, doc="""
+        Data synced from Bokeh ColumnDataSource supplied as a
+        dictionary of columns, where each column is a list of values
+        (for point-like data) or list of lists of values (for
+        path-like data).""")
 
     def __init__(self, empty_value=None, num_objects=0, styles={}, tooltip=None, **params):
         self.empty_value = empty_value
@@ -1747,6 +1848,12 @@ class PolyEdit(PolyDraw):
         The usual bokeh style options apply, e.g. fill_color,
         line_alpha, size, etc.
     """
+
+    data = param.Dict(constant=True, doc="""
+        Data synced from Bokeh ColumnDataSource supplied as a
+        dictionary of columns, where each column is a list of values
+        (for point-like data) or list of lists of values (for
+        path-like data).""")
 
     def __init__(self, vertex_style={}, shared=True, **params):
         self.shared = shared

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -53,14 +53,7 @@ def streams_list_from_dict(streams):
             from panel.depends import param_value_if_widget
             v = param_value_if_widget(v)
         if isinstance(v, param.Parameter) and v.owner is not None:
-            if isinstance(v.owner, type) and issubclass(v.owner, Stream):
-                stream_instance = v.owner()
-                # Nothing is holding onto this instance except via its
-                # parameters
-                pval = getattr(stream_instance.param, v.name)
-                params[k] = pval
-            else:
-                params[k] = v
+            params[k] = v
         else:
             raise TypeError('Cannot handle value %r in streams dictionary' % v)
     return Params.from_params(params)

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -12,7 +12,7 @@ from holoviews.core.options import Store
 from holoviews.element import Image, Scatter, Curve, Text, Points
 from holoviews.operation import histogram
 from holoviews.plotting.util import initialize_dynamic
-from holoviews.streams import Stream, LinkedStream, PointerXY, PointerX, PointerY, RangeX, Buffer
+from holoviews.streams import Stream, LinkedStream, PointerXY, PointerX, PointerY, RangeX, Buffer, pointer_types
 from holoviews.util import Dynamic
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -901,6 +901,7 @@ class DynamicStreamReset(ComparisonTestCase):
             return Curve(list(history))
 
         class NoMemoize(PointerX):
+            x = param.ClassSelector(class_=pointer_types, default=None, constant=True)
             @property
             def hashkey(self): return {'hash': uuid.uuid4().hex}
 

--- a/holoviews/tests/core/testdynamic.py
+++ b/holoviews/tests/core/testdynamic.py
@@ -598,6 +598,12 @@ class DynamicTransferStreams(ComparisonTestCase):
         with self.assertRaisesRegexp(Exception, exception):
             Dynamic(self.dmap, streams=[PointerX])
 
+    def test_dynamic_util_inherits_dim_streams_clash_dict(self):
+        exception = ("The supplied stream objects PointerX\(x=None\) and "
+                     "PointerX\(x=0\) clash on the following parameters: \['x'\]")
+        with self.assertRaisesRegexp(Exception, exception):
+            Dynamic(self.dmap, streams=dict(x=PointerX.param.x))
+
 
 
 class DynamicTestOperation(ComparisonTestCase):
@@ -628,6 +634,14 @@ class DynamicTestOperation(ComparisonTestCase):
         element = dmap_with_fn[()]
         self.assertEqual(element, Image(sine_array(0,5)*2+1))
         self.assertEqual(dmap_with_fn.streams, [posxy])
+
+    def test_dynamic_operation_on_element_dict(self):
+        img = Image(sine_array(0,5))
+        posxy = PointerXY(x=3, y=1)
+        dmap_with_fn = Dynamic(img, operation=lambda obj, x, y: obj.clone(obj.data*x+y),
+                               streams=dict(x=posxy.param.x, y=posxy.param.y))
+        element = dmap_with_fn[()]
+        self.assertEqual(element, Image(sine_array(0,5)*3+1))
 
     def test_dynamic_operation_with_kwargs(self):
         fn = lambda i: Image(sine_array(0,i))

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -1136,6 +1136,7 @@ class InspectorTests(ComparisonTestCase):
         points = inspect_points(self.img, max_indicators=3, dynamic=True,
                                 pixels=1, streams=dict(x=Tap.param.x, y=Tap.param.y))
         self.assertEqual(len(points.streams), 1)
+        self.assertEqual(isinstance(points.streams[0], Tap), True)
         self.assertEqual(points.streams[0].x, 0.4)
         self.assertEqual(points.streams[0].y, 0.7)
 
@@ -1145,5 +1146,6 @@ class InspectorTests(ComparisonTestCase):
                                             streams=dict(x=Tap.param.x, y=Tap.param.y))
         points = inspector(self.img)
         self.assertEqual(len(points.streams), 1)
+        self.assertEqual(isinstance(points.streams[0], Tap), True)
         self.assertEqual(points.streams[0].x, 0.2)
         self.assertEqual(points.streams[0].y, 0.3)

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -7,6 +7,7 @@ import numpy as np
 from holoviews import (Dimension, Curve, Points, Image, Dataset, RGB, Path,
                        Graph, TriMesh, QuadMesh, NdOverlay, Contours, Spikes,
                        Spread, Area, Rectangles, Segments, Polygons)
+from holoviews.streams import Tap
 from holoviews.element.comparison import ComparisonTestCase
 from numpy import nan
 
@@ -733,7 +734,7 @@ class DatashaderCatAggregateTests(ComparisonTestCase):
                               'C': Image((xs, ys, [[nan, nan], [0.3, nan]]), vdims='z')},
                              kdims=['cat'])
         self.assertEqual(img, expected)
-        
+
 
 
 class DatashaderShadeTests(ComparisonTestCase):
@@ -1047,7 +1048,7 @@ class DatashaderSpreadTests(ComparisonTestCase):
         spreaded = spread(Image(arr))
         arr = np.array([[0, 0, 0], [2, 3, 2], [2, 3, 2]]).T
         self.assertEqual(spreaded, Image(arr))
-        
+
 
 class DatashaderStackTests(ComparisonTestCase):
 
@@ -1107,6 +1108,9 @@ class InspectorTests(ComparisonTestCase):
         self.img = rasterize(points, dynamic=False,
                              x_range=(0, 1), y_range=(0, 1), width=4, height=4)
 
+    def tearDown(self):
+        Tap.x, Tap.y = None, None
+
     def test_points_inspection_1px_mask(self):
         points = inspect_points(self.img, max_indicators=3, dynamic=False, pixels=1, x=-0.1, y=-0.1)
         self.assertEqual(points.dimension_values('x'), np.array([]))
@@ -1126,3 +1130,20 @@ class InspectorTests(ComparisonTestCase):
         points = inspect_points(self.img, max_indicators=3, dynamic=False, pixels=5, x=-0.1, y=-0.1)
         self.assertEqual(points.dimension_values('x'), np.array([0.2, 0.4, 0]))
         self.assertEqual(points.dimension_values('y'), np.array([0.3, 0.7, 0.99]))
+
+    def test_points_inspection_dict_streams(self):
+        Tap.x, Tap.y = 0.4, 0.7
+        points = inspect_points(self.img, max_indicators=3, dynamic=True,
+                                pixels=1, streams=dict(x=Tap.param.x, y=Tap.param.y))
+        self.assertEqual(len(points.streams), 1)
+        self.assertEqual(points.streams[0].x, 0.4)
+        self.assertEqual(points.streams[0].y, 0.7)
+
+    def test_points_inspection_dict_streams_instance(self):
+        Tap.x, Tap.y = 0.2, 0.3
+        inspector = inspect_points.instance(max_indicators=3, dynamic=True, pixels=1,
+                                            streams=dict(x=Tap.param.x, y=Tap.param.y))
+        points = inspector(self.img)
+        self.assertEqual(len(points.streams), 1)
+        self.assertEqual(points.streams[0].x, 0.2)
+        self.assertEqual(points.streams[0].y, 0.3)

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -31,7 +31,6 @@ def test_all_stream_parameters_constant():
 def test_all_linked_stream_parameters_owners():
     "Test to ensure operations can accept parameters in streams dictionary"
     stream_classes = param.concrete_descendents(LinkedStream)
-    print(stream_classes)
     for stream_class in stream_classes.values():
         for name, p in stream_class.param.params().items():
             if name != 'name' and (p.owner != stream_class):

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -28,6 +28,18 @@ def test_all_stream_parameters_constant():
                                 % (name, stream_cls.__name__))
 
 
+def test_all_linked_stream_parameters_owners():
+    "Test to ensure operations can accept parameters in streams dictionary"
+    stream_classes = param.concrete_descendents(LinkedStream)
+    print(stream_classes)
+    for stream_class in stream_classes.values():
+        for name, p in stream_class.param.params().items():
+            if name != 'name' and (p.owner != stream_class):
+                msg = ("Linked stream %r has parameter %r which is "
+                       "inherited from %s. Parameter needs to be redeclared "
+                       "in the class definition of this linked stream.")
+                raise Exception(msg % (stream_class, name, p.owner))
+
 class TestStreamsDefine(ComparisonTestCase):
 
     def setUp(self):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -945,6 +945,9 @@ class Dynamic(param.ParameterizedFunction):
                 else:
                     params[name] = p
             stream_specs = streams_list_from_dict(params)
+            # Note that the correct stream instance will only be created
+            # correctly of the parameter's .owner points to the correct
+            # class (i.e the parameter isn't defined on a superclass)
             stream_specs += [stream(rename=rename) for stream, rename in streams.items()]
         else:
             stream_specs = self.p.streams

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -942,7 +942,10 @@ class Dynamic(param.ParameterizedFunction):
                            if v is None and k in op.p}
                 if updates:
                     reverse = {v: k for k, v in stream._rename.items()}
-                    stream.update(**{reverse.get(k, k): v for k, v in updates.items()})
+                    update_dict = {reverse.get(k, k): v for k, v in updates.items()}
+                    keywords = {(k[1] if isinstance(k, tuple) else k):v
+                                for k,v in update_dict.items() }
+                    stream.update(**keywords)
             streams.append(stream)
 
         params = {}

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -940,12 +940,10 @@ class Dynamic(param.ParameterizedFunction):
             if isinstance(op, Operation):
                 updates = {k: op.p.get(k) for k, v in stream.contents.items()
                            if v is None and k in op.p}
-                if updates:
+                if not isinstance(stream, Params):
                     reverse = {v: k for k, v in stream._rename.items()}
-                    update_dict = {reverse.get(k, k): v for k, v in updates.items()}
-                    keywords = {(k[1] if isinstance(k, tuple) else k):v
-                                for k,v in update_dict.items() }
-                    stream.update(**keywords)
+                    updates = {reverse.get(k, k): v for k, v in updates.items()}
+                stream.update(**updates)
             streams.append(stream)
 
         params = {}

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -23,7 +23,7 @@ from ..core.util import basestring, merge_options_to_dict, OrderedDict
 from ..core.operation import OperationCallable
 from ..core import util
 from ..operation.element import function
-from ..streams import Stream, Params
+from ..streams import Stream, Params, streams_list_from_dict
 from .settings import OutputSettings, list_formats, list_backends
 
 Store.output_settings = OutputSettings
@@ -902,7 +902,7 @@ class Dynamic(param.ParameterizedFunction):
     shared_data = param.Boolean(default=False, doc="""
         Whether the cloned DynamicMap will share the same cache.""")
 
-    streams = param.List(default=[], doc="""
+    streams = param.ClassSelector(default=[], class_=(list, dict), doc="""
         List of streams to attach to the returned DynamicMap""")
 
     def __call__(self, map_obj, **params):
@@ -929,9 +929,29 @@ class Dynamic(param.ParameterizedFunction):
         of supplied stream classes and instances are processed and
         added to the list.
         """
+        if isinstance(self.p.streams, dict):
+            streams = defaultdict(dict)
+            stream_specs, params = [], {}
+            for name, p in self.p.streams.items():
+                if not isinstance(p, param.Parameter):
+                    raise ValueError("Stream dictionary must map operation keywords "
+                                     "to parameter names. Cannot handle %r type."
+                                     % type(stream))
+                if inspect.isclass(p.owner) and issubclass(p.owner, Stream):
+                    if p.name != name:
+                        streams[p.owner][p.name] = name
+                    else:
+                        streams[p.owner] = {}
+                else:
+                    params[name] = p
+            stream_specs = streams_list_from_dict(params)
+            stream_specs += [stream(rename=rename) for stream, rename in streams.items()]
+        else:
+            stream_specs = self.p.streams
+
         streams = []
         op = self.p.operation
-        for stream in self.p.streams:
+        for stream in stream_specs:
             if inspect.isclass(stream) and issubclass(stream, Stream):
                 stream = stream()
             elif not (isinstance(stream, Stream) or util.is_param_method(stream)):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -936,7 +936,7 @@ class Dynamic(param.ParameterizedFunction):
                 if not isinstance(p, param.Parameter):
                     raise ValueError("Stream dictionary must map operation keywords "
                                      "to parameter names. Cannot handle %r type."
-                                     % type(stream))
+                                     % type(p))
                 if inspect.isclass(p.owner) and issubclass(p.owner, Stream):
                     if p.name != name:
                         streams[p.owner][p.name] = name


### PR DESCRIPTION
WIP PR to address https://github.com/holoviz/holoviews/issues/4807.

For testing, I've defined the `streams` parameter of `inspect_points` as:

```python
    streams = param.ClassSelector(default=dict(x=PointerXY.param.x,
                                               y=PointerXY.param.y),
                                  class_=(dict, list))
```

And here is the corresponding, working test example:

![PR](https://user-images.githubusercontent.com/890576/106511245-981eeb80-6495-11eb-8e97-533aacc86f39.gif)

However, there are some serious limitations right now. The minor one is that I have to set `hv.streams.PointerXY.x = 0` and 
`hv.streams.PointerXY.y = 0` due to an error processing dictionaries when allowing the `None` default. While I'm sure this can be fixed, this seems to be a far more fundamental problem right now:

<img width=300 src="https://user-images.githubusercontent.com/890576/106511103-6443c600-6495-11eb-9f20-3fe098324ebb.png"></img>

As operations use stream classes, not instances, how can I get back to the correct *class* with something like `Tap.param.x` when the owner of the parameter may be a superclass? The code needs to instantiate the correct stream instance. Any ideas @jbednar @philippjfr ?

If this can be solved quickly then I can work on this PR to get it into the next minor release. However, if this is a deeper issue (as I suspect it is) then this PR will need to wait for updates in param at the very least. Assuming this has a quick solution, the next steps would be:

- [x] Fix the dictionary keyword issue when the parameter values are initialized with `None`.
- [x] See if this dictionary support can be pushed further down into `Apply` and/or `Dynamic`.