### PR TITLE
Using packaging.version.Version as LooseVersion

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -163,7 +163,7 @@ class PandasInterface(Interface):
         column = dataset.data[dimension.name]
         if column.dtype.kind == 'O':
             if (not isinstance(dataset.data, pd.DataFrame) or
-                util.LooseVersion(pd.__version__) < '0.17.0'):
+                util.LooseVersion(pd.__version__) < util.LooseVersion('0.17.0')):
                 column = column.sort(inplace=False)
             else:
                 column = column.sort_values()
@@ -186,7 +186,7 @@ class PandasInterface(Interface):
 
     @classmethod
     def concat_fn(cls, dataframes, **kwargs):
-        if util.pandas_version >= '0.23.0':
+        if util.pandas_version >= util.LooseVersion('0.23.0'):
             kwargs['sort'] = False
         return pd.concat(dataframes, **kwargs)
 
@@ -291,7 +291,7 @@ class PandasInterface(Interface):
         cols = [dataset.get_dimension(d, strict=True).name for d in by]
 
         if (not isinstance(dataset.data, pd.DataFrame) or
-            util.LooseVersion(pd.__version__) < '0.17.0'):
+            util.LooseVersion(pd.__version__) < util.LooseVersion('0.17.0')):
             return dataset.data.sort(columns=cols, ascending=not reverse)
         return dataset.data.sort_values(by=cols, ascending=not reverse)
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -13,7 +13,7 @@ import datetime as dt
 from collections.abc import Iterable # noqa
 from collections import defaultdict, OrderedDict # noqa (compatibility)
 from contextlib import contextmanager
-from distutils.version import LooseVersion
+from packaging.version import Version as LooseVersion
 from functools import partial
 from threading import Thread, Event
 from types import FunctionType
@@ -47,13 +47,13 @@ except ImportError:
 if pd:
     pandas_version = LooseVersion(pd.__version__)
     try:
-        if pandas_version >= '1.3.0':
+        if pandas_version >= LooseVersion('1.3.0'):
             from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtypeType
             from pandas.core.dtypes.generic import ABCSeries, ABCIndex as ABCIndexClass
-        elif pandas_version >= '0.24.0':
+        elif pandas_version >= LooseVersion('0.24.0'):
             from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtypeType
             from pandas.core.dtypes.generic import ABCSeries, ABCIndexClass
-        elif pandas_version > '0.20.0':
+        elif pandas_version > LooseVersion('0.20.0'):
             from pandas.core.dtypes.dtypes import DatetimeTZDtypeType
             from pandas.core.dtypes.generic import ABCSeries, ABCIndexClass
         else:
@@ -64,10 +64,10 @@ if pd:
         datetime_types = datetime_types + pandas_datetime_types
         timedelta_types = timedelta_types + pandas_timedelta_types
         arraylike_types = arraylike_types + (ABCSeries, ABCIndexClass)
-        if pandas_version > '0.23.0':
+        if pandas_version > LooseVersion('0.23.0'):
             from pandas.core.dtypes.generic import ABCExtensionArray
             arraylike_types = arraylike_types + (ABCExtensionArray,)
-        if pandas_version > '1.0':
+        if pandas_version > LooseVersion('1.0'):
             from pandas.core.arrays.masked import BaseMaskedArray
             masked_types = (BaseMaskedArray,)
     except Exception as e:
