### PR TITLE
Don't skip each renderer's load_nb call when multiple extension calls are made in a single cell

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -184,9 +184,9 @@ class notebook_extension(extension):
             config.comms = comms
 
         same_cell_execution = getattr(self, '_repeat_execution_in_cell', False)
+        for r in [r for r in resources if r != 'holoviews']:
+            Store.renderers[r].load_nb(inline=p.inline)
         if not same_cell_execution:
-            for r in [r for r in resources if r != 'holoviews']:
-                Store.renderers[r].load_nb(inline=p.inline)
             Renderer.load_nb(inline=p.inline)
 
         if hasattr(ip, 'kernel') and not loaded:


### PR DESCRIPTION
Attempt to fix an issue observed when building hvPlot's docs, where no Plotly plot was displayed.

Each holoviews renderer (bokeh, mpl, plotly) has a `load_nb` method that actually doesn’t load any code in the notebook, it’s just doing some extra setting. Plotly’s one does the equivalent of `pn.extension('plotly')` minus the insertion of JS/CSS into the notebook, already done elsewhere. The new pyviz_comms/holoviews/panel have added a way to only load the code once in a notebook cell, even when `.extension()` is called multiple times. At the holoviews level though this also avoids calling each renderer’s `load_nb` method, leading in Plotly’s case to Panel not being set up properly.

The suggested solution is not to skip calling each renderer's `load_nb` method.