### PR TITLE
Copying matplotlib cmap to avoid mutating global colormaps

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
+import copy
 import math
 import warnings
 from types import FunctionType
@@ -979,6 +980,8 @@ class ColorbarPlot(ElementPlot):
                 if isinstance(self.color_levels, list):
                     palette, (vmin, vmax) = color_intervals(palette, self.color_levels, clip=(vmin, vmax))
             cmap = mpl_colors.ListedColormap(palette)
+
+        cmap = copy.copy(cmap)
         if 'max' in colors: cmap.set_over(**colors['max'])
         if 'min' in colors: cmap.set_under(**colors['min'])
         if 'NaN' in colors: cmap.set_bad(**colors['NaN'])


### PR DESCRIPTION
Fix for https://github.com/holoviz/holoviews/issues/4842.

Before:

![image](https://user-images.githubusercontent.com/890576/109652886-f0ddb480-7b25-11eb-9203-0c60fba9a0dd.png)

After:

![image](https://user-images.githubusercontent.com/890576/109652834-e02d3e80-7b25-11eb-972a-8e1f1deb6fd7.png)
