### PR TITLE
Generalized inspect operation

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1949,12 +1949,12 @@ class inspect_points(inspect_base):
 
 
 
-class inspect_poly(inspect_base):
+class inspect_polygons(inspect_base):
 
     @classmethod
     def _validate(cls, raster):
         if 'spatialpandas' not in raster.dataset.interface.datatype:
-            raise ValueError("inspect_poly only supports spatialpandas datatypes.")
+            raise ValueError("inspect_polygons only supports spatialpandas datatypes.")
 
     @classmethod
     def _element(cls, raster, df):
@@ -1984,5 +1984,5 @@ class inspect_poly(inspect_base):
 
 inspect._dispatch = {
     Points: inspect_points,
-    Polygons: inspect_poly
+    Polygons: inspect_polygons
 }

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1768,8 +1768,74 @@ class inspect_mask(Operation):
         return Polygons(data, kdims=kdims)
 
 
+class inspect(Operation):
+    """
+    Generalized inspect operation that detects the appropriate indicator
+    type.
+    """
 
-class inspect_base(Operation):
+    pixels = param.Integer(default=3, doc="""
+       Number of pixels in data space around the cursor point to search
+       for hits in. The hit within this box mask that is closest to the
+       cursor's position is displayed.""")
+
+    null_value = param.Number(default=0, doc="""
+       Value of raster which indicates no hits. For instance zero for
+       count aggregator (default) and commonly NaN for other (float)
+       aggregators. For RGBA images, the alpha channel is used which means
+       zero alpha acts as the null value.""")
+
+    value_bounds = param.NumericTuple(default=None, length=2, allow_None=True, doc="""
+       If not None, a numeric bounds for the pixel under the cursor in
+       order for hits to be computed. Useful for count aggregators where
+       a value of (1,1000) would make sure no more than a thousand
+       samples will be searched.""")
+
+    hits = param.DataFrame(default=pd.DataFrame(), allow_None=True)
+
+    max_indicators = param.Integer(default=1, doc="""
+       Maximum number of indicator elements to display within the mask
+       of size pixels. Points are prioritized by distance from the
+       cursor point. This means that the default value of one shows the
+       single closest sample to the cursor. Note that this limit is not
+       applies to the hits parameter.""")
+
+    transform = param.Callable(default=identity, doc="""
+      Function that transforms the hits dataframe before it is passed to
+      the Points element. Can be used to customize the value dimensions
+      e.g. to implement custom hover behavior.""")
+
+    # Stream values and overrides
+    streams = param.ClassSelector(default=dict(x=PointerXY.param.x,
+                                               y=PointerXY.param.y),
+                                  class_=(dict, list))
+    x = param.Number(default=0)
+    y = param.Number(default=0)
+    _dispatch = {}
+    def _process(self, raster, key=None):
+        inspect_operation = self._dispatch[self.get_input_type(raster.pipeline.operations)]
+        return inspect_operation(raster, pixels=self.p.pixels,
+                                 null_value=self.p.null_value,
+                                 value_bounds=self.p.value_bounds,
+                                 max_indicators=self.p.max_indicators,
+                                 x=self.p.x, y=self.p.y, dynamic=False)
+
+
+    def get_input_type(self, operations):
+        for op in operations:
+            output_type = getattr(op, 'output_type', None)
+            if output_type is not None:
+                if output_type in [el[0] for el in rasterize._transforms]:
+                    # Datashader output types that are also input types e.g for regrid
+                    if issubclass(output_type, (Image, RGB)):
+                        continue
+                    return output_type
+        raise RuntimeError('Could not establish input element type '
+                           'for datashader pipeline in the inspect operation.')
+
+
+
+class inspect_base(inspect):
     """
     Given datashaded aggregate (Image) output, return a set of
     (hoverable) points sampled from those near the cursor.
@@ -1937,69 +2003,5 @@ class inspect_poly(inspect_base):
         return df.iloc[distances.argsort().values]
 
 
-class inspect(Operation):
-    """
-    Generalized inspect operation that detects the appropriate indicator
-    type.
-    """
 
-    pixels = param.Integer(default=3, doc="""
-       Number of pixels in data space around the cursor point to search
-       for hits in. The hit within this box mask that is closest to the
-       cursor's position is displayed.""")
-
-    null_value = param.Number(default=0, doc="""
-       Value of raster which indicates no hits. For instance zero for
-       count aggregator (default) and commonly NaN for other (float)
-       aggregators. For RGBA images, the alpha channel is used which means
-       zero alpha acts as the null value.""")
-
-    value_bounds = param.NumericTuple(default=None, length=2, allow_None=True, doc="""
-       If not None, a numeric bounds for the pixel under the cursor in
-       order for hits to be computed. Useful for count aggregators where
-       a value of (1,1000) would make sure no more than a thousand
-       samples will be searched.""")
-
-    hits = param.DataFrame(default=pd.DataFrame(), allow_None=True)
-
-    max_indicators = param.Integer(default=1, doc="""
-       Maximum number of indicator elements to display within the mask
-       of size pixels. Points are prioritized by distance from the
-       cursor point. This means that the default value of one shows the
-       single closest sample to the cursor. Note that this limit is not
-       applies to the hits parameter.""")
-
-    transform = param.Callable(default=identity, doc="""
-      Function that transforms the hits dataframe before it is passed to
-      the Points element. Can be used to customize the value dimensions
-      e.g. to implement custom hover behavior.""")
-
-    # Stream values and overrides
-    streams = param.ClassSelector(default=dict(x=PointerXY.param.x,
-                                               y=PointerXY.param.y),
-                                  class_=(dict, list))
-    x = param.Number(default=0)
-    y = param.Number(default=0)
-    _dispatch = {Points : inspect_points,
-                 Polygons : inspect_poly}
-
-    def _process(self, raster, key=None):
-        inspect_operation = self._dispatch[self.get_input_type(raster.pipeline.operations)]
-        return inspect_operation(raster, pixels=self.p.pixels,
-                                 null_value=self.p.null_value,
-                                 value_bounds=self.p.value_bounds,
-                                 max_indicators=self.p.max_indicators,
-                                 x=self.p.x, y=self.p.y, dynamic=False)
-
-
-    def get_input_type(self, operations):
-        for op in operations:
-            output_type = getattr(op, 'output_type', None)
-            if output_type is not None:
-                if output_type in [el[0] for el in rasterize._transforms]:
-                    # Datashader output types that are also input types e.g for regrid
-                    if issubclass(output_type, (Image, RGB)):
-                        continue
-                    return output_type
-        raise RuntimeError('Could not establish input element type '
-                           'for datashader pipeline in the inspect operation.')
+inspect._dispatch = {Points : inspect_points, Polygons : inspect_poly}

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -24,7 +24,7 @@ except:
     hammer_bundle, connect_edges = object, object
 
 from ..core import (Operation, Element, Dimension, NdOverlay,
-                    CompositeOverlay, Dataset, Overlay, OrderedDict)
+                    CompositeOverlay, Dataset, Overlay, OrderedDict, Store)
 from ..core.data import PandasInterface, XArrayInterface, DaskInterface, cuDFInterface
 from ..core.util import (
     Iterable, LooseVersion, basestring, cftime_types, cftime_to_timestamp,
@@ -1958,8 +1958,11 @@ class inspect_polygons(inspect_base):
 
     @classmethod
     def _element(cls, raster, df):
-        return Polygons(df, kdims=raster.kdims, vdims=cls._vdims(raster, df)).opts(
-            color_index=None)
+        polygons = Polygons(df, kdims=raster.kdims, vdims=cls._vdims(raster, df))
+        if Store.loaded_backends() != []:
+            return polygons.opts(color_index=None)
+        else:
+            return polygons
 
     @classmethod
     def _sort_by_distance(cls, raster, df, x, y):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1862,44 +1862,6 @@ class inspect_base(inspect):
     (hoverable) points sampled from those near the cursor.
     """
 
-    pixels = param.Integer(default=3, doc="""
-       Number of pixels in data space around the cursor point to search
-       for hits in. The hit within this box mask that is closest to the
-       cursor's position is displayed.""")
-
-    null_value = param.Number(default=0, doc="""
-       Value of raster which indicates no hits. For instance zero for
-       count aggregator (default) and commonly NaN for other (float)
-       aggregators. For RGBA images, the alpha channel is used which means
-       zero alpha acts as the null value.""")
-
-    value_bounds = param.NumericTuple(default=None, length=2, allow_None=True, doc="""
-       If not None, a numeric bounds for the pixel under the cursor in
-       order for hits to be computed. Useful for count aggregators where
-       a value of (1,1000) would make sure no more than a thousand
-       samples will be searched.""")
-
-    hits = param.DataFrame(default=pd.DataFrame(), allow_None=True)
-
-    max_indicators = param.Integer(default=1, doc="""
-       Maximum number of indicator elements to display within the mask
-       of size pixels. Points are prioritized by distance from the
-       cursor point. This means that the default value of one shows the
-       single closest sample to the cursor. Note that this limit is not
-       applies to the hits parameter.""")
-
-    transform = param.Callable(default=identity, doc="""
-      Function that transforms the hits dataframe before it is passed to
-      the Points element. Can be used to customize the value dimensions
-      e.g. to implement custom hover behavior.""")
-
-    # Stream values and overrides
-    streams = param.ClassSelector(default=dict(x=PointerXY.param.x,
-                                               y=PointerXY.param.y),
-                                  class_=(dict, list))
-    x = param.Number(default=0)
-    y = param.Number(default=0)
-
     def _process(self, raster, key=None):
         self._validate(raster)
         if isinstance(raster, RGB):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1812,6 +1812,11 @@ class inspect(Operation):
     x = param.Number(default=0)
     y = param.Number(default=0)
     _dispatch = {}
+
+    @property
+    def mask(self):
+        raise NotImplementedError('The mask property is not available for %s inspector.' %
+                                  self.__class__.__name__)
     def _process(self, raster, key=None):
         inspect_operation = self._dispatch[self.get_input_type(raster.pipeline.operations)]
         return inspect_operation(raster, pixels=self.p.pixels,
@@ -1878,10 +1883,6 @@ class inspect_base(inspect):
                                   class_=(dict, list))
     x = param.Number(default=0)
     y = param.Number(default=0)
-
-    @property
-    def mask(self):
-        return inspect_mask.instance(pixels=self.p.pixels)
 
     def _process(self, raster, key=None):
         self._validate(raster)
@@ -1953,6 +1954,10 @@ class inspect_base(inspect):
 
 class inspect_points(inspect_base):
 
+    @property
+    def mask(self):
+        return inspect_mask.instance(pixels=self.p.pixels)
+
     @classmethod
     def _element(cls, raster, df):
         return Points(df, kdims=raster.kdims, vdims=cls._vdims(raster, df))
@@ -1972,6 +1977,10 @@ class inspect_points(inspect_base):
 
 
 class inspect_poly(inspect_base):
+
+    @property
+    def mask(self):
+        return inspect_mask.instance(pixels=self.p.pixels)
 
     @classmethod
     def _validate(cls, raster):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1985,7 +1985,11 @@ class inspect(Operation):
 
     def _process(self, raster, key=None):
         inspect_operation = self._dispatch[self.get_input_type(raster.pipeline.operations)]
-        return inspect_operation(raster, x=self.p.x, y=self.p.y, dynamic=False)
+        return inspect_operation(raster, pixels=self.p.pixels,
+                                 null_value=self.p.null_value,
+                                 value_bounds=self.p.value_bounds,
+                                 max_indicators=self.p.max_indicators,
+                                 x=self.p.x, y=self.p.y, dynamic=False)
 
 
     def get_input_type(self, operations):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1818,8 +1818,7 @@ class inspect(Operation):
 
     @property
     def mask(self):
-        raise NotImplementedError('The mask property is not available for %s inspector.' %
-                                  self.__class__.__name__)
+        return inspect_mask.instance(pixels=self.p.pixels)
 
     def _update_hits(self, event):
         self.hits = event.obj.hits
@@ -1932,10 +1931,6 @@ class inspect_base(inspect):
 
 class inspect_points(inspect_base):
 
-    @property
-    def mask(self):
-        return inspect_mask.instance(pixels=self.p.pixels)
-
     @classmethod
     def _element(cls, raster, df):
         return Points(df, kdims=raster.kdims, vdims=cls._vdims(raster, df))
@@ -1955,10 +1950,6 @@ class inspect_points(inspect_base):
 
 
 class inspect_poly(inspect_base):
-
-    @property
-    def mask(self):
-        return inspect_mask.instance(pixels=self.p.pixels)
 
     @classmethod
     def _validate(cls, raster):

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -1153,6 +1153,13 @@ class InspectorTests(ComparisonTestCase):
         self.assertEqual(points.dimension_values('x'), np.array([0.2, 0.4, 0]))
         self.assertEqual(points.dimension_values('y'), np.array([0.3, 0.7, 0.99]))
 
+    def test_inspection_5px_mask_points_df(self):
+        inspector = inspect.instance(max_indicators=3, dynamic=False, pixels=5,
+                                     x=-0.1, y=-0.1)
+        inspector(self.pntsimg)
+        self.assertEqual(list(inspector.hits['x']),[0.2,0.4,0.0])
+        self.assertEqual(list(inspector.hits['y']),[0.3,0.7,0.99])
+
     def test_points_inspection_dict_streams(self):
         Tap.x, Tap.y = 0.4, 0.7
         points = inspect_points(self.pntsimg, max_indicators=3, dynamic=True,
@@ -1179,6 +1186,18 @@ class InspectorTests(ComparisonTestCase):
                                  max_indicators=3, dynamic=False, pixels=1, x=6, y=5)
         self.assertEqual(polys, Polygons([{'x': [6, 3, 7], 'y': [7, 2, 5], 'z': 2}],
                                          vdims='z'))
+
+
+    def test_inspection_1px_mask_poly_df(self):
+        if spatialpandas is None:
+            raise SkipTest('Polygon inspect tests require spatialpandas')
+        inspector = inspect.instance(max_indicators=3, dynamic=False, pixels=1, x=6, y=5)
+        inspector(self.polysrgb)
+        self.assertEqual(len(inspector.hits), 1)
+        data = [[6.0, 7.0, 3.0, 2.0, 7.0, 5.0, 6.0, 7.0]]
+        self.assertEqual(inspector.hits.iloc[0].geometry,
+                         spatialpandas.geometry.polygon.Polygon(data))
+
 
     def test_polys_inspection_1px_mask_miss(self):
         if spatialpandas is None:

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -18,7 +18,8 @@ try:
     from holoviews.core.util import pd
     from holoviews.operation.datashader import (
         aggregate, regrid, ds_version, stack, directly_connect_edges,
-        shade, spread, rasterize, datashade, inspect_points, inspect_polygons, AggregationOperation
+        shade, spread, rasterize, datashade, AggregationOperation,
+        inspect, inspect_points, inspect_polygons
     )
 except:
     raise SkipTest('Datashader not available')
@@ -1121,6 +1122,17 @@ class InspectorTests(ComparisonTestCase):
     def tearDown(self):
         Tap.x, Tap.y = None, None
 
+
+    def test_inspect_points_or_polygons(self):
+        if spatialpandas is None:
+            raise SkipTest('Polygon inspect tests require spatialpandas')
+        polys = inspect(self.polysrgb,
+                        max_indicators=3, dynamic=False, pixels=1, x=6, y=5)
+        self.assertEqual(polys, Polygons([{'x': [6, 3, 7], 'y': [7, 2, 5], 'z': 2}], vdims='z'))
+        points = inspect(self.pntsimg, max_indicators=3, dynamic=False, pixels=1, x=-0.1, y=-0.1)
+        self.assertEqual(points.dimension_values('x'), np.array([]))
+        self.assertEqual(points.dimension_values('y'), np.array([]))
+
     def test_points_inspection_1px_mask(self):
         points = inspect_points(self.pntsimg, max_indicators=3, dynamic=False, pixels=1, x=-0.1, y=-0.1)
         self.assertEqual(points.dimension_values('x'), np.array([]))
@@ -1167,7 +1179,6 @@ class InspectorTests(ComparisonTestCase):
                                  max_indicators=3, dynamic=False, pixels=1, x=6, y=5)
         self.assertEqual(polys, Polygons([{'x': [6, 3, 7], 'y': [7, 2, 5], 'z': 2}],
                                          vdims='z'))
