### PR TITLE
Reenable SaveTool for plots with TileRenderer

### DIFF
--- a/holoviews/plotting/bokeh/tiles.py
+++ b/holoviews/plotting/bokeh/tiles.py
@@ -66,7 +66,4 @@ class TilePlot(ElementPlot):
         level = properties.pop('level', 'glyph')
         renderer = plot.add_tile(tile_source, level=level)
         renderer.alpha = properties.get('alpha', 1)
-
-        # Remove save tool
-        plot.tools = [t for t in plot.tools if not isinstance(t, SaveTool)]
         return renderer, tile_source


### PR DESCRIPTION
Seems like the SaveTool works with tile renderers again.