### PR TITLE
Notimplemented binop

### DIFF
--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -544,9 +544,10 @@ class Layout(Layoutable, ViewableTree):
 
     def __mul__(self, other, reverse=False):
         from .spaces import HoloMap
-        if not isinstance(other, (ViewableElement, HoloMap)):
+        if isinstance(other, (ViewableElement, HoloMap)):
+            return Layout([other*v if reverse else v*other for v in self])
+        else:
             return NotImplemented
-        return Layout([other*v if reverse else v*other for v in self])
 
     def __rmul__(self, other):
         return self.__mul__(other, reverse=True)

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -1004,7 +1004,10 @@ class UniformNdMapping(NdMapping):
 
         overlayed_items = [(k, other * el if reverse else el * other)
                            for k, el in self.items()]
-        return self.clone(overlayed_items)
+        try:
+            return self.clone(overlayed_items)
+        except NotImplementedError:
+            return NotImplemented
 
 
     def __rmul__(self, other):

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -14,7 +14,7 @@ import numpy as np
 import param
 from .dimension import Dimension, Dimensioned, ViewableElement, ViewableTree
 from .ndmapping import UniformNdMapping
-from .layout import Composable, Layout, AdjointLayout
+from .layout import Composable, Layout, AdjointLayout, Layoutable
 from .util import sanitize_identifier, unique_array, dimensioned_streams
 
 
@@ -66,7 +66,7 @@ class CompositeOverlay(ViewableElement, Composable):
             bin_range (tuple optional): Lower and upper bounds of bins
             adjoin (bool, optional): Whether to adjoin histogram
             index (int, optional): Index of layer to apply hist to
-            show_legend (bool, optional): Show legend in histogram 
+            show_legend (bool, optional): Show legend in histogram
                 (don't show legend by default).
 
         Returns:
@@ -99,7 +99,7 @@ class CompositeOverlay(ViewableElement, Composable):
                 )
                 for i, (elem_key, elem) in enumerate(self.items())
                 if (index is None) or (getattr(elem, "label", None) == index) or (index == i)
-            ]) 
+            ])
             for dim in dimension
         }
         # Create new Overlays of histograms
@@ -151,7 +151,7 @@ class CompositeOverlay(ViewableElement, Composable):
         return vals if expanded else unique_array(vals)
 
 
-class Overlay(ViewableTree, CompositeOverlay):
+class Overlay(ViewableTree, CompositeOverlay, Layoutable):
     """
     An Overlay consists of multiple Elements (potentially of
     heterogeneous type) presented one on top each other with a
@@ -197,12 +197,6 @@ class Overlay(ViewableTree, CompositeOverlay):
             else:
                 return default
         return super().get(identifier, default)
-
-
-    def __add__(self, other):
-        "Composes Overlay with other object into a Layout"
-        return Layout([self, other])
-
 
     def __mul__(self, other):
         "Adds layer(s) from other object to Overlay"

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -18,15 +18,17 @@ from .layout import Composable, Layout, AdjointLayout, Layoutable
 from .util import sanitize_identifier, unique_array, dimensioned_streams
 
 
-class Overlayable(object):
+class Overlayable:
     """
     Overlayable provides a mix-in class to support the
     mul operation for overlaying multiple elements.
     """
-
     def __mul__(self, other):
         "Overlay object with other object."
-        if type(other).__name__ == 'DynamicMap':
+        # Local import to break the import cyclic dependency
+        from .spaces import DynamicMap
+
+        if isinstance(other, DynamicMap):
             from .spaces import Callable
             def dynamic_mul(*args, **kwargs):
                 element = other[args]
@@ -35,14 +37,21 @@ class Overlayable(object):
             callback._is_overlay = True
             return other.clone(shared_data=False, callback=callback,
                                streams=dimensioned_streams(other))
-        if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):
-            items = [(k, self * v) for (k, v) in other.items()]
-            return other.clone(items)
-        elif isinstance(other, (AdjointLayout, ViewableTree)) and not isinstance(other, Overlay):
-            return NotImplemented
+        else:
+            if isinstance(self, Overlay):
+                if not isinstance(other, ViewableElement):
+                    return NotImplemented
+            else:
+                if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):
+                    items = [(k, self * v) for (k, v) in other.items()]
+                    return other.clone(items)
+                elif isinstance(other, (AdjointLayout, ViewableTree)) and not isinstance(other, Overlay):
+                    return NotImplemented
 
-        return Overlay([self, other])
-
+            try:
+                return Overlay([self, other])
+            except NotImplementedError:
+                return NotImplemented
 
 
 class CompositeOverlay(ViewableElement, Composable):
@@ -151,7 +160,7 @@ class CompositeOverlay(ViewableElement, Composable):
         return vals if expanded else unique_array(vals)
 
 
-class Overlay(ViewableTree, CompositeOverlay, Layoutable):
+class Overlay(ViewableTree, CompositeOverlay, Layoutable, Overlayable):
     """
     An Overlay consists of multiple Elements (potentially of
     heterogeneous type) presented one on top each other with a