@@ -803,7 +803,7 @@ def isnat(val):
     """
     if (isinstance(val, (np.datetime64, np.timedelta64)) or
         (isinstance(val, np.ndarray) and val.dtype.kind == 'M')):
-        if numpy_version >= '1.13':
+        if numpy_version >= LooseVersion('1.13'):
             return np.isnat(val)
         else:
             return val.view('i8') == nat_as_integer
@@ -841,7 +841,7 @@ def isfinite(val):
         elif val.dtype.kind in 'US':
             return ~pd.isna(val) if pd else np.ones_like(val, dtype=bool)
         finite = np.isfinite(val)
-        if pd and pandas_version >= '1.0.0':
+        if pd and pandas_version >= LooseVersion('1.0.0'):
             finite &= ~pd.isna(val)
         return finite
     elif isinstance(val, datetime_types+timedelta_types):
@@ -849,7 +849,7 @@ def isfinite(val):
     elif isinstance(val, (str, bytes)):
         return True
     finite = np.isfinite(val)
-    if pd and pandas_version >= '1.0.0':
+    if pd and pandas_version >= LooseVersion('1.0.0'):
         if finite is pd.NA:
             return False
         return finite & (~pd.isna(val))

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -494,13 +494,13 @@ class aggregate(AggregationOperation):
 
         if agg.ndim == 2:
             # Replacing x and y coordinates to avoid numerical precision issues
-            eldata = agg if ds_version > '0.5.0' else (xs, ys, agg.data)
+            eldata = agg if ds_version > LooseVersion('0.5.0') else (xs, ys, agg.data)
             return self.p.element_type(eldata, **params)
         else:
             layers = {}
             for c in agg.coords[agg_fn.column].data:
                 cagg = agg.sel(**{agg_fn.column: c})
-                eldata = cagg if ds_version > '0.5.0' else (xs, ys, cagg.data)
+                eldata = cagg if ds_version > LooseVersion('0.5.0') else (xs, ys, cagg.data)
                 layers[c] = self.p.element_type(eldata, **params)
             return NdOverlay(layers, kdims=[data.get_dimension(agg_fn.column)])
 
@@ -796,13 +796,13 @@ class geom_aggregate(AggregationOperation):
 
         if agg.ndim == 2:
             # Replacing x and y coordinates to avoid numerical precision issues
-            eldata = agg if ds_version > '0.5.0' else (xs, ys, agg.data)
+            eldata = agg if ds_version > LooseVersion('0.5.0') else (xs, ys, agg.data)
             return self.p.element_type(eldata, **params)
         else:
             layers = {}
             for c in agg.coords[agg_fn.column].data:
                 cagg = agg.sel(**{agg_fn.column: c})
-                eldata = cagg if ds_version > '0.5.0' else (xs, ys, cagg.data)
+                eldata = cagg if ds_version > LooseVersion('0.5.0') else (xs, ys, cagg.data)
                 layers[c] = self.p.element_type(eldata, **params)
             return NdOverlay(layers, kdims=[element.get_dimension(agg_fn.column)])
 
@@ -900,7 +900,7 @@ class regrid(AggregationOperation):
 
 
     def _process(self, element, key=None):
-        if ds_version <= '0.5.0':
+        if ds_version <= LooseVersion('0.5.0'):
             raise RuntimeError('regrid operation requires datashader>=0.6.0')
 
         # Compute coords, anges and size
@@ -1062,7 +1062,7 @@ class trimesh_rasterize(aggregate):
         precompute = self.p.precompute
         if interp == 'linear': interp = 'bilinear'
         wireframe = False
-        if (not (element.vdims or (isinstance(element, TriMesh) and element.nodes.vdims))) and ds_version <= '0.6.9':
+        if (not (element.vdims or (isinstance(element, TriMesh) and element.nodes.vdims))) and ds_version <= LooseVersion('0.6.9'):
             self.p.aggregator = ds.any() if isinstance(agg, ds.any) or agg == 'any' else ds.count()
             return aggregate._process(self, element, key)
         elif ((not interp and (isinstance(agg, (ds.any, ds.count)) or
@@ -1119,11 +1119,11 @@ class quadmesh_rasterize(trimesh_rasterize):
     """
 
     def _precompute(self, element, agg):
-        if ds_version <= '0.7.0':
+        if ds_version <= LooseVersion('0.7.0'):
             return super()._precompute(element.trimesh(), agg)
 
     def _process(self, element, key=None):
-        if ds_version <= '0.7.0':
+        if ds_version <= LooseVersion('0.7.0'):
             return super()._process(element, key)
 
         if element.interface.datatype != 'xarray':
@@ -1334,7 +1334,7 @@ class shade(LinkableOperation):
 
         if self.p.clims:
             shade_opts['span'] = self.p.clims
