### PR TITLE
Updating GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [2.7, 3.6, 3.7]
-        exclude:
-          - os: windows-latest
-            python-version: 2.7
+        python-version: [3.6, 3.7, 3.8]
+        # exclude:
+        #   - os: windows-latest
+        #     python-version: 2.7
     timeout-minutes: 60
     defaults:
       run:
@@ -27,10 +27,11 @@ jobs:
       DESC: "Python ${{ matrix.python-version }} tests"
       HV_REQUIREMENTS: "unit_tests"
       PYTHON_VERSION: ${{ matrix.python-version }}
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev"
-      CHANS: "-c pyviz"
+      CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge"
+      CHANS: "-c pyviz -c conda-forge"
       MPLBACKEND: "Agg"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MAMBA_NO_BANNER: 1
     steps:
       - uses: actions/checkout@v2
         with:
@@ -62,25 +63,25 @@ jobs:
           git describe
           echo "======"
           conda list
-      - name: bokeh update
-        if: startsWith(matrix.python-version, 3.)
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          conda install -c pyviz "bokeh>=2.3" "panel>=0.11"
-      - name: datashader pin
-        if: startsWith(matrix.python-version, 2.)
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          conda install -c pyviz "datashader=0.11.1"
-      - name: matplotlib patch
-        if: startsWith(matrix.python-version, 3.)
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          conda install matplotlib=3.0.3 --no-deps
-          python -c "import matplotlib; print(matplotlib.__version__);"
+      # - name: bokeh update
+      #   if: startsWith(matrix.python-version, 3.)
+      #   run: |
+      #     eval "$(conda shell.bash hook)"
+      #     conda activate test-environment
+      #     conda install "bokeh>=2.2"
+      # - name: datashader pin
+      #   if: startsWith(matrix.python-version, 2.)
+      #   run: |
+      #     eval "$(conda shell.bash hook)"
+      #     conda activate test-environment
+      #     conda install -c pyviz "datashader=0.11.1"
+      # - name: matplotlib patch
+      #   if: startsWith(matrix.python-version, 3.)
+      #   run: |
+      #     eval "$(conda shell.bash hook)"
+      #     conda activate test-environment
+      #     conda install matplotlib=3.0.3 --no-deps
+      #     python -c "import matplotlib; print(matplotlib.__version__);"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,13 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda install -c pyviz "datashader=0.11.1"
+      - name: matplotlib patch
+        if: startsWith(matrix.python-version, 3.)
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          conda install matplotlib=3.0.3 --no-deps
+          python -c "import matplotlib; print(matplotlib.__version__);"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
+          conda install mamba -c conda-forge
           conda list
           doit develop_install ${{ env.CHANS_DEV}} -o ${{ env.HV_REQUIREMENTS }}
           python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 60
     defaults:
       run:
-        shell: bash -l {0} 
+        shell: bash -l {0}
     env:
       DESC: "Python ${{ matrix.python-version }} tests"
       HV_REQUIREMENTS: "unit_tests"
@@ -41,6 +41,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
+          channels: conda-forge
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
       - name: conda setup
@@ -72,14 +73,6 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda install -c pyviz "datashader=0.11.1"
-      - name: matplotlib patch
-        if: startsWith(matrix.python-version, 3.)
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          conda uninstall matplotlib matplotlib-base --force
-          conda install matplotlib=3.0.3 --no-deps -c conda-forge
-          python -c "import matplotlib; print(matplotlib.__version__);"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,10 @@ jobs:
         exclude:
           - os: windows-latest
             python-version: 2.7
-          - os: macos-latest
-            python-version: 3.7
     timeout-minutes: 60
     defaults:
       run:
-        shell: bash -l {0} 
+        shell: bash -l {0}
     env:
       DESC: "Python ${{ matrix.python-version }} tests"
       HV_REQUIREMENTS: "unit_tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,6 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: [3.6, 3.7, 3.8]
-        # exclude:
-        #   - os: windows-latest
-        #     python-version: 2.7
     timeout-minutes: 60
     defaults:
       run:
@@ -63,25 +60,6 @@ jobs:
           git describe
           echo "======"
           conda list
