### PR TITLE
Respect series order in stacked area plot

### DIFF
--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -252,7 +252,7 @@ class Area(Curve):
         vdims = [vdim, baseline_name]
         baseline = None
         stacked = areas.clone(shared_data=False)
-        for key, sdf in df.groupby(level=levels):
+        for key, sdf in df.groupby(level=levels, sort=False):
             sdf = sdf.droplevel(levels).reindex(index=df.index.unique(-1), fill_value=0)
             if baseline is None:
                 sdf[baseline_name] = 0


### PR DESCRIPTION
This is a quick fix of #5235, until a more thorough refactoring (if ever) as discussed there.