-        elif ds_version > '0.5.0' and self.p.cnorm != 'eq_hist':
+        elif ds_version > LooseVersion('0.5.0') and self.p.cnorm != 'eq_hist':
             shade_opts['span'] = element.range(vdim)
 
         params = dict(get_param_values(element), kdims=kdims,
@@ -1589,7 +1589,7 @@ class SpreadingOperation(LinkableOperation):
     to make sparse plots more visible.
     """
 
-    how = param.ObjectSelector(default='source' if ds_version <= '0.11.1' else None,
+    how = param.ObjectSelector(default='source' if ds_version <= LooseVersion('0.11.1') else None,
             objects=[None, 'source', 'over', 'saturate', 'add', 'max', 'min'], doc="""
         The name of the compositing operator to use when combining
         pixels. Default of None uses 'over' operator for RGB elements

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -2,7 +2,6 @@
 Collection of either extremely generic or simple Operation
 examples.
 """
-from distutils.version import LooseVersion
 import warnings
 
 import numpy as np
@@ -15,7 +14,7 @@ from ..core import (Operation, NdOverlay, Overlay, GridMatrix,
 from ..core.data import ArrayInterface, DictInterface, default_datatype
 from ..core.data.util import dask_array_module
 from ..core.util import (
-    group_sanitizer, label_sanitizer, pd, datetime_types, isfinite,
+    LooseVersion, group_sanitizer, label_sanitizer, pd, datetime_types, isfinite,
     dt_to_int, isdatetime, is_dask_array, is_cupy_array, is_ibis_expr
 )
 from ..element.chart import Histogram, Scatter
@@ -717,7 +716,7 @@ class histogram(Operation):
         is_cupy = is_cupy_array(data)
         if is_cupy:
             import cupy
-            full_cupy_support = LooseVersion(cupy.__version__) > '8.0'
+            full_cupy_support = LooseVersion(cupy.__version__) > LooseVersion('8.0')
             if not full_cupy_support and (normed or self.p.weight_dimension):
                 data = cupy.asnumpy(data)
                 is_cupy = False

--- a/holoviews/operation/timeseries.py
+++ b/holoviews/operation/timeseries.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from ..core import Operation, Element
 from ..core.data import PandasInterface
-from ..core.util import pandas_version
+from ..core.util import pandas_version, LooseVersion
 from ..element import Scatter
 
 
@@ -50,7 +50,7 @@ class rolling(Operation,RollingBase):
         df = df.set_index(xdim).rolling(win_type=self.p.window_type,
                                         **self._roll_kwargs())
         if self.p.window_type is None:
-            kwargs = {'raw': True} if pandas_version >= '0.23.0' else {}
+            kwargs = {'raw': True} if pandas_version >= LooseVersion('0.23.0') else {}
             rolled = df.apply(self.p.function, **kwargs)
         else:
             if self.p.function is np.mean:

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -29,9 +29,9 @@ from ...streams import (
     BoxEdit, PointDraw, PolyDraw, PolyEdit, CDSStream, FreehandDraw,
     CurveEdit, SelectionXY, Lasso, SelectMode
 )
-from .util import bokeh_version, convert_timestamp
+from .util import LooseVersion, bokeh_version, convert_timestamp
 
-if bokeh_version >= '2.3.0':
+if bokeh_version >= LooseVersion('2.3.0'):
     CUSTOM_TOOLTIP = 'description'
 else:
     CUSTOM_TOOLTIP = 'custom_tooltip'

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -24,7 +24,7 @@ from .styles import (
     expand_batched_style, base_properties, line_properties, fill_properties,
     mpl_to_bokeh, rgb2hex
 )
-from .util import bokeh_version, categorize_array
+from .util import LooseVersion, bokeh_version, categorize_array
 
 
 class PointPlot(LegendPlot, ColorbarPlot):
@@ -859,7 +859,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
 
         # Enable legend if colormapper is categorical
         cmapper = cmapping['color']['transform']
-        legend_prop = 'legend_field' if bokeh_version >= '1.3.5' else 'legend'
+        legend_prop = 'legend_field' if bokeh_version >= LooseVersion('1.3.5') else 'legend'
         if ('color' in cmapping and self.show_legend and
             isinstance(cmapper, CategoricalColorMapper)):
             mapping[legend_prop] = cdim.name

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -43,7 +43,7 @@ from .styles import (
 )
 from .tabular import TablePlot
 from .util import (
-    TOOL_TYPES, bokeh_version, date_to_integer, decode_bytes, get_tab_title,
+    LooseVersion, TOOL_TYPES, bokeh_version, date_to_integer, decode_bytes, get_tab_title,
     glyph_order, py2js_tickformatter, recursive_model_update,
     theme_attr_json, cds_column_replace, hold_policy, match_dim_specs,
     compute_layout_properties, wrap_formatter, match_ax_type,
@@ -60,12 +60,12 @@ try:
 except ImportError:
     BinnedTicker = None
 
-if bokeh_version >= '2.0.1':
+if bokeh_version >= LooseVersion('2.0.1'):
     try:
         TOOLS_MAP = Tool._known_aliases
     except Exception:
         TOOLS_MAP = TOOL_TYPES
-elif bokeh_version >= '2.0.0':
+elif bokeh_version >= LooseVersion('2.0.0'):
     from bokeh.plotting._tools import TOOLS_MAP
 else:
     from bokeh.plotting.helpers import _known_tools as TOOLS_MAP
@@ -594,7 +594,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         # this will override theme if not set to the default 12pt
         title_font = self._fontsize('title').get('fontsize')
         if title_font != '12pt':
-            title_font = title_font if bokeh_version > '2.2.3' else value(title_font)
+            title_font = title_font if bokeh_version > LooseVersion('2.2.3') else value(title_font)
             opts['text_font_size'] = title_font
         return opts
 
@@ -630,7 +630,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         if ((axis == 'x' and self.xaxis in ['bottom-bare', 'top-bare', 'bare']) or
             (axis == 'y' and self.yaxis in ['left-bare', 'right-bare', 'bare'])):
-            zero_pt = '0pt' if bokeh_version > '2.2.3' else value('0pt')
+            zero_pt = '0pt' if bokeh_version > LooseVersion('2.2.3') else value('0pt')
             axis_props['axis_label_text_font_size'] = zero_pt
             axis_props['major_label_text_font_size'] = zero_pt
             axis_props['major_tick_line_color'] = None
@@ -641,7 +641,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 axis_props['axis_label_text_font_size'] = labelsize
             ticksize = self._fontsize('%sticks' % axis, common=False).get('fontsize')
             if ticksize:
-                ticksize = ticksize if bokeh_version > '2.2.3' else value(ticksize)
+                ticksize = ticksize if bokeh_version > LooseVersion('2.2.3') else value(ticksize)
                 axis_props['major_label_text_font_size'] = ticksize
             rotation = self.xrotation if axis == 'x' else self.yrotation
             if rotation:
@@ -1144,7 +1144,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 else:
                     field = k
                 if categorical and getattr(self, 'show_legend', False):
-                    legend_prop = 'legend_field' if bokeh_version >= '1.3.5' else 'legend'
+                    legend_prop = 'legend_field' if bokeh_version >= LooseVersion('1.3.5') else 'legend'
                     new_style[legend_prop] = field
                 key = {'field': field, 'transform': cmapper}
             new_style[k] = key
@@ -1196,7 +1196,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             else:
                 legend = element.label
             if legend and self.overlaid:
-                legend_prop = 'legend_label' if bokeh_version >= '1.3.5' else 'legend'
+                legend_prop = 'legend_label' if bokeh_version >= LooseVersion('1.3.5') else 'legend'
                 properties[legend_prop] = legend
         return properties
 
@@ -1224,7 +1224,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         allowed_properties = glyph.properties()
         properties = mpl_to_bokeh(properties)
         merged = dict(properties, **mapping)
-        legend_props = ('legend_field', 'legend_label') if bokeh_version >= '1.3.5' else ('legend',)
+        legend_props = ('legend_field', 'legend_label') if bokeh_version >= LooseVersion('1.3.5') else ('legend',)
         for lp in legend_props:
             legend = merged.pop(lp, None)
             if legend is not None:
@@ -1272,7 +1272,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 event = ModelChangedEvent(self.document, source, 'data',
                                           source.data, empty_data, empty_data,
                                           setter='empty')
-                if bokeh_version >= '2.4.0':
+                if bokeh_version >= LooseVersion('2.4.0'):
                     self.document.callbacks._held_events.append(event)
                 else:
                     self.document._held_events.append(event)
@@ -1951,7 +1951,7 @@ class ColorbarPlot(ElementPlot):
 
         data[field] = cdata
         if factors is not None and self.show_legend:
-            legend_prop = 'legend_field' if bokeh_version >= '1.3.5' else 'legend'
+            legend_prop = 'legend_field' if bokeh_version >= LooseVersion('1.3.5') else 'legend'
             mapping[legend_prop] = field
         mapping[name] = {'field': field, 'transform': mapper}
 

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -13,7 +13,7 @@ from .styles import (
     expand_batched_style, base_properties, line_properties, fill_properties,
     mpl_to_bokeh, validate
 )
-from .util import bokeh_version, multi_polygons_data
+from .util import LooseVersion, bokeh_version, multi_polygons_data
 
 
 class PathPlot(LegendPlot, ColorbarPlot):
@@ -273,7 +273,7 @@ class ContourPlot(PathPlot):
         cmapper = self._get_colormapper(cdim, element, ranges, style, factors)
         mapping[self._color_style] = {'field': dim_name, 'transform': cmapper}
         if self.show_legend:
-            legend_prop = 'legend_field' if bokeh_version >= '1.3.5' else 'legend'
+            legend_prop = 'legend_field' if bokeh_version >= LooseVersion('1.3.5') else 'legend'
             mapping[legend_prop] = dim_name
         return data, mapping, style
 

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -20,7 +20,7 @@ from .chart import AreaPlot
 from .element import CompositeElementPlot, ColorbarPlot, LegendPlot
 from .path import PolygonPlot
 from .styles import base_properties, fill_properties, line_properties
-from .util import bokeh_version, decode_bytes
+from .util import LooseVersion, bokeh_version, decode_bytes
 
 
 class DistributionPlot(AreaPlot):

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -102,7 +102,7 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
     def _glyph_properties(self, plot, element, source, ranges, style, group=None):
         properties = dict(style, source=source)
         if self.show_legend and not element.kdims and self.overlaid:
-            legend_prop = 'legend_label' if bokeh_version >= '1.3.5' else 'legend'
+            legend_prop = 'legend_label' if bokeh_version >= LooseVersion('1.3.5') else 'legend'
             properties[legend_prop] = element.label
         return properties
 
@@ -592,7 +592,7 @@ class ViolinPlot(BoxWhiskerPlot):
                 group='violin', factors=factors)
             style['violin_fill_color'] = {'field': repr(split_dim), 'transform': cmapper}
             if self.show_legend:
-                legend_prop = 'legend_field' if bokeh_version >= '1.3.5' else 'legend'
+                legend_prop = 'legend_field' if bokeh_version >= LooseVersion('1.3.5') else 'legend'
                 kde_map[legend_prop] = repr(split_dim)
 
         for k, v in list(style.items()):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -665,7 +665,7 @@ def hold_policy(document, policy, server=False):
     """
     Context manager to temporary override the hold policy.
     """
-    if bokeh_version >= '2.4':
+    if bokeh_version >= LooseVersion('2.4'):
         old_policy = document.callbacks.hold_value
         document.callbacks._hold = policy
     else:
@@ -676,7 +676,7 @@ def hold_policy(document, policy, server=False):
     finally:
         if server and not old_policy:
             document.unhold()
-        elif bokeh_version >= '2.4':
+        elif bokeh_version >= LooseVersion('2.4'):
             document.callbacks._hold = old_policy
         else:
             document._hold = old_policy
@@ -726,7 +726,7 @@ def update_shared_sources(f):
         for source in shared_sources:
             source.data.clear()
             if doc:
-                event_obj = doc.callbacks if bokeh_version >= '2.4' else doc
+                event_obj = doc.callbacks if bokeh_version >= LooseVersion('2.4') else doc
                 event_obj._held_events = event_obj._held_events[:-1]
 
         ret = f(self, *args, **kwargs)

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -31,7 +31,7 @@ from .tabular import * # noqa (API import)
 from .renderer import MPLRenderer
 
 
-mpl_ge_150 = LooseVersion(mpl.__version__) >= '1.5.0'
+mpl_ge_150 = LooseVersion(mpl.__version__) >= LooseVersion('1.5.0')
 
 if pd:
     try:

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -9,7 +9,7 @@ from matplotlib.dates import DateFormatter, date2num
 from ...core.dimension import Dimension, dimension_name
 from ...core.options import Store, abbreviated_exception
 from ...core.util import (
-    match_spec, isfinite, dt_to_int, dt64_to_dt, search_indices,
+    LooseVersion, match_spec, isfinite, dt_to_int, dt64_to_dt, search_indices,
     unique_array, isscalar, isdatetime
 )
 from ...element import Raster, HeatMap
@@ -123,7 +123,7 @@ class ErrorPlot(ColorbarPlot):
     def init_artists(self, ax, plot_data, plot_kwargs):
         handles = ax.errorbar(*plot_data, **plot_kwargs)
         bottoms, tops = None, None
-        if mpl_version >= str('2.0'):
+        if mpl_version >= LooseVersion('2.0'):
             _, caps, verts = handles
             if caps:
                 bottoms, tops = caps

--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -10,7 +10,7 @@ from ..util import map_colors
 from .element import ColorbarPlot
 from .chart import PointPlot
 from .path import PathPlot
-from .util import mpl_version
+from .util import LooseVersion, mpl_version
 
 
 class Plot3D(ColorbarPlot):
@@ -78,7 +78,7 @@ class Plot3D(ColorbarPlot):
         if self.disable_axes:
             axis.set_axis_off()
 
-        if mpl_version <= '1.5.9':
+        if mpl_version <= LooseVersion('1.5.9'):
             axis.set_axis_bgcolor(self.bgcolor)
         else:
             axis.set_facecolor(self.bgcolor)

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -21,7 +21,7 @@ from ...util.transform import dim
 from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import process_cmap, color_intervals, dim_range_key
 from .plot import MPLPlot, mpl_rc_context
-from .util import EqHistNormalize, mpl_version, validate, wrap_formatter
+from .util import LooseVersion, EqHistNormalize, mpl_version, validate, wrap_formatter
 
 
 class ElementPlot(GenericElementPlot, MPLPlot):
@@ -127,7 +127,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         subplots = list(self.subplots.values()) if self.subplots else []
         if self.zorder == 0 and key is not None:
             if self.bgcolor:
-                if mpl_version <= '1.5.9':
+                if mpl_version <= LooseVersion('1.5.9'):
                     axis.set_axis_bgcolor(self.bgcolor)
                 else:
                     axis.set_facecolor(self.bgcolor)

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -7,7 +7,7 @@ from ...core.util import match_spec, max_range, unique_iterator
 from ...element.raster import Image, Raster, RGB
 from .element import ElementPlot, ColorbarPlot, OverlayPlot
 from .plot import MPLPlot, GridPlot, mpl_rc_context
-from .util import get_raster_array, mpl_version
+from .util import LooseVersion, get_raster_array, mpl_version
 
 
 class RasterBasePlot(ElementPlot):
@@ -167,7 +167,7 @@ class QuadMeshPlot(ColorbarPlot):
         locs = plot_kwargs.pop('locs', None)
         artist = ax.pcolormesh(*plot_args, **plot_kwargs)
         colorbar = self.handles.get('cbar')
-        if colorbar and mpl_version < '3.1':
+        if colorbar and mpl_version < LooseVersion('3.1'):
             colorbar.set_norm(artist.norm)
             if hasattr(colorbar, 'set_array'):
                 # Compatibility with mpl < 3

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -85,7 +85,7 @@ def get_old_rcparams():
     ]
     old_rcparams = {
         k: v for k, v in matplotlib.rcParams.items()
-        if mpl_version < '3.0' or k not in deprecated_rcparams
+        if mpl_version < LooseVersion('3.0') or k not in deprecated_rcparams
     }
     return old_rcparams
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -30,7 +30,7 @@ from ..core.layout import Empty, NdLayout, Layout
 from ..core.options import Store, Compositor, SkipRendering, lookup_options
 from ..core.overlay import NdOverlay
 from ..core.spaces import HoloMap, DynamicMap
-from ..core.util import stream_parameters, isfinite
+from ..core.util import LooseVersion, stream_parameters, isfinite
 from ..element import Table, Graph
 from ..streams import Stream, RangeXY, RangeX, RangeY
 from ..util.transform import dim
@@ -112,7 +112,7 @@ class Plot(param.Parameterized):
             not isinstance(self, GenericAdjointLayoutPlot)):
             doc.on_session_destroyed(self._session_destroy)
             from .bokeh.util import bokeh_version
-            if self._document and bokeh_version >= '2.4.0':
+            if self._document and bokeh_version >= LooseVersion('2.4.0'):
                 if isinstance(self._document.callbacks._session_destroyed_callbacks, set):
                     self._document.callbacks._session_destroyed_callbacks.discard(self._session_destroy)
                 else:

--- a/holoviews/plotting/plotly/__init__.py
+++ b/holoviews/plotting/plotly/__init__.py
@@ -25,7 +25,7 @@ from .callbacks import *             # noqa (API import)
 from .shapes import *                # noqa (API import)
 from .images import *                # noqa (API import)
 
-if LooseVersion(plotly.__version__) < '4.0.0':
+if LooseVersion(plotly.__version__) < LooseVersion('4.0.0'):
     raise VersionError(
         "The plotly extension requires a plotly version >=4.0.0, "
         "please upgrade from plotly %s to a more recent version."

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -673,7 +673,7 @@ class Params(Stream):
         Parameters on the parameterized to watch.""")
 
     def __init__(self, parameterized=None, parameters=None, watch=True, watch_only=False, **params):
