### PR TITLE
Fix log axis lower bound when data minimum is <= 0

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -923,7 +923,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
 
         y0, y1 = ranges.get(ydim.name, {'combined': (None, None)})['combined']
         if self.logy:
-            bottom = (ydim.range[0] or (10**(np.log10(y1)-2)) if y1 else 0.01)
+            bottom = (ydim.range[0] or (0.01 if y1 > 0.01 else 10**(np.log10(y1)-2)))
         else:
             bottom = 0
         # Map attributes to data

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -932,7 +932,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 low, high = util.max_range([(low, high), shared])
             if invert: low, high = high, low
             if not isinstance(low, util.datetime_types) and log and (low is None or low <= 0):
-                low = 0.01 if high < 0.01 else 10**(np.log10(high)-2)
+                low = 0.01 if high > 0.01 else 10**(np.log10(high)-2)
                 self.param.warning(
                     "Logarithmic axis range encountered value less "
                     "than or equal to zero, please supply explicit "

--- a/holoviews/tests/plotting/bokeh/test_areaplot.py
+++ b/holoviews/tests/plotting/bokeh/test_areaplot.py
@@ -135,7 +135,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
         self.assertEqual(x_range.end, 3.2)
-        self.assertEqual(y_range.start, 0.033483695221017122)
+        self.assertEqual(y_range.start, 0.01)
         self.assertEqual(y_range.end, 3.3483695221017129)
         self.log_handler.assertContains('WARNING', 'Logarithmic axis range encountered value less than')
 

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -83,8 +83,8 @@ class TestBarPlot(TestBokehPlot):
         y_range = plot.handles['y_range']
         self.assertEqual(list(source.data['Index']), ['A', 'B', 'C'])
         self.assertEqual(source.data['Value'], np.array([1, 2, 3]))
-        self.assertEqual(glyph.bottom, 10**(np.log10(3)-2))
-        self.assertEqual(y_range.start, 0.03348369522101712)
+        self.assertEqual(glyph.bottom, 0.01)
+        self.assertEqual(y_range.start, 0.01)
         self.assertEqual(y_range.end, 3.348369522101713)
 
     def test_bars_logy_explicit_range(self):
@@ -146,7 +146,7 @@ class TestBarPlot(TestBokehPlot):
         bars = Bars([(1, 2), (2, 1), (3, 3)]).options(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(bars)
         y_range = plot.handles['y_range']
-        self.assertEqual(y_range.start, 0.033483695221017122)
+        self.assertEqual(y_range.start, 0.01)
         self.assertEqual(y_range.end, 3.3483695221017129)
 
     ###########################

--- a/holoviews/tests/plotting/bokeh/test_histogramplot.py
+++ b/holoviews/tests/plotting/bokeh/test_histogramplot.py
@@ -130,7 +130,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.19999999999999996)
         self.assertEqual(x_range.end, 3.8)
-        self.assertEqual(y_range.start, 0.033483695221017122)
+        self.assertEqual(y_range.start, 0.01)
         self.assertEqual(y_range.end, 3.3483695221017129)
         self.log_handler.assertContains('WARNING', 'Logarithmic axis range encountered value less than')
 


### PR DESCRIPTION
Set the lower bound as originally intended in https://github.com/holoviz/holoviews/pull/1691 (see latest comments)