### PR TITLE
fix(core.data.interface): check if data.interface is a class

### DIFF
--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -203,7 +203,7 @@ class Interface(param.Parameterized):
             vdims = pvals.get('vdims') if vdims is None else vdims
 
         # Process Element data
-        if (hasattr(data, 'interface') and issubclass(data.interface, Interface)):
+        if hasattr(data, 'interface') and isinstance(data.interface, type) and issubclass(data.interface, Interface):
             if datatype is None:
                 datatype = [dt for dt in data.datatype if dt in eltype.datatype]
                 if not datatype:

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -165,6 +165,10 @@ class BasePandasInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
         ds = Dataset(df.groupby(['x', 'y']).mean(), [('x', 'X'), ('y', 'Y')])
         self.assertEqual(ds, Dataset(df, [('x', 'X'), ('y', 'Y')]))
 
+    def test_dataset_with_interface_column(self):
+        df = pd.DataFrame([1], columns=['interface'])
+        ds = Dataset(df)
+        self.assertEqual(list(ds.data.columns), ['interface'])
 
 
 class PandasInterfaceTests(BasePandasInterfaceTests):


### PR DESCRIPTION
 check if data.interface is a class before calling issubclass()

Fixes https://github.com/holoviz/hvplot/issues/645