-
 
     def test_polys_inspection_1px_mask_miss(self):
         if spatialpandas is None:

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -1105,35 +1105,35 @@ class InspectorTests(ComparisonTestCase):
     """
     def setUp(self):
         points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
-        self.img = rasterize(points, dynamic=False,
+        self.pntsimg = rasterize(points, dynamic=False,
                              x_range=(0, 1), y_range=(0, 1), width=4, height=4)
 
     def tearDown(self):
         Tap.x, Tap.y = None, None
 
     def test_points_inspection_1px_mask(self):
-        points = inspect_points(self.img, max_indicators=3, dynamic=False, pixels=1, x=-0.1, y=-0.1)
+        points = inspect_points(self.pntsimg, max_indicators=3, dynamic=False, pixels=1, x=-0.1, y=-0.1)
         self.assertEqual(points.dimension_values('x'), np.array([]))
         self.assertEqual(points.dimension_values('y'), np.array([]))
 
     def test_points_inspection_2px_mask(self):
-        points = inspect_points(self.img, max_indicators=3, dynamic=False, pixels=2, x=-0.1, y=-0.1)
+        points = inspect_points(self.pntsimg, max_indicators=3, dynamic=False, pixels=2, x=-0.1, y=-0.1)
         self.assertEqual(points.dimension_values('x'), np.array([0.2]))
         self.assertEqual(points.dimension_values('y'), np.array([0.3]))
 
     def test_points_inspection_4px_mask(self):
-        points = inspect_points(self.img, max_indicators=3, dynamic=False, pixels=4, x=-0.1, y=-0.1)
+        points = inspect_points(self.pntsimg, max_indicators=3, dynamic=False, pixels=4, x=-0.1, y=-0.1)
         self.assertEqual(points.dimension_values('x'), np.array([0.2, 0.4]))
         self.assertEqual(points.dimension_values('y'), np.array([0.3, 0.7]))
 
     def test_points_inspection_5px_mask(self):
-        points = inspect_points(self.img, max_indicators=3, dynamic=False, pixels=5, x=-0.1, y=-0.1)
+        points = inspect_points(self.pntsimg, max_indicators=3, dynamic=False, pixels=5, x=-0.1, y=-0.1)
         self.assertEqual(points.dimension_values('x'), np.array([0.2, 0.4, 0]))
         self.assertEqual(points.dimension_values('y'), np.array([0.3, 0.7, 0.99]))
 
     def test_points_inspection_dict_streams(self):
         Tap.x, Tap.y = 0.4, 0.7
-        points = inspect_points(self.img, max_indicators=3, dynamic=True,
+        points = inspect_points(self.pntsimg, max_indicators=3, dynamic=True,
                                 pixels=1, streams=dict(x=Tap.param.x, y=Tap.param.y))
         self.assertEqual(len(points.streams), 1)
         self.assertEqual(isinstance(points.streams[0], Tap), True)
@@ -1144,7 +1144,7 @@ class InspectorTests(ComparisonTestCase):
         Tap.x, Tap.y = 0.2, 0.3
         inspector = inspect_points.instance(max_indicators=3, dynamic=True, pixels=1,
                                             streams=dict(x=Tap.param.x, y=Tap.param.y))
-        points = inspector(self.img)
+        points = inspector(self.pntsimg)
         self.assertEqual(len(points.streams), 1)
         self.assertEqual(isinstance(points.streams[0], Tap), True)
         self.assertEqual(points.streams[0].x, 0.2)

--- a/holoviews/tests/operation/testdatashader.py
+++ b/holoviews/tests/operation/testdatashader.py
@@ -1160,10 +1160,18 @@ class InspectorTests(ComparisonTestCase):
         self.assertEqual(points.streams[0].x, 0.2)
         self.assertEqual(points.streams[0].y, 0.3)
 
-    def test_polys_inspection_1px_mask(self):
+    def test_polys_inspection_1px_mask_hit(self):
         if spatialpandas is None:
             raise SkipTest('Polygon inspect tests require spatialpandas')
         polys = inspect_polygons(self.polysrgb,
-                                 max_indicators=3, dynamic=False, pixels=1, x=-6, y=5)
-        self.assertEqual(polys.dimension_values('x'), np.array([6, 3, 7, 6]))
-        self.assertEqual(polys.dimension_values('y'), np.array([7, 2, 5, 7]))
+                                 max_indicators=3, dynamic=False, pixels=1, x=6, y=5)
+        self.assertEqual(polys, Polygons([{'x': [6, 3, 7], 'y': [7, 2, 5], 'z': 2}],
+                                         vdims='z'))
+
+
+    def test_polys_inspection_1px_mask_miss(self):
+        if spatialpandas is None:
+            raise SkipTest('Polygon inspect tests require spatialpandas')
+        polys = inspect_polygons(self.polysrgb,
+                                 max_indicators=3, dynamic=False, pixels=1, x=0, y=0)
+        self.assertEqual(polys, Polygons([], vdims='z'))


### PR DESCRIPTION
WIP.

This generalized operation inspects the pipeline to figure out which concrete `inspect_X` operation to dispatch to:

![PR2](https://user-images.githubusercontent.com/890576/107235497-5b4d7a00-69ea-11eb-8bef-104b246ace79.gif)

The idea is that for most uses, users only ever need to know about `inspect`.

### TODO

- [x] Make sure the `hits` dataframe is mirrored properly.
- [x] Support the `mask` operation.
- [x] Try to reduce the repetition of parameter definitions.