### PR TITLE
Updated Dashboards user guide to show pn.bind first

### DIFF
--- a/examples/getting_started/1-Introduction.ipynb
+++ b/examples/getting_started/1-Introduction.ipynb
@@ -210,7 +210,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "points = hv.Points(station_info, ['lon','lat'])\n",
+    "points = hv.Points(station_info, ['lon','lat']).opts(color=\"red\")\n",
     "image + image * points"
    ]
   },
@@ -218,8 +218,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
     "On the left, we have the visual representation of the ``image`` object we declared. Using ``+`` we put it into a ``Layout`` together with a new compositional object created with the ``*`` operator called an ``Overlay``. This particular overlay displays the station positions on top of our image, which works correctly because the data in both elements exists in the same space, namely New York City.\n",
+    "\n",
+    "The `.opts()` method call for specifying the visual style is part of the HoloViews options system, which is described in the next ['Getting started' section](2-Customization.ipynb).\n",
     "\n",
     "This overlay on the right lets us see the location of all the subway stations in relation to our midnight taxi dropoffs. Of course,  HoloViews allows you to visually express more of the available information with our points.  For instance, you could represent the ridership of each subway by point color or point size. For more information see [Applying Customizations](../user_guide/03-Applying_Customizations.ipynb)."
    ]
@@ -306,15 +307,13 @@
     "\n",
     "composition.opts(\n",
     "    opts.Image(xrotation=90),\n",
-    "    opts.Points(color='deepskyblue', marker='v', size=6))"
+    "    opts.Points(color='red', marker='v', size=6))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `.opts()` method call for specifying the visual style is part of the HoloViews options system, which is described in the next ['Getting started' section](2-Customization.ipynb).\n",
-    "\n",
     "In the cell above we created and styled a composite object with a few short lines of code. Furthermore, this composite object relates tabular and array data and is immediately presented in a way that can be explored interactively. This way of working enables highly productive exploration, allowing new insights to be gained easily. For instance, after exploring with the slider we notice a hotspot of taxi dropoffs at 7am, which we can select as follows:"
    ]
   },

