### PR TITLE
Execute deprecations for 2.0

### DIFF
--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -561,7 +561,7 @@ class Opts(object):
         """
         if self._mode is None:
             apply_groups, _, _ = util.deprecated_opts_signature(args, kwargs)
-            if apply_groups and util.config.future_deprecations:
+            if apply_groups:
                 msg = ("Calling the .opts method with options broken down by options "
                        "group (i.e. separate plot, style and norm groups) is deprecated. "
                        "Use the .options method converting to the simplified format "

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -296,7 +296,6 @@ class Dimension(param.Parameterized):
                 raise ValueError('%r default %s not in declared range: %s' %
                                  (self, self.default, self.range))
 
-
     @property
     def spec(self):
         """"Returns the Dimensions tuple specification
@@ -305,13 +304,6 @@ class Dimension(param.Parameterized):
             tuple: Dimension tuple specification
         """
         return (self.name, self.label)
-
-
-    def __call__(self, spec=None, **overrides):
-        self.param.warning('Dimension.__call__ method has been deprecated, '
-                           'use the clone method instead.')
-        return self.clone(spec=spec, **overrides)
-
 
     def clone(self, spec=None, **overrides):
         """Clones the Dimension with new parameters
@@ -1203,8 +1195,6 @@ class Dimensioned(LabelledData):
         if not dimension_range:
             return lower, upper
         return util.dimension_range(lower, upper, dimension.range, dimension.soft_range)
-
-
     def __repr__(self):
         return PrettyPrinter.pprint(self)
 
@@ -1213,17 +1203,6 @@ class Dimensioned(LabelledData):
 
     def __unicode__(self):
         return unicode(PrettyPrinter.pprint(self))
-
-    def __call__(self, options=None, **kwargs):
-        self.param.warning(
-            'Use of __call__ to set options will be deprecated '	
-            'in the next major release (1.14.0). Use the equivalent .opts '
-            'method instead.')	
-
-        if not kwargs and options is None:	
-            return self.opts.clear()
-
-        return self.opts(options, **kwargs)
 
     def options(self, *args, **kwargs):
         """Applies simplified option definition returning a new object.
@@ -1352,17 +1331,6 @@ class ViewableTree(AttrTree, Dimensioned):
 
         AttrTree.__init__(self, items, identifier, parent, **kwargs)
         Dimensioned.__init__(self, self.data, **params)
-
-
-    @classmethod
-    def from_values(cls, vals):
-        "Deprecated method to construct tree from list of objects"
-        name = cls.__name__        
-        param.main.param.warning("%s.from_values is deprecated, the %s "
-                                 "constructor may now be used directly."
-                                 % (name, name))
-        return cls(items=cls._process_items(vals))
-
 
     @classmethod
     def _process_items(cls, vals):

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -85,28 +85,15 @@ class Element(ViewableElement, Composable, Overlayable):
         """
         return True
 
-
     def __contains__(self, dimension):
         "Whether element contains the Dimension"
         return dimension in self.dimensions()
-
 
     def __iter__(self):
         "Disable iterator interface."
         raise NotImplementedError('Iteration on Elements is not supported.')
 
-
     __bool__ = __nonzero__
-
-
-    @classmethod
-    def collapse_data(cls, data, function=None, kdims=None, **kwargs):
-        """
-        Deprecated method to perform collapse operations, which may
-        now be performed through concatenation and aggregation.
-        """
-        raise NotImplementedError("Collapsing not implemented for %s." % cls.__name__)
-
 
     def closest(self, coords, **kwargs):
         """Snap list or dict of coordinates to closest position.
@@ -122,7 +109,6 @@ class Element(ViewableElement, Composable, Overlayable):
             NotImplementedError: Raised if snapping is not supported
         """
         raise NotImplementedError