-        if util.param_version < '1.8.0' and watch:
+        if util.param_version < util.LooseVersion('1.8.0') and watch:
             raise RuntimeError('Params stream requires param version >= 1.8.0, '
                                'to support watching parameters.')
         if parameters is None:

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -20,7 +20,7 @@ try:
     import xarray as xr
     from holoviews.core.util import pd
     from holoviews.operation.datashader import (
-        aggregate, regrid, ds_version, stack, directly_connect_edges,
+        LooseVersion, aggregate, regrid, ds_version, stack, directly_connect_edges,
         shade, spread, rasterize, datashade, AggregationOperation,
         inspect, inspect_points, inspect_polygons
     )

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -721,7 +721,7 @@ class DatashaderAggregateTests(ComparisonTestCase):
 class DatashaderCatAggregateTests(ComparisonTestCase):
 
     def setUp(self):
-        if ds_version < '0.11.0':
+        if ds_version < LooseVersion('0.11.0'):
             raise SkipTest('Regridding operations require datashader>=0.11.0')
 
     def test_aggregate_points_categorical(self):
@@ -807,7 +807,7 @@ class DatashaderRegridTests(ComparisonTestCase):
     """
 
     def setUp(self):
-        if ds_version <= '0.5.0':
+        if ds_version <= LooseVersion('0.5.0'):
             raise SkipTest('Regridding operations require datashader>=0.6.0')
 
     def test_regrid_mean(self):
@@ -885,7 +885,7 @@ class DatashaderRasterizeTests(ComparisonTestCase):
     """
 
     def setUp(self):
