### PR TITLE
Fix batch watching of parameters in Params stream

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -707,7 +707,7 @@ class Params(Stream):
         if watch:
             # Subscribe to parameters
             keyfn = lambda x: id(x.owner)
-            for _, group in groupby(sorted(parameters, key=keyfn)):
+            for _, group in groupby(sorted(parameters, key=keyfn), key=keyfn):
                 group = list(group)
                 watcher = group[0].owner.param.watch(self._watcher, [p.name for p in group])
                 self._watchers.append(watcher)

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -295,6 +295,22 @@ class TestParamsStream(LoggingComparisonTestCase):
         inner.x = 0
         self.assertEqual(values, [{'action': inner.action, 'x': 0}])
 
+    def test_params_stream_batch_watch(self):
+        tap = Tap(x=0, y=1)
+        params = Params(parameters=[tap.param.x, tap.param.y])
+
+        values = []
+        def subscriber(**kwargs):
+            values.append(kwargs)
+        params.add_subscriber(subscriber)
+
+        tap.param.trigger('x', 'y')
+
+        assert values == [{'x': 0, 'y': 1}]
+
+        tap.event(x=1, y=2)
+
+        assert values == [{'x': 0, 'y': 1}, {'x': 1, 'y': 2}]
 
 
 class TestParamMethodStream(ComparisonTestCase):


### PR DESCRIPTION
The Params stream logic to batch the watching of parameters on the same Parameterized class or instance was not correct causing it to watch each parameter separately.