-
 
     def sample(self, samples=[], bounds=None, closest=False, **sample_values):
         """Samples values at supplied coordinates.
@@ -257,48 +243,6 @@ class Element(ViewableElement, Composable, Overlayable):
         if len(set(types)) > 1:
             columns = [c.astype('object') for c in columns]
         return np.column_stack(columns)
-
-
-    ######################
-    #    Deprecations    #
-    ######################
-
-    def table(self, datatype=None):
-        "Deprecated method to convert any Element to a Table."
-        self.param.warning(
-            "The table method is deprecated and should no "
-            "longer be used. Instead cast the %s to a "
-            "a Table directly." % type(self).__name__)
-
-        if datatype and not isinstance(datatype, list):
-            datatype = [datatype]
-        from ..element import Table
-        return Table(self, **(dict(datatype=datatype) if datatype else {}))
-
-
-    def mapping(self, kdims=None, vdims=None, **kwargs):
-        "Deprecated method to convert data to dictionary"
-        self.param.warning(
-            "The mapping method is deprecated and should no "
-            "longer be used. Use another one of the common "
-            "formats instead, e.g. .dframe, .array or .columns.")
-
-        length = len(self)
-        if not kdims: kdims = self.kdims
-        if kdims:
-            keys = zip(*[self.dimension_values(dim.name)
-                         for dim in self.kdims])
-        else:
-            keys = [()]*length
-
-        if not vdims: vdims = self.vdims
-        if vdims:
-            values = zip(*[self.dimension_values(dim.name)
-                           for dim in vdims])
-        else:
-            values = [()]*length
-        return OrderedDict(zip(keys, values))
-
 
 
 class Tabular(Element):

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -578,47 +578,6 @@ class MultiDimensionalMapping(Dimensioned):
     def __len__(self):
         return len(self.data)
 
-    ######################
-    #    Deprecations    #
-    ######################
-
-    def table(self, datatype=None, **kwargs):
-        """
-        Deprecated method to convert an MultiDimensionalMapping of
-        Elements to a Table.
-        """
-        self.param.warning("The table method is deprecated and should no "
-                           "longer be used. If using a HoloMap use "
-                           "HoloMap.collapse() instead to return a Dataset.")
-
-        from .data.interface import Interface
-        from ..element.tabular import Table
-        new_data = [(key, value.table(datatype=datatype, **kwargs))
-                    for key, value in self.data.items()]
-        tables = self.clone(new_data)
-        return Interface.concatenate(tables, new_type=Table)
-
-
-    def dframe(self):
-        """
-        Deprecated method to convert a MultiDimensionalMapping to
-        a pandas DataFrame. Conversion to a dataframe now only
-        supported by specific subclasses such as UniformNdMapping
-        types.
-        """
-        self.param.warning("The MultiDimensionalMapping.dframe method is "
-                           "deprecated and should no longer be used. "
-                           "Use a more specific subclass which does support "
-                           "the dframe method instead, e.g. a HoloMap.")
-        try:
-            import pandas
-        except ImportError:
-            raise Exception("Cannot build a DataFrame without the pandas library.")
-        labels = self.dimensions('key', True) + [self.group]
-        return pandas.DataFrame(
-            [dict(zip(labels, k + (v,))) for (k, v) in self.data.items()])
-
-
 
 class NdMapping(MultiDimensionalMapping):
     """

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -276,25 +276,6 @@ class Overlay(ViewableTree, CompositeOverlay):
     def shape(self):
         raise NotImplementedError
 