--- a/examples/user_guide/17-Dashboards.ipynb
+++ b/examples/user_guide/17-Dashboards.ipynb
@@ -53,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we already have widgets for Symbol and Variable, as those are dimensions in the DynamicMap, but what if we wanted a widget to control the `rolling_window` window width value in the HoloViews operation?  We could redefine the DynamicMap to include the operation and accept that parameter as another dimension, but in complex cases we would quickly find we need more flexibility in defining widgets and layouts than DynamicMap can give us directly."
+    "Here we already have widgets for Symbol and Variable, as those are dimensions in the DynamicMap, but what if we wanted a widget to control the `rolling_window`width value in the HoloViews operation?  We could redefine the DynamicMap to include the operation and accept that parameter as another dimension, but in complex cases we would quickly find we need more flexibility in defining widgets and layouts than DynamicMap can give us directly."
    ]
   },
   {
@@ -88,7 +88,7 @@
    "source": [
     "As you can see, these widgets can be displayed but they aren't yet attached to anything, so they don't do much. We can now use ``pn.bind`` to bind the `symbol` and `variable` widgets to the arguments of the DynamicMap callback function, and provide `rolling_window` to the `rolling` operation argument. (HoloViews operations accept Panel widgets or param Parameter values, and they will then update reactively to changes in those widgets.)\n",
     "\n",
-    "We can then lay it all out into a simple application which works similarly to the regular DynamicMap display but where we can add our additional widget and control every aspect of the widget configuration and the layout:"
+    "We can then lay it all out into a simple application that works similarly to the regular DynamicMap display but where we can add our additional widget and control every aspect of the widget configuration and the layout:"
    ]
   },
   {
@@ -100,15 +100,27 @@
     "dmap = hv.DynamicMap(pn.bind(load_symbol, symbol=symbol, variable=variable))\n",
     "smoothed = rolling(dmap, rolling_window=rolling_window)\n",
     "\n",
-    "pn.Row(pn.WidgetBox('## Stock Explorer', symbol, variable, rolling_window), \n",
-    "       smoothed.opts(width=500, framewise=True))"
+    "app = pn.Row(pn.WidgetBox('## Stock Explorer', symbol, variable, rolling_window), \n",
+    "             smoothed.opts(width=500, framewise=True)).servable()\n",
+    "app"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we chose to lay the widgets out into a box to the left of the plot, but we could put the widgets each in different locations, add different plots, etc., to create a full-featured dashboard. See [panel.holoviz.org](https://panel.holoviz.org) for the full set of widgets and layouts supported."
+    "Here we chose to lay the widgets out into a box to the left of the plot, but we could put the widgets each in different locations, add different plots, etc., to create a full-featured dashboard. See [panel.holoviz.org](https://panel.holoviz.org) for the full set of widgets and layouts supported.\n",
+    "\n",
+    "Now that we have an app, we can launch it in a separate server if we wish (using `app.show()`), run it as an entirely separate process (`panel serve <thisfilename>.ipynb`, to serve the object marked `servable` above), or export it to a static HTML file (sampling the space of parameter values using \"embed\"):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.save(\"dashboard.html\", embed=True)"
    ]
   },
   {
@@ -117,7 +129,7 @@
    "source": [
     "## Declarative dashboards\n",
     "\n",
-    "What if we want our analysis code usable both as a Dashboard and also in \"headless\" contexts such as batch jobs or remote execution? Both Panel and HoloViews are built on the [param](https://param.holoviz.org) library, which lets you capture the definitions and allowable values for your widgets in a way that's not attached to any GUI. That way you can declare all of your attributes and allowed values once, presenting a GUI if you want to explore them interactively or else simply provide specific values if you want batch operation.\n",
+    "What if we want our analysis code usable both as a dashboard and also in \"headless\" contexts such as batch jobs or remote execution? Both Panel and HoloViews are built on the [param](https://param.holoviz.org) library, which lets you capture the definitions and allowable values for your widgets in a way that's not attached to any GUI. That way you can declare all of your attributes and allowed values once, presenting a GUI if you want to explore them interactively or else simply provide specific values if you want batch operation.\n",
     "\n",
     "With this approach, we declare a ``StockExplorer`` class subclassing ``Parameterized`` and defining three parameters, namely the rolling window, the symbol, and the variable to show for that symbol:"
    ]
@@ -147,7 +159,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here the StockExplorer class will look similar to the Panel code above, defining most of the same information that's in the Panel widgets, but without any dependency on Panel or other GUI libraries; it's simply declaring that this code accepts certain parameter values of the specified types and ranges. These declarations are useful even outside a GUI context, because they allow type and range checking for detecting user errors, but they are also sufficient for creating a GUI later.\n",
+    "Here the StockExplorer class will look similar to the Panel code above, defining most of the same information that's in the Panel widgets, but without any dependency on Panel or other GUI libraries; it's simply declaring that this code accepts certain parameter values of the specified types and ranges. These declarations are useful even outside a GUI context, because they allow type and range checking for detecting user errors, but they are also sufficient for creating a GUI later. \n",
+    "\n",
+    "Instead of using `pn.bind` to bind widget values to functions, here we are declaring that each method depends on the specified parameters, which can be expressed independently of whether there is a widget controlling those parameters; it simply declares (in a way that Panel can utilize) that the given method needs re-running when any of the parameters in that list changes. \n",
     "\n",
     "Now let's use the `load_symbol` method, which already declares which parameters it depends on, as the callback of a DynamicMap and create widgets out of those parameters to build a little GUI:"
    ]

