### PR TITLE
Delay projection comparison to optimize geoviews

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -693,7 +693,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         elif axis == 'y':
             axis_obj = plot.yaxis[0]
 
-        if self.geographic and self.projection == 'mercator':
+        if (self.geographic and isinstance(self.projection, str)
+            and self.projection == 'mercator'):
             dimension = 'lon' if axis == 'x' else 'lat'
             axis_props['ticker'] = MercatorTicker(dimension=dimension)
             axis_props['formatter'] = MercatorTickFormatter(dimension=dimension)

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -171,7 +171,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 if self.logy:
                     axis.set_yscale('log')
 
-                if not self.projection == '3d':
+                if not isinstance(self.projection, str) and self.projection == '3d':
                     self._set_axis_position(axis, 'x', self.xaxis)
                     self._set_axis_position(axis, 'y', self.yaxis)
 
@@ -207,7 +207,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             self._set_axis_formatter(axis.xaxis, xdim, self.xformatter)
         if ydim:
             self._set_axis_formatter(axis.yaxis, ydim, self.yformatter)
-        if self.projection == '3d':
+        if isinstance(self.projection, str) and self.projection == '3d':
             zdim = dimensions[2] if ndims > 2 else None
             if zdim or self.zformatter is not None:
                 self._set_axis_formatter(axis.zaxis, zdim, self.zformatter)
@@ -220,7 +220,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         self._set_axis_ticks(axis.yaxis, yticks, log=self.logy,
                              rotation=self.yrotation)
 
-        if self.projection == '3d':
+        if isinstance(self.projection, str) and self.projection == '3d':
             zticks = zticks if zticks else self.zticks
             self._set_axis_ticks(axis.zaxis, zticks, log=self.logz,
                                  rotation=self.zrotation)
@@ -292,7 +292,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         """
         Set the aspect on the axes based on the aspect setting.
         """
