### PR TITLE
Fix regressions in dim transforms

### DIFF
--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -280,7 +280,10 @@ class dim(object):
             try:
                 ns = getattr(ns, ops[-1]['fn'])
             except Exception as e:
-                pass
+                # If the namespace doesn't know the method we are
+                # calling then we are using custom API of the dim
+                # transform itself, so set namespace to None
+                ns = None 
         extras = {ns_attr for ns_attr in dir(ns) if not ns_attr.startswith('_')}
         if attr in extras and attr not in super(dim, self).__dir__():
             return type(self)(self, attr, accessor=True)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -279,11 +279,11 @@ class dim(object):
         if ops and ops[-1]['kwargs'].get('accessor'):
             try:
                 ns = getattr(ns, ops[-1]['fn'])
-            except Exception as e:
+            except Exception:
                 # If the namespace doesn't know the method we are
                 # calling then we are using custom API of the dim
                 # transform itself, so set namespace to None
-                ns = None 
+                ns = None
         extras = {ns_attr for ns_attr in dir(ns) if not ns_attr.startswith('_')}
         if attr in extras and attr not in super(dim, self).__dir__():
             return type(self)(self, attr, accessor=True)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -272,6 +272,8 @@ class dim(object):
 
     def __getattribute__(self, attr):
         self_dict = super().__getattribute__('__dict__')
+        if '_ns' not in self_dict: # Not yet initialized
+            return super().__getattribute__(attr)
         ns = self_dict['_ns']
         ops = super().__getattribute__('ops')
         if ops and ops[-1]['kwargs'].get('accessor'):

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -275,7 +275,10 @@ class dim(object):
         ns = self_dict['_ns']
         ops = super().__getattribute__('ops')
         if ops and ops[-1]['kwargs'].get('accessor'):
-            ns = getattr(ns, ops[-1]['fn'])
+            try:
+                ns = getattr(ns, ops[-1]['fn'])
+            except Exception as e:
+                pass
         extras = {ns_attr for ns_attr in dir(ns) if not ns_attr.startswith('_')}
         if attr in extras and attr not in super(dim, self).__dir__():
             return type(self)(self, attr, accessor=True)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     "param >=1.9.3,<2.0",
     "numpy >=1.0",
     "pyviz_comms >=0.7.4",
-    "panel >=0.9.5",
+    "panel ==0.11.3",
     "colorcet",
     "pandas  <1.3.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     "pyviz_comms >=0.7.4",
     "panel >=0.9.5",
     "colorcet",
-    "pandas >=0.20.0",
+    "pandas  <1.3.0",
 ]
 
 extras_require = {}

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ install_requires = [
     "param >=1.9.3,<2.0",
     "numpy >=1.0",
     "pyviz_comms >=0.7.4",
-    "panel ==0.11.3",
+    "panel >=0.9.5",
     "colorcet",
-    "pandas  <1.3.0",
+    "pandas >=0.20.0",
 ]
 
 extras_require = {}


### PR DESCRIPTION
Namespace object does not necessarily have the attribute you're looking up and the class may not be initialized yet when `__getattribute__` is called the first time.