### PR TITLE
Fix for xarray coordinate validation

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -215,9 +215,11 @@ class XArrayInterface(GridInterface):
             # not need to be canonicalized
             if any(len(da.coords[c].shape) > 1 for c in da.coords):
                 continue
+            # Do not enforce validation for coords which reference
+            # dimensions already declared as part of another kdim
             undeclared = [
                 c for c in da.coords if c not in kdims and len(da[c].shape) == 1 and
-                da[c].shape[0] > 1]
+                da[c].shape[0] > 1 and not all(d in kdims for d in da[c].dims)]
             if undeclared:
                 raise DataError(
                     'The coordinates on the %r DataArray do not match the '

--- a/holoviews/tests/core/data/test_xarrayinterface.py
+++ b/holoviews/tests/core/data/test_xarrayinterface.py
@@ -65,8 +65,8 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         da = xr.DataArray(np.arange(8).reshape((2, 2, 2)),
                           coords, ['time', 'lat', 'lon']).assign_coords(
                               lat1=xr.DataArray([2,3], dims=['lat']))
-        ds = Dataset(da, ['time', 'lat', 'lon'], vdims='value')
-        assert ds.kdims == ['time', 'lat', 'lon']
+        assert Dataset(da, ['time', 'lat', 'lon'], vdims='value').kdims == ['time', 'lat', 'lon']
+        assert Dataset(da, ['time', 'lat1', 'lon'], vdims='value').kdims == ['time', 'lat1', 'lon']
 
     def test_xarray_dataset_irregular_shape(self):
         ds = Dataset(self.get_multi_dim_irregular_dataset())

--- a/holoviews/tests/core/data/test_xarrayinterface.py
+++ b/holoviews/tests/core/data/test_xarrayinterface.py
@@ -60,6 +60,14 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
                                 'time': pd.date_range('2014-09-06', periods=3),
                                 'reference_time': pd.Timestamp('2014-09-05')})
 
+    def test_ignore_dependent_dimensions_if_not_specified(self):
+        coords = OrderedDict([('time', [0, 1]), ('lat', [0, 1]), ('lon', [0, 1])])
+        da = xr.DataArray(np.arange(8).reshape((2, 2, 2)),
+                          coords, ['time', 'lat', 'lon']).assign_coords(
+                              lat1=xr.DataArray([2,3], dims=['lat']))
+        ds = Dataset(da, ['time', 'lat', 'lon'], vdims='value')
+        assert ds.kdims == ['time', 'lat', 'lon']
+
     def test_xarray_dataset_irregular_shape(self):
         ds = Dataset(self.get_multi_dim_irregular_dataset())
         shape = ds.interface.shape(ds, gridded=True)


### PR DESCRIPTION
The new validation for xarray coordinates introduced in https://github.com/holoviz/holoviews/pull/5140 did not consider coordinates which are either an alias of an existing coordinate or that share the same indexing as an existing coordinate, e.g. in the test case below:

<img width="707" alt="Screen Shot 2021-12-16 at 1 38 10 PM" src="https://user-images.githubusercontent.com/1550771/146373578-4763b816-97cb-477e-b381-a4ac3309036e.png">

the `lat1` coordinates simply provides alternate indexing along the `lat` dimension so as long as either `lat1` or `lat` is specified we should allow it.