### PR TITLE
Bump the panel version required to 0.10.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
           conda activate test-environment
           conda install ${{ env.CHANS_DEV}} "freetype=2.10.4"
       - name: Patch - do not install cffi 1.15.0 on macos and for python != 3.6
-        if: matrix.os == 'macos-latest' and matrix.python-version != '3.6'
+        if: matrix.os == 'macos-latest' && matrix.python-version != '3.6'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,12 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda install ${{ env.CHANS_DEV}} "freetype=2.10.4"
+      - name: Patch - do not install cffi 1.15.0 on macos and for python != 3.6
+        if: matrix.os == 'macos-latest' and matrix.python-version != '3.6'
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          conda install ${{ env.CHANS_DEV}} "cffi!=1.15.0"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -41,7 +41,6 @@ from .util import (
     split_dmap_overlay, get_axis_padding, get_range, get_minimum_span,
     get_plot_frame, scale_fontsize, dynamic_update
 )
-from panel.util import bokeh_version
 
 class Plot(param.Parameterized):
     """
@@ -112,6 +111,7 @@ class Plot(param.Parameterized):
             self.root is self.handles.get('plot') and
             not isinstance(self, GenericAdjointLayoutPlot)):
             doc.on_session_destroyed(self._session_destroy)
+            from .bokeh.util import bokeh_version
             if self._document and bokeh_version >= '2.4.0':
                 if isinstance(self._document.callbacks._session_destroyed_callbacks, set):
                     self._document.callbacks._session_destroyed_callbacks.discard(self._session_destroy)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     "param >=1.9.3,<2.0",
     "numpy >=1.0",
     "pyviz_comms >=0.7.4",
-    "panel >=0.10.0",
+    "panel >=0.9.5",
     "colorcet",
     "pandas >=0.20.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     "param >=1.9.3,<2.0",
     "numpy >=1.0",
     "pyviz_comms >=0.7.4",
-    "panel >=0.9.5",
+    "panel >=0.10.0",
     "colorcet",
     "pandas >=0.20.0",
 ]


### PR DESCRIPTION
In https://github.com/holoviz/holoviews/pull/5084 `bokeh_version` is imported from `panel.util`, which was added in panel at the 0.10.0 release.

Alternatively we could get the bokeh version from `holoviews/plotting/bokeh/util.py`. What do you prefer @jlstevens ?