### PR TITLE
Allow plotting anonymous pandas.Series

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -33,7 +33,8 @@ class PandasInterface(Interface):
         kdim_param = element_params['kdims']
         vdim_param = element_params['vdims']
         if util.is_series(data):
-            data = data.to_frame()
+            name = data.name or util.anonymous_dimension_label
+            data = data.to_frame(name=name)
         if util.is_dataframe(data):
             ncols = len(data.columns)
             index_names = data.index.names if isinstance(data, pd.DataFrame) else [data.index.name]

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -36,6 +36,8 @@ timedelta_types = (np.timedelta64, dt.timedelta,)
 arraylike_types = (np.ndarray,)
 masked_types = ()
 
+anonymous_dimension_label = '_'
+
 try:
     import pandas as pd
 except ImportError:


### PR DESCRIPTION
If a Series has no name (empty string or None), uses a default "y" name
to avoid exceptions.

Fixes #4970