### PR TITLE
Update Plotting_with_Matplotlib.ipynb

### DIFF
--- a/examples/user_guide/Plotting_with_Matplotlib.ipynb
+++ b/examples/user_guide/Plotting_with_Matplotlib.ipynb
@@ -208,7 +208,7 @@
     "One of the major differences between the matplotlib extension and others is the way plot sizes work. In Plotly and Bokeh plot sizes are inside out, i.e. each plot defines its height and can then be composed together as needed, while matplotlib defines the size of the figure and the size of each subplot is relative to that. This affords greater control over plot aspect but can also make things more difficult. In HoloViews the size of a plot can be controlled using a couple of main options\n",
     "\n",
     "- **``aspect``**: Determines the aspect ratio of a subplot\n",
-    "- **``fig_bounds``**: A four-tuple declaring the (left, right, bottom, top) of the plot in figure coordinates with a range of 0-1.\n",
+    "- **``fig_bounds``**: A four-tuple declaring the (left, bottom, right, top) of the plot in figure coordinates with a range of 0-1.\n",
     "- **``fig_inches``**: The size of the plot in inches can be a single which will be scaled according to the plots aspect or a tuple specifying both width and height).\n",
     "- **``fig_size``**: A percentage scaling factor."
    ]


### PR DESCRIPTION
Ordering of the fig_bounds tuple in the documentation was different from that in e.g. https://github.com/holoviz/holoviews/blob/40977c515dd9837019aaa0e5708773e78809fbe1/holoviews/plotting/mpl/plot.py#L69