### PR TITLE
Fix for Contours consistent of empty and nonempty paths

### DIFF
--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -40,7 +40,14 @@ class PathPlot(LegendPlot, ColorbarPlot):
 
     def _element_transform(self, transform, element, ranges):
         if isinstance(element, Contours):
-            return super()._element_transform(transform, element, ranges)
+            data = super()._element_transform(transform, element, ranges)
+            new_data = []
+            for d in data:
+                if isinstance(d, np.ndarray) and len(d) == 1:
+                    new_data.append(d[0])
+                else:
+                    new_data.append(d)
+            return np.array(new_data)
         return np.concatenate([transform.apply(el, ranges=ranges, flat=True)
                                for el in element.split()])
 

--- a/holoviews/tests/plotting/bokeh/test_pathplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pathplot.py
@@ -411,8 +411,9 @@ class TestContoursPlot(TestBokehPlot):
         ], vdims=['color', 'line_width']).opts(
             color='color', line_width='line_width')
         plot = bokeh_renderer.get_plot(contours)
-        cds = plot.handles['source']
-        self.assertEqual(cds.data['color'], np.array(['red']))
+        glyph = plot.handles['glyph']
+        self.assertEqual(glyph.line_color, 'red')
+        self.assertEqual(glyph.line_width, 3)
 
 
     def test_contours_linear_color_op_update(self):

--- a/holoviews/tests/plotting/bokeh/test_pathplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pathplot.py
@@ -16,7 +16,6 @@ except:
     pass
 
 
-
 class TestPathPlot(TestBokehPlot):
 
     def test_batched_path_line_color_and_color(self):
@@ -401,6 +400,20 @@ class TestContoursPlot(TestBokehPlot):
         self.assertIsInstance(cmapper, LinearColorMapper)
         self.assertEqual(cmapper.low, 3)
         self.assertEqual(cmapper.high, 7)
+
+    def test_contours_empty_path(self):
+        import pandas as pd
+        contours = Contours([
+            pd.DataFrame([], columns=['x', 'y', 'color', 'line_width']),
+            pd.DataFrame({'x': np.random.rand(10), 'y': np.random.rand(10),
+                          'color': ['red']*10, 'line_width': [3]*10},
+                         columns=['x', 'y', 'color', 'line_width'])
+        ], vdims=['color', 'line_width']).opts(
+            color='color', line_width='line_width')
+        plot = bokeh_renderer.get_plot(contours)
+        cds = plot.handles['source']
+        self.assertEqual(cds.data['color'], np.array(['red']))
+
 
     def test_contours_linear_color_op_update(self):
         contours = HoloMap({


### PR DESCRIPTION
The test case would fail because the style data would contain nested arrays.