### PR TITLE
Fix unhandled numpy.round overflow return value in core/util.py:bound_range(...)

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1964,7 +1964,9 @@ def bound_range(vals, density, time_unit='us'):
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', r'invalid value encountered in double_scalars')
             full_precision_density = compute_density(low, high, len(vals)-1)
+            error = np.seterr(over="ignore")
             density = round(full_precision_density, sys.float_info.dig)
+            np.seterr(**error)
         if density == 0 or density == np.inf:
             density = full_precision_density
     if density == 0:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1964,9 +1964,8 @@ def bound_range(vals, density, time_unit='us'):
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', r'invalid value encountered in double_scalars')
             full_precision_density = compute_density(low, high, len(vals)-1)
-            error = np.seterr(over="ignore")
-            density = round(full_precision_density, sys.float_info.dig)
-            np.seterr(**error)
+            with np.errstate(over='ignore'):
+                density = round(full_precision_density, sys.float_info.dig)
         if density == 0 or density == np.inf:
             density = full_precision_density
     if density == 0:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1965,7 +1965,7 @@ def bound_range(vals, density, time_unit='us'):
             warnings.filterwarnings('ignore', r'invalid value encountered in double_scalars')
             full_precision_density = compute_density(low, high, len(vals)-1)
             density = round(full_precision_density, sys.float_info.dig)
-        if density == 0:
+        if density == 0 or density == np.inf:
             density = full_precision_density
     if density == 0:
         raise ValueError('Could not determine Image density, ensure it has a non-zero range.')


### PR DESCRIPTION
For the detailed analysis, I created an issue: #5094

#### Suggested changes

1. Check additional for infinity: 
```
        with warnings.catch_warnings():
            warnings.filterwarnings('ignore', r'invalid value encountered in double_scalars')
            full_precision_density = compute_density(low, high, len(vals)-1)
            density = round(full_precision_density, sys.float_info.dig)
        if density == 0 or density == np.inf:
            density = full_precision_density
```

2. Disable Overflow FloatingPointErrors for the round call:
```
        with warnings.catch_warnings():
            warnings.filterwarnings('ignore', r'invalid value encountered in double_scalars')
            full_precision_density = compute_density(low, high, len(vals)-1)
            error = np.seterr(over="ignore")
            density = round(full_precision_density, sys.float_info.dig)
            np.seterr(**error)
        if density == 0:
            density = full_precision_density
```