--- a/examples/user_guide/17-Dashboards.ipynb
+++ b/examples/user_guide/17-Dashboards.ipynb
@@ -26,7 +26,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the [Data Processing Pipelines section](./14-Data_Pipelines.ipynb) we discovered how to declare a ``DynamicMap`` and control multiple processing steps with the use of custom streams as described in the [Responding to Events](./12-Responding_to_Events.ipynb) guide. Here we will use the same example exploring a dataset of stock timeseries and build a small dashboard using the [Panel](https://panel.pyviz.org) library, which allows us to declare easily declare custom widgets and link them to our streams. We will begin by once again declaring our function that loads the stock data:"
+    "In the [Data Processing Pipelines section](./14-Data_Pipelines.ipynb) we discovered how to declare a ``DynamicMap`` and control multiple processing steps with the use of custom streams as described in the [Responding to Events](./12-Responding_to_Events.ipynb) guide. A DynamicMap works like a tiny web application, with widgets that select values along a dimension, and a plot that updates.  Let's start with a function that loads stock data and see what a DynamicMap can do:"
    ]
   },
   {
@@ -35,15 +35,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def load_symbol(symbol, variable='adj_close', **kwargs):\n",
+    "def load_symbol(symbol, variable, **kwargs):\n",
     "    df = pd.DataFrame(getattr(stocks, symbol))\n",
     "    df['date'] = df.date.astype('datetime64[ns]')\n",
     "    return hv.Curve(df, ('date', 'Date'), variable).opts(framewise=True)\n",
     "\n",
     "stock_symbols = ['AAPL', 'IBM', 'FB', 'GOOG', 'MSFT']\n",
-    "dmap = hv.DynamicMap(load_symbol, kdims='Symbol').redim.values(Symbol=stock_symbols)\n",
+    "variables = ['open', 'high', 'low', 'close', 'volume', 'adj_close']\n",
+    "dmap = hv.DynamicMap(load_symbol, kdims=['Symbol','Variable'])\n",
+    "dmap = dmap.redim.values(Symbol=stock_symbols, Variable=variables)\n",
     "\n",
-    "dmap.opts(framewise=True)"
+    "dmap.opts(framewise=True)\n",
+    "rolling(dmap, rolling_window=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we already have widgets for Symbol and Variable, as those are dimensions in the DynamicMap, but what if we wanted a widget to control the `rolling_window` window width value in the HoloViews operation?  We could redefine the DynamicMap to include the operation and accept that parameter as another dimension, but in complex cases we would quickly find we need more flexibility in defining widgets and layouts than DynamicMap can give us directly."
    ]
   },
   {
@@ -52,9 +62,64 @@
    "source": [
     "## Building dashboards\n",
     "\n",
-    "Controlling stream events manually from the Python prompt can be a bit cumbersome. However since you can now trigger events from Python we can easily bind any Python based widget framework to the stream. HoloViews itself is based on param and param has various UI toolkits that accompany it and allow you to quickly generate a set of widgets. Here we will use ``panel``, which is based on bokeh to control our stream values.\n",
+    "For more flexibility, we can build a full-featured dashboard using the [Panel](https://panel.pyviz.org) library, which is what a DynamicMap is already using internally to generate widgets and layouts. We can easily declare our own custom Panel widgets and link them to HoloViews streams to get dynamic, user controllable analysis workflows.\n",
     "\n",
-    "To do so we will declare a ``StockExplorer`` class subclassing ``Parameterized`` and defines two parameters, the ``rolling_window`` as an integer and the ``symbol`` as an ObjectSelector. Additionally we define a view method, which defines the DynamicMap and applies the two operations we have already played with, returning an overlay of the smoothed ``Curve`` and outlier ``Scatter``.\n"
+    "Here, let's start with defining various Panel widgets explicitly, choosing a `RadioButtonGroup` for the `symbol` instead of DynamicMaps's default `Select` widget:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "\n",
+    "symbol = pn.widgets.RadioButtonGroup(options=stock_symbols)\n",
+    "variable = pn.widgets.Select(options=variables)\n",
+    "rolling_window = pn.widgets.IntSlider(name='Rolling Window', value=10, start=1, end=365)\n",
+    "\n",
+    "pn.Column(symbol, variable, rolling_window)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, these widgets can be displayed but they aren't yet attached to anything, so they don't do much. We can now use ``pn.bind`` to bind the `symbol` and `variable` widgets to the arguments of the DynamicMap callback function, and provide `rolling_window` to the `rolling` operation argument. (HoloViews operations accept Panel widgets or param Parameter values, and they will then update reactively to changes in those widgets.)\n",
+    "\n",
+    "We can then lay it all out into a simple application which works similarly to the regular DynamicMap display but where we can add our additional widget and control every aspect of the widget configuration and the layout:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dmap = hv.DynamicMap(pn.bind(load_symbol, symbol=symbol, variable=variable))\n",
+    "smoothed = rolling(dmap, rolling_window=rolling_window)\n",
+    "\n",
+    "pn.Row(pn.WidgetBox('## Stock Explorer', symbol, variable, rolling_window), \n",
+    "       smoothed.opts(width=500, framewise=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we chose to lay the widgets out into a box to the left of the plot, but we could put the widgets each in different locations, add different plots, etc., to create a full-featured dashboard. See [panel.holoviz.org](https://panel.holoviz.org) for the full set of widgets and layouts supported."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declarative dashboards\n",
+    "\n",
+    "What if we want our analysis code usable both as a Dashboard and also in \"headless\" contexts such as batch jobs or remote execution? Both Panel and HoloViews are built on the [param](https://param.holoviz.org) library, which lets you capture the definitions and allowable values for your widgets in a way that's not attached to any GUI. That way you can declare all of your attributes and allowed values once, presenting a GUI if you want to explore them interactively or else simply provide specific values if you want batch operation.\n",
+    "\n",
+    "With this approach, we declare a ``StockExplorer`` class subclassing ``Parameterized`` and defining three parameters, namely the rolling window, the symbol, and the variable to show for that symbol:"
    ]
   },
   {
@@ -64,16 +129,11 @@
    "outputs": [],
    "source": [
     "import param\n",
-    "import panel as pn\n",
-    "\n",
-    "variables = ['open', 'high', 'low', 'close', 'volume', 'adj_close']\n",
     "\n",
     "class StockExplorer(param.Parameterized):\n",
     "\n",
     "    rolling_window = param.Integer(default=10, bounds=(1, 365))\n",
-    "    \n",
     "    symbol = param.ObjectSelector(default='AAPL', objects=stock_symbols)\n",
-    "    \n",
     "    variable = param.ObjectSelector(default='adj_close', objects=variables)\n",
     "\n",
     "    @param.depends('symbol', 'variable')\n",
@@ -87,7 +147,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You will have noticed the ``param.depends`` decorator on the ``load_symbol`` method above, this declares that the method depends on these two parameters. When we pass the method to a ``DynamicMap`` it will now automatically listen to changes to the 'symbol', and 'variable' parameters. To generate a set of widgets to control these parameters we can simply supply the ``explorer.param`` accessor to a panel layout, and combining the two we can quickly build a little GUI:"
+    "Here the StockExplorer class will look similar to the Panel code above, defining most of the same information that's in the Panel widgets, but without any dependency on Panel or other GUI libraries; it's simply declaring that this code accepts certain parameter values of the specified types and ranges. These declarations are useful even outside a GUI context, because they allow type and range checking for detecting user errors, but they are also sufficient for creating a GUI later.\n",
+    "\n",
+    "Now let's use the `load_symbol` method, which already declares which parameters it depends on, as the callback of a DynamicMap and create widgets out of those parameters to build a little GUI:"
    ]
   },
   {
@@ -97,17 +159,15 @@
    "outputs": [],
    "source": [
     "explorer = StockExplorer()\n",
-    "\n",
     "stock_dmap = hv.DynamicMap(explorer.load_symbol)\n",
-    "\n",
-    "pn.Row(pn.panel(explorer.param, parameters=['symbol', 'variable']), stock_dmap)"
+    "pn.Row(explorer.param, stock_dmap)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``rolling_window`` parameter is not yet connected to anything however, so just like in the [Data Processing Pipelines section](./14-Data_Pipelines.ipynb) we will see  how we can get the widget to control the parameters of an operation. Both the ``rolling`` and ``rolling_outlier_std`` operations accept a ``rolling_window`` parameter, so we simply pass that parameter into the operation. Finally we compose everything into a panel ``Row``:"
+    "Here you'll notice that the `rolling_window` widget doesn't do anything, because it's not connected to anything (e.g., nothing `@param.depends` on it). As we saw in the [Data Processing Pipelines section](./14-Data_Pipelines.ipynb), the ``rolling`` and ``rolling_outlier_std`` operations both accept a ``rolling_window`` parameter, so lets provide that to the operations and display the output of those operations. Finally we compose everything into a panel ``Row``:"
    ]
   },
   {
@@ -124,38 +184,6 @@
     "    color='red', marker='triangle')\n",
     "\n",
     "pn.Row(explorer.param, (smoothed * outliers).opts(width=600))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## A function based approach\n",
-    "\n",
-    "Instead of defining a whole Parameterized class we can also use the ``depends`` decorator to directly link the widgets to a DynamicMap callback function. This approach makes the link between the widgets and the computation very explicit at the cost of tying the widget and display code very closely together.\n",
-    "\n",
-    "Instead of declaring the dependencies as strings we map the parameter instance to a particular keyword argument in the ``depends`` call. In this way we can link the symbol to the ``RadioButtonGroup`` value and the ``variable`` to the ``Select`` widget value:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "symbol = pn.widgets.RadioButtonGroup(options=stock_symbols)\n",
-    "variable = pn.widgets.Select(options=variables)\n",
-    "rolling_window = pn.widgets.IntSlider(name='Rolling Window', value=10, start=1, end=365)\n",
-    "\n",
-    "@pn.depends(symbol=symbol.param.value, variable=variable.param.value)\n",
-    "def load_symbol_cb(symbol, variable):\n",
-    "    return load_symbol(symbol, variable)\n",
-    "\n",
-    "dmap = hv.DynamicMap(load_symbol_cb)\n",
-    "\n",
-    "smoothed = rolling(dmap, rolling_window=rolling_window.param.value)\n",
-    "\n",
-    "pn.Row(pn.WidgetBox('## Stock Explorer', symbol, variable, rolling_window), smoothed.opts(width=500, framewise=True))"
    ]
   },
   {
@@ -215,7 +243,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see using streams we have bound the widgets to the streams letting us easily control the stream values and making it trivial to define complex dashboards. For more information on how to deploy bokeh apps from HoloViews and build dashboards see the [Deploying Bokeh Apps](./Deploying_Bokeh_Apps.ipynb)."
+    "As you can see using streams we have bound the widgets to the streams letting us easily control the stream values and making it trivial to define complex dashboards. For more information on how to deploy bokeh apps from HoloViews and build dashboards see the [Deploying Bokeh Apps](./Deploying_Bokeh_Apps.ipynb) user guide section."
    ]
   }
  ],

