### PR TITLE
Expose `rescale_discrete_levels` in the Bokeh backend

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           miniconda-version: "latest"
           mamba-version: "*"
-          channels: pyviz/label/dev,conda-forge,nodefaults
+          channels: pyviz/label/dev,bokeh/label/dev,conda-forge,nodefaults
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow -f
       - name: Set output

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
     env:
       HV_REQUIREMENTS: "-o unit_tests"
       MPLBACKEND: "Agg"
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh -c conda-forge -c nodefaults"
+      CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge -c nodefaults"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
@@ -43,7 +43,7 @@ jobs:
           conda update -n base -c defaults conda
           conda config --prepend channels nodefaults
           conda config --prepend channels conda-forge
-          conda config --prepend channels bokeh
+          conda config --prepend channels bokeh/label/dev
           conda config --prepend channels pyviz/label/dev
           conda config --remove channels defaults
           conda create -n test-environment python=${{ matrix.python-version }} pyctdev
@@ -103,7 +103,7 @@ jobs:
       MAMBA_NO_BANNER: 1
       HV_REQUIREMENTS: "-o unit_tests"
       MPLBACKEND: "Agg"
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh -c conda-forge -c nodefaults"
+      CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge -c nodefaults"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
@@ -113,7 +113,7 @@ jobs:
         with:
           miniconda-version: "latest"
           mamba-version: "*"
-          channels: pyviz/label/dev,bokeh,conda-forge,nodefaults
+          channels: pyviz/label/dev,bokeh/label/dev,conda-forge,nodefaults
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
       - name: conda setup

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1759,6 +1759,14 @@ class ColorbarPlot(ElementPlot):
     logz = param.Boolean(default=False, doc="""
          Whether to apply log scaling to the z-axis.""")
 
+    rescale_discrete_levels = param.Boolean(default=True, doc="""
+        If ``cnorm='eq_hist`` and there are only a few discrete values,
+        then ``rescale_discrete_levels=True`` decreases the lower
+        limit of the autoranged span so that the values are rendering
+        towards the (more visible) top of the palette, thus
+        avoiding washout of the lower values.  Has no effect if
+        ``cnorm!=`eq_hist``.""")
+
     symmetric = param.Boolean(default=False, doc="""
         Whether to make the colormap symmetric around zero.""")
 
@@ -1961,6 +1969,7 @@ class ColorbarPlot(ElementPlot):
 
     def _get_cmapper_opts(self, low, high, factors, colors):
         if factors is None:
+            opts = {}
             if self.cnorm == 'linear':
                 colormapper = LinearColorMapper
             if self.cnorm == 'log' or self.logz:
@@ -1983,6 +1992,8 @@ class ColorbarPlot(ElementPlot):
                                       "Note that the option cnorm='eq_hist' requires "
                                       "bokeh 2.2.3 or higher.")
                 colormapper = EqHistColorMapper
+                if bokeh_version >= LooseVersion('2.4.3'):
+                    opts['rescale_discrete_levels'] = True
             if isinstance(low, (bool, np.bool_)): low = int(low)
             if isinstance(high, (bool, np.bool_)): high = int(high)
             # Pad zero-range to avoid breaking colorbar (as of bokeh 1.0.4)
@@ -1990,7 +2001,6 @@ class ColorbarPlot(ElementPlot):
                 offset = self.default_span / 2
                 low -= offset
                 high += offset
-            opts = {}
             if util.isfinite(low):
                 opts['low'] = low
             if util.isfinite(high):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1993,7 +1993,7 @@ class ColorbarPlot(ElementPlot):
                                       "bokeh 2.2.3 or higher.")
                 colormapper = EqHistColorMapper
                 if bokeh_version >= LooseVersion('2.4.3'):
-                    opts['rescale_discrete_levels'] = True
+                    opts['rescale_discrete_levels'] = self.rescale_discrete_levels
             if isinstance(low, (bool, np.bool_)): low = int(low)
             if isinstance(high, (bool, np.bool_)): high = int(high)
             # Pad zero-range to avoid breaking colorbar (as of bokeh 1.0.4)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1992,7 +1992,7 @@ class ColorbarPlot(ElementPlot):
                                       "Note that the option cnorm='eq_hist' requires "
                                       "bokeh 2.2.3 or higher.")
                 colormapper = EqHistColorMapper
-                if bokeh_version >= LooseVersion('2.4.3'):
+                if bokeh_version > LooseVersion('2.4.2'):
                     opts['rescale_discrete_levels'] = self.rescale_discrete_levels
             if isinstance(low, (bool, np.bool_)): low = int(low)
             if isinstance(high, (bool, np.bool_)): high = int(high)


### PR DESCRIPTION
This colormap parameter has just been added to Bokeh (https://github.com/bokeh/bokeh/pull/12121) and will be released in part of Bokeh `2.4.3`.

@jbednar I've set it to `True` by default, can you confirm this is correct?