### PR TITLE
Updated operation streams parameter definitions

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -857,7 +857,8 @@ class decimate(Operation):
     random_seed = param.Integer(default=42, doc="""
         Seed used to initialize randomization.""")
 
-    streams = param.List(default=[RangeXY], doc="""
+    streams = param.ClassSelector(default=[RangeXY], class_=(dict, list),
+                                   doc="""
         List of streams that are applied if dynamic=True, allowing
         for dynamic interaction with the plot.""")
 


### PR DESCRIPTION
Running the Large Data notebook on current master revealed a param bug (https://github.com/holoviz/param/issues/455) where `decimate` was failing despite having a valid declaration.

The issue is that https://github.com/holoviz/holoviews/pull/4818 generalized the allowable values for the `streams` parameter but the param bug referenced above means that *all* operations need to use the same `ClassSelector` definition even if the current declaration is a valid subset of what is accepted by the base class (i.e `param.List` or `param.Dict`).

I realize that I probably updated a bunch of parameter definitions in https://github.com/holoviz/holoviews/pull/4818 even though it wasn't strictly necessary (if the param bug wasn't an issue).

It is important to fix this param issue as all user defined operations will also be affected: users shouldn't have to update their `streams` parameter definitions.