### PR TITLE
Attempt to deploy the docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     
 jobs:
-  test_suite:
+  build_docs:
     name: Documentation
     runs-on: 'ubuntu-latest'
     timeout-minutes: 120

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,6 +57,7 @@ jobs:
           conda activate test-environment
           conda list
           doit develop_install ${{ env.CHANS_DEV}} -o doc
+          conda install -c pyviz "jupyter_client<7"
           conda install -c conda-forge geckodriver selenium awscli
       - name: doit env_capture
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,8 @@ on:
     - 'v[0-9]+.[0-9]+.[0-9]+a[0-9]+'
     - 'v[0-9]+.[0-9]+.[0-9]+b[0-9]+'
     - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
-
+  workflow_dispatch:
+    
 jobs:
   test_suite:
     name: Documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       DESC: "Documentation build"
       HV_REQUIREMENTS: "doc"
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh -c conda-forge"
+      CHANS_DEV: "-c pyviz/label/dev -c bokeh"
       CHANS: "-c pyviz"
       MPLBACKEND: "Agg"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
           conda activate test-environment
           conda list
           doit develop_install ${{ env.CHANS_DEV}} -o doc
-          conda install -c conda-forge geckodriver selenium
+          conda install -c conda-forge geckodriver selenium awscli
       - name: bokeh sampledata
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,6 +58,11 @@ jobs:
           conda list
           doit develop_install ${{ env.CHANS_DEV}} -o doc
           conda install -c conda-forge geckodriver selenium awscli
+      - name: doit env_capture
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit env_capture
       - name: bokeh sampledata
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,8 +11,6 @@ jobs:
   test_suite:
     name: Documentation
     runs-on: 'ubuntu-latest'
-    strategy:
-      fail-fast: false
     timeout-minutes: 120
     defaults:
       run:

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ extras_require["basic_tests"] = (
 
 extras_require["nbtests"] = extras_require["recommended"] + [
     "nose",
-    "awscli",
     "deepdiff",
 ]
 
@@ -95,7 +94,6 @@ extras_require['doc'] = extras_require['examples'] + [
     'sphinx',
     'sphinx_holoviz_theme',
     'mpl_sample_data >=3.1.3',
-    'awscli',
     'pscript',
     'graphviz',
     'bokeh >2.2'


### PR DESCRIPTION
Currently `ibis-framework` cannot be installed on Ubuntu from conda-forge (https://github.com/conda-forge/ibis-framework-feedstock/issues/54), yet it can be installed from defaults.

The only dependency that is not available on defaults from the `-o doc` option is awscli. It's thus removed from `setup.py` and installed after `develop install` from conda-forge. Note this is already done for selenium and geckodriver. After this change, `develop_install` won't rely on conda-forge anymore.

This PR also adds the possibility to trigger the docs workflow manually from the UI (https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/).