-      # - name: bokeh update
-      #   if: startsWith(matrix.python-version, 3.)
-      #   run: |
-      #     eval "$(conda shell.bash hook)"
-      #     conda activate test-environment
-      #     conda install "bokeh>=2.2"
-      # - name: datashader pin
-      #   if: startsWith(matrix.python-version, 2.)
-      #   run: |
-      #     eval "$(conda shell.bash hook)"
-      #     conda activate test-environment
-      #     conda install -c pyviz "datashader=0.11.1"
-      # - name: matplotlib patch
-      #   if: startsWith(matrix.python-version, 3.)
-      #   run: |
-      #     eval "$(conda shell.bash hook)"
-      #     conda activate test-environment
-      #     conda install matplotlib=3.0.3 --no-deps
-      #     python -c "import matplotlib; print(matplotlib.__version__);"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 60
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -l {0} 
     env:
       DESC: "Python ${{ matrix.python-version }} tests"
       HV_REQUIREMENTS: "unit_tests"
@@ -78,7 +78,7 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda uninstall matplotlib matplotlib-base --force
-          conda install matplotlib=3.0.3 --no-deps
+          conda install matplotlib=3.0.3 --no-deps -c conda-forge
           python -c "import matplotlib; print(matplotlib.__version__);"
       - name: doit env_capture
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
       CHANS: "-c pyviz -c conda-forge"
       MPLBACKEND: "Agg"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      MAMBA_NO_BANNER: 1
     steps:
       - uses: actions/checkout@v2
         with:
@@ -39,7 +38,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          channels: conda-forge
+          channels: conda-forge,defaults
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
       - name: conda setup
@@ -52,7 +51,6 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          conda install mamba -c conda-forge
           conda list
           doit develop_install ${{ env.CHANS_DEV}} -o ${{ env.HV_REQUIREMENTS }}
           python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
@@ -83,7 +81,6 @@ jobs:
       - name: run coveralls
         env:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        if: startsWith(matrix.python-version, 3.)
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment

--- a/dodo.py
+++ b/dodo.py
@@ -15,37 +15,3 @@ def task_pip_on_conda():
         # this interferes with pip-installed nose
         'conda remove -y --force nose'
     ]}
-
-import pyctdev._conda
-python_develop = 'python -m pip install --no-deps --no-build-isolation -e .'
-pyctdev._conda.python_develop = python_develop
-
-from pyctdev._conda import _join_the_club, get_buildreqs, _get_dependencies, echo, _pin
-
-
-def _conda_build_deps(channel):
-    buildreqs = get_buildreqs()
-    deps = " ".join('"%s"'%_join_the_club(dep) for dep in buildreqs)
-    if len(buildreqs)>0:
-        return "mamba install -y %s %s"%(" ".join(['-c %s'%c for c in channel]),deps)
-    else:
-        return echo("Skipping conda install (no build dependencies)")
-
-
-def _conda_install_with_options(options,channel,env_name_again,no_pin_deps,all_extras):
-    # TODO: list v string form for _pin
-    deps = _get_dependencies(['install_requires']+options,all_extras=all_extras)
-    deps = [_join_the_club(d) for d in deps]
-
-    if len(deps)>0:
-        deps = _pin(deps) if no_pin_deps is False else deps
-        deps = " ".join('"%s"'%dep for dep in deps)
-        # TODO and join the club?
-        e = '' if env_name_again=='' else '-n %s'%env_name_again
-        return "mamba install -y " + e + " %s %s"%(" ".join(['-c %s'%c for c in channel]),deps)
-    else:
-        return echo("Skipping conda install (no dependencies)")
-
-
-pyctdev._conda._conda_build_deps = _conda_build_deps
-pyctdev._conda._conda_install_with_options = _conda_install_with_options

--- a/dodo.py
+++ b/dodo.py
@@ -19,3 +19,16 @@ def task_pip_on_conda():
 import pyctdev._conda
 python_develop = 'python -m pip install --no-deps --no-build-isolation -e .'
 pyctdev._conda.python_develop = python_develop
+
+from pyctdev._conda import _join_the_club, get_buildreqs
+
+
+def _conda_build_deps(channel):
+    buildreqs = get_buildreqs()
+    deps = " ".join('"%s"'%_join_the_club(dep) for dep in buildreqs)
+    if len(buildreqs)>0:
+        return "mamba install -y %s %s"%(" ".join(['-c %s'%c for c in channel]),deps)
+    else:
+        return echo("Skipping conda install (no build dependencies)")
+
+pyctdev._conda._conda_build_deps = _conda_build_deps

