### PR TITLE
Handle None renderers when merging HoverTool.renderers

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2284,7 +2284,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             if tool:
                 tool_renderers = [] if tool.renderers == 'auto' else tool.renderers
                 hover_renderers = [] if hover.renderers == 'auto' else hover.renderers
-                renderers = tool_renderers + hover_renderers
+                renderers = [r for r in tool_renderers + hover_renderers if r is not None]
                 tool.renderers = list(util.unique_iterator(renderers))
                 if 'hover' not in self.handles:
                     self.handles['hover'] = tool

--- a/holoviews/tests/plotting/bokeh/testoverlayplot.py
+++ b/holoviews/tests/plotting/bokeh/testoverlayplot.py
@@ -76,6 +76,12 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertIn(curve_plot.handles['glyph_renderer'], curve_plot.handles['hover'].renderers)
         self.assertEqual(plot.handles['hover'].tooltips, tooltips)
 
+    def test_hover_tool_overlay_renderers(self):
+        overlay = Curve(range(2)).opts(tools=['hover']) * ErrorBars([]).opts(tools=['hover'])
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertEqual(len(plot.handles['hover'].renderers), 1)
+        self.assertEqual(plot.handles['hover'].tooltips, [('x', '@{x}'), ('y', '@{y}')])
+
     def test_hover_tool_nested_overlay_renderers(self):
         overlay1 = NdOverlay({0: Curve(range(2)), 1: Curve(range(3))}, kdims=['Test'])
         overlay2 = NdOverlay({0: Curve(range(4)), 1: Curve(range(5))}, kdims=['Test'])


### PR DESCRIPTION
The renderers attribute contained Nones raising property errors.