### PR TITLE
Allow lower dimensional views on arbitrary dimensioned elements

### DIFF
--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -329,7 +329,10 @@ class GridInterface(DictInterface):
         dropped = [dims.index(d) for d in dims
                    if d not in dataset.kdims+virtual_coords]
         if dropped:
-            data = np.squeeze(data, axis=tuple(dropped))
+            if len(dropped) == data.ndim:
+                data = data.flatten()
+            else:
+                data = np.squeeze(data, axis=tuple(dropped))
 
         if not any(cls.irregular(dataset, d) for d in dataset.kdims):
             inds = [dims.index(kd.name) for kd in dataset.kdims]

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -226,7 +226,7 @@ class XArrayInterface(GridInterface):
                     # Skip if all the dims on the coord are present on another coord
                     continue
                 undeclared.append(c)
-            if undeclared:
+            if undeclared and eltype.param.kdims.bounds[1] not in (0, None):
                 raise DataError(
                     'The coordinates on the %r DataArray do not match the '
                     'provided key dimensions (kdims). The following coords '


### PR DESCRIPTION
Recent enforcement of the dimensionality of gridded data when passed to an element has caused some issues. In particular it is technically valid to create elements which support arbitrary dimensionality to be given a higher dimensional array but only express indexes only for a subset of those dimensions. Reasons you might want to do this:

1) You want to aggregate the array along the non-declared dimensions
2) The element itself aggregates the data during the plotting step (e.g. stats plots like box-whisker and violin)

Fixes current errors in the doc build.

Fixes https://github.com/holoviz/hvplot/issues/698