--- a/dodo.py
+++ b/dodo.py
@@ -15,3 +15,7 @@ def task_pip_on_conda():
         # this interferes with pip-installed nose
         'conda remove -y --force nose'
     ]}
+
+import pyctdev._conda
+python_develop = 'python -m pip install --no-deps --no-build-isolation -e .'
+pyctdev._conda.python_develop = python_develop

--- a/dodo.py
+++ b/dodo.py
@@ -20,7 +20,7 @@ import pyctdev._conda
 python_develop = 'python -m pip install --no-deps --no-build-isolation -e .'
 pyctdev._conda.python_develop = python_develop
 
-from pyctdev._conda import _join_the_club, get_buildreqs
+from pyctdev._conda import _join_the_club, get_buildreqs, _get_dependencies, echo, _pin
 
 
 def _conda_build_deps(channel):
@@ -31,4 +31,21 @@ def _conda_build_deps(channel):
     else:
         return echo("Skipping conda install (no build dependencies)")
 
+
+def _conda_install_with_options(options,channel,env_name_again,no_pin_deps,all_extras):
+    # TODO: list v string form for _pin
+    deps = _get_dependencies(['install_requires']+options,all_extras=all_extras)
+    deps = [_join_the_club(d) for d in deps]
+
+    if len(deps)>0:
+        deps = _pin(deps) if no_pin_deps is False else deps
+        deps = " ".join('"%s"'%dep for dep in deps)
+        # TODO and join the club?
+        e = '' if env_name_again=='' else '-n %s'%env_name_again
+        return "mamba install -y " + e + " %s %s"%(" ".join(['-c %s'%c for c in channel]),deps)
+    else:
+        return echo("Skipping conda install (no dependencies)")
+
+
 pyctdev._conda._conda_build_deps = _conda_build_deps
+pyctdev._conda._conda_install_with_options = _conda_install_with_options

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -133,16 +133,18 @@ class ErrorPlot(ColorbarPlot):
             _, (bottoms, tops), verts = handles
         return {'bottoms': bottoms, 'tops': tops, 'verts': verts[0], 'artist': verts[0]}
 
-
     def get_data(self, element, ranges, style):
         with abbreviated_exception():
             style = self._apply_transforms(element, ranges, style)
-        color = style.get('color')
+        color = style.pop('color', None)
         if isinstance(color, np.ndarray):
             style['ecolor'] = color
         if 'edgecolor' in style:
             style['ecolor'] = style.pop('edgecolor')
         c = style.get('c')
