### PR TITLE
Fixed missing handling of nodata for count aggregator with column

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -315,7 +315,11 @@ class AggregationOperation(ResamplingOperation):
                                  "Ensure the aggregator references an existing "
                                  "dimension." % (column,element))
             if isinstance(agg_fn, (ds.count, ds.count_cat)):
-                vdims = dims[0].clone('%s %s Count' % (vdim_prefix, column), nodata=0)
+                if vdim_prefix:
+                    vdim_name = '%s%s Count' % (vdim_prefix, column)
+                else:
+                    vdim_name = '%s Count' % column
+                vdims = dims[0].clone(vdim_name, nodata=0)
             else:
                 vdims = dims[0].clone(vdim_prefix + column)
         elif category:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -229,7 +229,7 @@ class AggregationOperation(ResamplingOperation):
         no column is defined the first value dimension of the element
         will be used. May also be defined as a string.""")
 
-    vdim_prefix = param.String(default='{kdims} ', doc="""
+    vdim_prefix = param.String(default='{kdims} ', allow_None=True, doc="""
         Prefix to prepend to value dimension name where {kdims}
         templates in the names of the input element key dimensions.""")
 
@@ -297,8 +297,11 @@ class AggregationOperation(ResamplingOperation):
         params = dict(get_param_values(element), kdims=[x, y],
                       datatype=['xarray'], bounds=bounds)
 
-        kdim_list = '_'.join(str(kd) for kd in params['kdims'])
-        vdim_prefix = self.vdim_prefix.format(kdims=kdim_list)
+        if self.vdim_prefix is not None:
+            kdim_list = '_'.join(str(kd) for kd in params['kdims'])
+            vdim_prefix = self.vdim_prefix.format(kdims=kdim_list)
+        else:
+            vdim_prefix = ''
 
         category = None
         if hasattr(agg_fn, 'reduction'):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -297,7 +297,7 @@ class AggregationOperation(ResamplingOperation):
         params = dict(get_param_values(element), kdims=[x, y],
                       datatype=['xarray'], bounds=bounds)
 
-        if self.vdim_prefix is not None:
+        if self.vdim_prefix:
             kdim_list = '_'.join(str(kd) for kd in params['kdims'])
             vdim_prefix = self.vdim_prefix.format(kdims=kdim_list)
         else:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -311,7 +311,7 @@ class AggregationOperation(ResamplingOperation):
                 raise ValueError("Aggregation column '%s' not found on '%s' element. "
                                  "Ensure the aggregator references an existing "
                                  "dimension." % (column,element))
-            if isinstance(agg_fn, ds.count_cat):
+            if isinstance(agg_fn, (ds.count, ds.count_cat)):
                 vdims = dims[0].clone('%s %s Count' % (vdim_prefix, column), nodata=0)
             else:
                 vdims = dims[0].clone(vdim_prefix + column)

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -66,7 +66,7 @@ class DatashaderAggregateTests(ComparisonTestCase):
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2, aggregator=ds.count('z'))
         expected = Image(([0.25, 0.75], [0.25, 0.75], [[0, 0], [1, 0]]),
-                         vdims=[Dimension(' z Count', nodata=0)])
+                         vdims=[Dimension('z Count', nodata=0)])
         self.assertEqual(img, expected)
 
     @cudf_skip

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -61,6 +61,14 @@ class DatashaderAggregateTests(ComparisonTestCase):
                          vdims=[Dimension('Count', nodata=0)])
         self.assertEqual(img, expected)
 
+    def test_aggregate_points_count_column(self):
+        points = Points([(0.2, 0.3, np.NaN), (0.4, 0.7, 22), (0, 0.99,np.NaN)], vdims='z')
+        img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
+                        width=2, height=2, aggregator=ds.count('z'))
+        expected = Image(([0.25, 0.75], [0.25, 0.75], [[0, 0], [1, 0]]),
+                         vdims=[Dimension(' z Count', nodata=0)])
+        self.assertEqual(img, expected)
+
     @cudf_skip
     def test_aggregate_points_cudf(self):
         points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)], datatype=['cuDF'])


### PR DESCRIPTION
The `count_cat` aggregators were handled but `count` wasn't. Simple fix that shouldn't need much discussion once a corresponding unit test is added.