-        if ds_version <= '0.6.4':
+        if ds_version <= LooseVersion('0.6.4'):
             raise SkipTest('Regridding operations require datashader>=0.7.0')
 
         self.simplexes = [(0, 1, 2), (3, 2, 1)]
@@ -1159,7 +1159,7 @@ class DatashaderSpreadTests(ComparisonTestCase):
         self.assertEqual(spreaded, RGB(arr))
 
     def test_spread_img_1px(self):
-        if ds_version < '0.12.0':
+        if ds_version < LooseVersion('0.12.0'):
             raise SkipTest('Datashader does not support DataArray yet')
         arr = np.array([[0, 0, 0], [0, 0, 0], [1, 1, 1]]).T
         spreaded = spread(Image(arr))
@@ -1206,7 +1206,7 @@ class DatashaderStackTests(ComparisonTestCase):
 class GraphBundlingTests(ComparisonTestCase):
 
     def setUp(self):
-        if ds_version <= '0.7.0':
+        if ds_version <= LooseVersion('0.7.0'):
             raise SkipTest('Regridding operations require datashader>=0.7.0')
         self.source = np.arange(8)
         self.target = np.zeros(8)

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -23,7 +23,7 @@ try:
     from bokeh.models import (FuncTickFormatter, PrintfTickFormatter,
                               NumeralTickFormatter, LogTicker,
                               LinearColorMapper, LogColorMapper)