@@ -197,22 +206,6 @@ class Overlay(ViewableTree, CompositeOverlay, Layoutable):
             else:
                 return default
         return super().get(identifier, default)
-
-    def __mul__(self, other):
-        "Adds layer(s) from other object to Overlay"
-        if type(other).__name__ == 'DynamicMap':
-            from .spaces import Callable
-            def dynamic_mul(*args, **kwargs):
-                element = other[args]
-                return self * element
-            callback = Callable(dynamic_mul, inputs=[self, other])
-            callback._is_overlay = True
-            return other.clone(shared_data=False, callback=callback,
-                               streams=dimensioned_streams(other))
-        elif not isinstance(other, ViewableElement):
-            return NotImplemented
-        return Overlay([self, other])
-
 
     def collate(self):
         """

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -15,7 +15,7 @@ import param
 from . import traversal, util
 from .accessors import Opts, Redim
 from .dimension import OrderedDict, Dimension, ViewableElement
-from .layout import Layout, AdjointLayout, NdLayout, Empty
+from .layout import Layout, AdjointLayout, NdLayout, Empty, Layoutable
 from .ndmapping import UniformNdMapping, NdMapping, item_check
 from .overlay import Overlay, CompositeOverlay, NdOverlay, Overlayable
 from .options import Store, StoreOptions
@@ -23,7 +23,7 @@ from ..streams import Stream, Params, streams_list_from_dict
 
 
 
-class HoloMap(UniformNdMapping, Overlayable):
+class HoloMap(Layoutable, UniformNdMapping, Overlayable):
     """
     A HoloMap is an n-dimensional mapping of viewable elements or
     overlays. Each item in a HoloMap has an tuple key defining the
@@ -294,12 +294,6 @@ class HoloMap(UniformNdMapping, Overlayable):
             return self.clone(items, label=self._label, group=self._group)
         else:
             return NotImplemented
-
-
-    def __add__(self, obj):
-        "Composes HoloMap with other object into a Layout"
-        return Layout([self, obj])
-
 
     def __lshift__(self, other):
         "Adjoin another object to this one returning an AdjointLayout"
@@ -1725,7 +1719,7 @@ class DynamicMap(HoloMap):
 
 
 
-class GridSpace(UniformNdMapping):
+class GridSpace(Layoutable, UniformNdMapping):
     """
     Grids are distinct from Layouts as they ensure all contained
     elements to be of the same type. Unlike Layouts, which have
@@ -1837,12 +1831,6 @@ class GridSpace(UniformNdMapping):
         count the full set of keys.
         """
         return max([(len(v) if hasattr(v, '__len__') else 1) for v in self.values()] + [0])
-
-
-    def __add__(self, obj):
-        "Composes the GridSpace with another object into a Layout."
-        return Layout([self, obj])
-
 
     @property
     def shape(self):


### PR DESCRIPTION
Mainly fix `__add__` and `__radd__` to avoid raising `NotImplementedError` and return `NotImplemented` instead [1]. Also deduplicates some code to avoid having to copy-paste the handling in various places. 

[1] https://docs.python.org/3/library/constants.html#NotImplemented

Fixes https://github.com/holoviz/holoviews/issues/3577

note: The following tests are failing on my setup, as they are on the master branch:
```
FAILED holoviews/tests/element/test_elementconstructors.py::ElementConstructorTest::test_empty_element_constructor - AssertionError: ['Sankey'] != []
FAILED holoviews/tests/plotting/matplotlib/test_renderer.py::MPLRendererTest::test_get_size_column_plot - AssertionError: (288, 511) != (288, 509)
FAILED holoviews/tests/plotting/matplotlib/test_renderer.py::MPLRendererTest::test_get_size_row_plot - AssertionError: (576, 259) != (576, 257)
```