### PR TITLE
Fixed small typos in error messages

### DIFF
--- a/holoviews/tests/core/test_dimensioned.py
+++ b/holoviews/tests/core/test_dimensioned.py
@@ -85,7 +85,7 @@ class TestDimensioned_options(CustomBackendTestCase):
 
     def test_apply_options_explicit_backend_style_invalid_no_match(self):
         err = ("Unexpected option 'zxy' for ExampleElement type when using the "
-               "'backend_2' extension. No similar options founds\.")
+               "'backend_2' extension. No similar options found\.")
         with self.assertRaisesRegex(ValueError, err):
             ExampleElement([]).options(zxy='A', backend='backend_2')
 

--- a/holoviews/tests/element/test_annotations.py
+++ b/holoviews/tests/element/test_annotations.py
@@ -13,7 +13,7 @@ class AnnotationTests(ComparisonTestCase):
     """
 
     def test_hline_invalid_constructor(self):
-        err = "Parameter 'y' value must be an instance of"
+        err = "ClassSelector parameter 'y' value must be an instance of"
         with pytest.raises(ValueError) as excinfo:
             HLine(None)
         assert err in str(excinfo.value)

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -366,7 +366,7 @@ class opts(param.ParameterizedFunction):
             else:
                 raise ValueError('Unexpected option %r for %s type '
                                  'when using the %r extension. No '
-                                 'similar options founds.' %
+                                 'similar options found.' %
                                  (opt, objtype, backend))
 
         # Check option is invalid for all backends


### PR DESCRIPTION
In two places, the phrase "options found" was typed as "options founds."