### PR TITLE
Tile source replacement warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 Version 1.14.4
 ==============
 
-This release primarily focuses on a number of bug fixes. Many thanks
-to @Hoxbro, @nitrocalcite, @brl0, @hyamanieu, @rafiyr, @jbednar and
-@philippjfr for contributing.
+This release primarily focuses on a number of bug fixes. Many thanks to
+@Hoxbro, @nitrocalcite, @brl0, @hyamanieu, @rafiyr, @jbednar, @jlstevens
+and @philippjfr for contributing.
 
 Enhancements:
 
@@ -40,6 +40,15 @@ Documentation:
 - Updated docs to correctly declare Scatter kdims
   ([#4914](https://github.com/holoviz/holoviews/pull/4914))
 
+Compatibility:
+
+- The `Wikipedia` tile source is no longer available as it is no longer
+  being served outside the wikimedia domain. As one of the most
+  frequently used tile sources, HoloViews now issues a warning and
+  switches to the OpenStreetMap (OSM) tile source instead.
+- The `CartoMidnight` and `CartoEco` tile sources are no longer publicly
+  available. Attempting to use these tile sources will result in a
+  deprecation warning.
 
 Version 1.14.3
 ==============

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ Documentation:
 
 Compatibility:
 
+Unfortunately a number of tile sources are no longer publicly
+available. Attempting to use these tile sources will now issue warnings
+unless `hv.config.raise_deprecated_tilesource_exception` is set to
+`True` in which case exceptions will be raised instead.
+
 - The `Wikipedia` tile source is no longer available as it is no longer
   being served outside the wikimedia domain. As one of the most
   frequently used tile sources, HoloViews now issues a warning and

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -7,9 +7,9 @@ Version 1.14
 Version 1.14.4
 **************
 
-This release primarily focuses on a number of bug fixes. Many thanks
-to @Hoxbro, @nitrocalcite, @brl0, @hyamanieu, @rafiyr, @jbednar and
-@philippjfr for contributing.
+This release primarily focuses on a number of bug fixes. Many thanks to
+@Hoxbro, @nitrocalcite, @brl0, @hyamanieu, @rafiyr, @jbednar, @jlstevens
+and @philippjfr for contributing.
 
 Enhancements:
 
@@ -45,6 +45,21 @@ Documentation:
   (`#4907 <https://github.com/holoviz/holoviews/pull/4907>`_)
 - Updated docs to correctly declare Scatter kdims
   (`#4914 <https://github.com/holoviz/holoviews/pull/4914>`_)
+
+Compatibility:
+
+Unfortunately a number of tile sources are no longer publicly available.
+Attempting to use these tile sources will now issue warnings unless
+``hv.config.raise_deprecated_tilesource_exception`` is set to ``True``
+in which case exceptions will be raised instead.
+
+-  The ``Wikipedia`` tile source is no longer available as it is no
+   longer being served outside the wikimedia domain. As one of the most
+   frequently used tile sources, HoloViews now issues a warning and
+   switches to the OpenStreetMap (OSM) tile source instead.
+-  The ``CartoMidnight`` and ``CartoEco`` tile sources are no longer
+   publicly available. Attempting to use these tile sources will result
+   in a deprecation warning.
 
 
 Version 1.14.3

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -163,16 +163,6 @@ class Config(param.ParameterizedFunction):
        Global default colormap for HeatMap elements. Prior to HoloViews
        1.14.0, the default value was the 'RdYlBu_r' colormap.""")
 
-    wikimedia_tile_source_replacement = param.String(default='OSM-with-warning', doc="""
-       If set to the special sentinal value of OSM-with-warning, replace
-       wikimedia tile source with OpenStreetMap (OSM) and warn. If set
-       explicitly with a suitable Tile source URL, apply replacement for
-       wikimedia tile source without warning.
-
-       This config parameter was introduced as wikimedia tile sources
-       can no longer be used outside the wikimedia domain, as of
-       April 2021.""")
-
     def __call__(self, **params):
         self.param.set_param(**params)
         return self

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -163,6 +163,10 @@ class Config(param.ParameterizedFunction):
        Global default colormap for HeatMap elements. Prior to HoloViews
        1.14.0, the default value was the 'RdYlBu_r' colormap.""")
 
+    raise_deprecated_tilesource_exception = param.Boolean(default=False,
+       doc=""" Whether deprecated tile sources should raise a
+       deprecation exception instead of issuing warnings.""")
+
     def __call__(self, **params):
         self.param.set_param(**params)
         return self

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -170,7 +170,8 @@ class Config(param.ParameterizedFunction):
        wikimedia tile source without warning.
 
        This config parameter was introduced as wikimedia tile sources
-       can no longer be used outside the wikimedia domain.""")
+       can no longer be used outside the wikimedia domain, as of
+       April 2021.""")
 
     def __call__(self, **params):
         self.param.set_param(**params)

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -163,6 +163,15 @@ class Config(param.ParameterizedFunction):
        Global default colormap for HeatMap elements. Prior to HoloViews
        1.14.0, the default value was the 'RdYlBu_r' colormap.""")
 
+    wikimedia_tile_source_replacement = param.String(default='OSM-with-warning', doc="""
+       If set to the special sentinal value of OSM-with-warning, replace
+       wikimedia tile source with OpenStreetMap (OSM) and warn. If set
+       explicitly with a suitable Tile source URL, apply replacement for
+       wikimedia tile source without warning.
+
+       This config parameter was introduced as wikimedia tile sources
+       can no longer be used outside the wikimedia domain.""")
+
     def __call__(self, **params):
         self.param.set_param(**params)
         return self

--- a/holoviews/element/tiles.py
+++ b/holoviews/element/tiles.py
@@ -171,16 +171,12 @@ ESRI = EsriImagery # For backwards compatibility with gv 1.5
 
 
 def wikimedia_replacement():
-    if util.config.wikimedia_tile_source_replacement == 'OSM-with-warning':
-        param.main.param.warning('Wikimedia tile source no longer available outside '
-                                 'wikimedia domain as of April 2021; switching to OpenStreetMap (OSM) tile '
-                                 'source. You can set wikimedia_tile_source_replacement '
-                                 'to your chosen replacement tile source URL in hv.config'
-                                 ' to disable this warning. See release notes for HoloViews'
-                                 ' 1.14.4 for more details')
-        return Tiles('https://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png', name="OSM")
-    else:
-        return Tiles(util.config.wikimedia_tile_source_replacement, name="Wikipedia")
+    param.main.param.warning('Wikimedia tile source no longer available outside '
+                             'wikimedia domain as of April 2021; switching '
+                             'to OpenStreetMap (OSM) tile source. '
+                             'See release notes for HoloViews'
+                             ' 1.14.4 for more details')
+    return Tiles('https://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png', name="OSM")
 
 # Miscellaneous
 OSM = lambda: Tiles('https://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png', name="OSM")

--- a/holoviews/element/tiles.py
+++ b/holoviews/element/tiles.py
@@ -133,6 +133,8 @@ _ATTRIBUTIONS = {
 
 def deprecation_warning(name, url, reason):
     def deprecated_tilesource_warning():
+        if util.config.raise_deprecated_tilesource_exception:
+            raise DeprecationWarning('%s tile source is deprecated: %s' % (name, reason))
         param.main.param.warning('%s tile source is deprecated and is likely to be unusable: %s' %  (name, reason))
         return Tiles(url, name=name)
     return deprecated_tilesource_warning
@@ -171,7 +173,11 @@ ESRI = EsriImagery # For backwards compatibility with gv 1.5
 
 
 def wikimedia_replacement():
-    param.main.param.warning('Wikimedia tile source no longer available outside '
+    if util.config.raise_deprecated_tilesource_exception:
+        raise DeprecationWarning('Wikipedia tile source no longer available outside '
+                                 'wikimedia domain as of April 2021.')
+
+    param.main.param.warning('Wikipedia tile source no longer available outside '
                              'wikimedia domain as of April 2021; switching '
                              'to OpenStreetMap (OSM) tile source. '
                              'See release notes for HoloViews'

--- a/holoviews/element/tiles.py
+++ b/holoviews/element/tiles.py
@@ -186,4 +186,6 @@ def wikimedia_replacement():
 OSM = lambda: Tiles('https://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png', name="OSM")
 Wikipedia = wikimedia_replacement
 
-tile_sources = {k: v for k, v in locals().items() if isinstance(v, FunctionType) and k not in ['ESRI', 'lon_lat_to_easting_northing', 'easting_northing_to_lon_lat']}
+tile_sources = {k: v for k, v in locals().items() if isinstance(v, FunctionType) and k not in
+                ['ESRI', 'lon_lat_to_easting_northing', 'easting_northing_to_lon_lat',
+                 'deprecation_warning', 'wikimedia_replacement']}

--- a/holoviews/element/tiles.py
+++ b/holoviews/element/tiles.py
@@ -133,7 +133,7 @@ _ATTRIBUTIONS = {
 
 def deprecation_warning(name, url, reason):
     def deprecated_tilesource_warning():
-        param.main.param.warning('%s tile source is deprecated: %s' %  (name, reason))
+        param.main.param.warning('%s tile source is deprecated and is likely to be unusable: %s' %  (name, reason))
         return Tiles(url, name=name)
     return deprecated_tilesource_warning
 
@@ -143,10 +143,10 @@ CartoDark = lambda: Tiles('https://cartodb-basemaps-4.global.ssl.fastly.net/dark
 CartoLight = lambda: Tiles('https://cartodb-basemaps-4.global.ssl.fastly.net/light_all/{Z}/{X}/{Y}.png', name="CartoLight")
 CartoMidnight = deprecation_warning('CartoMidnight',
                                     'https://3.api.cartocdn.com/base-midnight/{Z}/{X}/{Y}.png',
-                                    'this tile source is no longer publicly available.')
+                                    'no longer publicly available.')
 CartoEco = deprecation_warning('CartoEco',
                                'https://3.api.cartocdn.com/base-eco/{Z}/{X}/{Y}.png',
-                               'this tile source is no longer publicly available.')
+                               'no longer publicly available.')
 
 
 # Stamen basemaps
@@ -173,7 +173,7 @@ ESRI = EsriImagery # For backwards compatibility with gv 1.5
 def wikimedia_replacement():
     if util.config.wikimedia_tile_source_replacement == 'OSM-with-warning':
         param.main.param.warning('Wikimedia tile source no longer available outside '
-                                 'wikimedia domain, switching to OpenStreetMap (OSM) tile '
+                                 'wikimedia domain as of April 2021; switching to OpenStreetMap (OSM) tile '
                                  'source. You can set wikimedia_tile_source_replacement '
                                  'to your chosen replacement tile source URL in hv.config'
                                  ' to disable this warning. See release notes for HoloViews'

--- a/holoviews/element/tiles.py
+++ b/holoviews/element/tiles.py
@@ -143,10 +143,10 @@ CartoDark = lambda: Tiles('https://cartodb-basemaps-4.global.ssl.fastly.net/dark
 CartoLight = lambda: Tiles('https://cartodb-basemaps-4.global.ssl.fastly.net/light_all/{Z}/{X}/{Y}.png', name="CartoLight")
 CartoMidnight = deprecation_warning('CartoMidnight',
                                     'https://3.api.cartocdn.com/base-midnight/{Z}/{X}/{Y}.png',
-                                    'this tile source is no longer public')
+                                    'this tile source is no longer publicly available.')
 CartoEco = deprecation_warning('CartoEco',
                                'https://3.api.cartocdn.com/base-eco/{Z}/{X}/{Y}.png',
-                               'this tile source is no longer public')
+                               'this tile source is no longer publicly available.')
 
 
 # Stamen basemaps

--- a/holoviews/element/tiles.py
+++ b/holoviews/element/tiles.py
@@ -157,8 +157,21 @@ EsriStreet = lambda: Tiles('https://server.arcgisonline.com/ArcGIS/rest/services
 EsriReference = lambda: Tiles('https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Reference_Overlay/MapServer/tile/{Z}/{Y}/{X}', name="EsriReference")
 ESRI = EsriImagery # For backwards compatibility with gv 1.5
 
+
+def wikimedia_replacement():
+    if util.config.wikimedia_tile_source_replacement == 'OSM-with-warning':
+        param.main.param.warning('Wikimedia tile source no longer available outside '
+                                 'wikimedia domain, switching to OpenStreetMap (OSM) tile '
+                                 'source. You can set wikimedia_tile_source_replacement '
+                                 'to your chosen replacement tile source URL in hv.config'
+                                 ' to disable this warning. See release notes for HoloViews'
+                                 ' 1.14.4 for more details')
+        return Tiles('https://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png', name="OSM")
+    else:
+        return Tiles(util.config.wikimedia_tile_source_replacement, name="Wikipedia")
+
 # Miscellaneous
 OSM = lambda: Tiles('https://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png', name="OSM")
-Wikipedia = lambda: Tiles('https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png', name="Wikipedia")
+Wikipedia = wikimedia_replacement
 
 tile_sources = {k: v for k, v in locals().items() if isinstance(v, FunctionType) and k not in ['ESRI', 'lon_lat_to_easting_northing', 'easting_northing_to_lon_lat']}

--- a/holoviews/element/tiles.py
+++ b/holoviews/element/tiles.py
@@ -131,11 +131,18 @@ _ATTRIBUTIONS = {
     )
 }
 
+def deprecated_tilesource(name, reason):
+    def raise_deprecation_error():
+        raise DeprecationWarning('%s tile source is deprecated: %s' % (name, reason))
+    return raise_deprecation_error
+
+
 # CartoDB basemaps
 CartoDark = lambda: Tiles('https://cartodb-basemaps-4.global.ssl.fastly.net/dark_all/{Z}/{X}/{Y}.png', name="CartoDark")
-CartoEco = lambda: Tiles('https://3.api.cartocdn.com/base-eco/{Z}/{X}/{Y}.png', name="CartoEco")
+CartoEco = deprecated_tilesource('CartoEco', 'this tile source is no longer public.')
 CartoLight = lambda: Tiles('https://cartodb-basemaps-4.global.ssl.fastly.net/light_all/{Z}/{X}/{Y}.png', name="CartoLight")
-CartoMidnight = lambda: Tiles('https://3.api.cartocdn.com/base-midnight/{Z}/{X}/{Y}.png', name="CartoMidnight")
+CartoMidnight = deprecated_tilesource('CartoMidnight', 'this tile source is no longer public.')
+
 
 # Stamen basemaps
 StamenTerrain = lambda: Tiles('https://stamen-tiles.a.ssl.fastly.net/terrain/{Z}/{X}/{Y}.png', name="StamenTerrain")

--- a/holoviews/element/tiles.py
+++ b/holoviews/element/tiles.py
@@ -131,17 +131,22 @@ _ATTRIBUTIONS = {
     )
 }
 
-def deprecated_tilesource(name, reason):
-    def raise_deprecation_error():
-        raise DeprecationWarning('%s tile source is deprecated: %s' % (name, reason))
-    return raise_deprecation_error
+def deprecation_warning(name, url, reason):
+    def deprecated_tilesource_warning():
+        param.main.param.warning('%s tile source is deprecated: %s' %  (name, reason))
+        return Tiles(url, name=name)
+    return deprecated_tilesource_warning
 
 
 # CartoDB basemaps
 CartoDark = lambda: Tiles('https://cartodb-basemaps-4.global.ssl.fastly.net/dark_all/{Z}/{X}/{Y}.png', name="CartoDark")
-CartoEco = deprecated_tilesource('CartoEco', 'this tile source is no longer public.')
 CartoLight = lambda: Tiles('https://cartodb-basemaps-4.global.ssl.fastly.net/light_all/{Z}/{X}/{Y}.png', name="CartoLight")
-CartoMidnight = deprecated_tilesource('CartoMidnight', 'this tile source is no longer public.')
+CartoMidnight = deprecation_warning('CartoMidnight',
+                                    'https://3.api.cartocdn.com/base-midnight/{Z}/{X}/{Y}.png',
+                                    'this tile source is no longer public')
+CartoEco = deprecation_warning('CartoEco',
+                               'https://3.api.cartocdn.com/base-eco/{Z}/{X}/{Y}.png',
+                               'this tile source is no longer public')
 
 
 # Stamen basemaps


### PR DESCRIPTION
After quite some discussion with @jbednar  and @philippjfr, here is one proposal for how to handle the tile sources that no longer work.

To replace the `Wikipedia` tile source (showing how you set your own default to disable the warning):

![image](https://user-images.githubusercontent.com/890576/118874801-ea531380-b8b0-11eb-9baf-8a19655730ae.png)

And now that `CartoMidnight` and `CartoEco` no longer work:

![image](https://user-images.githubusercontent.com/890576/118874734-d8717080-b8b0-11eb-9d06-e0459f5d4c96.png)

I think this is as good as we can do once we explain the changes in the release notes. That said, I'm sure we can improve the warning messages further...