-    # Deprecated methods
-
-    def collapse(self, function):
-        "Deprecated method to collapse layers in the Overlay."
-        self.param.warning('Overlay.collapse is deprecated, to'
-                           'collapse multiple elements use a HoloMap.')
-
-        elements = list(self)
-        types = [type(el) for el in elements]
-        values = [el.group for el in elements]
-        if not len(set(types)) == 1 and len(set(values)) == 1:
-            raise Exception("Overlay is not homogeneous in type or group "
-                            "and cannot be collapsed.")
-        else:
-            return elements[0].clone(types[0].collapse_data([el.data for el in elements],
-                                                            function, self.kdims))
-
-
-
 
 class NdOverlay(Overlayable, UniformNdMapping, CompositeOverlay):
     """

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -396,20 +396,24 @@ def argspec(callable_obj):
     if (isinstance(callable_obj, type)
         and issubclass(callable_obj, param.ParameterizedFunction)):
         # Parameterized function.__call__ considered function in py3 but not py2
-        spec = _getargspec(callable_obj.__call__)
+        spec = inspect.getfullargspec(callable_obj.__call__)
         args = spec.args[1:]
-    elif inspect.isfunction(callable_obj):    # functions and staticmethods
-        spec = _getargspec(callable_obj)
+    elif inspect.isfunction(callable_obj):  # functions and staticmethods
+        spec = inspect.getfullargspec(callable_obj)
         args = spec.args
     elif isinstance(callable_obj, partial): # partials
         arglen = len(callable_obj.args)
-        spec =  _getargspec(callable_obj.func)
+        spec = inspect.getfullargspec(callable_obj.func)
         args = [arg for arg in spec.args[arglen:] if arg not in callable_obj.keywords]
     elif inspect.ismethod(callable_obj):    # instance and class methods
-        spec = _getargspec(callable_obj)
+        spec = inspect.getfullargspec(callable_obj)
         args = spec.args[1:]
-    else:                                   # callable objects
+    elif isinstance(callable_obj, type) and issubclass(callable_obj, param.Parameterized):
+        return argspec(callable_obj.__init__)
+    elif callable(callable_obj):            # callable objects
         return argspec(callable_obj.__call__)
+    else:
+        raise ValueError("Cannot determine argspec for non-callable type.")
 
     return inspect.ArgSpec(args=args,
                            varargs=spec.varargs,

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -186,38 +186,14 @@ class Histogram(Selection1DExpr, Chart):
 
     _binned = True
 
-    def __init__(self, data, edges=None, **params):
+    def __init__(self, data, **params):
         if data is None:
             data = []
-        if edges is not None:
-            self.param.warning(
-                "Histogram edges should be supplied as a tuple "
-                "along with the values, passing the edges will "
-                "be deprecated in holoviews 2.0.")
-            data = (edges, data)
-        elif isinstance(data, tuple) and len(data) == 2 and len(data[0])+1 == len(data[1]):
+        if (isinstance(data, tuple) and len(data) == 2 and
+            len(data[0])+1 == len(data[1])):
             data = data[::-1]
 
         super().__init__(data, **params)
-
-    def __setstate__(self, state):
-        """
-        Ensures old-style Histogram types without an interface can be unpickled.
-
-        Note: Deprecate as part of 2.0
-        """
-        if 'interface' not in state:
-            self.interface = GridInterface
-            x, y = state['_kdims_param_value'][0], state['_vdims_param_value'][0]
-            state['data'] = {x.name: state['data'][1], y.name: state['data'][0]}
-        super(Dataset, self).__setstate__(state)
-
-    @property
-    def values(self):
-        "Property to access the Histogram values provided for backward compatibility"
-        self.param.warning('Histogram.values is deprecated in favor of '
-                           'common dimension_values method.')
-        return self.dimension_values(1)
 
     @property
     def edges(self):

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -4,7 +4,6 @@ import param
 from ..core import util
 from ..core import Dimension, Dataset, Element2D, NdOverlay, Overlay
 from ..core.dimension import process_dimensions
-from ..core.data import GridInterface
 from .geom import Rectangles, Points, VectorField # noqa: backward compatible import
 from .selection import Selection1DExpr, Selection2DExpr
 

--- a/holoviews/element/chart3d.py
+++ b/holoviews/element/chart3d.py
@@ -66,19 +66,6 @@ class TriSurface(Element3D, Points):
         return Points.__getitem__(self, slc)
 
 
-class Trisurface(TriSurface):
-    """
-    Old name for TriSurface. Retaining for backwards compatibility
-    until holoviews 2.0.
-    """
-
-    group = param.String(default='Trisurface', constant=True)
-
-    def __init__(self, *args, **kwargs):
-        self.param.warning('Deprecation: Please use TriSurface element instead')
-        super().__init__(*args, **kwargs)
-
-
 class Scatter3D(Element3D, Points):
     """
     Scatter3D is a 3D element representing the position of a collection

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -171,7 +171,6 @@ class Comparison(ComparisonInterface):
         cls.equality_type_funcs[Scatter] =      cls.compare_scatter
         cls.equality_type_funcs[Scatter3D] =    cls.compare_scatter3d
         cls.equality_type_funcs[TriSurface] =   cls.compare_trisurface
-        cls.equality_type_funcs[Trisurface] =   cls.compare_trisurface
         cls.equality_type_funcs[Histogram] =    cls.compare_histogram
         cls.equality_type_funcs[Bars] =         cls.compare_bars
         cls.equality_type_funcs[Spikes] =       cls.compare_spikes
@@ -302,10 +301,6 @@ class Comparison(ComparisonInterface):
         # 'Deep' equality of dimension metadata (all parameters)
         dim1_params = dict(dim1.param.get_param_values())
         dim2_params = dict(dim2.param.get_param_values())
