### PR TITLE
Sanitize uses of contextlib.contextmanager

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -233,8 +233,10 @@ def options_policy(skip_invalid, warn_on_skip):
     """
     settings = (Options.skip_invalid, Options.warn_on_skip)
     (Options.skip_invalid, Options.warn_on_skip) = (skip_invalid, warn_on_skip)
-    yield
-    (Options.skip_invalid, Options.warn_on_skip) = settings
+    try:
+        yield
+    finally:
+        (Options.skip_invalid, Options.warn_on_skip) = settings
 
 
 class Keywords(param.Parameterized):
@@ -1752,17 +1754,19 @@ class StoreOptions(object):
         See holoviews.core.options.set_options function for more
         information on the options specification format.
         """
-        if (options is None) and kwargs == {}: yield
-        else:
+        if (options is not None) or kwargs:
             Store._options_context = True
             optstate = cls.state(obj)
             groups = Store.options().groups.keys()
             options = cls.merge_options(groups, options, **kwargs)
             cls.set_options(obj, options)
+
+        try:
             yield
-        if options is not None:
-            Store._options_context = True
-            cls.state(obj, state=optstate)
+        finally:
+            if options is not None:
+                Store._options_context = True
+                cls.state(obj, state=optstate)
 
     @classmethod
     def id_offset(cls):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -671,8 +671,6 @@ def dynamicmap_memoization(callable_obj, streams):
     callable_obj._stream_memoization &= not any(s.transient and s._triggering for s in streams)
     try:
         yield
-    except:
-        raise
     finally:
         callable_obj._stream_memoization = memoization_state
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1563,8 +1563,6 @@ def disable_constant(parameterized):
         p.constant = False
     try:
         yield
-    except:
-        raise
     finally:
         for (p, const) in zip(params, constants):
             p.constant = const

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -117,16 +117,11 @@ def dynamic_optstate(element, state=None):
 @contextmanager
 def option_state(element):
     optstate = dynamic_optstate(element)
-    raised_exception = False
     try:
         yield
     except Exception:
-        raised_exception = True
+        dynamic_optstate(element, state=optstate)
         raise
-    finally:
-        if raised_exception:
-            dynamic_optstate(element, state=optstate)
-
 
 
 def display_hook(fn):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -38,8 +38,6 @@ def triggering_streams(streams):
         stream._triggering = True
     try:
         yield
-    except:
-        raise
     finally:
         for stream in streams:
             stream._triggering = False


### PR DESCRIPTION
* try/finally around the yield statement in order to execute the 2nd
  part if an exception is raised in the with statement block

* "except: raise" is unncessary, that is the default behaviour of any
  try/finally construct.