### PR TITLE
Add support for pandas>=1.3

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -44,7 +44,10 @@ except ImportError:
 if pd:
     pandas_version = LooseVersion(pd.__version__)
     try:
-        if pandas_version >= '0.24.0':
+        if pandas_version >= '1.3.0':
+            from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtypeType
+            from pandas.core.dtypes.generic import ABCSeries, ABCIndex as ABCIndexClass
+        elif pandas_version >= '0.24.0':
             from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtypeType
             from pandas.core.dtypes.generic import ABCSeries, ABCIndexClass
         elif pandas_version > '0.20.0':

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     "pyviz_comms >=0.7.4",
     "panel >=0.9.5",
     "colorcet",
-    "pandas <1.3.0",
+    "pandas >=0.20.0",
 ]
 
 extras_require = {}


### PR DESCRIPTION
This PR addresses the issue https://github.com/holoviz/holoviews/issues/5009. It adds another check to handle pandas 1.3+ in `holoviews/core/utils.py`, and reverts the `install_requires` to what is what before https://github.com/holoviz/holoviews/pull/4976.

All the tests that were not skipped pass in my branch, in my fresh environment (Mac OS). I'm not sure how to un-skip tests, but PR https://github.com/holoviz/holoviews/pull/4976 mentions that there are 111 failed tests so I'm a bit worried there are other things required to fully support pandas 1.3