### PR TITLE
Fixed example of line spreading, color key, and cmap for antialiasing

### DIFF
--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -423,7 +423,7 @@
     "c = dynspread(datashade(hv.NdOverlay(gaussians, kdims='k'), aggregator=ds.by('k', ds.count())))\n",
     "m = dynspread(datashade(hv.NdOverlay(gaussians, kdims='k'), aggregator=ds.by('k', ds.mean(\"i\"))))\n",
     "\n",
-    "(c + m).opts(opts.RGB(width=400))"
+    "c.opts(width=400) + m.opts(width=400)"
    ]
   },
   {

--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -297,7 +297,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, the `linear` map is easy to interpret, but nearly all of the pixels are drawn in the lightest blue, because the highest-count pixel (around a count of 6000) is much larger in value than the typical pixels. The other two plots show the full structure (five concentrations of data points, including one in the background), with `log` using a standard logarithmic transformation of the count data before colormapping, and `eq_hist` using a histogram-equalization technique (see the [Datashader docs](https://datashader.org/getting_started/Pipeline.html) to reveal structure without any assumptions about the incoming distribution (but with an irregularly spaced colormap that makes the numeric values difficult to reason about). In practice, it is generally a good idea to use `eq_hist` when exploring a large dataset initially, so that you will see any structure present, then switch to `log` or `linear` to share the plots with a simpler-to-explain colormap. All three of these options are supported by the various backends (including Bokeh version 2.2.3 or later)  and by `shade()` and `datashade()` except that `eq_hist` is not yet available for the Plotly backend."
+    "Here, the `linear` map is easy to interpret, but nearly all of the pixels are drawn in the lightest blue, because the highest-count pixel (around a count of 6000) is much larger in value than the typical pixels. The other two plots show the full structure (five concentrations of data points, including one in the background), with `log` using a standard logarithmic transformation of the count data before colormapping, and `eq_hist` using a histogram-equalization technique (see the [Datashader docs](https://datashader.org/getting_started/Pipeline.html)) to reveal structure without any assumptions about the incoming distribution (but with an irregularly spaced colormap that makes the numeric values difficult to reason about). In practice, it is generally a good idea to use `eq_hist` when exploring a large dataset initially, so that you will see any structure present, then switch to `log` or `linear` to share the plots with a simpler-to-explain colormap. All three of these options are supported by the various backends (including Bokeh version 2.2.3 or later)  and by `shade()` and `datashade()` except that `eq_hist` is not yet available for the Plotly backend."
    ]
   },
   {
@@ -350,7 +350,7 @@
     "However, many monitors are sufficiently high resolution that a single-pixel point or line can be difficult to see---one pixel may not be visible at all on its own, and even if it is visible it is often difficult to see its color. To compensate for this, HoloViews provides access to Datashader's raster-based \"spreading\" (a generalization of image dilation and convolution), which makes isolated nonzero cells \"spread\" into adjacent ones for visibility.  There are two varieties of spreading supported:\n",
     "\n",
     "1. ``spread``: fixed spreading of a certain number of cells (pixels), which is useful if you want to be sure how much spreading is done regardless of the properties of the data.\n",
-    "2. ``dynspread``: spreads up to a maximum size as long as it does not exceed a specified fraction of adjacency between cells (pixels).\n",
+    "2. ``dynspread``: spreads up to a maximum size as long as it does not exceed a specified fraction of adjacency between cells (pixels) (controlled by a `threshold` parameter).\n",
     "\n",
     "Dynamic spreading is typically more useful for interactive plotting, because it adjusts depending on how close the datapoints are to each other on screen. As of Datashader 0.12, both types of spreading are supported for both `rasterize()` and `shade()`, but previous Datashader versions only support spreading on the RGB output of `shade()`.\n",
     "\n",
@@ -376,7 +376,7 @@
     "\n",
     "Both plots show the same data, and look identical when zoomed out, but when zoomed in enough you should be able to see the individual data points on the right while the ones on the left are barely visible.  The dynspread parameters typically need some hand tuning, as the only purpose of such spreading is to make things visible on a particular monitor for a particular observer; the underlying mathematical operations in Datashader do not normally need parameters to be adjusted.\n",
     "\n",
-    "The same operation works similarly for line segments:"
+    "Dynspread is not usable with connected plots like trajectories or curves, because the spreading amount is measured by the fraction of cells that have neighbors closer than the given spread distance, which is always 100% when datapoints are connected together. For connected plots you can instead use `spread` with a fixed value to expand patterns by `px` in every direction after they are drawn, or (for Datashader 0.14 or later) pass an explicit width like `line_width=1` to the rasterizer (at some cost in performance):"
    ]
   },
   {
@@ -385,7 +385,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rasterize(paths) + dynspread(rasterize(paths), threshold=0.6)"
+    "rasterize(paths) + spread(rasterize(paths), px=2) + rasterize(paths, line_width=4)"
    ]
   },
   {
@@ -464,7 +464,7 @@
     "\n",
     "from datashader.colors import Sets1to3 # default datashade() and shade() color cycle\n",
     "color_key = list(enumerate(Sets1to3[0:num_ks]))\n",
-    "color_points = hv.NdOverlay({k: hv.Points([0,0], label=str(k)).opts(color=v, size=0) for k, v in color_key})\n",
+    "color_points = hv.NdOverlay({k: hv.Points(([0,0]), label=str(k)).opts(color=v, size=0) for k, v in color_key})\n",
     "\n",
     "(color_points * gaussspread2).opts(width=600)"
    ]
