### PR TITLE
Handle the empty string as a group name

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -346,7 +346,7 @@ def tree_attribute(identifier):
     These custom attributes start with a capitalized character when
     applicable (not applicable to underscore or certain unicode characters)
     """
-    if not identifier:
+    if identifier == '':
         return True
     if identifier[0].upper().isupper() is False and identifier[0] != '_':
         return True

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -346,6 +346,8 @@ def tree_attribute(identifier):
     These custom attributes start with a capitalized character when
     applicable (not applicable to underscore or certain unicode characters)
     """
+    if not identifier:
+        return True
     if identifier[0].upper().isupper() is False and identifier[0] != '_':
         return True
     else:
@@ -1750,7 +1752,10 @@ def capitalize(string):
     """
     Capitalizes the first letter of a string.
     """
-    return string[0].upper() + string[1:]
+    if string:
+        return string[0].upper() + string[1:]
+    else:
+        return string
 
 
 def get_path(item):

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -6,6 +6,7 @@ from unittest import SkipTest
 import numpy as np
 import pytest
 
+from holoviews import util
 from holoviews import Store, Histogram, Image, Curve, Points, DynamicMap, opts
 from holoviews.core.options import (
     OptionError, Cycle, Options, OptionTree, StoreOptions, options_policy
@@ -312,6 +313,12 @@ class TestStoreInheritanceDynamic(ComparisonTestCase):
         options = Store.options()
         options.Image = Options('style', cmap='hot', interpolation='nearest')
         return options
+
+    def test_empty_group(self):
+        "Test to prevent regression of issue fixed in #5131"
+        ls = np.linspace(0, 10, 200)
+        xx, yy = np.meshgrid(ls, ls)
+        util.render(Image(np.sin(xx)*np.cos(yy), group="").opts(cmap="greys"))
 
     def test_merge_keywords(self):
         options = self.initialize_option_tree()


### PR DESCRIPTION
Fixes #5130 by making `hv.utils.capitalize` work properly for empty strings and by considering the empty string a tree attribute.