-    from holoviews.plotting.bokeh.util import bokeh_version
+    from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
 except:
     pass
 
@@ -42,11 +42,11 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         fig = plot.state
         xaxis = plot.handles['xaxis']
         yaxis = plot.handles['yaxis']
-        if bokeh_version > '2.2.3':
+        if bokeh_version > LooseVersion('2.2.3'):
             self.assertEqual(fig.title.text_font_size, '24pt')
         else:
             self.assertEqual(fig.title.text_font_size, {'value': '24pt'})
-        if bokeh_version < '2.0.2':
+        if bokeh_version < LooseVersion('2.0.2'):
             self.assertEqual(xaxis.axis_label_text_font_size, '20pt')
             self.assertEqual(yaxis.axis_label_text_font_size, '20pt')
             self.assertEqual(xaxis.major_label_text_font_size, '16pt')
@@ -63,13 +63,13 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         fig = plot.state
         xaxis = plot.handles['xaxis']
         yaxis = plot.handles['yaxis']
-        if bokeh_version > '2.2.3':
+        if bokeh_version > LooseVersion('2.2.3'):
             self.assertEqual(fig.title.text_font_size, '28pt')
         else:
             self.assertEqual(fig.title.text_font_size, {'value': '28pt'})
         self.assertEqual(xaxis.axis_label_text_font_size, '28pt')
         self.assertEqual(yaxis.axis_label_text_font_size, '28pt')
