### PR TITLE
Fixes cudf tests

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -797,7 +797,7 @@ argument to specify a selection specification""")
         # may be replaced with more general handling
         # see https://github.com/holoviz/holoviews/issues/1173
         from ...element import Table, Curve
-        datatype = ['dataframe', 'dictionary', 'dask', 'ibis']
+        datatype = ['dataframe', 'dictionary', 'dask', 'ibis', 'cuDF']
         if len(samples) == 1:
             sel = {kd.name: s for kd, s in zip(self.kdims, samples[0])}
             dims = [kd for kd, v in sel.items() if not np.isscalar(v)]

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -282,7 +282,13 @@ class cuDFInterface(PandasInterface):
             if not hasattr(reindexed, agg):
                 raise ValueError('%s aggregation is not supported on cudf DataFrame.' % agg)
             agg = getattr(reindexed, agg)()
-            data = dict(((col, [v]) for col, v in zip(agg.index.values_host, agg.to_array())))
+            try:
+                data = dict(((col, [v]) for col, v in zip(agg.index.values_host, agg.to_numpy())))
+            except Exception:
+                # Give FutureWarning: 'The to_array method will be removed in a future cuDF release.
+                # Consider using `to_numpy` instead.'
+                # Seen in cudf=21.12.01
+                data = dict(((col, [v]) for col, v in zip(agg.index.values_host, agg.to_array())))
             df = util.pd.DataFrame(data, columns=list(agg.index.values_host))
 
         dropped = []

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -245,7 +245,7 @@ class cuDFInterface(PandasInterface):
 
         indexed = cls.indexed(dataset, selection)
         if selection_mask is not None:
-            df = df.loc[selection_mask]
+            df = df.iloc[selection_mask]
         if indexed and len(df) == 1 and len(dataset.vdims) == 1:
             return df[dataset.vdims[0].name].iloc[0]
         return df

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -463,8 +463,13 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
     # Test literal formats
 
     def test_dataset_expanded_dimvals_ht(self):
-        self.assertEqual(self.table.dimension_values('Gender', expanded=False),
-                         np.array(['M', 'F']))
+        # This will runs unique(), which for pandas return
+        # in order of appearance, but can be sorted for other
+        # interface like cudf.
+        #   pd.Series(["M", "M", "F"]).unique()   -> ["M", "F"]
+        #   cudf.Series(["M", "M", "F"]).unique() -> ["F", "M"]
+        data = self.table.dimension_values('Gender', expanded=False)
+        self.assertEqual(np.sort(data), np.array(['F', 'M']))
 
     def test_dataset_implicit_indexing_init(self):
         dataset = Scatter(self.ys, kdims=['x'], vdims=['y'])

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -465,7 +465,7 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
     def test_dataset_expanded_dimvals_ht(self):
         # This will run unique(), which for pandas return
         # in order of appearance, but can be sorted for other
-        # interface like cudf.
+        # interfaces like cudf.
         #   pd.Series(["M", "M", "F"]).unique()   -> ["M", "F"]
         #   cudf.Series(["M", "M", "F"]).unique() -> ["F", "M"]
         data = self.table.dimension_values('Gender', expanded=False)

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -463,7 +463,7 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
     # Test literal formats
 
     def test_dataset_expanded_dimvals_ht(self):
-        # This will runs unique(), which for pandas return
+        # This will run unique(), which for pandas return
         # in order of appearance, but can be sorted for other
         # interface like cudf.
         #   pd.Series(["M", "M", "F"]).unique()   -> ["M", "F"]


### PR DESCRIPTION
Fixes #5164

With these changes my tests passes. 

Environment
``` yaml
cudf                      21.12.01        cuda_11_py38_ga0a0a3a317_0    rapidsai
libcudf                   21.12.01        cuda11_ga0a0a3a317_0    rapidsai
```

For the sorting see: [pandas](https://pandas.pydata.org/docs/reference/api/pandas.unique.html) and [cudf](https://docs.rapids.ai/api/libcudf/stable/group__column__sort.html)

Furthermore, there is two warnings when running the tests for cudf:
``` python
  /home/shh/miniconda3/envs/holoviz/lib/python3.8/site-packages/cudf/core/series.py:1659: FutureWarning: The to_array method will be removed in a future cuDF release. Consider using `to_numpy` instead.
    warnings.warn(

holoviews/tests/core/data/test_cudfinterface.py: 12 warnings
  /home/shh/miniconda3/envs/holoviz/lib/python3.8/site-packages/cudf/core/frame.py:3086: FutureWarning: Calling take with a boolean array is deprecated and will be removed in the future.
    warnings.warn(
```

The first one I have added a try/except to be able to handle both cases. For the second one I have done nothing to fix it. 