-        if self.projection == '3d':
+        if isinstance(self.projection, str) and self.projection == '3d':
             return
 
         if ((isinstance(aspect, str) and aspect != 'square') or
@@ -324,7 +324,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         coords = [coord if np.isreal(coord) or isinstance(coord, np.datetime64) else np.NaN for coord in extents]
         coords = [date2num(util.dt64_to_dt(c)) if isinstance(c, np.datetime64) else c
                   for c in coords]
-        if self.projection == '3d' or len(extents) == 6:
+        if isinstance(self.projection, str) and self.projection == '3d' or len(extents) == 6:
             l, b, zmin, r, t, zmax = coords
             if self.invert_zaxis or any(p.invert_zaxis for p in subplots):
                 zmin, zmax = zmax, zmin

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1320,7 +1320,7 @@ class GenericElementPlot(DimensionedPlot):
         ndims = len(dims)
         xdim = xdim or (dims[0] if ndims else None)
         ydim = ydim or (dims[1] if ndims > 1 else None)
-        if self.projection == '3d':
+        if isinstance(self.projection, str) and self.projection == '3d':
             zdim = zdim or (dims[2] if ndims > 2 else None)
         else:
             zdim = None
@@ -1364,7 +1364,7 @@ class GenericElementPlot(DimensionedPlot):
         elif ydim is None:
             y0, y1 = np.NaN, np.NaN
 
-        if self.projection == '3d':
+        if isinstance(self.projection, str) and self.projection == '3d':
             if range_type == 'soft':
                 z0, z1 = zsrange
             elif range_type == 'data':
@@ -1407,14 +1407,17 @@ class GenericElementPlot(DimensionedPlot):
         This allows Overlay plots to obtain each range and combine them
         appropriately for all the objects in the overlay.
         """
-        num = 6 if self.projection == '3d' else 4
+        num = 6 if (isinstance(self.projection, str) and self.projection == '3d') else 4
         if self.apply_extents and range_type in ('combined', 'extents'):
             norm_opts = self.lookup_options(element, 'norm').options
             if norm_opts.get('framewise', False) or self.dynamic:
                 extents = element.extents
             else:
                 extent_list = self.hmap.traverse(lambda x: x.extents, [Element])
-                extents = util.max_extents(extent_list, self.projection == '3d')
+                extents = util.max_extents(
+                    extent_list,
+                    isinstance(self.projection, str) and self.projection == '3d'
+                )
         else:
             extents = (np.NaN,) * num
 
@@ -1427,7 +1430,10 @@ class GenericElementPlot(DimensionedPlot):
             range_extents = (np.NaN,) * num
 
         if getattr(self, 'shared_axes', False) and self.subplot:
-            combined = util.max_extents([range_extents, extents], self.projection == '3d')
+            combined = util.max_extents(
+                [range_extents, extents],
+                isinstance(self.projection, str) and self.projection == '3d'
+            )
         else:
             max_extent = []
             for l1, l2 in zip(range_extents, extents):
@@ -1437,7 +1443,7 @@ class GenericElementPlot(DimensionedPlot):
                     max_extent.append(l1)
             combined = tuple(max_extent)
 
-        if self.projection == '3d':
+        if isinstance(self.projection, str) and self.projection == '3d':
             x0, y0, z0, x1, y1, z1 = combined
         else:
             x0, y0, x1, y1 = combined
@@ -1460,7 +1466,7 @@ class GenericElementPlot(DimensionedPlot):
                 if stream not in self._trigger and (self.xlim or self.ylim):
                     self._trigger.append(stream)
 
-        if self.projection == '3d':
+        if isinstance(self.projection, str) and self.projection == '3d':
             z0, z1 = util.dimension_range(z0, z1, self.zlim, (None, None))
             return (x0, y0, z0, x1, y1, z1)
         return (x0, y0, x1, y1)
@@ -1480,7 +1486,8 @@ class GenericElementPlot(DimensionedPlot):
 
         if getattr(self, 'zlabel', None) is not None:
             zlabel = self.zlabel
-        elif self.projection == '3d' and len(dimensions) >= 3 and zlabel is None:
+        elif (isinstance(self.projection, str) and self.projection == '3d'
+              and len(dimensions) >= 3 and zlabel is None):
             zlabel = dim_axis_label(dimensions[2]) if dimensions[2] else ''
         return xlabel, ylabel, zlabel
 
@@ -1800,7 +1807,7 @@ class GenericOverlayPlot(GenericElementPlot):
 
     def get_extents(self, overlay, ranges, range_type='combined'):
         subplot_extents = self._get_subplot_extents(overlay, ranges, range_type)
-        zrange = self.projection == '3d'
+        zrange = isinstance(self.projection, str) and self.projection == '3d'
         extents = {k: util.max_extents(rs, zrange) for k, rs in subplot_extents.items()}
         if range_type != 'combined':
             return extents[range_type]
@@ -1834,7 +1841,7 @@ class GenericOverlayPlot(GenericElementPlot):
 
         # Combine with Element.extents
         combined = util.max_extents([padded, extents['extents']], zrange)
-        if self.projection == '3d':
+        if isinstance(self.projection, str) and self.projection == '3d':
             x0, y0, z0, x1, y1, z1 = combined
         else:
             x0, y0, x1, y1 = combined
@@ -1842,7 +1849,7 @@ class GenericOverlayPlot(GenericElementPlot):
         # Apply xlim, ylim, zlim plot option
         x0, x1 = util.dimension_range(x0, x1, self.xlim, (None, None))
         y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))
-        if self.projection == '3d':
+        if isinstance(self.projection, str) and self.projection == '3d':
             z0, z1 = util.dimension_range(z0, z1, getattr(self, 'zlim', (None, None)), (None, None))
             return (x0, y0, z0, x1, y1, z1)
         return (x0, y0, x1, y1)

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -525,7 +525,7 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
                 mapbox["zoom"] = min(max_x_zoom, max_y_zoom)
             layout["mapbox"] = mapbox
 
-        if self.projection == '3d':
+        if isinstance(self.projection, str) and self.projection == '3d':
             scene = dict(xaxis=xaxis, yaxis=yaxis)
             if zdim:
                 zrange = [z1, z0] if self.invert_zaxis else [z0, z1]


### PR DESCRIPTION
`geoviews` depends on `cartopy` for all sorts of projections related operations. `cartopy` now (0.20) relies on `pyproj` for coordinate transformations, which is more robust and versatile. There's one downside though, at least for `geoviews`: now an equality comparison that is False, like `projection == 'not a projection'` is significantly slower (about 1,000,000x) than before. See this [comment](https://github.com/SciTools/cartopy/issues/1895#issuecomment-982982168) for a simple benchmark. This makes the creation of some geoviews plots [very slow](https://github.com/holoviz/geoviews/issues/529). The equality comparison is slower because a CRS/projection can be created in many different ways, so `PROJ`, the underlying library `pyproj` is using, will exhaust all possibilities until it finds out that the projections are not equal, and this apparently takes a lot of time.

`holoviews` had many occurrences of the comparison `self.projection == '3d'`, which in this PR I replace by `isinstance(self.projection, str) and self.projection == '3d'`. This solves the issue of slowing down `geoviews`. While I believe this shouldn't impact `holoviews` performance-wise, it may be worthwhile checking this is not the case. @philippjfr @jlstevens if that is relevant, could you point me to `holoviews` plots that make a large number of calls to `get_extents`? 