--- a/examples/user_guide/Continuous_Coordinates.ipynb
+++ b/examples/user_guide/Continuous_Coordinates.ipynb
@@ -365,7 +365,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Similarly, if we ask for the value of a given *y* location in continuous space, we will get a ``Curve`` with the array row closest to that *y* value in the ``Image`` 2D array returned as arrays of $x$ values and the corresponding *z* value from the image:"
+    "Similarly, if we ask for the value of a given *y* location in continuous space, we will get a ``Curve`` with the array row closest to that *y* value in the ``Image`` 2D array returned as arrays of `x` values and the corresponding *z* value from the image:"
    ]
   },
   {


### PR DESCRIPTION
The Dashboards user guide was written before Panel supported `pn.bind`, first showing a Parameterized class and then showing `pn.depends` while saying that the `pn.depends` approach tightly ties the GUI and analysis code together. `pn.bind` doesn't tie it together in that same way, and indeed no longer needs the dummy function that previously was needed so that `pn.depends` could  decorate the analysis function.  All told, I think it's cleaner and clearer to present `pn.bind` first, explicitly creating some widgets and then attaching them to DynamicMap arguments and operation arguments.  So I've done that, motivating it by needing to get a widget to control the operation argument.  Only after that do we get into Parameterized classes.

I think this approach works pretty well, but I'll admit I got lost a bit in the Parameterized sections. I don't think anything there is incorrect, but it seems a bit bewiildering.  What I'd want a user to get out of that section is a solid understanding of how to make dynamic apps with HoloViews + Panel. Panel's own docs can cover everything about how to make apps in general, but having responsive, efficient apps where widgets dynamically affect just a small aspect of a plot seems appropriate to explain here in the HoloViews docs.  I think that's implicit in the current material already, but it would be great if @philippjfr could read through that and more clearly express how one uses the features of HoloViews and Panel to make efficiently responsive apps.