### PR TITLE
Heatmap Fixes

### DIFF
--- a/examples/reference/elements/bokeh/HeatMap.ipynb
+++ b/examples/reference/elements/bokeh/HeatMap.ipynb
@@ -47,14 +47,30 @@
    "source": [
     "data = [(i, chr(97+j),  i*j) for i in range(5) for j in range(5) if i!=j]\n",
     "hm = hv.HeatMap(data).sort()\n",
-    "hm.opts(xticks=None)"
+    "hm"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is important to note that the data should be aggregated before plotting as the ``HeatMap`` cannot display multiple values for one coordinate and will simply use the first value it finds for each combination of x- and y-coordinates."
+    "For a coarse grid like this, it can be useful to overlay the actual values onto the heatmap cells:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hm * hv.Labels(hm).opts(padding=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is important to note that the data should be aggregated before plotting as the ``HeatMap`` cannot display multiple values for one coordinate and will simply use the first value it finds for each combination of x- and y-coordinates (causing a warning)."
    ]
   },
   {

--- a/examples/user_guide/Continuous_Coordinates.ipynb
+++ b/examples/user_guide/Continuous_Coordinates.ipynb
@@ -41,7 +41,7 @@
     "hv.extension('bokeh')\n",
     "\n",
     "np.set_printoptions(precision=2, linewidth=80)\n",
-    "opts.defaults(opts.HeatMap(cmap='fire'), opts.Layout(shared_axes=False))"
+    "opts.defaults(opts.Layout(shared_axes=False))"
    ]
   },
   {
@@ -109,8 +109,11 @@
    "source": [
     "r5 = hv.Raster(f5, label=\"R5\")\n",
     "i5 = hv.Image( f5, label=\"I5\", bounds=region)\n",
-    "h5 = hv.HeatMap([(x, y, f5[4-y,x]) for x in range(0,5) for y in range(0,5)], label=\"H5\")\n",
-    "r5+i5+h5"
+    "h5 = hv.HeatMap([(x, y, round(f5[4-y,x],2)) for x in range(0,5) for y in range(0,5)], label=\"H5\")\n",
+    "\n",
+    "h5_labels = hv.Labels(h5).opts(padding=0)\n",
+    "\n",
+    "r5 + i5 + h5*h5_labels"
    ]
   },
   {

--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "## Working with bokeh directly\n",
     "\n",
-    "When HoloViews outputs bokeh plots it creates and manipulates bokeh models in the background. If at any time you need access to the underlying plotly representation of an object you can use the ``hv.render`` function to convert it. For example let us convert a HoloViews ``Image`` to a bokeh Figure, which will let us access and modify every aspect of the plot:"
+    "When HoloViews outputs bokeh plots it creates and manipulates bokeh models in the background. If at any time you need access to the underlying Bokeh representation of an object you can use the ``hv.render`` function to convert it. For example let us convert a HoloViews ``Image`` to a bokeh Figure, which will let us access and modify every aspect of the plot:"
    ]
   },
   {


### PR DESCRIPTION
The HeatMap and Continuous_Coordinates notebooks were written long ago, and various changes to the docs over the years have caused them to have issues that we apparently never noticed:

- Previously, HeatMap had a default colormap of `RdYlBu_r`, while the Raster types had a default of `fire`. Both defaults were updated to `kbc_r`, but Continuous_Coordinates was still overriding `RdYlBu_r` to match the Raster `fire`, and now the result is _not_ matching the Raster `kbc_r`. Removed this override now that the defaults match (as they should).
- Matplotlib's HeatMap shows labels overlaid by default (which itself is an issue; see https://github.com/holoviz/holoviews/issues/5108), while Bokeh does not. The Bokeh approach is a better choice anyway, for composability, but switching to the Bokeh version meant that those labels disappeared. Added an example of adding labels explicitly to HeatMap.ipynb, and added labels to Continuous_Coordinates since the text was assuming the heat map had explicit labels. Note that overlaying labels looks pretty bad unless `padding=0`, so I added that to the example.
- Matplotlib doesn't show minor ticks by default on a HeatMap, which is appropriate for coarse grids. When adding the Bokeh version of this Element, it looks like there was an attempt to turn off minor ticks with `.opts(xticks=None)`, but that doesn't appear to have any effect. Moreover, there doesn't seem to be a reliable way to turn off those ticks at all, for which I opened a separate ticket https://github.com/holoviz/holoviews/issues/5261 . For now, just accepted having minor ticks shown.


Before this PR:
<img width="873" alt="image" src="https://user-images.githubusercontent.com/1695496/162064533-0d73200a-a513-4ce6-b7b5-b2ba85af47ae.png">

After this PR:
<img width="893" alt="image" src="https://user-images.githubusercontent.com/1695496/162064425-5ed2133f-e79b-432d-9ab8-7a823f5926af.png">