-        if bokeh_version < '2.0.2':
+        if bokeh_version < LooseVersion('2.0.2'):
             self.assertEqual(xaxis.major_label_text_font_size, '16pt')
             self.assertEqual(yaxis.major_label_text_font_size, '16pt')
         else:
@@ -84,13 +84,13 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         fig = plot.state
         xaxis = plot.handles['xaxis']
         yaxis = plot.handles['yaxis']
-        if bokeh_version > '2.2.3':
+        if bokeh_version > LooseVersion('2.2.3'):
             self.assertEqual(fig.title.text_font_size, '200%')
         else:
             self.assertEqual(fig.title.text_font_size, {'value': '200%'})
         self.assertEqual(xaxis.axis_label_text_font_size, '24pt')
         self.assertEqual(xaxis.major_label_text_font_size, '2.4em')
-        if bokeh_version < '2.0.2':
+        if bokeh_version < LooseVersion('2.0.2'):
             self.assertEqual(yaxis.axis_label_text_font_size, '20pt')
             self.assertEqual(yaxis.major_label_text_font_size, '16pt')
         else:
@@ -891,7 +891,7 @@ class TestColorbarPlot(LoggingComparisonTestCase, TestBokehPlot):
         img = Image(np.array([[0, 1], [2, 3]])).opts(colorbar=True, fontscale=2)
         plot = bokeh_renderer.get_plot(img)
         colorbar = plot.handles['colorbar']
-        if bokeh_version < '2.0.2':
+        if bokeh_version < LooseVersion('2.0.2'):
             self.assertEqual(colorbar.title_text_font_size, '20pt')
             self.assertEqual(colorbar.major_label_text_font_size, '16pt')
         else:

--- a/holoviews/tests/plotting/bokeh/test_gridplot.py
+++ b/holoviews/tests/plotting/bokeh/test_gridplot.py
@@ -11,7 +11,7 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 try:
     from bokeh.layouts import Column
     from bokeh.models import Div, ToolbarBox
-    from holoviews.plotting.bokeh.util import bokeh_version
+    from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
 except:
     pass
 
@@ -66,7 +66,7 @@ class TestGridPlot(TestBokehPlot):
                             for j in range(2,4) if not (i==1 and j == 2)})
         plot = bokeh_renderer.get_plot(grid)
         size = bokeh_renderer.get_size(plot.state)
-        if bokeh_version < '2.0.2':
+        if bokeh_version < LooseVersion('2.0.2'):
             self.assertEqual(size, (318, 310))
         else:
             self.assertEqual(size, (320, 311))

--- a/holoviews/tests/plotting/bokeh/test_hextilesplot.py
+++ b/holoviews/tests/plotting/bokeh/test_hextilesplot.py
@@ -5,7 +5,7 @@ import numpy as np
 from holoviews.core import Dimension
 from holoviews.element import HexTiles
 from holoviews.plotting.bokeh.hex_tiles import hex_binning
-from holoviews.plotting.bokeh.util import bokeh_version
+from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
@@ -14,7 +14,7 @@ class TestHexTilesOperation(TestBokehPlot):
 
     def setUp(self):
         super().setUp()
-        if bokeh_version < '0.12.15':
+        if bokeh_version < LooseVersion('0.12.15'):
             raise SkipTest("Bokeh >= 0.12.15 required to test HexTiles operation.")
 
     def test_hex_tiles_count_aggregation(self):
@@ -42,7 +42,7 @@ class TestHexTilesPlot(TestBokehPlot):
 
     def setUp(self):
         super().setUp()
