### PR TITLE
Use any as default aggregator for Curve

### DIFF
--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -516,7 +516,7 @@
    "source": [
     "dates = pd.date_range(start=\"2014-01-01\", end=\"2016-01-01\", freq='1D') # or '1min'\n",
     "curve = hv.Curve((dates, time_series(N=len(dates), sigma = 1)))\n",
-    "rasterize(curve, width=800, line_width=3, pixel_ratio=2).opts(width=800, cmap=['lightblue','blue'])"
+    "rasterize(curve, width=800, line_width=3, pixel_ratio=2).opts(width=800)"
    ]
   },
   {
@@ -538,8 +538,8 @@
     "smoothed = rolling(curve, rolling_window=50)\n",
     "outliers = rolling_outlier_std(curve, rolling_window=50, sigma=2)\n",
     "\n",
-    "ds_curve    = rasterize(curve, line_width=2.5, pixel_ratio=2).opts(cmap=[\"lightblue\",\"blue\"])\n",
-    "curvespread = rasterize(smoothed, line_width=6, pixel_ratio=2).opts(cmap=[\"pink\",\"red\"], width=800) \n",
+    "ds_curve    = rasterize(curve, line_width=2.5, pixel_ratio=2)\n",
+    "curvespread = rasterize(smoothed, line_width=6, pixel_ratio=2).opts(cmap=[\"red\"], width=800) \n",
     "\n",
     "(ds_curve * curvespread * outliers).opts(\n",
     "    opts.Scatter(line_color=\"black\", fill_color=\"red\", size=10, tools=['hover', 'box_select'], width=800))"

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -122,7 +122,7 @@ class ResamplingOperation(LinkableOperation):
     _transfer_options = []
 
     @bothmethod
-    def instance(self_or_cls,**params):
+    def instance(self_or_cls, **params):
         filtered = {k:v for k,v in params.items() if k in self_or_cls.param}
         inst = super(ResamplingOperation, self_or_cls).instance(**filtered)
         inst._precomputed = {}
@@ -257,6 +257,7 @@ class AggregationOperation(ResamplingOperation):
     }
 
     def _get_aggregator(self, element, add_field=True):
+        self._default_agg = self.p.aggregator is self.param.aggregator.default
         agg = self.p.aggregator
         if isinstance(agg, str):
             if agg not in self._agg_methods:
@@ -502,8 +503,13 @@ class aggregate(LineAggregationOperation):
         cvs = ds.Canvas(plot_width=width, plot_height=height,
                         x_range=x_range, y_range=y_range)
 
+        # If we are datashading a Curve and no explicit aggregator
+        # was set use any()
+        if isinstance(element, Curve) and self._default_agg:
+            agg_fn = rd.any()
+
         agg_kwargs = {}
-        if self.p.line_width and glyph == 'line' and ds_version >= LooseVersion('0.14.0'):
+        if self.p.line_width and glyph == 'line':
             agg_kwargs['line_width'] = self.p.line_width
 
         dfdata = PandasInterface.as_dframe(data)


### PR DESCRIPTION
Better behavior for simple time-series or other Curve plots where self-intersections are spurious and entirely dependent on zoom-level.

![bokeh_plot - 2022-05-20T174814 455](https://user-images.githubusercontent.com/1550771/169566786-be3a0670-d64c-4599-9ccb-01711e598bb5.png)
![bokeh_plot - 2022-05-20T174801 032](https://user-images.githubusercontent.com/1550771/169566790-d2177503-05aa-460f-ac8e-fc66a14cc8cf.png)

