### PR TITLE
Issuing improved error message when __radd__ called with an integer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          conda install "bokeh>=2.2"
+          conda install -c pyviz "bokeh>=2.3" "panel>=0.11"
       - name: datashader pin
         if: startsWith(matrix.python-version, 2.)
         run: |

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -111,7 +111,7 @@ class annotate(param.ParameterizedFunction):
             if isinstance(annotator, Layout):
                 l, ts = annotator
                 layers.append(l)
-                tables += ts
+                tables += list(ts)
             elif isinstance(annotator, annotate):
                 layers.append(annotator.plot)
                 tables += [t[0].object for t in annotator.editor]

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -23,6 +23,13 @@ class Composable(object):
         "Compose objects into a Layout"
         return Layout([self, obj])
 
+    def __radd__(self, other):
+        if isinstance(other, list): # Hack for Annotators?
+            return NotImplemented
+        if isinstance(other, int):
+            raise TypeError("unsupported operand type(s) for +: 'int' and 'Overlay'. "
+                            "If you are using `sum(elements)` to combine a list of elements,"
+                            "we recommend you to use `Layout(elements)` instead.")
 
     def __lshift__(self, other):
         "Compose objects into an AdjointLayout"
@@ -309,6 +316,12 @@ class AdjointLayout(Dimensioned):
         "Composes plot into a Layout with another object."
         return Layout([self, obj])
 
+    def __radd__(self, other):
+        if isinstance(other, int):
+            raise TypeError("unsupported operand type(s) for +: 'int' and 'Overlay'. "
+                            "If you are using `sum(elements)` to combine a list of elements,"
+                            "we recommend you to use `Layout(elements)` instead.")
+        return super(AdjointLayout, self).__radd__(self, other)
 
     def __len__(self):
         "Number of items in the AdjointLayout"
@@ -378,6 +391,13 @@ class NdLayout(UniformNdMapping):
         "Composes the NdLayout with another object into a Layout"
         return Layout([self, obj])
 
+
+    def __radd__(self, other):
+        if isinstance(other, int):
+            raise TypeError("unsupported operand type(s) for +: 'int' and 'Overlay'. "
+                            "If you are using `sum(elements)` to combine a list of elements,"
+                            "we recommend you to use `Layout(elements)` instead.")
+        return super(NdLayout, self).__radd__(self, other)
 
     @property
     def last(self):

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -26,8 +26,10 @@ class Composable(object):
     def __radd__(self, other):
         if isinstance(other, int):
             raise TypeError("unsupported operand type(s) for +: 'int' and 'Overlay'. "
-                            "If you are trying to use a reduction like `sum(elements)` to combine a list of elements,"
-                            "we recommend you to use `Layout(elements)` (and similarly Overlay(elements) for making an overlay from a list) instead.")
+                            "If you are trying to use a reduction like `sum(elements)` "
+                            "to combine a list of elements, we recommend you use "
+                            "`Layout(elements)` (and similarly `Overlay(elements)` for "
+                            "making an overlay from a list) instead.")
 
     def __lshift__(self, other):
         "Compose objects into an AdjointLayout"
@@ -317,8 +319,10 @@ class AdjointLayout(Dimensioned):
     def __radd__(self, other):
         if isinstance(other, int):
             raise TypeError("unsupported operand type(s) for +: 'int' and 'Overlay'. "
-                            "If you are using `sum(elements)` to combine a list of elements,"
-                            "we recommend you to use `Layout(elements)` instead.")
+                            "If you are trying to use a reduction like `sum(elements)` "
+                            "to combine a list of elements, we recommend you use "
+                            "`Layout(elements)` (and similarly `Overlay(elements)` for "
+                            "making an overlay from a list) instead.")
         return super(AdjointLayout, self).__radd__(self, other)
 
     def __len__(self):
@@ -393,8 +397,10 @@ class NdLayout(UniformNdMapping):
     def __radd__(self, other):
         if isinstance(other, int):
             raise TypeError("unsupported operand type(s) for +: 'int' and 'Overlay'. "
-                            "If you are using `sum(elements)` to combine a list of elements,"
-                            "we recommend you to use `Layout(elements)` instead.")
+                            "If you are trying to use a reduction like `sum(elements)` "
+                            "to combine a list of elements, we recommend you use "
+                            "`Layout(elements)` (and similarly `Overlay(elements)` for "
+                            "making an overlay from a list) instead.")
         return super(NdLayout, self).__radd__(self, other)
 
     @property

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -24,8 +24,6 @@ class Composable(object):
         return Layout([self, obj])
 
     def __radd__(self, other):
-        if isinstance(other, list): # Hack for Annotators?
-            return NotImplemented
         if isinstance(other, int):
             raise TypeError("unsupported operand type(s) for +: 'int' and 'Overlay'. "
                             "If you are using `sum(elements)` to combine a list of elements,"

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -26,8 +26,8 @@ class Composable(object):
     def __radd__(self, other):
         if isinstance(other, int):
             raise TypeError("unsupported operand type(s) for +: 'int' and 'Overlay'. "
-                            "If you are using `sum(elements)` to combine a list of elements,"
-                            "we recommend you to use `Layout(elements)` instead.")
+                            "If you are trying to use a reduction like `sum(elements)` to combine a list of elements,"
+                            "we recommend you to use `Layout(elements)` (and similarly Overlay(elements) for making an overlay from a list) instead.")
 
     def __lshift__(self, other):
         "Compose objects into an AdjointLayout"


### PR DESCRIPTION
Simple change to address https://github.com/holoviz/holoviews/issues/4834 and help people who try to use `sum` to build `Overlays`.