### PR TITLE
Avoid tornado import

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -14,7 +14,6 @@ from bokeh.models import (
 )
 from panel.io.state import state
 from panel.io.model import hold
-from tornado import gen
 
 from ...core import OrderedDict
 from ...core.options import CallbackError
@@ -340,8 +339,7 @@ class Callback(object):
         self._last_event = time.time()
         return False
 
-    @gen.coroutine
-    def process_on_event_coroutine(self):
+    async def process_on_event_coroutine(self):
         self.process_on_event()
 
     def process_on_event(self):
@@ -378,8 +376,7 @@ class Callback(object):
         else:
             self._active = False
 
-    @gen.coroutine
-    def process_on_change_coroutine(self):
+    async def process_on_change_coroutine(self):
         self.process_on_change()
 
     def process_on_change(self):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
+import asyncio
 import time
 
 from collections import defaultdict
@@ -89,11 +90,6 @@ class Callback(object):
       received within the `throttle_timeout` duration.
     """
 
-    # Throttling configuration
-    adaptive_window = 3
-    throttle_timeout = 100
-    throttling_scheme = 'adaptive'
-
     # Attributes to sync
     attributes = {}
 
@@ -123,7 +119,7 @@ class Callback(object):
         self._active = False
         self._prev_msg = None
         self._last_event = time.time()
-        self._history = []
+        self._tasks = []
 
     def _transform(self, msg):
         for transform in self._transforms:
@@ -277,22 +273,7 @@ class Callback(object):
         with edit_readonly(state):
             state.busy = busy
 
-    def _schedule_callback(self, cb, timeout=None, offset=True):
-        if timeout is None:
-            if self._history and self.throttling_scheme == 'adaptive':
-                timeout = int(np.array(self._history).mean()*1000)
-            else:
-                timeout = self.throttle_timeout
-            if self.throttling_scheme != 'debounce' and offset:
-                # Subtract the time taken since event started
-                diff = time.time()-self._last_event
-                timeout = max(timeout-(diff*1000), 50)
-        if not pn.state.curdoc:
-            cb()
-        else:
-            pn.state.curdoc.add_timeout_callback(cb, int(timeout))
-
-    def on_change(self, attr, old, new):
+    async def on_change(self, attr, old, new):
         """
         Process change events adding timeout to process multiple concerted
         value change at once rather than firing off multiple plot updates.
@@ -301,13 +282,9 @@ class Callback(object):
         if not self._active and self.plot.document:
             self._active = True
             self._set_busy(True)
-            if self.plot.renderer.mode == 'server':
-                self._schedule_callback(self.process_on_change, offset=False)
-            else:
-                with hold(self.plot.document):
-                    self.process_on_change()
+            asyncio.create_task(self.process_on_change())
 
