### PR TITLE
use Renderer's center property for HoloViews pane

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -303,7 +303,7 @@ class Renderer(Exporter):
             plot = self.get_widget(obj, fmt)
             fmt = 'html'
         elif dynamic or (self._render_with_panel and fmt == 'html'):
-            plot = HoloViewsPane(obj, center=self_or_cls.center, backend=self.backend,
+            plot = HoloViewsPane(obj, center=self.center, backend=self.backend,
                                  renderer=self)
         else:
             plot = self.get_plot(obj, renderer=self, **kwargs)

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -303,7 +303,7 @@ class Renderer(Exporter):
             plot = self.get_widget(obj, fmt)
             fmt = 'html'
         elif dynamic or (self._render_with_panel and fmt == 'html'):
-            plot = HoloViewsPane(obj, center=True, backend=self.backend,
+            plot = HoloViewsPane(obj, center=self_or_cls.center, backend=self.backend,
                                  renderer=self)
         else:
             plot = self.get_plot(obj, renderer=self, **kwargs)


### PR DESCRIPTION
Hi, I noticed that there are 2 places where HoloViewsPane is instantiated: in one case its center property is set using Renderer's center property, in another it is set to always = True, not sure if this is intended behavior, but I assume this should be fixed, as currently you need to wrap you plot into panel manually if you don't want to center it, which is a bit inconvenient.