@@ -487,7 +487,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "HoloViews also makes it possible to datashade large timeseries using the ``datashade`` and ``rasterize`` operations. To improve the look of the line plots datashader implements anti-aliasing if a `line_width` > 0 is set:"
+    "HoloViews also makes it possible to datashade large timeseries using the ``datashade`` and ``rasterize`` operations. For smoother lines, datashader implements anti-aliasing if a `line_width` > 0 is set:"
    ]
   },
   {
@@ -500,7 +500,7 @@
     "\n",
     "dates = pd.date_range(start=\"2014-01-01\", end=\"2016-01-01\", freq='1D') # or '1min'\n",
     "curve = hv.Curve((dates, time_series(N=len(dates), sigma = 1)))\n",
-    "rasterize(curve, width=800, line_width=1).opts(width=800, cmap=['blue'])"
+    "rasterize(curve, width=800, line_width=1).opts(width=800, cmap=['lightblue','blue'])"
    ]
   },
   {
@@ -520,8 +520,8 @@
     "smoothed = rolling(curve, rolling_window=50)\n",
     "outliers = rolling_outlier_std(curve, rolling_window=50, sigma=2)\n",
     "\n",
-    "ds_curve = rasterize(curve, line_width=1).opts(cmap=[\"blue\"])\n",
-    "curvespread = dynspread(datashade(smoothed, cmap=[\"red\"], line_width=1, width=800),max_px=1) \n",
+    "ds_curve = rasterize(curve, line_width=1).opts(cmap=['lightblue',\"blue\"])\n",
+    "curvespread = dynspread(datashade(smoothed, cmap=[\"pink\",\"red\"], line_width=3, width=800),max_px=1) \n",
     "\n",
     "(ds_curve * curvespread * outliers).opts(\n",
     "    opts.Scatter(line_color=\"black\", fill_color=\"red\", size=10, tools=['hover', 'box_select'], width=800))"


### PR DESCRIPTION
The Large Data guide had a few issues:

- It had been claiming that dynspread worked for paths and curves, but that hasn't been true since 6/2021 when we fixed dynspread to have reasonable behavior. Since then, any connected path will have no dynamic spreading, since all pixels have a connected neighbor. Suggested alternatives instead.
- The fake categorical color_key example was using [0,0] as the data, which works for some reason, but I think it needs to be ([0,0]), i.e. a single point (x,y)
- The new examples of `line_width=X` weren't showing antialiasing, because  they had only a single color in their colormap. Added colormaps for those.
- The seemingly valid syntax `(c + m).opts(opts.RGB(width=400))` has started showing `WARNING:param.main: Calling the .opts method with options broken down by options group (i.e. separate plot, style and norm groups) is deprecated.`, which seems like a bogus warning since the option _is_ applied and is not broken down by options group. Silenced it by switching to  `c.opts(width=400) + m.opts(width=400)`, but that code was previously legal and presumably should not be warning.