### PR TITLE
Fix wrong subsection level for version number

### DIFF
--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -5,7 +5,7 @@ Version 1.14
 ~~~~~~~~~~~~
 
 Version 1.14.2
-==============
+**************
 
 Date: 2021-03-02
 
@@ -76,7 +76,7 @@ Documentation:
    `#4811 <https://github.com/holoviz/holoviews/pull/4811>`__)
 
 Version 1.14.1
-==============
+**************
 
 Date: 2020-12-22
 


### PR DESCRIPTION
Fixes a wrong subsection level for version number in https://holoviews.org/releases.html

![2021-03-06 15_17_16](https://user-images.githubusercontent.com/19758978/110213139-11e43380-7e9f-11eb-9eca-d040c9ff09e2.png)
