### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,9 @@ setup_args.update(
         platforms=["Windows", "Mac OS X", "Linux"],
         license="BSD",
         url="https://www.holoviews.org",
+        project_urls={
+            "Source": "https://github.com/holoviz/holoviews",
+        },
         entry_points={"console_scripts": ["holoviews = holoviews.util.command:main"]},
         packages=find_packages(),
         include_package_data=True,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)