### PR TITLE
Adding geodataframe to DataConversion

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -129,7 +129,8 @@ class DataConversion(object):
             else:
                 selected = self._element
         else:
-            if pd and issubclass(self._element.interface, PandasInterface):
+            df_interfaces = tuple(v for k, v in Interface.interfaces.items() if "dataframe" in k.lower())
+            if issubclass(self._element.interface, df_interfaces):
                 ds_dims = self._element.dimensions()
                 ds_kdims = [self._element.get_dimension(d) if d in ds_dims else d
                             for d in groupby+kdims]


### PR DESCRIPTION
First part (1/2) of fix for https://discourse.holoviz.org/t/small-multiples-aka-facetted-plots/3760/2

This will make it possible to run:
``` python
import geopandas as gpd
import hvplot.pandas

countries = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
countries.hvplot(geo=True, by="continent")
```

I'm actually not sure if `cuDF` should be added to `df_interfaces`

Before fix:
![image](https://user-images.githubusercontent.com/19758978/171051063-33a3adef-3543-4b29-b47e-a151d8c35d5d.png)


After fix:
![image](https://user-images.githubusercontent.com/19758978/171050986-eba04026-eed8-41d4-b5fc-fbc2ab908b7c.png)