-
-        # Special handling of deprecated 'initial' values argument
-        dim1_params['values'] = [] if dim1.values=='initial' else dim1.values
-        dim2_params['values'] = [] if dim2.values=='initial' else dim2.values
 
         if set(dim1_params.keys()) != set(dim2_params.keys()):
             raise cls.failureException("Dimension parameter sets mismatched: %s != %s"

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -29,8 +29,6 @@ class RedimGraph(Redim):
             new_data = new_data + (self._obj.edgepaths.redim(specs, **dimensions),)
         return redimmed.clone(new_data)
 
-redim_graph = RedimGraph # Deprecate: pickle compatibility - remove in 2.0
-
 
 class layout_nodes(Operation):
     """

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -10,8 +10,8 @@ import numpy as np
 import param
 from ..core import Dataset
 from ..core.data import MultiInterface
-from ..core.dimension import Dimension, asdim
-from ..core.util import OrderedDict, disable_constant
+from ..core.dimension import Dimension
+from ..core.util import OrderedDict
 from .geom import Geometry
 from .selection import SelectionPolyExpr
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -5,7 +5,7 @@ import colorsys
 import param
 
 from ..core import util, config, Dimension, Element2D, Overlay, Dataset
-from ..core.data import ImageInterface, GridInterface
+from ..core.data import ImageInterface
 from ..core.data.interface import DataError
 from ..core.dimension import dimension_name
 from ..core.boundingregion import BoundingRegion, BoundingBox

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -100,17 +100,6 @@ class Raster(Element2D):
         else:
             return super().dimension_values(dim)
 
-    @classmethod
-    def collapse_data(cls, data_list, function, kdims=None, **kwargs):
-        param.main.param.warning(
-            'Raster.collapse_data is deprecated, collapsing '
-            'may now be performed through concatenation '
-            'and aggregation.')
-        if isinstance(function, np.ufunc):
-            return function.reduce(data_list)
-        else:
-            return function(np.dstack(data_list), axis=-1, **kwargs)
-
     def sample(self, samples=[], bounds=None, **sample_values):
         """
         Sample the Raster along one or both of its dimensions,
@@ -393,18 +382,6 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
                              'are supplied, otherwise they must match the data. To change '
                              'the displayed extents set the range on the x- and y-dimensions.')
 
-    def __setstate__(self, state):
-        """
-        Ensures old-style unpickled Image types without an interface
-        use the ImageInterface.
-
-        Note: Deprecate as part of 2.0
-        """
-        self.__dict__ = state
-        if isinstance(self.data, np.ndarray):
-            self.interface = ImageInterface
-        super(Dataset, self).__setstate__(state)
-
     def clone(self, data=None, shared_data=True, new_type=None, link=True,
               *args, **overrides):
         """
@@ -521,23 +498,6 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
             return (b, t) if idx else (l, r)
         else:
             return super().range(dim, data_range, dimension_range)
-
-    def table(self, datatype=None):
-        """
-        Converts the data Element to a Table, optionally may
-        specify a supported data type. The default data types
-        are 'numpy' (for homogeneous data), 'dataframe', and
-        'dictionary'.
-        """
-        self.param.warning(
-            "The table method is deprecated and should no longer "
-            "be used. Instead cast the %s to a a Table directly."
-            % type(self).__name__)
-        if datatype and not isinstance(datatype, list):
-            datatype = [datatype]
-        from ..element import Table
-        return self.clone(self.columns(), new_type=Table,
-                          **(dict(datatype=datatype) if datatype else {}))
 
     def _coord2matrix(self, coord):
         return self.sheet2matrixidx(*coord)
@@ -775,20 +735,6 @@ class QuadMesh(Selection2DExpr, Dataset, Element2D):
                             "element or aggregate the data (e.g. using "
                             "np.histogram2d)." %
                             (type(self).__name__, self.interface.__name__))
-
-    def __setstate__(self, state):
-        """
-        Ensures old-style QuadMesh types without an interface can be unpickled.
-
-        Note: Deprecate as part of 2.0
-        """
-        if 'interface' not in state:
-            self.interface = GridInterface
-            x, y = state['_kdims_param_value']
-            z = state['_vdims_param_value'][0]
-            data = state['data']
-            state['data'] = {x.name: data[0], y.name: data[1], z.name: data[2]}
-        super(Dataset, self).__setstate__(state)
 
     def trimesh(self):
         """

