### PR TITLE
Protect matplotlib tests from global styles

### DIFF
--- a/holoviews/tests/plotting/matplotlib/test_elementplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_elementplot.py
@@ -1,4 +1,5 @@
 import numpy as np
+from matplotlib import style
 
 from holoviews.core.spaces import DynamicMap
 from holoviews.element import Image, Curve, Scatter, Scatter3D
@@ -30,7 +31,15 @@ class TestElementPlot(TestMPLPlot):
 
     def test_element_font_scaling(self):
         curve = Curve(range(10)).options(fontscale=2, title='A title')
-        plot = mpl_renderer.get_plot(curve)
+        with style.context(
+            {
+                "axes.labelsize": 10,
+                "axes.titlesize": 12,
+                "xtick.labelsize": 10,
+                "ytick.labelsize": 10,
+            }
+        ):
+            plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         self.assertEqual(ax.title.get_fontsize(), 24)
         self.assertEqual(ax.xaxis.label.get_fontsize(), 20)
@@ -40,7 +49,16 @@ class TestElementPlot(TestMPLPlot):
 
     def test_element_font_scaling_fontsize_override_common(self):
         curve = Curve(range(10)).options(fontscale=2, fontsize=14, title='A title')
-        plot = mpl_renderer.get_plot(curve)
+        with style.context(
+            {
+                "axes.labelsize": 10,
+                "axes.titlesize": 12,
+                "font.size": 10,
+                "xtick.labelsize": 10,
+                "ytick.labelsize": 10,
+            }
+        ):
+            plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         self.assertEqual(ax.title.get_fontsize(), 28)
         self.assertEqual(ax.xaxis.label.get_fontsize(), 28)
@@ -51,7 +69,15 @@ class TestElementPlot(TestMPLPlot):
     def test_element_font_scaling_fontsize_override_specific(self):
         curve = Curve(range(10)).options(
             fontscale=2, fontsize={'title': 16, 'xticks': 12, 'xlabel': 6}, title='A title')
-        plot = mpl_renderer.get_plot(curve)
+        with style.context(
+            {
+                "axes.labelsize": 10,
+                "axes.titlesize": 12,
+                "xtick.labelsize": 10,
+                "ytick.labelsize": 10,
+            }
+        ):
+            plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         self.assertEqual(ax.title.get_fontsize(), 32)
         self.assertEqual(ax.xaxis.label.get_fontsize(), 12)

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -9,6 +9,7 @@ from unittest import SkipTest
 
 import numpy as np
 import param
+from matplotlib import style
 
 from holoviews import (DynamicMap, HoloMap, Image, ItemTable, Store,
                        GridSpace, Table, Curve)
@@ -62,12 +63,14 @@ class MPLRendererTest(ComparisonTestCase):
         self.assertEqual((w, h), (288, 288))
 
     def test_get_size_row_plot(self):
-        plot = self.renderer.get_plot(self.image1+self.image2)
+        with style.context("default"):
+            plot = self.renderer.get_plot(self.image1 + self.image2)
         w, h = self.renderer.get_size(plot)
         self.assertEqual((w, h), (576, 257))
 
     def test_get_size_column_plot(self):
-        plot = self.renderer.get_plot((self.image1+self.image2).cols(1))
+        with style.context("default"):
+            plot = self.renderer.get_plot((self.image1 + self.image2).cols(1))
         w, h = self.renderer.get_size(plot)
         self.assertEqual((w, h), (288, 509))
 


### PR DESCRIPTION
This PR closes #5310. In "test_elementplot.py", the affected tests now set the specific `rcParams` on which they depend for checking the text sizes. In "test_renderer.py", the tests instead call for *matplotlib*'s default style, because it's unclear from the tests which `rcParams` are relevant. For example, I found that the `test_get_size_row_plot` test was affected by

*   `font.family`,
*   `font.size`, and
*   `figure.dpi`,

and the `test_get_size_column_plot` was affected by those plus

*   `xtick.major.size` and
*   `ytick.major.size`.

However, those two tests could be subject to future changes by *matplotlib* to its default style,

Although I ran the tests related to *matplotlib* using several style sheets, I may have missed some affected tests or relevant `rcParams`.