### PR TITLE
Don't test ibis on Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,7 @@ jobs:
           doit develop_install -c pyviz/label/dev -c bokeh ${{ env.HV_REQUIREMENTS }}
           # Pin panel on Python 3.6 because one or more dev releases on the 0.13.* series
           # can be installed on Python 3.6 but are actually not compatible with Python 3.6
-          # Install ibis-framework instead of ibis-sqlite as it's only available starting from Python 3.7
-          conda install $CHANS_DEV "ibis-framework=2" "panel=0.12"
+          conda install $CHANS_DEV "panel=0.12"
           python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
           echo "-----"
           git describe


### PR DESCRIPTION
To prepare the release, this is **not targeting master**.