### PR TITLE
Forward DynamicMap.hist dimension parameter to histogram creation

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1665,8 +1665,13 @@ class DynamicMap(HoloMap):
             if isinstance(obj, (NdOverlay, Overlay)):
                 index = kwargs.get('index', 0)
                 obj = obj.get(index)
-            return obj.hist(num_bins=num_bins, bin_range=bin_range,
-                            adjoin=False, **kwargs)
+            return obj.hist(
+                dimension=dimension,
+                num_bins=num_bins,
+                bin_range=bin_range,
+                adjoin=False,
+                **kwargs
+            )
 
         from ..util import Dynamic
         hist = Dynamic(self, streams=self.streams, link_inputs=False,


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/5036

```python
DynamicMap.hist(dimension='y')
```
Results in:
* Before fix:
  <img src="https://user-images.githubusercontent.com/951093/126271151-793c84d6-b59c-4d81-a2d1-439e1c3ced70.png" alt="hist-wrong-dimension" width="350">
* After fix:
   <img src="https://user-images.githubusercontent.com/951093/126280715-aa573faf-63ad-486f-a6e2-f97f2b8201d6.png" alt="hist-wrong-dimension" width="400">
