### PR TITLE
Removed unneeded list from dynamic map example (docs)

### DIFF
--- a/examples/reference/containers/bokeh/DynamicMap.ipynb
+++ b/examples/reference/containers/bokeh/DynamicMap.ipynb
@@ -56,8 +56,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "frequencies = [0.5, 0.75, 1.0, 1.25]\n",
-    "\n",
     "def sine_curve(phase, freq):\n",
     "    xvals = [0.1* i for i in range(100)]\n",
     "    return hv.Curve((xvals, [np.sin(phase+freq*x) for x in xvals]))\n",


### PR DESCRIPTION
The `frequencies` list is defined, but not used or needed in the Dynamicmap reference notebook