### PR TITLE
Schedule CI runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,10 @@ on:
     - 'v[0-9]+.[0-9]+.[0-9]+a[0-9]+'
     - 'v[0-9]+.[0-9]+.[0-9]+b[0-9]+'
     - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
+  # Dry-run only
+  workflow_dispatch:
+  schedule:
+    - cron: '0 14 * * SUN'
 
 jobs:
   conda_build:
@@ -45,10 +49,10 @@ jobs:
       - name: conda build
         run: doit package_build $CHANS_DEV $PKG_TEST_PYTHON --test-group=unit
       - name: conda dev upload
-        if: (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc'))
+        if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: doit package_upload --token=$CONDA_UPLOAD_TOKEN --label=dev
       - name: conda main upload
-        if: (!(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+        if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: doit package_upload --token=$CONDA_UPLOAD_TOKEN --label=dev --label=main
   pip_build:
     name: Build PyPI Packages
@@ -104,6 +108,7 @@ jobs:
           conda activate test-environment
           doit ecosystem=pip package_build
       - name: pip upload
+        if: github.event_name == 'push'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,9 @@ on:
         - main
         - dryrun
         required: true
-        default: dev
+        default: dryrun
+  schedule:
+    - cron: '0 14 * * SUN'
 
 jobs:
   build_docs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - '*'
   workflow_dispatch:
+  schedule:
+    - cron: '0 14 * * SUN'
 
 jobs:
   test_suite:


### PR DESCRIPTION
Run the tests, docs and builds workflows in a dry-run mode on Sundays.