--- a/holoviews/element/tabular.py
+++ b/holoviews/element/tabular.py
@@ -62,15 +62,6 @@ class ItemTable(Element):
             raise KeyError("%r not in available headings." % heading)
         return np.array(self.data.get(heading, np.NaN))
 
-    @classmethod
-    def collapse_data(cls, data, function, **kwargs):
-        param.main.param.warning(
-            'ItemTable.collapse_data is deprecated and '
-            'should no longer be used.')
-        groups = np.vstack([np.array(odict.values()) for odict in data]).T
-        return OrderedDict(zip(data[0].keys(), function(groups, axis=-1, **kwargs)))
-
-
     def dimension_values(self, dimension, expanded=True, flat=True):
         dimension = self.get_dimension(dimension, strict=True).name
         if dimension in self.dimensions('value', label=True):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -26,7 +26,8 @@ from ..core import (Operation, Element, Dimension, NdOverlay,
 from ..core.data import PandasInterface, XArrayInterface, DaskInterface, cuDFInterface
 from ..core.util import (
     Iterable, LooseVersion, basestring, cftime_types, cftime_to_timestamp,
-    datetime_types, dt_to_int, isfinite, get_param_values, max_range, config)
+    datetime_types, dt_to_int, isfinite, get_param_values, max_range
+)
 from ..element import (Image, Path, Curve, RGB, Graph, TriMesh,
                        QuadMesh, Contours, Spikes, Area, Rectangles,
                        Spread, Segments, Scatter, Points, Polygons)

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1186,11 +1186,6 @@ class shade(LinkableOperation):
         and any valid transfer function that accepts data, mask, nbins
         arguments.""")
 
-    normalization = param.ClassSelector(default='eq_hist',
-                                        precedence=-1,
-                                        class_=(basestring, Callable),
-                                        doc="Deprecated parameter (use cnorm instead)")
-
     clims = param.NumericTuple(default=None, length=2, doc="""
         Min and max data values to use for colormap interpolation, when
         wishing to override autoranging.
@@ -1286,22 +1281,9 @@ class shade(LinkableOperation):
         array = element.data[vdim]
         kdims = element.kdims
 
-        overrides = dict(self.p.items())
-        if 'normalization' in overrides:
-            if 'cnorm' in overrides:
-                self.param.warning("Both the 'cnorm' and 'normalization' keywords"
-                                   "specified; 'cnorm' value taking precedence over "
-                                   "deprecated 'normalization' option")
-            elif config.future_deprecations:
-                self.param.warning("Shading 'normalization' parameter deprecated, "
-                                   "use 'cnorm' parameter instead'")
-            cnorm = overrides.get('cnorm', overrides['normalization'])
-        else:
-            cnorm = self.p.cnorm
-
         # Compute shading options depending on whether
         # it is a categorical or regular aggregate
