### PR TITLE
Added example of multiple RGB images as glyphs

### DIFF
--- a/examples/reference/elements/bokeh/RGB.ipynb
+++ b/examples/reference/elements/bokeh/RGB.ipynb
@@ -140,6 +140,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "RGB elements can be positioned in the plot space using their bounds, with transparency if defined for that image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.Overlay([hv.RGB.load_image('../assets/penguins.png', bounds=(2*i,2*i,3*i,3*i))\n",
+    "            for i in range(1,8)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "One additional way to create RGB objects is via the separate [ImaGen](https://github.com/pyviz-topics/imagen) library, which creates parameterized streams of images for experiments, simulations, or machine-learning applications.\n",
     "\n",
     "For full documentation and the available style and plot options, use ``hv.help(hv.RGB).``"

--- a/examples/reference/elements/matplotlib/RGB.ipynb
+++ b/examples/reference/elements/matplotlib/RGB.ipynb
@@ -127,6 +127,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "RGB elements can be positioned in the plot space using their bounds, with transparency if defined for that image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.Overlay([hv.RGB.load_image('../assets/penguins.png', bounds=(2*i,2*i,3*i,3*i))\n",
+    "            for i in range(1,8)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "One additional way to create RGB objects is via the separate [ImaGen](https://github.com/pyviz-topics/imagen) library, which creates parameterized streams of images for experiments, simulations, or machine-learning applications.\n",
     "\n",
     "For full documentation and the available style and plot options, use ``hv.help(hv.RGB).``"

--- a/examples/reference/elements/plotly/RGB.ipynb
+++ b/examples/reference/elements/plotly/RGB.ipynb
@@ -140,6 +140,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "RGB elements can be positioned in the plot space using their bounds, with transparency if defined for that image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.Overlay([hv.RGB.load_image('../assets/penguins.png', bounds=(2*i,2*i,3*i,3*i))\n",
+    "            for i in range(1,8)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "One additional way to create RGB objects is via the separate [ImaGen](https://github.com/pyviz-topics/imagen) library, which creates parameterized streams of images for experiments, simulations, or machine-learning applications.\n",
     "\n",
     "For full documentation and the available style and plot options, use ``hv.help(hv.RGB).``"


### PR DESCRIPTION
Expanded docs to cover the case requested in https://stackoverflow.com/questions/70385613/how-to-use-images-as-glyphs-in-holoviews: 

![image](https://user-images.githubusercontent.com/1695496/146588387-a0df7fad-5a4a-450f-ad58-1b1b2ca5ca53.png)
