### PR TITLE
Don't load any html in the notebook when no logo is required

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -195,7 +195,7 @@ class notebook_extension(extension):
 
         # Create a message for the logo (if shown)
         if not same_cell_execution and p.logo:
-            self.load_hvjs(logo=p.logo,
+            self.load_logo(logo=p.logo,
                            bokeh_logo=  p.logo and ('bokeh' in resources),
                            mpl_logo=    p.logo and (('matplotlib' in resources)
                                                     or resources==['holoviews']),
@@ -247,10 +247,9 @@ class notebook_extension(extension):
         return resources
 
     @classmethod
-    def load_hvjs(cls, logo=False, bokeh_logo=False, mpl_logo=False, plotly_logo=False,
-                  JS=True, message='HoloViewsJS successfully loaded.'):
+    def load_logo(cls, logo=False, bokeh_logo=False, mpl_logo=False, plotly_logo=False):
         """
-        Displays javascript and CSS to initialize HoloViews widgets.
+        Allow to display Holoviews' logo and the plotting extensions' logo.
         """
         import jinja2
 
@@ -260,8 +259,7 @@ class notebook_extension(extension):
         html = template.render({'logo':        logo,
                                 'bokeh_logo':  bokeh_logo,
                                 'mpl_logo':    mpl_logo,
-                                'plotly_logo': plotly_logo,
-                                'message':     message})
+                                'plotly_logo': plotly_logo})
         publish_display_data(data={'text/html': html})
 
 

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -192,11 +192,12 @@ class notebook_extension(extension):
                                                   "hv-extension-comm")
 
         # Create a message for the logo (if shown)
-        self.load_hvjs(logo=p.logo,
-                       bokeh_logo=  p.logo and ('bokeh' in resources),
-                       mpl_logo=    p.logo and (('matplotlib' in resources)
-                                                or resources==['holoviews']),
-                       plotly_logo= p.logo and ('plotly' in resources))
+        if p.logo:
+            self.load_hvjs(logo=p.logo,
+                        bokeh_logo=  p.logo and ('bokeh' in resources),
+                        mpl_logo=    p.logo and (('matplotlib' in resources)
+                                                    or resources==['holoviews']),
+                        plotly_logo= p.logo and ('plotly' in resources))
 
     @classmethod
     def completions_sorting_key(cls, word):


### PR DESCRIPTION
This avoids calling `publish_display_data` in a notebook when calling `hv.extension()` with `logo=False` because unfortunately in JupyterLab each call to `publish_display_data` ends up adding an empty line.

The call to `publish_display_data` loads HTML from the `load_notebook.html` template which only contains the logos base64 encoded. So it seems safe to avoid loading this HTML when no logo is required.