### PR TITLE
Fix xaxis/yaxis options with Matplotlib 

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -324,7 +324,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         coords = [coord if isinstance(coord, np.datetime64) or np.isreal(coord) else np.NaN for coord in extents]
         coords = [date2num(util.dt64_to_dt(c)) if isinstance(c, np.datetime64) else c
                   for c in coords]
-        if isinstance(self.projection, str) and self.projection == '3d' or len(extents) == 6:
+        if (isinstance(self.projection, str) and self.projection == '3d') or len(extents) == 6:
             l, b, zmin, r, t, zmax = coords
             if self.invert_zaxis or any(p.invert_zaxis for p in subplots):
                 zmin, zmax = zmax, zmin

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -171,7 +171,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 if self.logy:
                     axis.set_yscale('log')
 
-                if not isinstance(self.projection, str) and self.projection == '3d':
+                if not (isinstance(self.projection, str) and self.projection == '3d'):
                     self._set_axis_position(axis, 'x', self.xaxis)
                     self._set_axis_position(axis, 'y', self.yaxis)
 

--- a/holoviews/tests/plotting/matplotlib/test_elementplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_elementplot.py
@@ -59,6 +59,14 @@ class TestElementPlot(TestMPLPlot):
         self.assertEqual(ax.xaxis._major_tick_kw['labelsize'], 24)
         self.assertEqual(ax.yaxis._major_tick_kw['labelsize'], 20)
 
+    def test_element_no_xaxis_yaxis(self):
+        element = Curve(range(10)).options(xaxis=None, yaxis=None)
+        axes = mpl_renderer.get_plot(element).handles['axis']
+        xaxis = axes.get_xaxis()
+        yaxis = axes.get_yaxis()
+        self.assertEqual(xaxis.get_visible(), False)
+        self.assertEqual(yaxis.get_visible(), False)
+
     def test_element_xlabel(self):
         element = Curve(range(10)).options(xlabel='custom x-label')
         axes = mpl_renderer.get_plot(element).handles['axis']


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/holoviz/holoviews/pull/5152 and adds a test that would have caught it.