### PR TITLE
Add support for setting line_width on datashader line aggregation

### DIFF
--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -487,7 +487,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "HoloViews also makes it possible to datashade large timeseries using the ``datashade`` and ``rasterize`` operations:"
+    "HoloViews also makes it possible to datashade large timeseries using the ``datashade`` and ``rasterize`` operations. To improve the look of the line plots datashader implements anti-aliasing if a `line_width` > 0 is set:"
    ]
   },
   {
@@ -500,7 +500,7 @@
     "\n",
     "dates = pd.date_range(start=\"2014-01-01\", end=\"2016-01-01\", freq='1D') # or '1min'\n",
     "curve = hv.Curve((dates, time_series(N=len(dates), sigma = 1)))\n",
-    "rasterize(curve, width=800).opts(width=800, cmap=['blue'])"
+    "rasterize(curve, width=800, line_width=1).opts(width=800, cmap=['blue'])"
    ]
   },
   {
@@ -520,8 +520,8 @@
     "smoothed = rolling(curve, rolling_window=50)\n",
     "outliers = rolling_outlier_std(curve, rolling_window=50, sigma=2)\n",
     "\n",
-    "ds_curve = rasterize(curve).opts(cmap=[\"blue\"])\n",
-    "curvespread = dynspread(datashade(smoothed, cmap=[\"red\"], width=800),max_px=1) \n",
+    "ds_curve = rasterize(curve, line_width=1).opts(cmap=[\"blue\"])\n",
+    "curvespread = dynspread(datashade(smoothed, cmap=[\"red\"], line_width=1, width=800),max_px=1) \n",
     "\n",
     "(ds_curve * curvespread * outliers).opts(\n",
     "    opts.Scatter(line_color=\"black\", fill_color=\"red\", size=10, tools=['hover', 'box_select'], width=800))"

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1246,6 +1246,13 @@ class shade(LinkableOperation):
         undersaturation, i.e. poorly visible low-value datapoints, at
         the expense of the overall dynamic range..""")
 
+    rescale_discrete_levels = param.Boolean(default=False, doc="""
+        If ``cnorm='eq_hist`` and there are only a few discrete values,
+        then ``rescale_discrete_levels=True`` decreases the lower
+        limit of the autoranged span so that the values are rendering
+        towards the (more visible) top of the ``cmap`` range, thus
+        avoiding washout of the lower values.  Has no effect if
+        ``cnorm!=`eq_hist``.""")
 
     @classmethod
     def concatenate(cls, overlay):
@@ -1330,11 +1337,14 @@ class shade(LinkableOperation):
         array = element.data[vdim]
         kdims = element.kdims
 
+        shade_opts = dict(
+            how=self.p.cnorm, min_alpha=self.p.min_alpha, alpha=self.p.alpha
+        )
+        if ds_version >= LooseVersion('0.14.0'):
+            shade_opts['rescale_discrete_levels'] = self.p.rescale_discrete_levels
+
         # Compute shading options depending on whether
         # it is a categorical or regular aggregate
-        shade_opts = dict(how=self.p.cnorm,
-                          min_alpha=self.p.min_alpha,
-                          alpha=self.p.alpha)
         if element.ndims > 2:
             kdims = element.kdims[1:]
             categories = array.shape[-1]


### PR DESCRIPTION
Adds support for setting `line_width` on datashader aggregation operations if datashader version >= 0.14.

Also adds support for `rescale_discrete_levels` option on `shade` operation. 