### PR TITLE
Optimize and clean up options system

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -699,7 +699,7 @@ class OptionTree(AttrTree):
         elif isinstance(val, Options) and val.key[0].isupper():
             groups = ', '.join(repr(el) for el in Options._option_groups)
             raise AttributeError(
-                "OptionTree only accepts Options using keys that are one of {groups}."
+                f"OptionTree only accepts Options using keys that are one of {groups}."
             )
         elif isinstance(val, Options):
             group_items = {val.key: val}

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -763,8 +763,8 @@ class OptionTree(AttrTree):
         )
         # Try to get a cache hit in the backend lookup cache
         backend = backend or Store.current_backend
-        cache = Store._lookup_cache[backend]
-        cache_key = opts_spec+(group, defaults,)
+        cache = Store._lookup_cache.get(backend, {})
+        cache_key = opts_spec+(group, defaults, id(self.root))
         if cache_key in cache:
             return cache[cache_key]
 
@@ -1169,6 +1169,7 @@ class Store(object):
         if val is None:
             return cls._options[backend]
         else:
+            cls._lookup_cache[backend] = {}
             cls._options[backend] = val
 
     @classmethod
@@ -1788,6 +1789,7 @@ class StoreOptions(object):
         backend = Store.current_backend if backend is None else backend
         # Update the custom option entries for the current backend
         Store.custom_options(backend=backend).update(custom_trees)
+        Store._lookup_cache[backend] = {}
 
         # Propagate option ids for non-selected backends
         for b in Store.loaded_backends():

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -34,7 +34,6 @@ Store:
 """
 import difflib
 import inspect
-import functools
 import pickle
 import traceback
 

--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -68,6 +68,13 @@ class AttrTree(object):
             self.set_path(path, item)
 
     @property
+    def root(self):
+        root = self
+        while root.parent is not None:
+            root = root.parent
+        return root
+
+    @property
     def path(self):
         "Returns the path up to the root for the current node."
         if self.parent:

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -67,13 +67,13 @@ class TestOptions(ComparisonTestCase):
         try:
             Options('test', allowed_keywords=['kw1'], kw='value')
         except OptionError as e:
-            self.assertEqual(str(e), "Invalid option 'kw', valid options are: ['kw1']")
+            self.assertEqual(str(e), "Invalid option 'kw', valid options are: ['kw1'].")
 
     def test_options_invalid_keywords2(self):
         try:
             Options('test', allowed_keywords=['kw2'], kw2='value', kw3='value')
         except OptionError as e:
-            self.assertEqual(str(e), "Invalid option 'kw3', valid options are: ['kw2']")
+            self.assertEqual(str(e), "Invalid option 'kw3', valid options are: ['kw2'].")
 
     def test_options_invalid_keywords_skip1(self):
         with options_policy(skip_invalid=True, warn_on_skip=False):
@@ -126,7 +126,7 @@ class TestOptions(ComparisonTestCase):
         try:
             opts(**new_kws)
         except OptionError as e:
-            self.assertEqual(str(e), "Invalid option 'kw4', valid options are: ['kw2', 'kw3']")
+            self.assertEqual(str(e), "Invalid option 'kw4', valid options are: ['kw2', 'kw3'].")
 
 
 
@@ -296,8 +296,10 @@ class TestStoreInheritanceDynamic(ComparisonTestCase):
             raise SkipTest('Matplotlib backend not available.')
         self.backend = 'matplotlib'
         Store.set_current_backend(self.backend)
-        self.store_copy = OptionTree(sorted(Store.options().items()),
-                                     groups=Options._option_groups)
+        options = Store.options()
+        self.store_copy = OptionTree(sorted(options.items()),
+                                     groups=Options._option_groups,
+                                     backend=options.backend)
         super().setUp()
 
     def tearDown(self):
@@ -494,7 +496,9 @@ class TestStoreInheritance(ComparisonTestCase):
         Store.set_current_backend(self.backend)
         self.store_copy = OptionTree(sorted(Store.options().items()),
                                      groups=Options._option_groups)
-        Store.options(val=OptionTree(groups=['plot', 'style']))
+        Store.options(val=OptionTree(
+            groups=['plot', 'style'], backend=self.backend
+        ))
 
         options = Store.options()
 
@@ -824,11 +828,13 @@ class TestCrossBackendOptions(ComparisonTestCase):
         self.plotly_options = Store._options.pop('plotly', None)
         self.store_mpl = OptionTree(
             sorted(Store.options(backend='matplotlib').items()),
-            groups=Options._option_groups
+            groups=Options._option_groups,
+            backend='matplotlib'
         )
         self.store_bokeh = OptionTree(
             sorted(Store.options(backend='bokeh').items()),
-            groups=Options._option_groups
+            groups=Options._option_groups,
+            backend='bokeh'
         )
         self.clear_options()
         super().setUp()
@@ -836,8 +842,10 @@ class TestCrossBackendOptions(ComparisonTestCase):
 
     def clear_options(self):
         # Clear global options..
-        Store.options(val=OptionTree(groups=['plot', 'style']), backend='matplotlib')
-        Store.options(val=OptionTree(groups=['plot', 'style']), backend='bokeh')
+        Store.options(val=OptionTree(groups=['plot', 'style'], backend='matplotlib'),
+                      backend='matplotlib')
+        Store.options(val=OptionTree(groups=['plot', 'style'], backend='bokeh'),
+                      backend='bokeh')
         # ... and custom options
         Store.custom_options({}, backend='matplotlib')
         Store.custom_options({}, backend='bokeh')
@@ -1022,10 +1030,14 @@ class TestCrossBackendOptionSpecification(ComparisonTestCase):
 
         # Some tests require that plotly isn't loaded
         self.plotly_options = Store._options.pop('plotly', None)
-        self.store_mpl = OptionTree(sorted(Store.options(backend='matplotlib').items()),
-                                    groups=Options._option_groups)
-        self.store_bokeh = OptionTree(sorted(Store.options(backend='bokeh').items()),
-                                    groups=Options._option_groups)
+        self.store_mpl = OptionTree(
+            sorted(Store.options(backend='matplotlib').items()),
+            groups=Options._option_groups, backend='matplotlib'
+        )
+        self.store_bokeh = OptionTree(
+            sorted(Store.options(backend='bokeh').items()),
+            groups=Options._option_groups, backend='bokeh'
+        )
         super().setUp()
 
     def tearDown(self):


### PR DESCRIPTION
A number of optimizations improvements for the options system:

1. Options objects are no longer Parameterized's
2. Store maintains a `_lookup_cache` per backend which resets every time an option is set.

The lookup cache in particular is very important, in my particular example it reduced the number of lookups and therefore instantiation of Options objects from 2168 to 8, shaving off almost 40% of the rendering time.