### PR TITLE
Add warning to linked selection

### DIFF
--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -179,6 +179,10 @@ class _base_link_selections(param.ParameterizedFunction):
                     callback.operation)
             else:
                 # This is a DynamicMap that we don't know how to recurse into.
+                self.param.warning(
+                    "linked selection: Encountered DynamicMap that we don't know "
+                    "how to recurse into:\n{!r}".format(hvobj)
+                )
                 return hvobj
         elif isinstance(hvobj, Element):
             # Register hvobj to receive selection expression callbacks


### PR DESCRIPTION
`hv.selection.link_selections` does not work on all objects, if it doesn't know how to recurse into an object it just returns the object (without a warning): https://github.com/holoviz/holoviews/blob/effaf45f9c2e7bf33c9f7ee830c2aa355badaae2/holoviews/selection.py#L180-L182

The absense of any indication that the `link_selections` might not work can be confusing, as I experience myself. I propose adding a warning to signal the user that the `link_selections` might not work as expected.

For example see:
<img src="https://user-images.githubusercontent.com/951093/126804914-9cc77994-df93-4d6b-82e8-10c2f7d36608.gif" width="600">

Please let me know if you think this is a good idea