### PR TITLE
Enhance resolve_dependent_value if value is list or tuples

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -2228,3 +2228,30 @@ def cast_array_to_int64(array):
             category=FutureWarning,
         )
         return array.astype('int64')
+
+
+def flatten(line):
+    """
+    Flatten an arbitrarily nested sequence.
+
+    Inspired by: pd.core.common.flatten
+
+    Parameters
+    ----------
+    line : sequence
+        The sequence to flatten
+
+    Notes
+    -----
+    This only flattens list, tuple, and dict sequences.
+
+    Returns
+    -------
+    flattened : generator
+    """
+
+    for element in line:
+        if any(isinstance(element, tp) for tp in (list, tuple, dict)):
+            yield from flatten(element)
+        else:
+            yield element

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1517,8 +1517,15 @@ def resolve_dependent_value(value):
        resolved.
     """
     range_widget = False
-    if isinstance(value, (tuple, list)):
+    if isinstance(value, list):
         value = [resolve_dependent_value(v) for v in value]
+    elif isinstance(value, tuple):
+        value = tuple(resolve_dependent_value(v) for v in value)
+    elif isinstance(value, dict):
+        value = {
+            resolve_dependent_value(k): resolve_dependent_value(v) for k, v in value.items()
+        }
+
     if 'panel' in sys.modules:
         from panel.widgets import RangeSlider, Widget
         range_widget = isinstance(value, RangeSlider)

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1505,14 +1505,15 @@ def is_param_method(obj, has_deps=False):
 def resolve_dependent_value(value):
     """Resolves parameter dependencies on the supplied value
 
-    Resolves parameter values, Parameterized instance methods and
-    parameterized functions with dependencies on the supplied value.
+    Resolves parameter values, Parameterized instance methods,
+    parameterized functions with dependencies on the supplied value,
+    including such parameters embedded in a list or tuple.
 
     Args:
        value: A value which will be resolved
 
     Returns:
-       A new dictionary where any parameter dependencies have been
+       A new value where any parameter dependencies have been
        resolved.
     """
     range_widget = False
@@ -1552,7 +1553,7 @@ def resolve_dependent_kwargs(kwargs):
        kwargs (dict): A dictionary of keyword arguments
 
     Returns:
-       A new dictionary with where any parameter dependencies have been
+       A new dictionary where any parameter dependencies have been
        resolved.
     """
     return {k: resolve_dependent_value(v) for k, v in kwargs.items()}

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1516,6 +1516,8 @@ def resolve_dependent_value(value):
        resolved.
     """
     range_widget = False
+    if isinstance(value, (tuple, list)):
+        value = [resolve_dependent_value(v) for v in value]
     if 'panel' in sys.modules:
         from panel.widgets import RangeSlider, Widget
         range_widget = isinstance(value, RangeSlider)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -330,6 +330,7 @@ class dim(object):
         params = {}
         for op in self.ops:
             op_args = list(op['args'])+list(op['kwargs'].values())
+            op_args = pd.core.common.flatten(op_args)
             for op_arg in op_args:
                 if 'panel' in sys.modules:
                     from panel.widgets.base import Widget

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -8,7 +8,7 @@ import param
 
 from ..core.data import PandasInterface
 from ..core.dimension import Dimension
-from ..core.util import pd, resolve_dependent_value, unique_iterator
+from ..core.util import flatten, pd, resolve_dependent_value, unique_iterator
 
 
 def _maybe_map(numpy_fn):
@@ -330,7 +330,7 @@ class dim(object):
         params = {}
         for op in self.ops:
             op_args = list(op['args'])+list(op['kwargs'].values())
-            op_args = pd.core.common.flatten(op_args)
+            op_args = flatten(op_args)
             for op_arg in op_args:
                 if 'panel' in sys.modules:
                     from panel.widgets.base import Widget


### PR DESCRIPTION
Recursive calling `resolve_dependent_value` if value is a list or tuple. If this implementation crash and burn in the CI an alternative is the changes described here https://github.com/holoviz/hvplot/issues/697#issuecomment-1013895746.

This PR should make it able to run:
``` python
import holoviews as hv
import panel as pn
from bokeh.sampledata.autompg import autompg_clean as df

hv.extension("bokeh")

xaxis = pn.widgets.RadioButtonGroup(name="X axis", options=["mpg", "yr"])
ds = hv.Dataset(df)
transform = hv.util.transform.df_dim("*")
transform.groupby(["origin", xaxis]).apply(ds, keep_index=True, compute=False).mean()
```

Will add a unit test later this week. 