### PR TITLE
Fix AdjointLayout in link_selections

### DIFF
--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -10,6 +10,7 @@ from .core.dimension import OrderedDict
 from .core.element import Element, Layout
 from .core.options import CallbackError, Store
 from .core.overlay import NdOverlay, Overlay
+from .core.layout import AdjointLayout
 from .core.spaces import GridSpace
 from .streams import (
     Stream, SelectionExprSequence, CrossFilterSet,
@@ -192,7 +193,7 @@ class _base_link_selections(param.ParameterizedFunction):
                     self._selection_expr_streams.get(element, None), cache=self._cache
                 )
             return hvobj
-        elif isinstance(hvobj, (Layout, Overlay, NdOverlay, GridSpace)):
+        elif isinstance(hvobj, (Layout, Overlay, NdOverlay, GridSpace, AdjointLayout)):
             data = OrderedDict([(k, self._selection_transform(v, operations))
                                  for k, v in hvobj.items()])
             if isinstance(hvobj, NdOverlay):


### PR DESCRIPTION
Fixed `AdjointLayout` not working with `link_selections` as illustrated in: https://github.com/holoviz/holoviews/issues/5028

Fix:
<img src="https://user-images.githubusercontent.com/951093/126027932-114ddf12-f4bc-4286-bf2c-09eebde1ffe8.gif" alt="adjoint_layout_working" width="400"/>
