### PR TITLE
Added release notes for the 1.14.5 hotfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+Version 1.14.5
+==============
+
+This is a hotfix release with a number of important bug fixes. Most
+importantly, this version supports for the recent pandas 1.3.0
+release. Many thanks to @kgullikson88, @philippjfr and @jlstevens for
+contributing the fixes in this release.
+
+Bug fixes:
+
+- Support for pandas>=1.3
+  ([#5013](https://github.com/holoviz/holoviews/pull/5013))
+- Various bug fixes relating to dim transforms including the use of
+  parameters in slices and the use of getattribute
+  ([#4993](https://github.com/holoviz/holoviews/pull/4993),
+  [#5001](https://github.com/holoviz/holoviews/pull/5001),
+  [#5005](https://github.com/holoviz/holoviews/pull/5005))
+
+
 Version 1.14.4
 ==============
 **May 18, 2021**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Version 1.14.5
 ==============
+**July 16, 2021**
 
+	
 This is a hotfix release with a number of important bug fixes. Most
 importantly, this version supports for the recent pandas 1.3.0
 release. Many thanks to @kgullikson88, @philippjfr and @jlstevens for

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -4,6 +4,25 @@ Releases
 Version 1.14
 ~~~~~~~~~~~~
 
+Version 1.14.5
+**************
+
+This is a hotfix release with a number of important bug fixes. Most
+importantly, this version supports for the recent pandas 1.3.0 release.
+Many thanks to @kgullikson88, @philippjfr and @jlstevens for
+contributing the fixes in this release.
+
+Bug fixes:
+
+-  Support for pandas>=1.3
+   (`#5013 <https://github.com/holoviz/holoviews/pull/5013>`__)
+-  Various bug fixes relating to dim transforms including the use of
+   parameters in slices and the use of getattribute
+   (`#4993 <https://github.com/holoviz/holoviews/pull/4993>`__,
+   `#5001 <https://github.com/holoviz/holoviews/pull/5001>`__,
+   `#5005 <https://github.com/holoviz/holoviews/pull/5005>`__)
+
+   
 Version 1.14.4
 **************
 


### PR DESCRIPTION
It was a bit of a rush getting 1.14.5 due to the breakage around pandas 1.3.0 which meant the release notes weren't added. Once this PR is merged I'll add these notes to the github tag release description and update the website accordingly.

- [x] Add RST version to releases.rst