### PR TITLE
Fix for Dimension pickling

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -348,6 +348,14 @@ class Dimension(param.Parameterized):
         """
         return hash(self.spec)
 
+    def __setstate__(self, d):
+        """
+        Compatibility for pickles before alias attribute was introduced.
+        """
+        super(Dimension, self).__setstate__(d)
+        if '_label_param_value' not in d:
+            self.label = self.name
+
     def __eq__(self, other):
         "Implements equals operator including sanitized comparison."
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -348,13 +348,6 @@ class Dimension(param.Parameterized):
         """
         return hash(self.spec)
 
-    def __setstate__(self, d):
-        """
-        Compatibility for pickles before alias attribute was introduced.
-        """
-        super(Dimension, self).__setstate__(d)
-        self.label = self.name
-
     def __eq__(self, other):
         "Implements equals operator including sanitized comparison."
 


### PR DESCRIPTION
Fixes #4838 by removing the custom `__setstate__` on `Dimension`.

The key thing it was doing `self.label = self.name` which was needed a long time ago before `Dimension` has separate `name` and `label` concepts. The question is whether we still need this to try to unpickle *really* old pickles (>4 years old) in which case a fix for the custom `__setstate__` is needed instead of simply removing it.