+        if 'linewidth' in style:
+            # Breaks if it is a numpy array, so forces it to be a list.
+            style["elinewidth"] = np.asarray(style.pop('linewidth')).tolist()
         if isinstance(c, np.ndarray):
             with abbreviated_exception():
                 raise ValueError('Mapping a continuous or categorical '
@@ -193,8 +195,8 @@ class ErrorPlot(ColorbarPlot):
             tops.set_ydata(tys)
         if 'ecolor' in style:
             verts.set_edgecolors(style['ecolor'])
-        if 'linewidth' in style:
-            verts.set_linewidths(style['linewidth'])
+        if 'elinewidth' in style:
+            verts.set_linewidths(style['elinewidth'])
 
         return axis_kwargs
 

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -141,10 +141,10 @@ class ErrorPlot(ColorbarPlot):
             style['ecolor'] = color
         if 'edgecolor' in style:
             style['ecolor'] = style.pop('edgecolor')
-        c = style.get('c')
         if 'linewidth' in style:
-            # Breaks if it is a numpy array, so forces it to be a list.
+            # Raise ValueError if a numpy array, so needs to be a list.
             style["elinewidth"] = np.asarray(style.pop('linewidth')).tolist()
+        c = style.get('c')
         if isinstance(c, np.ndarray):
             with abbreviated_exception():
                 raise ValueError('Mapping a continuous or categorical '

--- a/holoviews/tests/plotting/matplotlib/testcurveplot.py
+++ b/holoviews/tests/plotting/matplotlib/testcurveplot.py
@@ -19,20 +19,20 @@ class TestCurvePlot(TestMPLPlot):
         dates = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]
         curve = Curve((dates, np.random.rand(10)))
         plot = mpl_renderer.get_plot(curve)
-        self.assertEqual(plot.handles['axis'].get_xlim(), (735964.0, 735973.0))
+        self.assertEqual(plot.handles['axis'].get_xlim(), (16801.0, 16810.0))
 
     @pd_skip
     def test_curve_pandas_timestamps(self):
         dates = pd.date_range('2016-01-01', '2016-01-10', freq='D')
         curve = Curve((dates, np.random.rand(10)))
         plot = mpl_renderer.get_plot(curve)
-        self.assertEqual(plot.handles['axis'].get_xlim(), (735964.0, 735973.0))
+        self.assertEqual(plot.handles['axis'].get_xlim(), (16801.0, 16810.0))
 
     def test_curve_dt_datetime(self):
         dates = [dt.datetime(2016,1,i) for i in range(1, 11)]
         curve = Curve((dates, np.random.rand(10)))
         plot = mpl_renderer.get_plot(curve)
-        self.assertEqual(tuple(map(round, plot.handles['axis'].get_xlim())), (735964.0, 735973.0))
+        self.assertEqual(tuple(map(round, plot.handles['axis'].get_xlim())), (16801.0, 16810.0))
 
     def test_curve_heterogeneous_datetime_types_overlay(self):
         dates64 = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]
@@ -40,7 +40,7 @@ class TestCurvePlot(TestMPLPlot):
         curve_dt64 = Curve((dates64, np.random.rand(10)))
         curve_dt = Curve((dates, np.random.rand(10)))
         plot = mpl_renderer.get_plot(curve_dt*curve_dt64)
-        self.assertEqual(tuple(map(round, plot.handles['axis'].get_xlim())), (735964.0, 735974.0))
+        self.assertEqual(tuple(map(round, plot.handles['axis'].get_xlim())), (16801.0, 16811.0))
 
     @pd_skip
     def test_curve_heterogeneous_datetime_types_with_pd_overlay(self):
@@ -51,7 +51,7 @@ class TestCurvePlot(TestMPLPlot):
         curve_dt = Curve((dates, np.random.rand(10)))
         curve_pd = Curve((dates_pd, np.random.rand(10)))
         plot = mpl_renderer.get_plot(curve_dt*curve_dt64*curve_pd)
-        self.assertEqual(plot.handles['axis'].get_xlim(), (735964.0, 735976.0))
+        self.assertEqual(plot.handles['axis'].get_xlim(), (16801.0, 16813.0))
 
     def test_curve_padding_square(self):
         curve = Curve([1, 2, 3]).options(padding=0.1)
@@ -131,8 +131,8 @@ class TestCurvePlot(TestMPLPlot):
         )
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
-        self.assertEqual(x_range[0], 736054.80000000005)
-        self.assertEqual(x_range[1], 736057.19999999995)
+        self.assertEqual(x_range[0], 16891.8)
+        self.assertEqual(x_range[1], 16894.2)
         self.assertEqual(y_range[0], 0.8)
         self.assertEqual(y_range[1], 3.2)
 
@@ -142,8 +142,8 @@ class TestCurvePlot(TestMPLPlot):
         )
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
-        self.assertEqual(x_range[0], 736054.90000000002)
-        self.assertEqual(x_range[1], 736057.09999999998)
+        self.assertEqual(x_range[0], 16891.9)
+        self.assertEqual(x_range[1], 16894.1)
         self.assertEqual(y_range[0], 0.8)
         self.assertEqual(y_range[1], 3.2)
 

--- a/holoviews/tests/plotting/matplotlib/testgraphplot.py
+++ b/holoviews/tests/plotting/matplotlib/testgraphplot.py
@@ -208,7 +208,7 @@ class TestMplGraphPlot(TestMPLPlot):
         graph = Graph((edges, nodes)).options(node_alpha='alpha')
 
         if Version(mpl.__version__) < Version("3.4.0"):
-            # Python 3.6 only get matplotlib 3.3
+            # Python 3.6 only support up to matplotlib 3.3
             with self.assertRaises(Exception):
                 mpl_renderer.get_plot(graph)
         else:
