### PR TITLE
Look at id if owner has no name for streams

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -768,7 +768,7 @@ class Params(Stream):
         for p in self.parameters:
             pkey = (p.owner, p.name)
             pname = self._rename.get(pkey, p.name)
-            key = ' '.join([str(id(p)), pname])
+            key = ' '.join([str(id(p.owner)), pname])
             if self._rename.get(pkey, True) is not None:
                 hashkey[key] = getattr(p.owner, p.name)
         hashkey['_memoize_key'] = self._memoize_counter

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -768,7 +768,7 @@ class Params(Stream):
         for p in self.parameters:
             pkey = (p.owner, p.name)
             pname = self._rename.get(pkey, p.name)
-            key = ' '.join([p.owner.name, pname])
+            key = ' '.join([p.owner.name or str(id(p)), pname])
             if self._rename.get(pkey, True) is not None:
                 hashkey[key] = getattr(p.owner, p.name)
         hashkey['_memoize_key'] = self._memoize_counter

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -768,7 +768,7 @@ class Params(Stream):
         for p in self.parameters:
             pkey = (p.owner, p.name)
             pname = self._rename.get(pkey, p.name)
-            key = ' '.join([p.owner.name or str(id(p)), pname])
+            key = ' '.join([str(id(p)), pname])
             if self._rename.get(pkey, True) is not None:
                 hashkey[key] = getattr(p.owner, p.name)
         hashkey['_memoize_key'] = self._memoize_counter

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -273,7 +273,7 @@ class TestParamsStream(LoggingComparisonTestCase):
         def subscriber(**kwargs):
             values.append(kwargs)
             self.assertEqual(set(stream.hashkey),
-                             {'%s action' % inner.name, '_memoize_key'})
+                             {'%s action' % id(inner), '_memoize_key'})
 
         stream.add_subscriber(subscriber)
         inner.action(inner)
@@ -289,7 +289,7 @@ class TestParamsStream(LoggingComparisonTestCase):
             values.append(kwargs)
             self.assertEqual(
                 set(stream.hashkey),
-                {'%s action' % inner.name, '%s x' % inner.name, '_memoize_key'})
+                {'%s action' % id(inner), '%s x' % id(inner), '_memoize_key'})
 
         stream.add_subscriber(subscriber)
         inner.action(inner)
@@ -530,7 +530,7 @@ class TestParamMethodStream(ComparisonTestCase):
         def subscriber(**kwargs):
             values.append(kwargs)
             self.assertEqual(set(stream.hashkey),
-                             {'%s action' % inner.name, '_memoize_key'})
+                             {'%s action' % id(inner), '_memoize_key'})
 
         stream.add_subscriber(subscriber)
         inner.action(inner)
@@ -550,7 +550,7 @@ class TestParamMethodStream(ComparisonTestCase):
             values.append(kwargs)
             self.assertEqual(
                 set(stream.hashkey),
-                {'%s action' % inner.name, '%s x' % inner.name, '_memoize_key'})
+                {'%s action' % id(inner), '%s x' % id(inner), '_memoize_key'})
 
         stream.add_subscriber(subscriber)
         stream.add_subscriber(lambda **kwargs: dmap[()])

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from unittest import SkipTest
 
 import param
+from panel.widgets import IntSlider
 
 from holoviews.core.spaces import DynamicMap
 from holoviews.core.util import LooseVersion, pd
@@ -311,6 +312,18 @@ class TestParamsStream(LoggingComparisonTestCase):
         tap.event(x=1, y=2)
 
         assert values == [{'x': 0, 'y': 1}, {'x': 1, 'y': 2}]
+
+    def test_params_no_names(self):
+        a = IntSlider()
+        b = IntSlider()
+        p = Params(parameters=[a.param.value, b.param.value])
+        assert len(p.hashkey) == 3  # the two widgets + _memoize_key
+
+    def test_params_identical_names(self):
+        a = IntSlider(name="Name")
+        b = IntSlider(name="Name")
+        p = Params(parameters=[a.param.value, b.param.value])
+        assert len(p.hashkey) == 3  # the two widgets + _memoize_key
 
 
 class TestParamMethodStream(ComparisonTestCase):


### PR DESCRIPTION
This caused a problem when multiple widgets did not have names and would therefore only update the last widget with no name. The problem is seen in https://github.com/holoviz/hvplot/issues/697#issuecomment-1013895746.  