### PR TITLE
Let page background show through for zero counts

### DIFF
--- a/examples/getting_started/1-Introduction.ipynb
+++ b/examples/getting_started/1-Introduction.ipynb
@@ -194,13 +194,16 @@
    "outputs": [],
    "source": [
     "bounds = (-74.05, 40.70, -73.90, 40.80)\n",
-    "image = hv.Image(taxi_dropoffs['0'], ['lon','lat'], bounds=bounds)"
+    "image = hv.Image(taxi_dropoffs['0'], ['lon','lat'], bounds=bounds).redim.nodata(z=0)\n",
+    "image"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Here we also specified that 0 is a `nodata` value for this array, where the page background should show through.\n",
+    "\n",
     "HoloViews supports ``numpy``, ``xarray``, and ``dask`` arrays when working with array data (see [Gridded Datasets](4-Gridded_Datasets.ipynb)).  We can also compose elements containing array data with those containing tabular data. To illustrate, let's pass our tabular station data to a [``Points``](../reference/elements/bokeh/Points.ipynb) element, which is used to mark positions in two-dimensional space:"
    ]
   },
@@ -240,7 +243,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dictionary = {int(hour):hv.Image(arr, ['lon','lat'], bounds=bounds) \n",
+    "dictionary = {int(hour):hv.Image(arr, ['lon','lat'], bounds=bounds).redim.nodata(z=0)\n",
     "              for hour, arr in taxi_dropoffs.items()}\n",
     "hv.HoloMap(dictionary, kdims='Hour')"
    ]


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/5303 , using a suggestion from @Hoxbro. It's unfortunate that we'd have to use `redim.nodata` on this very first introductory page, but I don't see a way around it, because the underlying data is not just float in datatype, but also its data is all fractional values that can't be converted to integer (e.g. 1.7). Are they densities of some sort? The page seems to indicate that they are counts, but they clearly are not, at least not directly.

An alternative to this PR would be to regenerate this data as integer counts, store it as integer arrays, and then use `.opts(nodata=0)` instead of `.redim.nodata(z=0)`. That's a little simpler and more obvious, but I'm not sure how the data was generated originally.