### PR TITLE
Pin freetype on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,12 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda install -c pyviz "panel=0.12.2" "nbconvert>5"
+      - name: Patch with an older version of freetype since 2.11.0 is broken with Matplotlib on Windows
+        if: (matrix.os == 'windows-latest')
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          conda install ${{ env.CHANS_DEV}} "freetype=2.10.4"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"


### PR DESCRIPTION
Issue already observed on the CI of colorcet and datashader. The new release of freetype (2.11.0) on the `main` channel breaks matplotlib plotting somehow.