### PR TITLE
Switch to using bokeh rangesupdate event for Range streams

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -657,12 +657,16 @@ class RangeXYCallback(Callback):
     Returns the x/y-axis ranges of a plot.
     """
 
-    attributes = {'x0': 'x_range.attributes.start',
-                  'x1': 'x_range.attributes.end',
-                  'y0': 'y_range.attributes.start',
-                  'y1': 'y_range.attributes.end'}
-    models = ['x_range', 'y_range']
-    on_changes = ['start', 'end']
+    on_events = ['rangesupdate']
+
+    models = ['plot']
+
+    attributes = {
+        'x0': 'cb_obj.x0',
+        'y0': 'cb_obj.y0',
+        'x1': 'cb_obj.x1',
+        'y1': 'cb_obj.y1'
+    }
 
     def _process_msg(self, msg):
         data = {}
@@ -694,9 +698,14 @@ class RangeXCallback(RangeXYCallback):
     Returns the x-axis range of a plot.
     """
 
-    attributes = {'x0': 'x_range.attributes.start',
-                  'x1': 'x_range.attributes.end'}
-    models = ['x_range']
+    on_events = ['rangesupdate']
+
+    models = ['plot']
+
+    attributes = {
+        'x0': 'cb_obj.x0',
+        'x1': 'cb_obj.x1',
+    }
 
 
 class RangeYCallback(RangeXYCallback):
@@ -704,10 +713,14 @@ class RangeYCallback(RangeXYCallback):
     Returns the y-axis range of a plot.
     """
 
-    attributes = {'y0': 'y_range.attributes.start',
-                  'y1': 'y_range.attributes.end'}
-    models = ['y_range']
+    on_events = ['rangesupdate']
 
+    models = ['plot']
+
+    attributes = {
+        'y0': 'cb_obj.y0',
+        'y1': 'cb_obj.y1'
+    }
 
 
 class PlotSizeCallback(Callback):

--- a/holoviews/tests/plotting/bokeh/test_server.py
+++ b/holoviews/tests/plotting/bokeh/test_server.py
@@ -80,12 +80,6 @@ class TestBokehServerSetup(ComparisonTestCase):
         cb = bokeh_renderer.last_plot.callbacks[0]
         self.assertIsInstance(cb, RangeXYCallback)
         self.assertEqual(cb.streams, [stream])
-        x_range = bokeh_renderer.last_plot.handles['x_range']
-        self.assertIn(cb.on_change, x_range._callbacks['start'])
-        self.assertIn(cb.on_change, x_range._callbacks['end'])
-        y_range = bokeh_renderer.last_plot.handles['y_range']
-        self.assertIn(cb.on_change, y_range._callbacks['start'])
-        self.assertIn(cb.on_change, y_range._callbacks['end'])
 
     def test_set_up_linked_event_stream_on_server_doc(self):
         obj = Curve([])
@@ -95,8 +89,6 @@ class TestBokehServerSetup(ComparisonTestCase):
         cb = bokeh_renderer.last_plot.callbacks[0]
         self.assertIsInstance(cb, ResetCallback)
         self.assertEqual(cb.streams, [stream])
-        plot = bokeh_renderer.last_plot.state
-        self.assertIn(cb.on_event, plot._event_callbacks['reset'])
 
 
 

--- a/holoviews/tests/plotting/bokeh/test_server.py
+++ b/holoviews/tests/plotting/bokeh/test_server.py
@@ -80,6 +80,7 @@ class TestBokehServerSetup(ComparisonTestCase):
         cb = bokeh_renderer.last_plot.callbacks[0]
         self.assertIsInstance(cb, RangeXYCallback)
         self.assertEqual(cb.streams, [stream])
+        assert 'rangesupdate' in bokeh_renderer.last_plot.state._event_callbacks
 
     def test_set_up_linked_event_stream_on_server_doc(self):
         obj = Curve([])
@@ -133,12 +134,7 @@ class TestBokehServer(ComparisonTestCase):
         cb = plot.callbacks[0]
         self.assertIsInstance(cb, RangeXYCallback)
         self.assertEqual(cb.streams, [stream])
-        x_range = bokeh_renderer.last_plot.handles['x_range']
-        self.assertIn(cb.on_change, x_range._callbacks['start'])
-        self.assertIn(cb.on_change, x_range._callbacks['end'])
-        y_range = bokeh_renderer.last_plot.handles['y_range']
-        self.assertIn(cb.on_change, y_range._callbacks['start'])
-        self.assertIn(cb.on_change, y_range._callbacks['end'])
+        assert 'rangesupdate' in plot.state._event_callbacks
 
     def test_launch_server_with_complex_plot(self):
         dmap = DynamicMap(lambda x_range, y_range: Curve([]), streams=[RangeXY()])


### PR DESCRIPTION
Uses the new rangeupdates bokeh event for the `Range{X}{Y}` streams. The benefit is that we do not have to manually throttle these events since only a single event is triggered even if all x0, y0, x1, y1 all change. Do not backport since this requires bokeh>=2.4.