@@ -403,7 +403,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
         trimesh = TriMesh((edges, Nodes(nodes, vdims='alpha'))).options(node_alpha='alpha')
 
         if Version(mpl.__version__) < Version("3.4.0"):
-            # Python 3.6 only get matplotlib 3.3
+            # Python 3.6 only support up to matplotlib 3.3
             with self.assertRaises(Exception):
                 mpl_renderer.get_plot(trimesh)
         else:

--- a/holoviews/tests/plotting/matplotlib/testgraphplot.py
+++ b/holoviews/tests/plotting/matplotlib/testgraphplot.py
@@ -200,11 +200,21 @@ class TestMplGraphPlot(TestMPLPlot):
         self.assertEqual(artist.get_linewidths(), [12, 3, 5])
 
     def test_graph_op_node_alpha(self):
+        import matplotlib as mpl
+        from packaging.version import Version
+
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 0.2), (0, 1, 1, 0.6), (1, 1, 2, 1)], vdims='alpha')
         graph = Graph((edges, nodes)).options(node_alpha='alpha')
-        with self.assertRaises(Exception):
-            mpl_renderer.get_plot(graph)
+
+        if Version(mpl.__version__) < Version("3.4.0"):
+            # Python 3.6 only get matplotlib 3.3
+            with self.assertRaises(Exception):
+                mpl_renderer.get_plot(graph)
+        else:
+            plot = mpl_renderer.get_plot(graph)
+            artist = plot.handles['nodes']
+            self.assertEqual(artist.get_alpha(), np.array([0.2, 0.6, 1]))
 
     def test_graph_op_edge_color(self):
         edges = [(0, 1, 'red'), (0, 2, 'green'), (1, 3, 'blue')]
@@ -385,11 +395,21 @@ class TestMplTriMeshPlot(TestMPLPlot):
         self.assertEqual(artist.get_sizes(), np.array([9, 4, 64, 16]))
 
     def test_trimesh_op_node_alpha(self):
+        import matplotlib as mpl
+        from packaging.version import Version
+
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 0.2), (0, 0, 1, 0.6), (0, 1, 2, 1), (1, 0, 3, 0.3)]
         trimesh = TriMesh((edges, Nodes(nodes, vdims='alpha'))).options(node_alpha='alpha')
-        with self.assertRaises(Exception):
-            mpl_renderer.get_plot(trimesh)
+
+        if Version(mpl.__version__) < Version("3.4.0"):
+            # Python 3.6 only get matplotlib 3.3
+            with self.assertRaises(Exception):
+                mpl_renderer.get_plot(trimesh)
+        else:
+            plot = mpl_renderer.get_plot(trimesh)
+            artist = plot.handles['nodes']
+            self.assertEqual(artist.get_alpha(), np.array([0.2, 0.6, 1, 0.3]))
 
     def test_trimesh_op_node_line_width(self):
         edges = [(0, 1, 2), (1, 2, 3)]

--- a/holoviews/tests/plotting/matplotlib/testhistogramplot.py
+++ b/holoviews/tests/plotting/matplotlib/testhistogramplot.py
@@ -124,12 +124,13 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
                               vdims=['y', 'color']).options(color='color')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(histogram)
-        
-    def test_histogram_line_color_op(self):
-        histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                              vdims=['y', 'color']).options(edgecolor='color')
-        with self.assertRaises(Exception):
-            mpl_renderer.get_plot(histogram)
+
+    # This does not raise exception anymore... Ok to delete it?
+    # def test_histogram_line_color_op(self):
+    #     histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+    #                           vdims=['y', 'color']).options(edgecolor='color')
+    #     with self.assertRaises(Exception):
+    #         mpl_renderer.get_plot(histogram)
 
     def test_histogram_alpha_op(self):
         histogram = Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],

--- a/holoviews/tests/plotting/matplotlib/testhistogramplot.py
+++ b/holoviews/tests/plotting/matplotlib/testhistogramplot.py
@@ -125,12 +125,15 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(histogram)
 
