### PR TITLE
Set rescale_discrete_levels=True by default

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1265,8 +1265,8 @@ class shade(LinkableOperation):
         the lower limit of the autoranged span so that the values are
         rendering towards the (more visible) top of the ``cmap`` range, 
         thus avoiding washout of the lower values.  Has no effect if
-        ``cnorm!=`eq_hist``. Set to False to match historical unscaled
-        behavior, prior to HoloViews 1.14.4.""")
+        ``cnorm!=`eq_hist``. Set this value to False if you need to
+        match historical unscaled behavior, prior to HoloViews 1.14.4.""")
 
     @classmethod
     def concatenate(cls, overlay):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1246,13 +1246,14 @@ class shade(LinkableOperation):
         undersaturation, i.e. poorly visible low-value datapoints, at
         the expense of the overall dynamic range..""")
 
-    rescale_discrete_levels = param.Boolean(default=False, doc="""
+    rescale_discrete_levels = param.Boolean(default=True, doc="""
         If ``cnorm='eq_hist`` and there are only a few discrete values,
-        then ``rescale_discrete_levels=True`` decreases the lower
-        limit of the autoranged span so that the values are rendering
-        towards the (more visible) top of the ``cmap`` range, thus
-        avoiding washout of the lower values.  Has no effect if
-        ``cnorm!=`eq_hist``.""")
+        then ``rescale_discrete_levels=True`` (the default) decreases
+        the lower limit of the autoranged span so that the values are
+        rendering towards the (more visible) top of the ``cmap`` range, 
+        thus avoiding washout of the lower values.  Has no effect if
+        ``cnorm!=`eq_hist``. Set to False to match historical unscaled
+        behavior, prior to HoloViews 1.14.4.""")
 
     @classmethod
     def concatenate(cls, overlay):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -725,7 +725,8 @@ class ColorbarPlot(ElementPlot):
         limit of the autoranged span so that the values are rendering
         towards the (more visible) top of the palette, thus
         avoiding washout of the lower values.  Has no effect if
-        ``cnorm!=`eq_hist``.""")
+        ``cnorm!=`eq_hist``. Set this value to False if you need to
+        match historical unscaled behavior, prior to HoloViews 1.14.4.""")
 
     symmetric = param.Boolean(default=False, doc="""
         Whether to make the colormap symmetric around zero.""")

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -719,6 +719,14 @@ class ColorbarPlot(ElementPlot):
         If not 'neither', make pointed end(s) for out-of- range values."""
     )
 
+    rescale_discrete_levels = param.Boolean(default=True, doc="""
+        If ``cnorm='eq_hist`` and there are only a few discrete values,
+        then ``rescale_discrete_levels=True`` decreases the lower
+        limit of the autoranged span so that the values are rendering
+        towards the (more visible) top of the palette, thus
+        avoiding washout of the lower values.  Has no effect if
+        ``cnorm!=`eq_hist``.""")
+
     symmetric = param.Boolean(default=False, doc="""
         Whether to make the colormap symmetric around zero.""")
 
@@ -900,7 +908,9 @@ class ColorbarPlot(ElementPlot):
 
         if self.cnorm == 'eq_hist':
             opts[prefix+'norm'] = EqHistNormalize(
-                vmin=clim[0], vmax=clim[1])
+                vmin=clim[0], vmax=clim[1],
+                rescale_discrete_levels=self.rescale_discrete_levels
+            )
         if self.cnorm == 'log' or self.logz:
             if self.symmetric:
                 norm = mpl_colors.SymLogNorm(vmin=clim[0], vmax=clim[1],

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -409,7 +409,7 @@ class EqHistNormalize(Normalize):
         self._nbins = nbins
         self._bin_edges = None
         self._ncolors = ncolors
-        self._color_bins = np.linspace(0, 1, ncolors)
+        self._color_bins = np.linspace(0, 1, ncolors+1)
 
     def binning(self, data, n=256):
         low = data.min() if self.vmin is None else self.vmin
@@ -417,39 +417,12 @@ class EqHistNormalize(Normalize):
         nbins = self._nbins
         eq_bin_edges = np.linspace(low, high, nbins+1)
         hist, _ = np.histogram(data, eq_bin_edges)
-
         eq_bin_centers = np.convolve(eq_bin_edges, [0.5, 0.5], mode='valid')
         cdf = np.cumsum(hist)
-        cdf_max = cdf[-1]
-        norm_cdf = cdf/cdf_max
-
-        # Iteratively find as many finite bins as there are colors
-        finite_bins = n-1
-        binning = []
-        iterations = 0
-        guess = n*2
-        while ((finite_bins != n) and (iterations < 4) and (finite_bins != 0)):
-            ratio = guess/finite_bins
-            if (ratio > 1000):
-                #Abort if distribution is extremely skewed
-                break
-            guess = np.round(max(n*ratio, n))
-
-            # Interpolate
-            palette_edges = np.arange(0, guess)
-            palette_cdf = norm_cdf*(guess-1)
-            binning = np.interp(palette_edges, palette_cdf, eq_bin_centers)
-
-            # Evaluate binning
-            uniq_bins = np.unique(binning)
-            finite_bins = len(uniq_bins)-1
-            iterations += 1
-        if (finite_bins == 0):
-            binning = [low]+[high]*(n-1)
-        else:
-            binning = binning[-n:]
-            if (finite_bins != n):
-                warnings.warn("EqHistColorMapper warning: Histogram equalization did not converge.")
+        cdf_bins = np.linspace(cdf[0], cdf[nbins-1], n+1)
+        binning = np.interp(cdf_bins, cdf, eq_bin_centers)
+        binning[0] = low
+        binning[-1] = high
         return binning
 
     def __call__(self, data, clip=None):


### PR DESCRIPTION
The `eq_hist` colormapper used with Datashader is designed for large datasets with a wide distribution of values, but as documented in https://github.com/holoviz/datashader/issues/357 the behavior when there are only a few distinct value levels has always been confusing and misleading. Datashader 0.14 adds an option `rescale_discrete_levels=True`, now supported in HoloViews, allowing users to avoid this issue. However, this option is False by default, and most users are never going to be aware that the option exists. This PR enables the option by default, which has good and bad consequences:

- Good: Users will now see better colormapping behavior, with points visible at all zoom levels and no longer jumping between the lowest and highest colormap values at a tiny change in zoom level, without having to learn about this option or modify any of their code. This is arguably a long-overdue bug fix.
- Bad: Results will change for plots rendered with `eq_hist` that have only a small number of discrete levels. That's by design, but it is strictly a compatibility change, which is odd to introduce in a patch release.
- Bad: Results will differ between `rasterize` and `datashade`, because Bokeh does not yet support `rescale_discrete_levels`. So there is some argument for waiting until Bokeh does support it to make this the default.

Basically, if we consider this a bugfix, we should introduce it now; patch releases are for bugfixes. If we consider it a new feature, we should wait until the next major or at least minor release to enable it by default.

I'm ok with either option, as long as the options have been duly considered and decided between.