-    def on_event(self, event):
+    async def on_event(self, event):
         """
         Process bokeh UIEvents adding timeout to process multiple concerted
         value change at once rather than firing off multiple plot updates.
@@ -316,44 +293,19 @@ class Callback(object):
         if not self._active and self.plot.document:
             self._active = True
             self._set_busy(True)
-            if self.plot.renderer.mode == 'server':
-                self._schedule_callback(self.process_on_event, offset=False)
-            else:
-                with hold(self.plot.document):
-                    self.process_on_event()
+            asyncio.create_task(self.process_on_event())
 
-    def throttled(self):
-        now = time.time()
-        timeout = self.throttle_timeout/1000.
-        if self.throttling_scheme in ('throttle', 'adaptive'):
-            diff = (now-self._last_event)
-            if self._history and self.throttling_scheme == 'adaptive':
-                timeout = np.array(self._history).mean()
-            if diff < timeout:
-                return int((timeout-diff)*1000)
-        else:
-            prev_event = self._queue[-1][-1]
-            diff = (now-prev_event)
-            if diff < timeout:
-                return self.throttle_timeout
-        self._last_event = time.time()
-        return False
-
-    async def process_on_event_coroutine(self):
-        self.process_on_event()
-
-    def process_on_event(self):
+    async def process_on_event(self, timeout=None):
         """
         Trigger callback change event and triggering corresponding streams.
         """
+        await asyncio.gather(*self._tasks)
+        self._tasks = []
         if not self._queue:
             self._active = False
             self._set_busy(False)
             return
-        throttled = self.throttled()
-        if throttled and pn.state.curdoc:
-            self._schedule_callback(self.process_on_event, throttled)
-            return
+
         # Get unique event types in the queue
         events = list(OrderedDict([(event.event_name, event)
                                    for event, dt in self._queue]).values())
@@ -368,25 +320,15 @@ class Callback(object):
                 model_obj = self.plot_handles.get(self.models[0])
                 msg[attr] = self.resolve_attr_spec(path, event, model_obj)
             self.on_msg(msg)
-        w = self.adaptive_window-1
-        diff = time.time()-self._last_event
-        self._history = self._history[-w:] + [diff]
-        if self.plot.renderer.mode == 'server':
-            self._schedule_callback(self.process_on_event)
-        else:
-            self._active = False
+        asyncio.create_task(self.process_on_event())
 
-    async def process_on_change_coroutine(self):
-        self.process_on_change()
-
-    def process_on_change(self):
+    async def process_on_change(self):
+        # Give on_change time to process new events
+        await asyncio.gather(*self._tasks)
+        self._tasks = []
         if not self._queue:
             self._active = False
             self._set_busy(False)
-            return
-        throttled = self.throttled()
-        if throttled and pn.state.curdoc:
-            self._schedule_callback(self.process_on_change, throttled)
             return
         self._queue = []
 
@@ -411,29 +353,28 @@ class Callback(object):
 
         if not equal or any(s.transient for s in self.streams):
             self.on_msg(msg)
-            w = self.adaptive_window-1
-            diff = time.time()-self._last_event
-            self._history = self._history[-w:] + [diff]
             self._prev_msg = msg
-
-        if self.plot.renderer.mode == 'server':
-            self._schedule_callback(self.process_on_change)
-        else:
-            self._active = False
+        asyncio.create_task(self.process_on_change())
 
     def set_callback(self, handle):
         """
         Set up on_change events for bokeh server interactions.
         """
         if self.on_events:
+            event_handler = lambda event: (
+                self._tasks.append(asyncio.create_task(self.on_event(event)))
+            )
             for event in self.on_events:
-                handle.on_event(event, self.on_event)
+                handle.on_event(event, event_handler)
         if self.on_changes:
+            change_handler = lambda attr, old, new: (
+                self._tasks.append(asyncio.create_task(self.on_change(attr, old, new)))
+            )
             for change in self.on_changes:
                 if change in ['patching', 'streaming']:
                     # Patch and stream events do not need handling on server
                     continue
-                handle.on_change(change, self.on_change)
+                handle.on_change(change, change_handler)
 
     def initialize(self, plot_id=None):
         handles = self._init_plot_handles()
@@ -463,7 +404,6 @@ class Callback(object):
         for handle in cb_handles:
             self.set_callback(handle)
         self._callbacks[cb_hash] = self
-
 
 
 class PointerXYCallback(Callback):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -27,9 +27,7 @@ from ...streams import (
     BoxEdit, PointDraw, PolyDraw, PolyEdit, CDSStream, FreehandDraw,
     CurveEdit, SelectionXY, Lasso, SelectMode
 )
-from .util import LooseVersion, bokeh_version, convert_timestamp
-
-CUSTOM_TOOLTIP = 'description'
+from .util import convert_timestamp
 
 
 class Callback(object):
@@ -979,7 +977,7 @@ class PointDrawCallback(GlyphDrawCallback):
         if stream.num_objects:
             kwargs['num_objects'] = stream.num_objects
         if stream.tooltip:
-            kwargs[CUSTOM_TOOLTIP] = stream.tooltip
+            kwargs['description'] = stream.tooltip
         if stream.styles:
             self._create_style_callback(cds, glyph)
         if stream.empty_value is not None:
@@ -1011,7 +1009,7 @@ class CurveEditCallback(GlyphDrawCallback):
         renderers = [renderer]
         kwargs = {}
         if stream.tooltip:
-            kwargs[CUSTOM_TOOLTIP] = stream.tooltip
+            kwargs['description'] = stream.tooltip
         point_tool = PointDrawTool(
             add=False, drag=True, renderers=renderers, **kwargs
         )
@@ -1058,7 +1056,7 @@ class PolyDrawCallback(GlyphDrawCallback):
         if stream.styles:
             self._create_style_callback(cds, glyph)
         if stream.tooltip:
-            kwargs[CUSTOM_TOOLTIP] = stream.tooltip
+            kwargs['description'] = stream.tooltip
         if stream.empty_value is not None:
             kwargs['empty_value'] = stream.empty_value
         poly_tool = PolyDrawTool(
@@ -1106,7 +1104,7 @@ class FreehandDrawCallback(PolyDrawCallback):
             self._create_style_callback(cds, glyph)
         kwargs = {}
         if stream.tooltip:
-            kwargs[CUSTOM_TOOLTIP] = stream.tooltip
+            kwargs['description'] = stream.tooltip
         if stream.empty_value is not None:
             kwargs['empty_value'] = stream.empty_value
         poly_tool = FreehandDrawTool(
@@ -1161,7 +1159,7 @@ class BoxEditCallback(GlyphDrawCallback):
         if stream.num_objects:
             kwargs['num_objects'] = stream.num_objects
         if stream.tooltip:
-            kwargs[CUSTOM_TOOLTIP] = stream.tooltip
+            kwargs['description'] = stream.tooltip
 
         renderer = self.plot.handles['glyph_renderer']
         if isinstance(self.plot, PathPlot):
@@ -1207,7 +1205,7 @@ class PolyEditCallback(PolyDrawCallback):
         stream = self.streams[0]
         kwargs = {}
         if stream.tooltip:
-            kwargs[CUSTOM_TOOLTIP] = stream.tooltip
+            kwargs['description'] = stream.tooltip
         if vertex_tool is None:
             vertex_style = dict({'size': 10}, **stream.vertex_style)
             r1 = plot.state.scatter([], [], **vertex_style)

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -6,7 +6,6 @@ import time
 from collections import defaultdict
 
 import numpy as np
-import panel as pn
 
 from bokeh.models import (
     CustomJS, FactorRange, DatetimeAxis, Range1d, DataRange1d,
@@ -14,8 +13,6 @@ from bokeh.models import (
     PointDrawTool
 )
 from panel.io.state import state
-from panel.io.model import hold
-
 from ...core import OrderedDict
 from ...core.options import CallbackError
 from ...core.util import (

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -192,8 +192,7 @@ class TestEditToolCallbacks(CallbackTestCase):
         points = Points([(0, 1)])
         PointDraw(source=points)
         plot = bokeh_server_renderer.get_plot(points)
-        self.assertEqual(plot.handles['source']._callbacks,
-                         {'data': [plot.callbacks[0].on_change]})
+        assert 'data' in plot.handles['source']._callbacks
 
     def test_point_draw_callback_with_vdims_initialization(self):
         points = Points([(0, 1, 'A')], vdims=['A'])
@@ -227,8 +226,7 @@ class TestEditToolCallbacks(CallbackTestCase):
         polys = Polygons([[(0, 0), (2, 2), (4, 0)]])
         PolyDraw(source=polys)
         plot = bokeh_server_renderer.get_plot(polys)
-        self.assertEqual(plot.handles['source']._callbacks,
-                         {'data': [plot.callbacks[0].on_change]})
+        assert 'data' in plot.handles['source']._callbacks
 
     def test_poly_draw_callback_with_vdims(self):
         polys = Polygons([{'x': [0, 2, 4], 'y': [0, 2, 0], 'A': 1}], vdims=['A'])
@@ -290,8 +288,7 @@ class TestEditToolCallbacks(CallbackTestCase):
         boxes = Polygons([Box(0, 0, 1)])
         BoxEdit(source=boxes)
         plot = bokeh_server_renderer.get_plot(boxes)
-        self.assertEqual(plot.handles['cds']._callbacks,
-                         {'data': [plot.callbacks[0].on_change]})
+        assert 'data' in plot.handles['cds']._callbacks
 
     def test_poly_edit_callback(self):
         polys = Polygons([[(0, 0), (2, 2), (4, 0)]])
@@ -308,8 +305,7 @@ class TestEditToolCallbacks(CallbackTestCase):
         polys = Polygons([[(0, 0), (2, 2), (4, 0)]])
         PolyEdit(source=polys)
         plot = bokeh_server_renderer.get_plot(polys)
-        self.assertEqual(plot.handles['source']._callbacks,
-                         {'data': [plot.callbacks[0].on_change]})
+        assert 'data' in plot.handles['source']._callbacks
 
     def test_poly_edit_shared_callback(self):
         polys = Polygons([[(0, 0), (2, 2), (4, 0)]])


### PR DESCRIPTION
Replaces `tornado.gen` decorator with `async` method.