### PR TITLE
Cleanup panel state after each test

### DIFF
--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from panel.io import state
+
+
+@pytest.fixture(autouse=True)
+def server_cleanup():
+    """
+    Clean up after test fails
+    """
+    try:
+        yield
+    finally:
+        state.kill_all_servers()
+        state._indicators.clear()
+        state._locations.clear()
+        state._curdoc = None
+        state.cache.clear()

--- a/holoviews/tests/plotting/bokeh/test_server.py
+++ b/holoviews/tests/plotting/bokeh/test_server.py
@@ -123,8 +123,7 @@ class TestBokehServer(ComparisonTestCase):
     
     def test_launch_simple_server(self):
         obj = Curve([])
-        server, _ = self._launcher(obj, port=6001)
-        server.stop()
+        self._launcher(obj, port=6001)
 
     def test_launch_server_with_stream(self):
         el = Curve([])
@@ -143,7 +142,6 @@ class TestBokehServer(ComparisonTestCase):
         y_range = bokeh_renderer.last_plot.handles['y_range']
         self.assertIn(cb.on_change, y_range._callbacks['start'])
         self.assertIn(cb.on_change, y_range._callbacks['end'])
-        server.stop()
 
     def test_launch_server_with_complex_plot(self):
         dmap = DynamicMap(lambda x_range, y_range: Curve([]), streams=[RangeXY()])
@@ -151,13 +149,12 @@ class TestBokehServer(ComparisonTestCase):
         static = Polygons([]) * Path([]) * Curve([])
         layout = overlay + static
 
-        server, _ = self._launcher(layout, port=6003)
-        server.stop()
+        self._launcher(layout, port=6003)
 
     def test_server_dynamicmap_with_dims(self):
         dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
         obj, _ = bokeh_renderer._validate(dmap, None)
-        server, session = self._launcher(obj, port=6004)
+        _, session = self._launcher(obj, port=6004)
         [(plot, _)] = obj._plots.values()
         [(doc, _)] = obj._documents.items()
 
@@ -170,13 +167,12 @@ class TestBokehServer(ComparisonTestCase):
         time.sleep(1)
         cds = self.session.document.roots[0].select_one({'type': ColumnDataSource})
         self.assertEqual(cds.data['y'][2], 3.1)
-        server.stop()
 
     def test_server_dynamicmap_with_stream(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y'], streams=[stream])
         obj, _ = bokeh_renderer._validate(dmap, None)
-        server, session = self._launcher(obj, port=6005)
+        _, session = self._launcher(obj, port=6005)
         [(doc, _)] = obj._documents.items()
 
         cds = session.document.roots[0].select_one({'type': ColumnDataSource})
@@ -187,14 +183,13 @@ class TestBokehServer(ComparisonTestCase):
         time.sleep(1)
         cds = self.session.document.roots[0].select_one({'type': ColumnDataSource})
         self.assertEqual(cds.data['y'][2], 3)
-        server.stop()
 
     def test_server_dynamicmap_with_stream_dims(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda x, y: Curve([x, 1, y]), kdims=['x', 'y'],
                           streams=[stream]).redim.values(x=[1, 2, 3])
         obj, _ = bokeh_renderer._validate(dmap, None)
-        server, session = self._launcher(obj, port=6006)
+        _, session = self._launcher(obj, port=6006)
         [(doc, _)] = obj._documents.items()
 
         orig_cds = session.document.roots[0].select_one({'type': ColumnDataSource})
@@ -214,4 +209,3 @@ class TestBokehServer(ComparisonTestCase):
         time.sleep(1)
         cds = self.session.document.roots[0].select_one({'type': ColumnDataSource})
         self.assertEqual(cds.data['y'][0], 3)
-        server.stop()


### PR DESCRIPTION
Define a fixture that kills all servers after each test so we don't have to shut down servers manually in tests.