-    # This does not raise exception anymore... Ok to delete it?
-    # def test_histogram_line_color_op(self):
-    #     histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-    #                           vdims=['y', 'color']).options(edgecolor='color')
-    #     with self.assertRaises(Exception):
-    #         mpl_renderer.get_plot(histogram)
+    def test_histogram_line_color_op(self):
+        histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+                              vdims=['y', 'color']).options(edgecolor='color')
+        plot = mpl_renderer.get_plot(histogram)
+        artist = plot.handles['artist']
+        children = artist.get_children()
+        self.assertEqual(children[0].get_edgecolor(), (0, 0, 0, 1))
+        self.assertEqual(children[1].get_edgecolor(), (1, 0, 0, 1))
+        self.assertEqual(children[2].get_edgecolor(), (0, 1, 0, 1))
 
     def test_histogram_alpha_op(self):
         histogram = Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],

--- a/holoviews/tests/plotting/matplotlib/testhistogramplot.py
+++ b/holoviews/tests/plotting/matplotlib/testhistogramplot.py
@@ -19,8 +19,8 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         plot = mpl_renderer.get_plot(hist)
         artist = plot.handles['artist']
         ax = plot.handles['axis']
-        self.assertEqual(ax.get_xlim(), (736330.0, 736333.0))
-        bounds = [736330.0, 736330.75, 736331.5, 736332.25]
+        self.assertEqual(ax.get_xlim(), (17167.0, 17170.0))
+        bounds = [17167.0, 17167.75, 17168.5, 17169.25]
         self.assertEqual([p.get_x() for p in artist.patches], bounds)
 
     def test_histogram_padding_square(self):
@@ -84,8 +84,8 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         )
         plot = mpl_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
-        self.assertEqual(x_range[0], 736054.19999999995)
-        self.assertEqual(x_range[1], 736057.80000000005)
+        self.assertEqual(x_range[0], 16891.2)
+        self.assertEqual(x_range[1], 16894.8)
         self.assertEqual(y_range[0], 0)
         self.assertEqual(y_range[1], 3.2)
 
@@ -95,8 +95,8 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         )
         plot = mpl_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
-        self.assertEqual(x_range[0], 736054.34999999998)
-        self.assertEqual(x_range[1], 736057.65000000002)
+        self.assertEqual(x_range[0], 16891.35)
+        self.assertEqual(x_range[1], 16894.65)
         self.assertEqual(y_range[0], 0)
         self.assertEqual(y_range[1], 3.2)
 

--- a/holoviews/tests/plotting/matplotlib/testpointplot.py
+++ b/holoviews/tests/plotting/matplotlib/testpointplot.py
@@ -137,8 +137,8 @@ class TestPointPlot(TestMPLPlot):
         )
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
-        self.assertEqual(x_range[0], 736054.80000000005)
-        self.assertEqual(x_range[1], 736057.19999999995)
+        self.assertEqual(x_range[0], 16891.8)
+        self.assertEqual(x_range[1], 16894.2)
         self.assertEqual(y_range[0], 0.8)
         self.assertEqual(y_range[1], 3.2)
 
@@ -148,8 +148,8 @@ class TestPointPlot(TestMPLPlot):
         )
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
-        self.assertEqual(x_range[0], 736054.90000000002)
-        self.assertEqual(x_range[1], 736057.09999999998)
+        self.assertEqual(x_range[0], 16891.9)
+        self.assertEqual(x_range[1], 16894.1)
         self.assertEqual(y_range[0], 0.8)
         self.assertEqual(y_range[1], 3.2)
 

--- a/holoviews/tests/plotting/matplotlib/testrenderer.py
+++ b/holoviews/tests/plotting/matplotlib/testrenderer.py
@@ -68,12 +68,12 @@ class MPLRendererTest(ComparisonTestCase):
     def test_get_size_row_plot(self):
         plot = self.renderer.get_plot(self.image1+self.image2)
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (576, 255))
+        self.assertEqual((w, h), (576, 257))  # Is this ok?
 
     def test_get_size_column_plot(self):
         plot = self.renderer.get_plot((self.image1+self.image2).cols(1))
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (288, 505))
+        self.assertEqual((w, h), (288, 509))  # Is this ok?
 
     def test_get_size_grid_plot(self):
         grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})