-        if bokeh_version < '0.12.15':
+        if bokeh_version < LooseVersion('0.12.15'):
             raise SkipTest("Bokeh >= 0.12.15 required to test HexTilesPlot.")
 
     def test_hex_tiles_empty(self):

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -7,7 +7,7 @@ from holoviews.element import Curve, Polygons, Table, Scatter, Path, Points
 from holoviews.plotting.links import (Link, RangeToolLink, DataLink)
 
 try:
-    from holoviews.plotting.bokeh.util import bokeh_version
+    from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
     from bokeh.models import ColumnDataSource
 except:
     pass
@@ -18,7 +18,7 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestLinkCallbacks(TestBokehPlot):
 
     def setUp(self):
-        if not bokeh_renderer or bokeh_version < '0.13':
+        if not bokeh_renderer or bokeh_version < LooseVersion('0.13'):
             raise SkipTest('RangeTool requires bokeh version >= 0.13')
         super().setUp()
 

--- a/holoviews/tests/plotting/bokeh/test_renderer.py
+++ b/holoviews/tests/plotting/bokeh/test_renderer.py
@@ -16,7 +16,7 @@ try:
 
     from bokeh.io import curdoc
     from holoviews.plotting.bokeh import BokehRenderer
-    from holoviews.plotting.bokeh.util import bokeh_version
+    from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
     from bokeh.themes.theme import Theme
 
     from panel.widgets import DiscreteSlider, Player, FloatSlider
@@ -72,7 +72,7 @@ class BokehRendererTest(ComparisonTestCase):
         grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
         plot = self.renderer.get_plot(grid)
         w, h = self.renderer.get_size(plot)
-        if bokeh_version < '2.0.2':
+        if bokeh_version < LooseVersion('2.0.2'):
             self.assertEqual((w, h), (444, 436))
         else:
             self.assertEqual((w, h), (446, 437))

--- a/holoviews/tests/plotting/matplotlib/test_graphplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_graphplot.py
@@ -3,6 +3,7 @@ import numpy as np
 from holoviews.core.data import Dataset
 from holoviews.core.options import Cycle
 from holoviews.core.spaces import HoloMap
+from holoviews.core.util import LooseVersion
 from holoviews.element import Graph, Nodes, TriMesh, Chord, circular_layout
 from holoviews.util.transform import dim
 
@@ -200,13 +201,11 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_node_alpha(self):
         import matplotlib as mpl
-        from packaging.version import Version
-
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 0.2), (0, 1, 1, 0.6), (1, 1, 2, 1)], vdims='alpha')
         graph = Graph((edges, nodes)).options(node_alpha='alpha')
 
-        if Version(mpl.__version__) < Version("3.4.0"):
+        if LooseVersion(mpl.__version__) < LooseVersion("3.4.0"):
             # Python 3.6 only support up to matplotlib 3.3
             with self.assertRaises(Exception):
                 mpl_renderer.get_plot(graph)
@@ -395,13 +394,12 @@ class TestMplTriMeshPlot(TestMPLPlot):
 
     def test_trimesh_op_node_alpha(self):
         import matplotlib as mpl
-        from packaging.version import Version
 
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 0.2), (0, 0, 1, 0.6), (0, 1, 2, 1), (1, 0, 3, 0.3)]
         trimesh = TriMesh((edges, Nodes(nodes, vdims='alpha'))).options(node_alpha='alpha')
 
-        if Version(mpl.__version__) < Version("3.4.0"):
+        if LooseVersion(mpl.__version__) < LooseVersion("3.4.0"):
             # Python 3.6 only support up to matplotlib 3.3
             with self.assertRaises(Exception):
                 mpl_renderer.get_plot(trimesh)

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -316,7 +316,7 @@ class TestParamsStream(LoggingComparisonTestCase):
 class TestParamMethodStream(ComparisonTestCase):
 
     def setUp(self):
-        if LooseVersion(param.__version__) < '1.8.0':
+        if LooseVersion(param.__version__) < LooseVersion('1.8.0'):
             raise SkipTest('Params stream requires param >= 1.8.0')
 
         class Inner(param.Parameterized):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     "pyviz_comms >=0.7.4",
     "panel >=0.9.5",
     "colorcet",
-    'packaging',
+    "packaging",
     "pandas >=0.20.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ install_requires = [
     "pyviz_comms >=0.7.4",
     "panel >=0.9.5",
     "colorcet",
+    'packaging',
     "pandas >=0.20.0",
 ]
 


### PR DESCRIPTION
An alternate approach to https://github.com/holoviz/holoviews/pull/5179: although the subclass approach in that PR would require fewer lines to be changed overall, this approach is more idiomatic in that no new classes are introduced.

Note that `packaging` is not expended to be a new dependency of HoloViews as HoloViews depends on Panel which in turn depends on Bokeh which pulls in `packaging`.