### PR TITLE
Fix escaping of HTML on Div element

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -1,5 +1,10 @@
 from collections import defaultdict
 
+try:
+    from html import escape
+except:
+    from cgi import escape
+
 import param
 import numpy as np
 
@@ -448,7 +453,7 @@ class DivPlot(BokehPlot, GenericElementPlot, AnnotationPlot):
         self.current_key = key
 
         data, _, _ = self.get_data(element, ranges, {})
-        div = HTML(text=data, width=self.width, height=self.height,
+        div = HTML(text=escape(data), width=self.width, height=self.height,
                    sizing_mode=self.sizing_mode)
         self.handles['plot'] = div
         self._execute_hooks(element)

--- a/holoviews/tests/plotting/bokeh/test_divplot.py
+++ b/holoviews/tests/plotting/bokeh/test_divplot.py
@@ -10,7 +10,7 @@ class TestDivPlot(TestBokehPlot):
         div = Div(html)
         plot = bokeh_renderer.get_plot(div)
         bkdiv = plot.handles['plot']
-        self.assertEqual(bkdiv.text, html)
+        self.assertEqual(bkdiv.text, '&lt;h1&gt;Test&lt;/h1&gt;')
 
     def test_div_plot_width(self):
         html = '<h1>Test</h1>'


### PR DESCRIPTION
The `HTML` model in Panel has required the HTML text to be escaped for **a long time**.