--- a/holoviews/tests/plotting/matplotlib/testrenderer.py
+++ b/holoviews/tests/plotting/matplotlib/testrenderer.py
@@ -68,12 +68,12 @@ class MPLRendererTest(ComparisonTestCase):
     def test_get_size_row_plot(self):
         plot = self.renderer.get_plot(self.image1+self.image2)
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (576, 257))  # Is this ok?
+        self.assertEqual((w, h), (576, 257))
 
     def test_get_size_column_plot(self):
         plot = self.renderer.get_plot((self.image1+self.image2).cols(1))
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (288, 509))  # Is this ok?
+        self.assertEqual((w, h), (288, 509))
 
     def test_get_size_grid_plot(self):
         grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})

--- a/holoviews/tests/plotting/matplotlib/testspikeplot.py
+++ b/holoviews/tests/plotting/matplotlib/testspikeplot.py
@@ -67,8 +67,8 @@ class TestSpikesPlot(TestMPLPlot):
         )
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
-        self.assertEqual(x_range[0], 736054.80000000005)
-        self.assertEqual(x_range[1], 736057.19999999995)
+        self.assertEqual(x_range[0], 16891.8)
+        self.assertEqual(x_range[1], 16894.2)
 
     def test_spikes_padding_datetime_square_heights(self):
         spikes = Spikes([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)], vdims=['Height']).options(
@@ -76,8 +76,8 @@ class TestSpikesPlot(TestMPLPlot):
         )
         plot = mpl_renderer.get_plot(spikes)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
-        self.assertEqual(x_range[0], 736054.80000000005)
-        self.assertEqual(x_range[1], 736057.19999999995)
+        self.assertEqual(x_range[0], 16891.8)
+        self.assertEqual(x_range[1], 16894.2)
         self.assertEqual(y_range[0], 0)
         self.assertEqual(y_range[1], 3.2)
 
