### PR TITLE
Allow customizing hover line_(width|join|cap|dash) properties

### DIFF
--- a/holoviews/plotting/bokeh/styles.py
+++ b/holoviews/plotting/bokeh/styles.py
@@ -27,7 +27,7 @@ base_properties = ['visible', 'muted']
 
 line_properties = ['line_color', 'line_alpha', 'color', 'alpha', 'line_width',
                    'line_join', 'line_cap', 'line_dash']
-line_properties += ['_'.join([prefix, prop]) for prop in line_properties[:4]
+line_properties += ['_'.join([prefix, prop]) for prop in line_properties
                     for prefix in property_prefixes]
 
 fill_properties = ['fill_color', 'fill_alpha']


### PR DESCRIPTION
Before this change the following code
```python
import holoviews as hv
hv.extension('bokeh')
hv.Curve([(1, 1), (2, 5), (3, 3)]).opts(tools=['hover'], hover_line_width=10)
```
threw the error
```
ValueError: Unexpected option 'hover_line_width' for Curve type across all extensions. Similar options for current extension ('bokeh') are: ['hover_line_alpha', 'hover_line_color', 'line_width'].
```