-        shade_opts = dict(how=cnorm,
+        shade_opts = dict(how=self.p.cnorm,
                           min_alpha=self.p.min_alpha,
                           alpha=self.p.alpha)
         if element.ndims > 2:
@@ -1333,7 +1315,7 @@ class shade(LinkableOperation):
 
         if self.p.clims:
             shade_opts['span'] = self.p.clims
-        elif ds_version > '0.5.0' and cnorm != 'eq_hist':
+        elif ds_version > '0.5.0' and self.p.cnorm != 'eq_hist':
             shade_opts['span'] = element.range(vdim)
 
         params = dict(get_param_values(element), kdims=kdims,

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -201,13 +201,10 @@ class ContourPlot(PathPlot):
 
         interface = element.interface
         scalar_kwargs = {'per_geom': True} if interface.multi else {}
-        npath = len([vs for vs in data.values()][0])
         for d in element.vdims:
             dim = util.dimension_sanitizer(d.name)
             if dim not in data:
-                if element.level is not None:
-                    data[dim] = np.full(npath, element.level)
-                elif interface.isunique(element, d, **scalar_kwargs):
+                if interface.isunique(element, d, **scalar_kwargs):
                     data[dim] = element.dimension_values(d, expanded=False)
                 else:
                     data[dim] = element.split(datatype='array', dimensions=[d])
@@ -248,8 +245,6 @@ class ContourPlot(PathPlot):
         if (((isinstance(color, dim) and color.applies(element)) or color in element) or
             (isinstance(fill_color, dim) and fill_color.applies(element)) or fill_color in element):
             cdim = None
-        elif None not in [element.level, self.color_index] and element.vdims:
-            cdim = element.vdims[0]
         else:
             cidx = self.color_index+2 if isinstance(self.color_index, int) else self.color_index
             cdim = element.get_dimension(cidx)
@@ -257,12 +252,8 @@ class ContourPlot(PathPlot):
         if cdim is None:
             return data, mapping, style
 
-        ncontours = len(xs)
         dim_name = util.dimension_sanitizer(cdim.name)
-        if element.level is not None:
-            values = np.full(ncontours, float(element.level))
-        else:
-            values = element.dimension_values(cdim, expanded=False)
+        values = element.dimension_values(cdim, expanded=False)
         data[dim_name] = values
 
         factors = None

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -138,7 +138,6 @@ Store.register({Curve: CurvePlot,
                 # Chart 3D
                 Surface: SurfacePlot,
                 TriSurface: TriSurfacePlot,
-                Trisurface: TriSurfacePlot, # Alias, remove in 2.0
                 Scatter3D: Scatter3DPlot,
                 Path3D: Path3DPlot,
 

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -137,9 +137,7 @@ class ContourPlot(PathPlot):
             style[color_prop] = style.pop('color')
 
         # Process deprecated color_index
-        if None not in [element.level, self.color_index]:
-            cdim = element.vdims[0]
-        elif 'array' not in style:
+        if 'array' not in style:
             cidx = self.color_index+2 if isinstance(self.color_index, int) else self.color_index
             cdim = element.get_dimension(cidx)
         else:
@@ -148,15 +146,12 @@ class ContourPlot(PathPlot):
         if cdim is None:
             return (paths,), style, {}
 
-        if element.level is not None:
-            array = np.full(len(paths), element.level)
-        else:
-            array = element.dimension_values(cdim, expanded=False)
-            if len(paths) != len(array):
-                # If there are multi-geometries the list of scalar values
-                # will not match the list of paths and has to be expanded
-                array = np.array([v for v, sps in zip(array, subpaths)
-                                  for _ in range(len(sps))])
+        array = element.dimension_values(cdim, expanded=False)
+        if len(paths) != len(array):
+            # If there are multi-geometries the list of scalar values
+            # will not match the list of paths and has to be expanded
+            array = np.array([v for v, sps in zip(array, subpaths)
+                              for _ in range(len(sps))])
 
         if array.dtype.kind not in 'uif':
             array = util.search_indices(array, util.unique_array(array))

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -708,8 +708,6 @@ class DimensionedPlot(Plot):
                 if hasattr(el, 'interface'):
                     if isinstance(el, Graph) and el_dim in el.nodes.dimensions():
                         dtype = el.nodes.interface.dtype(el.nodes, el_dim)
-                    elif isinstance(el, Contours) and el.level is not None:
-                        dtype = np.array([el.level]).dtype # Remove when deprecating level
                     else:
                         dtype = el.interface.dtype(el, el_dim)
                 elif hasattr(el, '__len__') and len(el):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -31,7 +31,7 @@ from ..core.options import Store, Compositor, SkipRendering, lookup_options
 from ..core.overlay import NdOverlay
 from ..core.spaces import HoloMap, DynamicMap
 from ..core.util import stream_parameters, isfinite
-from ..element import Table, Graph, Contours
+from ..element import Table, Graph
 from ..streams import Stream, RangeXY, RangeX, RangeY
 from ..util.transform import dim
 from .util import (

--- a/holoviews/plotting/plotly/__init__.py
+++ b/holoviews/plotting/plotly/__init__.py
@@ -63,7 +63,6 @@ Store.register({Points: ScatterPlot,
                 Surface: SurfacePlot,
                 Path3D: Path3DPlot,
                 TriSurface: TriSurfacePlot,
-                Trisurface: TriSurfacePlot, # Alias, remove in 2.0
 
                 # Tabular
                 Table: TablePlot,

--- a/holoviews/tests/element/testelementconstructors.py
+++ b/holoviews/tests/element/testelementconstructors.py
@@ -1,12 +1,12 @@
 import param
 import numpy as np
 
-from holoviews import (Dimension, Dataset, Element, Annotation, Curve,
-                       Path, Histogram, HeatMap, Contours, Scatter,
-                       Points, Polygons, VectorField, Spikes, Area,
-                       Bars, ErrorBars, BoxWhisker, Raster, Image,
-                       QuadMesh, RGB, Graph, TriMesh, Div, Tiles,
-                       Trisurface)
+from holoviews import (
+    Dimension, Dataset, Element, Annotation, Curve, Path, Histogram,
+    HeatMap, Contours, Scatter, Points, Polygons, VectorField, Spikes,
+    Area, Bars, ErrorBars, BoxWhisker, Raster, Image, QuadMesh, RGB,
+    Graph, TriMesh, Div, Tiles
+)
 from holoviews.element.path import BaseShape
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -31,7 +31,7 @@ class ElementConstructorTest(ComparisonTestCase):
     def test_empty_element_constructor(self):
         failed_elements = []
         for name, el in param.concrete_descendents(Element).items():
-            if issubclass(el, (Annotation, BaseShape, Div, Tiles, Trisurface)):
+            if issubclass(el, (Annotation, BaseShape, Div, Tiles)):
                 continue
             try:
                 el([])

--- a/holoviews/tests/util/testutils.py
+++ b/holoviews/tests/util/testutils.py
@@ -3,9 +3,7 @@
 Unit tests of the helper functions in utils
 """
 from unittest import SkipTest
-import numpy as np
 
-import holoviews as hv
 from holoviews import notebook_extension
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews import Store

--- a/holoviews/tests/util/testutils.py
+++ b/holoviews/tests/util/testutils.py
@@ -97,40 +97,6 @@ class TestOptsUtil(LoggingComparisonTestCase):
         Store._custom_options = {k:{} for k in Store._custom_options.keys()}
         super().tearDown()
 
-    def test_cell_opts_util_style(self):
-        mat1 = hv.Image(np.random.rand(5,5), name='mat1')
-        self.assertEqual(mat1.id, None)
-        opts("Image (cmap='hot')", mat1)
-        self.assertNotEqual(mat1.id, None)
-
-        self.assertEqual(
-             Store.lookup_options('matplotlib',
-                                  mat1, 'style').options.get('cmap',None),'hot')
-        self.log_handler.assertContains('WARNING', 'Double positional argument signature of opts is deprecated')
-
-    def test_cell_opts_util_plot(self):
-
-        mat1 = hv.Image(np.random.rand(5,5), name='mat1')
-
-        self.assertEqual(mat1.id, None)
-        opts("Image [show_title=False]", mat1)
-        self.assertNotEqual(mat1.id, None)
-        self.assertEqual(
-            Store.lookup_options('matplotlib',
-                                 mat1, 'plot').options.get('show_title',True), False)
-        self.log_handler.assertContains('WARNING', 'Double positional argument signature of opts is deprecated')
-
-    def test_cell_opts_util_norm(self):
-        mat1 = hv.Image(np.random.rand(5,5), name='mat1')
-        self.assertEqual(mat1.id, None)
-        opts("Image {+axiswise}", mat1)
-        self.assertNotEqual(mat1.id, None)
-
-        self.assertEqual(
-            Store.lookup_options('matplotlib',
-                                 mat1, 'norm').options.get('axiswise',True), True)
-        self.log_handler.assertContains('WARNING', 'Double positional argument signature of opts is deprecated')
-
     def test_opts_builder_repr(self):
         magic= "Bivariate [bandwidth=0.5] (cmap='jet') Points [logx=True] (size=2)"
         expected= ["opts.Bivariate(bandwidth=0.5, cmap='jet')",

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -102,22 +102,6 @@ class opts(param.ParameterizedFunction):
         elif params and not args:
             return Options(**params)
 
-        if len(args) == 1:
-            msg = ("Positional argument signature of opts is deprecated, "
-                   "use opts.defaults instead.\nFor instance, instead of "
-                   "opts('Points (size=5)') use opts.defaults(opts.Points(size=5))")
-            self.param.warning(msg)
-            self._linemagic(args[0])
-        elif len(args) == 2:
-            msg = ("Double positional argument signature of opts is deprecated, "
-                   "use the .options method instead.\nFor instance, instead of "
-                   "opts('Points (size=5)', points) use points.opts(opts.Points(size=5))")
-
-            self.param.warning(msg)
-
-            self._cellmagic(args[0], args[1])
-
-
     @classmethod
     def _group_kwargs_to_options(cls, obj, kwargs):
         "Format option group kwargs into canonical options format"
@@ -259,26 +243,6 @@ class opts(param.ParameterizedFunction):
                 sys.stderr.write('Options specification will not be applied.')
                 return options, True
         return options, False
-
-    @classmethod
-    def _cellmagic(cls, options, obj, strict=False):
-        "Deprecated, not expected to be used by any current code"
-        options, failure = cls._process_magic(options, strict)
-        if failure: return obj
-        if not isinstance(obj, Dimensioned):
-            return obj
-        else:
-            return StoreOptions.set_options(obj, options)
-
-    @classmethod
-    def _linemagic(cls, options, strict=False, backend=None):
-        "Deprecated, not expected to be used by any current code"
-        backends = None if backend is None else [backend]
-        options, failure = cls._process_magic(options, strict, backends=backends)
-        if failure: return
-        with options_policy(skip_invalid=True, warn_on_skip=False):
-            StoreOptions.apply_customizations(options, Store.options(backend=backend))
-
 
     @classmethod
     def defaults(cls, *options, **kwargs):
@@ -638,9 +602,6 @@ class output(param.ParameterizedFunction):
             for k in options.keys():
                 if k not in Store.output_settings.allowed:
                     raise KeyError('Invalid keyword: %s' % k)
-            if 'filename' in options:
-                self.param.warning('The filename argument of output is deprecated. '
-                                   'Use hv.save instead.')
 
             def display_fn(obj, renderer):
                 try:

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -16,7 +16,7 @@ from ..core import (
     Dataset, DynamicMap, HoloMap, Dimensioned, ViewableElement,
     StoreOptions, Store
 )
-from ..core.options import options_policy, Keywords, Options
+from ..core.options import Keywords, Options
 from ..core.operation import Operation
 from ..core.overlay import Overlay
 from ..core.util import basestring, merge_options_to_dict, OrderedDict

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -16,7 +16,7 @@ from ..core import (
     Dataset, DynamicMap, HoloMap, Dimensioned, ViewableElement,
     StoreOptions, Store
 )
-from ..core.options import Keywords, Options
+from ..core.options import Keywords, Options, options_policy
 from ..core.operation import Operation
 from ..core.overlay import Overlay
 from ..core.util import basestring, merge_options_to_dict, OrderedDict
@@ -243,6 +243,14 @@ class opts(param.ParameterizedFunction):
                 sys.stderr.write('Options specification will not be applied.')
                 return options, True
         return options, False
+
+    @classmethod
+    def _linemagic(cls, options, strict=False, backend=None):
+        backends = None if backend is None else [backend]
+        options, failure = cls._process_magic(options, strict, backends=backends)
+        if failure: return
+        with options_policy(skip_invalid=True, warn_on_skip=False):
+            StoreOptions.apply_customizations(options, Store.options(backend=backend))
 
     @classmethod
     def defaults(cls, *options, **kwargs):


### PR DESCRIPTION
- `Dimensioned.opts` now warns about passing in style, plot, norm options.
- `Dimensioned.__call__` now removed (previously allowed setting options)
- `ViewableTree.from_values` removed
- `Element.collapse_data` removed
- `Element.mapping` removed
- `Element.table` removed
- `MultiDimensionalMapping.dframe` removed (now only on `UniformNdMapping`)
- `Overlay.collapse` removed
- `HoloMap.sample` removed
- `HoloMap.reduce` removed
- `DynamicMap`/`HoloMap.split_overlays` removed
- `Histogram` constructor no longer accepts `Histogram(values, edges)` only `Histogram((edges, values))`
- Pickle compatibility for `Histogram`/`QuadMesh` before interface introduction removed
- `Histogram.values` property removed
- `Trisurface` removed (was replaced with `TriSurface`)
- `holoviews.element.graphs.redim_graph` removed (was there for pickle compatibility)
- `Contours`/`Polygons` level parameter was removed
- `Image` pickle compatibility for the time before the `ImageInterface` was removed
- `datashade` `normalization` parameter removed (was renamed to `cnorm`)
- `hv.opts` no longer accepts magic strings, e.g. `hv.opts('Points [width=600]')`