@@ -87,8 +87,8 @@ class TestSpikesPlot(TestMPLPlot):
         )
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
-        self.assertEqual(x_range[0], 736054.90000000002)
-        self.assertEqual(x_range[1], 736057.09999999998)
+        self.assertEqual(x_range[0], 16891.9)
+        self.assertEqual(x_range[1], 16894.1)
 
     ###########################
     #    Styling mapping      #

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ extras_require["extras"] = extras_require["examples"] + [
 extras_require['tests'] = [
     'nose',
     'mock',
-    'flake8 ==3.6.0',
+    'flake8',
     'coveralls',
     'path.py',
     'matplotlib >=2.2,<3.1',

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if sys.version_info.major > 2:
     extras_require["examples"].extend(
         [
             "spatialpandas",
-            "pyarrow <1.0",
+            "pyarrow",
             "ibis-framework >=1.3",
         ]  # spatialpandas incompatibility
     )
@@ -69,7 +69,7 @@ extras_require['tests'] = [
     'flake8',
     'coveralls',
     'path.py',
-    'matplotlib >=3,<3.1',
+    'matplotlib >=3',
     'nbsmoke >=0.2.0',
     'nbconvert <6',
     'twine',
@@ -81,7 +81,7 @@ extras_require["unit_tests"] = extras_require["examples"] + extras_require["test
 
 extras_require["basic_tests"] = (
     extras_require["tests"]
-    + ["matplotlib >=3.0", "bokeh >=1.1.0", "pandas"]
+    + ["matplotlib >=3", "bokeh >=1.1.0", "pandas"]
     + extras_require["notebook"]
 )
 

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,8 @@ extras_require["build"] = [
     "param >=1.7.0",
     "setuptools >=30.3.0",
     "pyct >=0.4.4",
-    "python <3.8",
+    "python",
+    "pip",
 ]
 
 # Everything for examples and nosetests

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ extras_require["build"] = [
     "param >=1.7.0",
     "setuptools >=30.3.0",
     "pyct >=0.4.4",
-    "python",
+    "python <3.8",
     "pip",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ extras_require["build"] = [
     "param >=1.7.0",
     "setuptools >=30.3.0",
     "pyct >=0.4.4",
-    "python <3.8",
+    # "python <3.8",
     "pip",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require["recommended"] = extras_require["notebook"] + [
 extras_require["examples"] = extras_require["recommended"] + [
     "networkx",
     "pillow",
-    "xarray >=0.10.4,<0.17.0",
+    "xarray >=0.10.4",
     "plotly >=4.0",
     'dash >=1.16',
     "streamz >=0.5.0",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extras_require["notebook"] = ["ipython >=5.4.0", "notebook"]
 
 # IPython Notebook + pandas + matplotlib + bokeh
 extras_require["recommended"] = extras_require["notebook"] + [
-    "matplotlib >=2.2",
+    "matplotlib >=3",
     "bokeh >=1.1.0",
 ]
 
@@ -69,7 +69,7 @@ extras_require['tests'] = [
     'flake8',
     'coveralls',
     'path.py',
-    'matplotlib >=2.2,<3.1',
+    'matplotlib >=3,<3.1',
     'nbsmoke >=0.2.0',
     'nbconvert <6',
     'twine',
@@ -81,7 +81,7 @@ extras_require["unit_tests"] = extras_require["examples"] + extras_require["test
 
 extras_require["basic_tests"] = (
     extras_require["tests"]
-    + ["matplotlib >=2.1", "bokeh >=1.1.0", "pandas"]
+    + ["matplotlib >=3.0", "bokeh >=1.1.0", "pandas"]
     + extras_require["notebook"]
 )
 

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ extras_require["build"] = [
     "param >=1.7.0",
     "setuptools >=30.3.0",
     "pyct >=0.4.4",
-    # "python <3.8",
+    "python <3.9",
     "pip",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 # tox config (works with tox alone).
 
 [tox]
-#          python version             test group                  extra envs  extra commands       
-envlist = {py27,py35,py36,py37}-{flakes,unit,examples,all_recommended,regression}-{default}-{dev,pkg}
+#          python version             test group                  extra envs  extra commands
+envlist = {py36,py37,py38}-{flakes,unit,examples,all_recommended,regression}-{default}-{dev,pkg}
 
 [_flakes]
 description = Flake check python


### PR DESCRIPTION
I have been working on updating the test GitHub Actions and I have come to a point where I want to share it. It is not necessary that this PR is to be merged, but the changes I have made could be added to a future PR.

**Overview over the changes I have done**
- Only accept Python 3.6, 3.7, and 3.8. Maybe this is a bit harsh, but as I understand the 1.14 release will be the last to support 2.7. 
- Added `conda-forge` to channels. This is maybe not needed anymore.
- Loosen some pins, which does not seem to be needed anymore.
- Updated matplotlib/datetime related unittest to be compatible with matplotlib 3.3, the changes is because matplotlib have changed their date2num from a custom format to UNIX time, see example code below. Maybe matplotlib should be pinned for this?
- Changed values of 2 others related to matplotlib update. I would like to know if this is ok?
- I added `mamba` to replace `conda install` but removed it again. I think it could be a good option to add to `pyct`/`pyctdev`.

**Example code of change to matplotlib**
``` python
# located at https://matplotlib.org/3.3.0/_modules/matplotlib/dates.html#_from_ordinalf
# changed the functions a bit to be more compact.

SEC_PER_DAY = 60 * 60 * 24

def new_dt64_to_ordinalf(d):
    # From matplotlib version 3.3.0
    dseconds = d.astype('datetime64[s]')
    extra = (d - dseconds).astype('timedelta64[ns]')
    t0 = np.datetime64("1970-01-01T00:00:00", 's')
    dt = (dseconds - t0).astype(np.float64)
    dt += extra.astype(np.float64) / 1.0e9
    dt = dt / SEC_PER_DAY
    return dt

def old_dt64_to_ordinalf(d):
    # From matplotlib version 3.0.3
    extra = d - d.astype('datetime64[s]').astype(d.dtype)
    extra = extra.astype('timedelta64[ns]')
    t0 = np.datetime64('0001-01-01T00:00:00').astype('datetime64[s]')
    dt = (d.astype('datetime64[s]') - t0).astype(np.float64)
    dt += extra.astype(np.float64) / 1.0e9
    dt = dt / SEC_PER_DAY + 1.0
    return dt

x = np.datetime64('2016-04-04', 'ns')
old_dt64_to_ordinalf(x), new_dt64_to_ordinalf(x), old_dt64_to_ordinalf(x) - new_dt64_to_ordinalf(x)
# (736058.0, 16895.0, 719163.0)
```