### PR TITLE
Test suite clean up and fix for the pip build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,9 +29,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "100"
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
@@ -43,7 +40,6 @@ jobs:
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
       - name: conda setup
         run: |
-          conda config --set always_yes True
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
       - name: conda build
@@ -73,9 +69,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "100"
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
@@ -84,7 +77,6 @@ jobs:
         run: git fetch --prune --tags --unshallow -f
       - name: conda setup
         run: |
-          conda config --set always_yes True
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
           doit env_create $CHANS_DEV --python=$PYTHON_VERSION
@@ -92,9 +84,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          doit develop_install $CHANS_DEV -o unit_tests
-          # See https://github.com/holoviz/holoviews/issues/5167
-          conda install $CHANS_DEV "nbconvert<6"
+          doit develop_install $CHANS_DEV
           pip uninstall -y holoviews
           doit pip_on_conda
       - name: doit env_capture

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          doit develop_install $CHANS_DEV
+          doit develop_install $CHANS_DEV -o flakes
           pip uninstall -y holoviews
           doit pip_on_conda
       - name: doit env_capture

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      HV_REQUIREMENTS: "-o flakes -o tests -o examples"
+      HV_REQUIREMENTS: "-o flakes -o tests -o examples_tests"
       MPLBACKEND: "Agg"
       CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge -c nodefaults"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      HV_REQUIREMENTS: "-o unit_tests"
+      HV_REQUIREMENTS: "-o flakes -o tests -o examples"
       MPLBACKEND: "Agg"
       CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge -c nodefaults"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -19,6 +19,7 @@ from threading import Thread, Event
 from types import FunctionType
 
 import numpy as np
+import pandas as pd
 import param
 
 # Python 2 builtins
@@ -39,40 +40,34 @@ masked_types = ()
 
 anonymous_dimension_label = '_'
 
+pandas_version = LooseVersion(pd.__version__)
 try:
-    import pandas as pd
-except ImportError:
-    pd = None
-
-if pd:
-    pandas_version = LooseVersion(pd.__version__)
-    try:
-        if pandas_version >= LooseVersion('1.3.0'):
-            from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtypeType
-            from pandas.core.dtypes.generic import ABCSeries, ABCIndex as ABCIndexClass
-        elif pandas_version >= LooseVersion('0.24.0'):
-            from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtypeType
-            from pandas.core.dtypes.generic import ABCSeries, ABCIndexClass
-        elif pandas_version > LooseVersion('0.20.0'):
-            from pandas.core.dtypes.dtypes import DatetimeTZDtypeType
-            from pandas.core.dtypes.generic import ABCSeries, ABCIndexClass
-        else:
-            from pandas.types.dtypes import DatetimeTZDtypeType
-            from pandas.types.dtypes.generic import ABCSeries, ABCIndexClass
-        pandas_datetime_types = (pd.Timestamp, DatetimeTZDtypeType, pd.Period)
-        pandas_timedelta_types = (pd.Timedelta,)
-        datetime_types = datetime_types + pandas_datetime_types
-        timedelta_types = timedelta_types + pandas_timedelta_types
-        arraylike_types = arraylike_types + (ABCSeries, ABCIndexClass)
-        if pandas_version > LooseVersion('0.23.0'):
-            from pandas.core.dtypes.generic import ABCExtensionArray
-            arraylike_types = arraylike_types + (ABCExtensionArray,)
-        if pandas_version > LooseVersion('1.0'):
-            from pandas.core.arrays.masked import BaseMaskedArray
-            masked_types = (BaseMaskedArray,)
-    except Exception as e:
-        param.main.param.warning('pandas could not register all extension types '
-                                 'imports failed with the following error: %s' % e)
+    if pandas_version >= LooseVersion('1.3.0'):
+        from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtypeType
+        from pandas.core.dtypes.generic import ABCSeries, ABCIndex as ABCIndexClass
+    elif pandas_version >= LooseVersion('0.24.0'):
+        from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtypeType
+        from pandas.core.dtypes.generic import ABCSeries, ABCIndexClass
+    elif pandas_version > LooseVersion('0.20.0'):
+        from pandas.core.dtypes.dtypes import DatetimeTZDtypeType
+        from pandas.core.dtypes.generic import ABCSeries, ABCIndexClass
+    else:
+        from pandas.types.dtypes import DatetimeTZDtypeType
+        from pandas.types.dtypes.generic import ABCSeries, ABCIndexClass
+    pandas_datetime_types = (pd.Timestamp, DatetimeTZDtypeType, pd.Period)
+    pandas_timedelta_types = (pd.Timedelta,)
+    datetime_types = datetime_types + pandas_datetime_types
+    timedelta_types = timedelta_types + pandas_timedelta_types
+    arraylike_types = arraylike_types + (ABCSeries, ABCIndexClass)
+    if pandas_version > LooseVersion('0.23.0'):
+        from pandas.core.dtypes.generic import ABCExtensionArray
+        arraylike_types = arraylike_types + (ABCExtensionArray,)
+    if pandas_version > LooseVersion('1.0'):
+        from pandas.core.arrays.masked import BaseMaskedArray
+        masked_types = (BaseMaskedArray,)
+except Exception as e:
+    param.main.param.warning('pandas could not register all extension types '
+                                'imports failed with the following error: %s' % e)
 
 try:
     import cftime

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -3,7 +3,6 @@ Tests for the Dataset Element types.
 """
 
 import datetime
-from unittest import SkipTest, skipIf
 
 import numpy as np
 
@@ -16,13 +15,7 @@ from holoviews.util.transform import dim
 
 from collections import OrderedDict
 
-try:
-    import pandas as pd
-except:
-    pd = None
-
-pd_skip = skipIf(pd is None, "pandas is not available")
-
+import pandas as pd
 
 
 class DatatypeContext(object):
@@ -117,16 +110,12 @@ class HomogeneousColumnTests(object):
 
     def test_dataset_dataframe_init_hm(self):
         "Tests support for homogeneous DataFrames"
-        if pd is None:
-            raise SkipTest("Pandas not available")
         dataset = Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
                           kdims=['x'], vdims=['x2'])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_dataframe_init_hm_alias(self):
         "Tests support for homogeneous DataFrames"
-        if pd is None:
-            raise SkipTest("Pandas not available")
         dataset = Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
                           kdims=[('x', 'X-label')], vdims=[('x2', 'X2-label')])
         self.assertTrue(isinstance(dataset.data, self.data_type))
@@ -384,13 +373,11 @@ class HomogeneousColumnTests(object):
         arr = self.dataset_hm.array(['x'])
         self.assertEqual(arr, self.xs[:, np.newaxis])
 
-    @pd_skip
     def test_dataset_get_dframe(self):
         df = self.dataset_hm.dframe()
         self.assertEqual(df.x.values, self.xs)
         self.assertEqual(df.y.values, self.y_ints)
 
-    @pd_skip
     def test_dataset_get_dframe_by_dimension(self):
         df = self.dataset_hm.dframe(['x'])
         self.assertEqual(df, pd.DataFrame({'x': self.xs}, dtype=df.dtypes[0]))
@@ -438,13 +425,11 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
     # Test the constructor to be supported by all interfaces supporting
     # heterogeneous column types.
 
-    @pd_skip
     def test_dataset_dataframe_init_ht(self):
         "Tests support for heterogeneous DataFrames"
         dataset = Dataset(pd.DataFrame({'x':self.xs, 'y':self.ys}), kdims=['x'], vdims=['y'])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
-    @pd_skip
     def test_dataset_dataframe_init_ht_alias(self):
         "Tests support for heterogeneous DataFrames"
         dataset = Dataset(pd.DataFrame({'x':self.xs, 'y':self.ys}),
@@ -522,7 +507,6 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
 
     # Operations
 
-    @pd_skip
     def test_dataset_redim_with_alias_dframe(self):
         test_df = pd.DataFrame({'x': range(10), 'y': range(0,20,2)})
         dataset = Dataset(test_df, kdims=[('x', 'X-label')], vdims=['y'])

--- a/holoviews/tests/core/data/test_daskinterface.py
+++ b/holoviews/tests/core/data/test_daskinterface.py
@@ -1,9 +1,9 @@
 from unittest import SkipTest
 
 import numpy as np
+import pandas as pd
 
 try:
-    import pandas as pd
     import dask.dataframe as dd
 except:
     raise SkipTest("Could not import dask, skipping DaskInterface tests.")

--- a/holoviews/tests/core/data/test_gridinterface.py
+++ b/holoviews/tests/core/data/test_gridinterface.py
@@ -2,11 +2,12 @@ import datetime as dt
 
 from collections import OrderedDict
 from itertools import product
-from unittest import SkipTest, skipIf
+from unittest import SkipTest
 
 import numpy as np
+import pandas as pd
 from holoviews.core.data import Dataset
-from holoviews.core.util import pd, date_range
+from holoviews.core.util import date_range
 from holoviews.element import Image, Curve, RGB, HSV
 from holoviews.util.transform import dim
 
@@ -14,8 +15,6 @@ try:
     import dask.array as da
 except ImportError:
     da = None
-
-pd_skip = skipIf(pd is None, "pandas is not available")
 
 
 from .base import (
@@ -31,13 +30,11 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 
     __test__ = False
 
-    @pd_skip
     def test_dataset_dataframe_init_hm(self):
         with self.assertRaises(Exception):
             Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
                     kdims=['x'], vdims=['x2'])
 
-    @pd_skip
     def test_dataset_dataframe_init_hm_alias(self):
         with self.assertRaises(Exception):
             Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
@@ -519,7 +516,6 @@ class DaskGridInterfaceTests(GridInterfaceTests):
             partial = ds.to(Dataset, kdims=['Val'], vdims=['Val2'], groupby='y', dynamic=True)
             self.assertEqual(partial[19]['Val'], array[:, -1, :].T.flatten().compute())
 
-    @pd_skip
     def test_dataset_get_dframe(self):
         df = self.dataset_hm.dframe()
         self.assertEqual(df.x.values, self.xs)

--- a/holoviews/tests/core/data/test_multiinterface.py
+++ b/holoviews/tests/core/data/test_multiinterface.py
@@ -2,21 +2,15 @@
 Tests for the Dataset Element types.
 """
 
-from unittest import SkipTest
-
 import logging
 
 import numpy as np
+import pandas as pd
 
 from holoviews.core.data import Dataset, MultiInterface
 from holoviews.element import Path, Points, Polygons
 from holoviews.element.comparison import ComparisonTestCase
 from param import get_logger
-
-try:
-    import pandas as pd
-except:
-    pd = None
 
 try:
     import dask.dataframe as dd
@@ -50,8 +44,6 @@ class GeomTests(ComparisonTestCase):
             self.assertEqual(dict(cols), dict(dicts[i], geom_type='Line'))
 
     def test_df_dataset(self):
-        if not pd:
-            raise SkipTest('Pandas not available')
         dfs = [pd.DataFrame(np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]), columns=['x', 'y'])
                   for i in range(2)]
         mds = Path(dfs, kdims=['x', 'y'], datatype=[self.datatype])

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -1,11 +1,5 @@
-from unittest import SkipTest
-
 import numpy as np
-
-try:
-    import pandas as pd
-except:
-    raise SkipTest("Could not import pandas, skipping PandasInterface tests.")
+import pandas as pd
 
 from holoviews.core.dimension import Dimension
 from holoviews.core.data import Dataset

--- a/holoviews/tests/core/data/test_xarrayinterface.py
+++ b/holoviews/tests/core/data/test_xarrayinterface.py
@@ -4,9 +4,9 @@ from collections import OrderedDict
 from unittest import SkipTest
 
 import numpy as np
+import pandas as pd
 
 try:
-    import pandas as pd
     import xarray as xr
 except:
     raise SkipTest("Could not import xarray, skipping XArrayInterface tests.")

--- a/holoviews/tests/core/test_dimensions.py
+++ b/holoviews/tests/core/test_dimensions.py
@@ -1,16 +1,12 @@
 """
 Test cases for Dimension and Dimensioned object behaviour.
 """
-from unittest import SkipTest
 from holoviews.core import Dimensioned, Dimension
 from holoviews.element.comparison import ComparisonTestCase
 from ..utils import LoggingComparisonTestCase
 
 import numpy as np
-try:
-    import pandas as pd
-except:
-    pd = None
+import pandas as pd
 
 class DimensionNameLabelTest(LoggingComparisonTestCase):
 
@@ -167,31 +163,23 @@ class DimensionValuesTest(ComparisonTestCase):
         self.assertEqual(dim.values, self.values2)
 
     def test_dimension_values_series1(self):
-        if pd is None:
-            raise SkipTest("Pandas not available")
         df = pd.DataFrame({'col':self.values1})
         dim = Dimension('test', values=df['col'])
         self.assertEqual(dim.values, self.values1)
 
     def test_dimension_values_series2(self):
-        if pd is None:
-            raise SkipTest("Pandas not available")
         df = pd.DataFrame({'col':self.values2})
         dim = Dimension('test', values=df['col'])
         self.assertEqual(dim.values, self.values2)
 
 
     def test_dimension_values_series_duplicates1(self):
-        if pd is None:
-            raise SkipTest("Pandas not available")
         df = pd.DataFrame({'col':self.duplicates1})
         dim = Dimension('test', values=df['col'])
         self.assertEqual(dim.values, self.values1)
 
 
     def test_dimension_values_series_duplicates2(self):
-        if pd is None:
-            raise SkipTest("Pandas not available")
         df = pd.DataFrame({'col':self.duplicates2})
         dim = Dimension('test', values=df['col'])
         self.assertEqual(dim.values, self.values2)

--- a/holoviews/tests/core/test_dynamic.py
+++ b/holoviews/tests/core/test_dynamic.py
@@ -1,8 +1,6 @@
 import uuid
 import time
-import sys
 from collections import deque
-from unittest import SkipTest
 
 import param
 import numpy as np
@@ -58,8 +56,6 @@ class DynamicMapConstructor(ComparisonTestCase):
         DynamicMap(lambda x: x, streams=dict(x=pointerx.param.x))
 
     def test_simple_constructor_streams_dict_panel_widget(self):
-        if 'panel' not in sys.modules:
-            raise SkipTest('Panel not available')
         import panel
         DynamicMap(lambda x: x, streams=dict(x=panel.widgets.FloatSlider()))
 

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -1,8 +1,6 @@
 import os
 import pickle
 
-from unittest import SkipTest
-
 import numpy as np
 import pytest
 
@@ -16,23 +14,11 @@ from holoviews import plotting              # noqa Register backends
 
 Options.skip_invalid = False
 
-try:
-    # Needed a backend to register backend and options
-    from holoviews.plotting import mpl # noqa
-except:
-    pass
+# Needed a backend to register backend and options
+from holoviews.plotting import mpl # noqa
+from holoviews.plotting import bokeh # noqa
+from holoviews.plotting import plotly # noqa
 
-try:
-    # Needed to register backend  and options
-    from holoviews.plotting import bokeh # noqa
-except:
-    pass
-
-try:
-    # Needed to register backend  and options
-    from holoviews.plotting import plotly # noqa
-except:
-    pass
 
 class TestOptions(ComparisonTestCase):
 
@@ -207,8 +193,6 @@ class TestCycle(ComparisonTestCase):
 class TestOptionTree(ComparisonTestCase):
 
     def setUp(self):
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest('Matplotlib backend not available.')
         super().setUp()
         self.original_option_groups = Options._option_groups[:]
         Options._option_groups = ['group1', 'group2']
@@ -244,9 +228,6 @@ class TestOptionTree(ComparisonTestCase):
         self.assertEqual(options.MyType['group2'].options, {'kw2':'value2'})
 
     def test_optiontree_inheritance(self):
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest("General to specific option test requires matplotlib")
-
         options = OptionTree(groups=['group1', 'group2'])
 
         opts1 = Options(kw1='value1')
@@ -267,9 +248,6 @@ class TestOptionTree(ComparisonTestCase):
         """
         Tests for ordering problems manifested in issue #93
         """
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest("General to specific option test requires matplotlib")
-
         options = OptionTree(groups=['group1', 'group2'])
 
         opts3 = Options(kw3='value3')
@@ -293,8 +271,6 @@ class TestStoreInheritanceDynamic(ComparisonTestCase):
     """
 
     def setUp(self):
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest('Matplotlib backend not available.')
         self.backend = 'matplotlib'
         Store.set_current_backend(self.backend)
         options = Store.options()
@@ -345,9 +321,6 @@ class TestStoreInheritanceDynamic(ComparisonTestCase):
         Test order of specification starting with general and moving
         to specific
         """
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest("General to specific option test requires matplotlib")
-
         options = self.initialize_option_tree()
 
         obj = Image(np.random.rand(10,10), group='SomeGroup')
@@ -372,9 +345,6 @@ class TestStoreInheritanceDynamic(ComparisonTestCase):
         Test order of specification starting with general and moving
         to specific
         """
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest("General to specific option test requires matplotlib")
-
         options = self.initialize_option_tree()
 
         obj = Image(np.random.rand(10,10), group='SomeGroup', label='SomeLabel')
@@ -398,9 +368,6 @@ class TestStoreInheritanceDynamic(ComparisonTestCase):
         Test order of specification starting with a specific option and
         then specifying a general one
         """
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest("General to specific option test requires matplotlib")
-
         options = self.initialize_option_tree()
         options.Image.SomeGroup = Options('style', alpha=0.2)
 
@@ -424,9 +391,6 @@ class TestStoreInheritanceDynamic(ComparisonTestCase):
         Test order of specification starting with general and moving
         to specific
         """
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest("General to specific option test requires matplotlib")
-
         options = self.initialize_option_tree()
         options.Image.SomeGroup.SomeLabel = Options('style', alpha=0.2)
         obj = Image(np.random.rand(10,10), group='SomeGroup', label='SomeLabel')
@@ -467,8 +431,6 @@ class TestStoreInheritanceDynamic(ComparisonTestCase):
         Checks customs inheritance backs off to default tree correctly
         simulating the %%opts cell magic.
         """
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest("Custom magic inheritance test requires matplotlib")
         options = self.initialize_option_tree()
         options.Image.A.B = Options('style', alpha=0.2)
 
@@ -497,8 +459,6 @@ class TestStoreInheritance(ComparisonTestCase):
     """
 
     def setUp(self):
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest('Matplotlib backend not available.')
         self.backend = 'matplotlib'
         Store.set_current_backend(self.backend)
         self.store_copy = OptionTree(sorted(Store.options().items()),
@@ -569,9 +529,6 @@ class TestStoreInheritance(ComparisonTestCase):
         self.assertEqual(self.lookup_options(hist2, 'plot').options, self.default_plot)
 
     def test_style_transfer(self):
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest("test_style_transfer requires matplotlib")
-
         hist = self.hist.opts(style={'style1':'style_child'})
         hist2 = self.hist.opts()
         opts = Store.lookup_options('matplotlib', hist2, 'style').kwargs
@@ -585,8 +542,6 @@ class TestStoreInheritance(ComparisonTestCase):
 class TestOptionsMethod(ComparisonTestCase):
 
     def setUp(self):
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest('Matplotlib backend not available.')
         self.backend = 'matplotlib'
         Store.set_current_backend(self.backend)
         self.store_copy = OptionTree(sorted(Store.options().items()),
@@ -638,8 +593,6 @@ class TestOptionsMethod(ComparisonTestCase):
 class TestOptsMethod(ComparisonTestCase):
 
     def setUp(self):
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest('Matplotlib backend not available.')
         self.backend = 'matplotlib'
         Store.set_current_backend(self.backend)
         self.store_copy = OptionTree(sorted(Store.options().items()),
@@ -826,11 +779,6 @@ class TestCrossBackendOptions(ComparisonTestCase):
     """
 
     def setUp(self):
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest("Cross background tests assumes matplotlib is available")
-        if 'bokeh' not in Store.renderers:
-            raise SkipTest("Cross background tests assumes bokeh is available.")
-
         # Some tests require that plotly isn't loaded
         self.plotly_options = Store._options.pop('plotly', None)
         self.store_mpl = OptionTree(
@@ -973,20 +921,9 @@ class TestLookupOptions(ComparisonTestCase):
     def test_lookup_options_honors_backend(self):
         points = Points([[1, 2], [3, 4]])
 
-        try:
-            import holoviews.plotting.matplotlib # noqa
-        except:
-            pass
-
-        try:
-            import holoviews.plotting.bokeh # noqa
-        except:
-            pass
-
-        try:
-            import holoviews.plotting.plotly # noqa
-        except:
-            pass
+        import holoviews.plotting.matplotlib # noqa
+        import holoviews.plotting.bokeh # noqa
+        import holoviews.plotting.plotly # noqa
 
         backends = Store.loaded_backends()
 
@@ -1030,11 +967,6 @@ class TestCrossBackendOptionSpecification(ComparisonTestCase):
     """
 
     def setUp(self):
-        if 'matplotlib' not in Store.renderers:
-            raise SkipTest("Cross background tests assumes matplotlib is available")
-        if 'bokeh' not in Store.renderers:
-            raise SkipTest("Cross background tests assumes bokeh is available.")
-
         # Some tests require that plotly isn't loaded
         self.plotly_options = Store._options.pop('plotly', None)
         self.store_mpl = OptionTree(

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -921,7 +921,7 @@ class TestLookupOptions(ComparisonTestCase):
     def test_lookup_options_honors_backend(self):
         points = Points([[1, 2], [3, 4]])
 
-        import holoviews.plotting.matplotlib # noqa
+        import holoviews.plotting.mpl # noqa
         import holoviews.plotting.bokeh # noqa
         import holoviews.plotting.plotly # noqa
 

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -2,15 +2,9 @@
 Unit tests of the StoreOptions class used to control custom options on
 Store as used by the %opts magic.
 """
-
-from unittest import SkipTest
-
 import numpy as np
 
-try:
-    from holoviews.plotting import mpl # noqa Register backend
-except:
-    raise SkipTest('Matplotlib backend not available.')
+from holoviews.plotting import mpl # noqa Register backend
 
 from holoviews import Overlay, Curve, Image, HoloMap
 from holoviews.core.options import Store, StoreOptions

--- a/holoviews/tests/core/test_utils.py
+++ b/holoviews/tests/core/test_utils.py
@@ -6,15 +6,11 @@ import datetime
 import math
 import unittest
 
-from unittest import skipIf
 from itertools import product
 from collections import OrderedDict
 
 import numpy as np
-try:
-    import pandas as pd
-except:
-    pd = None
+import pandas as pd
 
 from holoviews.core.util import (
     sanitize_identifier_fn, find_range, max_range, wrap_tuple_streams,
@@ -27,8 +23,6 @@ from holoviews.streams import PointerXY
 from holoviews.element.comparison import ComparisonTestCase
 
 sanitize_identifier = sanitize_identifier_fn.instance()
-
-pd_skip = skipIf(pd is None, "pandas is not available")
 
 
 class TestDeepHash(ComparisonTestCase):
@@ -75,22 +69,18 @@ class TestDeepHash(ComparisonTestCase):
         arr2 = np.array([1,2,4])
         self.assertNotEqual(deephash(arr1), deephash(arr2))
 
-    @pd_skip
     def test_deephash_dataframe_equality(self):
         self.assertEqual(deephash(pd.DataFrame({'a':[1,2,3],'b':[4,5,6]})),
                          deephash(pd.DataFrame({'a':[1,2,3],'b':[4,5,6]})))
 
-    @pd_skip
     def test_deephash_dataframe_inequality(self):
         self.assertNotEqual(deephash(pd.DataFrame({'a':[1,2,3],'b':[4,5,6]})),
                             deephash(pd.DataFrame({'a':[1,2,3],'b':[4,5,8]})))
 
-    @pd_skip
     def test_deephash_series_equality(self):
         self.assertEqual(deephash(pd.Series([1,2,3])),
                          deephash(pd.Series([1,2,3])))
 
-    @pd_skip
     def test_deephash_series_inequality(self):
         self.assertNotEqual(deephash(pd.Series([1,2,3])),
                             deephash(pd.Series([1,2,7])))
@@ -115,7 +105,6 @@ class TestDeepHash(ComparisonTestCase):
         obj2 = [[1,2], (3,6,7, [True]), 'a', 9.2, 42, {1:3,2:'c'}]
         self.assertNotEqual(deephash(obj1), deephash(obj2))
 
-    @pd_skip
     def test_deephash_nested_mixed_equality(self):
         obj1 = [datetime.datetime(1,2,3), set([1,2,3]),
                 pd.DataFrame({'a':[1,2],'b':[3,4]}),
@@ -127,7 +116,6 @@ class TestDeepHash(ComparisonTestCase):
                 OrderedDict([(1,'a'),(2,'b')]), np.int64(34)]
         self.assertEqual(deephash(obj1), deephash(obj2))
 
-    @pd_skip
     def test_deephash_nested_mixed_inequality(self):
         obj1 = [datetime.datetime(1,2,3), set([1,2,3]),
                 pd.DataFrame({'a':[1,2],'b':[3,4]}),
@@ -501,7 +489,6 @@ class TestDatetimeUtils(unittest.TestCase):
         dt = np.datetime64(datetime.datetime(2017, 1, 1), 's')
         self.assertEqual(dt_to_int(dt), 1483228800000000.0)
 
-    @pd_skip
     def test_timestamp_to_us_int(self):
         dt = pd.Timestamp(datetime.datetime(2017, 1, 1))
         self.assertEqual(dt_to_int(dt), 1483228800000000.0)
@@ -522,7 +509,6 @@ class TestDatetimeUtils(unittest.TestCase):
         dt = np.datetime64(datetime.datetime(2017, 1, 1), 's')
         self.assertEqual(dt_to_int(dt, 's'), 1483228800.0)
 
-    @pd_skip
     def test_timestamp_to_s_int(self):
         dt = pd.Timestamp(datetime.datetime(2017, 1, 1))
         self.assertEqual(dt_to_int(dt, 's'), 1483228800.0)
@@ -541,7 +527,6 @@ class TestDatetimeUtils(unittest.TestCase):
         self.assertEqual(drange[0], start+np.timedelta64(50, 'ms'))
         self.assertEqual(drange[-1], end-np.timedelta64(50, 'ms'))
 
-    @pd_skip
     def test_timezone_to_int(self):
         import pytz
         timezone = pytz.timezone("Europe/Copenhagen")
@@ -597,55 +582,45 @@ class TestNumericUtilities(ComparisonTestCase):
         dt64 = np.timedelta64('NaT')
         self.assertFalse(isfinite(dt64))
 
-    @pd_skip
     def test_isfinite_pandas_timestamp_nat(self):
         dt64 = pd.Timestamp('NaT')
         self.assertFalse(isfinite(dt64))
 
-    @pd_skip
     def test_isfinite_pandas_period_nat(self):
         dt64 = pd.Period('NaT')
         self.assertFalse(isfinite(dt64))
 
-    @pd_skip
     def test_isfinite_pandas_period_index(self):
         daily = pd.date_range('2017-1-1', '2017-1-3', freq='D').to_period('D')
         self.assertEqual(isfinite(daily), np.array([True, True, True]))
 
-    @pd_skip
     def test_isfinite_pandas_period_series(self):
         daily = pd.date_range('2017-1-1', '2017-1-3', freq='D').to_period('D').to_series()
         self.assertEqual(isfinite(daily), np.array([True, True, True]))
 
-    @pd_skip
     def test_isfinite_pandas_period_index_nat(self):
         daily = pd.date_range('2017-1-1', '2017-1-3', freq='D').to_period('D')
         daily = pd.PeriodIndex(list(daily)+[pd.NaT])
         self.assertEqual(isfinite(daily), np.array([True, True, True, False]))
 
-    @pd_skip
     def test_isfinite_pandas_period_series_nat(self):
         daily = pd.date_range('2017-1-1', '2017-1-3', freq='D').to_period('D')
         daily = pd.Series(list(daily)+[pd.NaT])
         self.assertEqual(isfinite(daily), np.array([True, True, True, False]))
 
-    @pd_skip
     def test_isfinite_pandas_timestamp_index(self):
         daily = pd.date_range('2017-1-1', '2017-1-3', freq='D')
         self.assertEqual(isfinite(daily), np.array([True, True, True]))
 
-    @pd_skip
     def test_isfinite_pandas_timestamp_series(self):
         daily = pd.date_range('2017-1-1', '2017-1-3', freq='D').to_series()
         self.assertEqual(isfinite(daily), np.array([True, True, True]))
 
-    @pd_skip
     def test_isfinite_pandas_timestamp_index_nat(self):
         daily = pd.date_range('2017-1-1', '2017-1-3', freq='D')
         daily = pd.DatetimeIndex(list(daily)+[pd.NaT])
         self.assertEqual(isfinite(daily), np.array([True, True, True, False]))
 
-    @pd_skip
     def test_isfinite_pandas_timestamp_series_nat(self):
         daily = pd.date_range('2017-1-1', '2017-1-3', freq='D')
         daily = pd.Series(list(daily)+[pd.NaT])

--- a/holoviews/tests/element/test_elementselect.py
+++ b/holoviews/tests/element/test_elementselect.py
@@ -1,11 +1,7 @@
 from itertools import product
 import datetime as dt
 import numpy as np
-
-try:
-    import pandas as pd
-except ImportError:
-    pd = None
+import pandas as pd
 
 from holoviews.core import HoloMap
 from holoviews.element import Image, Contours, Curve
@@ -109,10 +105,9 @@ class DimensionedSelectionTest(ComparisonTestCase):
             self.assertEqual(el.select(time=
                 (dt.datetime(1999, 12, 31), dt.datetime(2000, 1, 2))), el[s:e]
             )
-            if pd:
-                self.assertEqual(el.select(
-                    time=(pd.Timestamp(s), pd.Timestamp(e))
-                ), el[pd.Timestamp(s):pd.Timestamp(e)])
+            self.assertEqual(el.select(
+                time=(pd.Timestamp(s), pd.Timestamp(e))
+            ), el[pd.Timestamp(s):pd.Timestamp(e)])
 
     def test_selection_spec_positional_error_message(self):
         s, e = '1999-12-31', '2000-1-2'

--- a/holoviews/tests/element/test_graphelement.py
+++ b/holoviews/tests/element/test_graphelement.py
@@ -1,20 +1,18 @@
 """
 Unit tests of Graph Element.
 """
-from unittest import SkipTest, skipIf
+from unittest import SkipTest
 
 import numpy as np
+import pandas as pd
 
 from holoviews.core.data import Dataset
-from holoviews.core import util
 from holoviews.element.chart import Points
 from holoviews.element.graphs import (
     Graph, Nodes, TriMesh, Chord, circular_layout, connect_edges,
     connect_edges_pd)
 from holoviews.element.sankey import Sankey
 from holoviews.element.comparison import ComparisonTestCase
-
-pd_skip = skipIf(util.pd is None, 'Pandas not available')
 
 
 class GraphTests(ComparisonTestCase):
@@ -62,14 +60,12 @@ class GraphTests(ComparisonTestCase):
         self.assertEqual(graph.nodes.dimension_values(3),
                          node_info.dimension_values(1))
 
-    @pd_skip
     def test_graph_node_info_merge_on_index_partial(self):
         node_info = Dataset((np.arange(5), np.arange(1,6)), 'index', 'label')
         graph = Graph(((self.source, self.target), node_info))
         expected = np.array([1., 2., 3., 4., 5., np.NaN, np.NaN, np.NaN])
         self.assertEqual(graph.nodes.dimension_values(3), expected)
 
-    @pd_skip
     def test_graph_edge_segments_pd(self):
         segments = connect_edges_pd(self.graph)
         paths = []
@@ -269,9 +265,8 @@ class TriMeshTests(ComparisonTestCase):
         self.assertEqual(trimesh.nodes.array([0, 1]), np.array(nodes).T)
         self.assertEqual(trimesh.nodes.dimension_values(2), np.arange(4))
 
-    @pd_skip
     def test_trimesh_constructor_df_nodes(self):
-        nodes_df = util.pd.DataFrame(self.nodes, columns=['x', 'y', 'z'])
+        nodes_df = pd.DataFrame(self.nodes, columns=['x', 'y', 'z'])
         trimesh = TriMesh((self.simplices, nodes_df))
         nodes = Nodes([(0, 0, 0, 0), (0.5, 1, 1, 1),
                        (1., 0, 2, 2), (1.5, 1, 3, 4)], vdims='z')

--- a/holoviews/tests/element/test_selection.py
+++ b/holoviews/tests/element/test_selection.py
@@ -2,7 +2,7 @@
 Test cases for the Comparisons class over the Chart elements
 """
 
-from unittest import SkipTest, skipIf
+from unittest import skipIf
 
 import numpy as np
 
@@ -40,10 +40,7 @@ ds_available = skipIf(ds is None, 'datashader not available')
 class TestSelection1DExpr(ComparisonTestCase):
 
     def setUp(self):
-        try:
-            import holoviews.plotting.bokeh # noqa
-        except:
-            raise SkipTest("Bokeh selection tests require bokeh.")
+        import holoviews.plotting.bokeh # noqa
         super().setUp()
         self._backend = Store.current_backend
         Store.set_current_backend('bokeh')
@@ -222,10 +219,7 @@ class TestSelection1DExpr(ComparisonTestCase):
 class TestSelection2DExpr(ComparisonTestCase):
 
     def setUp(self):
-        try:
-            import holoviews.plotting.bokeh # noqa
-        except:
-            raise SkipTest("Bokeh selection tests require bokeh.")
+        import holoviews.plotting.bokeh # noqa
         super().setUp()
         self._backend = Store.current_backend
         Store.set_current_backend('bokeh')
@@ -437,10 +431,7 @@ class TestSelection2DExpr(ComparisonTestCase):
 class TestSelectionGeomExpr(ComparisonTestCase):
 
     def setUp(self):
-        try:
-            import holoviews.plotting.bokeh # noqa
-        except:
-            raise SkipTest("Bokeh selection tests require bokeh.")
+        import holoviews.plotting.bokeh # noqa
         super().setUp()
         self._backend = Store.current_backend
         Store.set_current_backend('bokeh')
@@ -544,10 +535,7 @@ class TestSelectionGeomExpr(ComparisonTestCase):
 class TestSelectionPolyExpr(ComparisonTestCase):
 
     def setUp(self):
-        try:
-            import holoviews.plotting.bokeh # noqa
-        except:
-            raise SkipTest("Bokeh selection tests require bokeh.")
+        import holoviews.plotting.bokeh # noqa
         super().setUp()
         self._backend = Store.current_backend
         Store.set_current_backend('bokeh')

--- a/holoviews/tests/element/test_statselements.py
+++ b/holoviews/tests/element/test_statselements.py
@@ -1,16 +1,14 @@
-from unittest import SkipTest, skipIf
+from unittest import SkipTest
 
 import numpy as np
 import holoviews as hv
+import pandas as pd
 
 from holoviews.core.dimension import Dimension
 from holoviews.core.options import Compositor, Store
-from holoviews.core.util import pd
 from holoviews.element import (Distribution, Bivariate, Points, Image,
                                Curve, Area, Contours, Polygons)
 from holoviews.element.comparison import ComparisonTestCase
-
-pd_skip = skipIf(pd is None, 'Pandas not available')
 
 
 class StatisticalElementTest(ComparisonTestCase):
@@ -20,13 +18,11 @@ class StatisticalElementTest(ComparisonTestCase):
         self.assertEqual(dist.kdims, [Dimension('Value')])
         self.assertEqual(dist.vdims, [Dimension('Density')])
 
-    @pd_skip
     def test_distribution_dframe_constructor(self):
         dist = Distribution(pd.DataFrame({'Value': [0, 1, 2]}))
         self.assertEqual(dist.kdims, [Dimension('Value')])
         self.assertEqual(dist.vdims, [Dimension('Density')])
 
-    @pd_skip
     def test_distribution_series_constructor(self):
         dist = Distribution(pd.Series([0, 1, 2], name='Value'))
         self.assertEqual(dist.kdims, [Dimension('Value')])
@@ -47,7 +43,6 @@ class StatisticalElementTest(ComparisonTestCase):
         self.assertEqual(dist.kdims, [Dimension('x'), Dimension('y')])
         self.assertEqual(dist.vdims, [Dimension('Density')])
 
-    @pd_skip
     def test_bivariate_dframe_constructor(self):
         dist = Bivariate(pd.DataFrame({'x': [0, 1, 2], 'y': [0, 1, 2]}, columns=['x', 'y']))
         self.assertEqual(dist.kdims, [Dimension('x'), Dimension('y')])
@@ -117,10 +112,6 @@ class StatisticalCompositorTest(ComparisonTestCase):
     def setUp(self):
         try:
             import scipy # noqa
-        except:
-            raise SkipTest('SciPy not available')
-        try:
-            import matplotlib # noqa
         except:
             raise SkipTest('SciPy not available')
         self.renderer = hv.renderer('matplotlib')

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -3,6 +3,7 @@ import datetime as dt
 from unittest import SkipTest, skipIf
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from holoviews import (
@@ -18,7 +19,6 @@ try:
     import datashader as ds
     import dask.dataframe as dd
     import xarray as xr
-    from holoviews.core.util import pd
     from holoviews.operation.datashader import (
         LooseVersion, aggregate, regrid, ds_version, stack, directly_connect_edges,
         shade, spread, rasterize, datashade, AggregationOperation,

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -2,11 +2,7 @@ import datetime as dt
 from unittest import skipIf
 
 import numpy as np
-
-try:
-    import matplotlib as mpl
-except:
-    mpl = None
+import pandas as pd
 
 try:
     import dask.array as da
@@ -17,14 +13,11 @@ from holoviews import (HoloMap, NdOverlay, NdLayout, GridSpace, Image,
                        Contours, Polygons, Points, Histogram, Curve, Area,
                        QuadMesh, Dataset)
 from holoviews.core.data.grid import GridInterface
-from holoviews.core.util import pd
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.operation.element import (operation, transform, threshold,
                                          gradient, contours, histogram,
                                          interpolate_curve)
 
-pd_skip = skipIf(pd is None, "Pandas not available")
-mpl_skip = skipIf(mpl is None, "Matplotlib is not available")
 da_skip = skipIf(da is None, "dask.array is not available")
 
 
@@ -73,7 +66,6 @@ class OperationTests(ComparisonTestCase):
         op_img = gradient(img)
         self.assertEqual(op_img, img.clone(np.array([[3.162278, 3.162278], [3.162278, 3.162278]]), group='Gradient'))
 
-    @mpl_skip
     def test_image_contours(self):
         img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
         op_contours = contours(img, levels=[0.5])
@@ -83,14 +75,12 @@ class OperationTests(ComparisonTestCase):
                             vdims=img.vdims)
         self.assertEqual(op_contours, contour)
 
-    @mpl_skip
     def test_image_contours_no_range(self):
         img = Image(np.zeros((2, 2)))
         op_contours = contours(img, levels=2)
         contour = Contours([], vdims=img.vdims)
         self.assertEqual(op_contours, contour)
 
-    @mpl_skip
     def test_qmesh_contours(self):
         qmesh = QuadMesh(([0, 1, 2], [1, 2, 3], np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]])))
         op_contours = contours(qmesh, levels=[0.5])
@@ -100,7 +90,6 @@ class OperationTests(ComparisonTestCase):
                             vdims=qmesh.vdims)
         self.assertEqual(op_contours, contour)
 
-    @mpl_skip
     def test_qmesh_curvilinear_contours(self):
         x = y = np.arange(3)
         xs, ys = np.meshgrid(x, y)
@@ -113,7 +102,6 @@ class OperationTests(ComparisonTestCase):
                             vdims=qmesh.vdims)
         self.assertEqual(op_contours, contour)
 
-    @mpl_skip
     def test_qmesh_curvilinear_edges_contours(self):
         x = y = np.arange(3)
         xs, ys = np.meshgrid(x, y)
@@ -130,7 +118,6 @@ class OperationTests(ComparisonTestCase):
                             vdims=qmesh.vdims)
         self.assertEqual(op_contours, contour)
 
-    @mpl_skip
     def test_image_contours_filled(self):
         img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
         op_contours = contours(img, filled=True, levels=[2, 2.5])
@@ -254,7 +241,6 @@ class OperationTests(ComparisonTestCase):
         hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Frequency'))
         self.assertEqual(op_hist, hist)
 
-    @pd_skip
     def test_histogram_operation_pd_period(self):
         dates = pd.date_range('2017-01-01', '2017-01-04', freq='D').to_period('D')
         op_hist = histogram(Dataset(dates, 'Date'), num_bins=4, normed=True)

--- a/holoviews/tests/operation/test_timeseriesoperations.py
+++ b/holoviews/tests/operation/test_timeseriesoperations.py
@@ -1,9 +1,6 @@
-from unittest import SkipTest, skipIf
+from unittest import skipIf
 
-try:
-    import pandas as pd
-except:
-    raise SkipTest('Pandas not available')
+import pandas as pd
 
 try:
     import scipy # noqa

--- a/holoviews/tests/plotting/bokeh/test_boxwhiskerplot.py
+++ b/holoviews/tests/plotting/bokeh/test_boxwhiskerplot.py
@@ -6,10 +6,7 @@ from holoviews.element import BoxWhisker
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
-try:
-    from bokeh.models import ColumnDataSource, CategoricalColorMapper, LinearColorMapper
-except:
-    pass
+from bokeh.models import ColumnDataSource, CategoricalColorMapper, LinearColorMapper
 
 
 class TestBoxWhiskerPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -4,12 +4,12 @@ from collections import deque, namedtuple
 from unittest import SkipTest
 
 import numpy as np
+import pandas as pd
 import pytest
 import pyviz_comms as comms
 
 from holoviews.core import DynamicMap
 from holoviews.core.options import Store
-from holoviews.core.util import pd
 from holoviews.element import Points, Polygons, Box, Curve, Table, Rectangles
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import (
@@ -17,20 +17,17 @@ from holoviews.streams import (
     PlotReset, Selection1D, RangeXY, PlotSize, CDSStream, SingleTap
 )
 
-try:
-    from bokeh.events import Tap
-    from bokeh.io.doc import set_curdoc
-    from bokeh.models import Range1d, Plot, ColumnDataSource, Selection, PolyEditTool
-    from holoviews.plotting.bokeh.callbacks import (
-        Callback, PointDrawCallback, PolyDrawCallback, PolyEditCallback,
-        BoxEditCallback, PointerXCallback, TapCallback
-    )
-    from holoviews.plotting.bokeh.renderer import BokehRenderer
-    bokeh_server_renderer = BokehRenderer.instance(mode='server')
-    bokeh_renderer = BokehRenderer.instance()
-except:
-    bokeh_renderer = None
-    bokeh_server_renderer = None
+from bokeh.events import Tap
+from bokeh.io.doc import set_curdoc
+from bokeh.models import Range1d, Plot, ColumnDataSource, Selection, PolyEditTool
+from holoviews.plotting.bokeh.callbacks import (
+    Callback, PointDrawCallback, PolyDrawCallback, PolyEditCallback,
+    BoxEditCallback, PointerXCallback, TapCallback
+)
+from holoviews.plotting.bokeh.renderer import BokehRenderer
+
+bokeh_server_renderer = BokehRenderer.instance(mode='server')
+bokeh_renderer = BokehRenderer.instance()
 
 
 class CallbackTestCase(ComparisonTestCase):

--- a/holoviews/tests/plotting/bokeh/test_curveplot.py
+++ b/holoviews/tests/plotting/bokeh/test_curveplot.py
@@ -1,11 +1,10 @@
 import datetime as dt
-from unittest import skipIf
 
 import numpy as np
+import pandas as pd
 
 from holoviews.core import NdOverlay, HoloMap, DynamicMap
 from holoviews.core.options import Cycle, Palette
-from holoviews.core.util import pd
 from holoviews.element import Curve
 from holoviews.plotting.util import rgb2hex
 from holoviews.streams import PointerX
@@ -13,13 +12,8 @@ from holoviews.util.transform import dim
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
-try:
-    from bokeh.models import FactorRange, FixedTicker
-    from holoviews.plotting.bokeh.callbacks import Callback, PointerXCallback
-except:
-    pass
-
-pd_skip = skipIf(pd is None, 'Pandas not available')
+from bokeh.models import FactorRange, FixedTicker
+from holoviews.plotting.bokeh.callbacks import Callback, PointerXCallback
 
 
 class TestCurvePlot(TestBokehPlot):
@@ -136,7 +130,6 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(plot.handles['x_range'].start, np.datetime64(dt.datetime(2016, 1, 1)))
         self.assertEqual(plot.handles['x_range'].end, np.datetime64(dt.datetime(2016, 1, 10)))
 
-    @pd_skip
     def test_curve_pandas_timestamps(self):
         dates = pd.date_range('2016-01-01', '2016-01-10', freq='D')
         curve = Curve((dates, np.random.rand(10)))
@@ -160,7 +153,6 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(plot.handles['x_range'].start, np.datetime64(dt.datetime(2016, 1, 1)))
         self.assertEqual(plot.handles['x_range'].end, np.datetime64(dt.datetime(2016, 1, 11)))
 
-    @pd_skip
     def test_curve_heterogeneous_datetime_types_with_pd_overlay(self):
         dates_pd = pd.date_range('2016-01-04', '2016-01-13', freq='D')
         dates64 = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -15,18 +15,14 @@ from holoviews.util import render
 from .test_plot import TestBokehPlot, bokeh_renderer
 from ...utils import LoggingComparisonTestCase
 
-try:
-    import panel as pn
+import panel as pn
 
-    from bokeh.document import Document
-    from bokeh.models import tools
-    from bokeh.models import (FuncTickFormatter, PrintfTickFormatter,
-                              NumeralTickFormatter, LogTicker,
-                              LinearColorMapper, LogColorMapper)
-    from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
-except:
-    pass
-
+from bokeh.document import Document
+from bokeh.models import tools
+from bokeh.models import (FuncTickFormatter, PrintfTickFormatter,
+                            NumeralTickFormatter, LogTicker,
+                            LinearColorMapper, LogColorMapper)
+from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
 
 
 class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_geomplot.py
+++ b/holoviews/tests/plotting/bokeh/test_geomplot.py
@@ -1,15 +1,11 @@
-from unittest import SkipTest
+import pandas as pd
 
 from holoviews.core import NdOverlay
-from holoviews.core.util import pd
 from holoviews.element import Segments
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
-try:
-    from bokeh.models import FactorRange
-except:
-    pass
+from bokeh.models import FactorRange
 
 
 class TestSegmentPlot(TestBokehPlot):
@@ -49,8 +45,6 @@ class TestSegmentPlot(TestBokehPlot):
         self._test_hover_info(obj, tooltips)
 
     def test_segments_overlay_datetime_hover(self):
-        if pd is None:
-            raise SkipTest("Test requires pandas")
         obj = NdOverlay({
             i: Segments((
                 list(pd.date_range('2016-01-01', '2016-01-31')),

--- a/holoviews/tests/plotting/bokeh/test_graphplot.py
+++ b/holoviews/tests/plotting/bokeh/test_graphplot.py
@@ -4,11 +4,8 @@ from holoviews.core.data import Dataset
 from holoviews.element import Graph, Nodes, TriMesh, Chord, VLine, circular_layout
 from holoviews.util.transform import dim
 
-try:
-    from bokeh.models import (NodesAndLinkedEdges, EdgesAndLinkedNodes, NodesOnly, Patches)
-    from bokeh.models.mappers import CategoricalColorMapper, LinearColorMapper
-except:
-    pass
+from bokeh.models import (NodesAndLinkedEdges, EdgesAndLinkedNodes, NodesOnly, Patches)
+from bokeh.models.mappers import CategoricalColorMapper, LinearColorMapper
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 

--- a/holoviews/tests/plotting/bokeh/test_gridplot.py
+++ b/holoviews/tests/plotting/bokeh/test_gridplot.py
@@ -8,12 +8,9 @@ from holoviews.streams import Stream
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
-try:
-    from bokeh.layouts import Column
-    from bokeh.models import Div, ToolbarBox
-    from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
-except:
-    pass
+from bokeh.layouts import Column
+from bokeh.models import Div, ToolbarBox
+from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
 
 
 

--- a/holoviews/tests/plotting/bokeh/test_heatmapplot.py
+++ b/holoviews/tests/plotting/bokeh/test_heatmapplot.py
@@ -2,10 +2,7 @@ import numpy as np
 
 from holoviews.element import HeatMap, Points, Image
 
-try:
-    from bokeh.models import FactorRange, HoverTool, Range1d
-except:
-    pass
+from bokeh.models import FactorRange, HoverTool, Range1d
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 

--- a/holoviews/tests/plotting/bokeh/test_hextilesplot.py
+++ b/holoviews/tests/plotting/bokeh/test_hextilesplot.py
@@ -1,21 +1,13 @@
-from unittest import SkipTest
-
 import numpy as np
 
 from holoviews.core import Dimension
 from holoviews.element import HexTiles
 from holoviews.plotting.bokeh.hex_tiles import hex_binning
-from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
 
 class TestHexTilesOperation(TestBokehPlot):
-
-    def setUp(self):
-        super().setUp()
-        if bokeh_version < LooseVersion('0.12.15'):
-            raise SkipTest("Bokeh >= 0.12.15 required to test HexTiles operation.")
 
     def test_hex_tiles_count_aggregation(self):
         tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)])
@@ -39,11 +31,6 @@ class TestHexTilesOperation(TestBokehPlot):
 
 
 class TestHexTilesPlot(TestBokehPlot):
-
-    def setUp(self):
-        super().setUp()
-        if bokeh_version < LooseVersion('0.12.15'):
-            raise SkipTest("Bokeh >= 0.12.15 required to test HexTilesPlot.")
 
     def test_hex_tiles_empty(self):
         tiles = HexTiles([])

--- a/holoviews/tests/plotting/bokeh/test_labels.py
+++ b/holoviews/tests/plotting/bokeh/test_labels.py
@@ -3,10 +3,7 @@ import numpy as np
 from holoviews.core.dimension import Dimension
 from holoviews.element import Labels
 
-try:
-    from bokeh.models import LinearColorMapper, CategoricalColorMapper
-except:
-    pass
+from bokeh.models import LinearColorMapper, CategoricalColorMapper
 
 from ..utils import ParamLogStream
 from .test_plot import TestBokehPlot, bokeh_renderer

--- a/holoviews/tests/plotting/bokeh/test_layoutplot.py
+++ b/holoviews/tests/plotting/bokeh/test_layoutplot.py
@@ -10,12 +10,9 @@ from holoviews.streams import Stream
 from holoviews.util import render, opts
 from holoviews.util.transform import dim
 
-try:
-    from bokeh.layouts import Column, Row
-    from bokeh.models import Div, ToolbarBox, GlyphRenderer, Tabs, Panel, Spacer, GridBox, Title
-    from bokeh.plotting import Figure
-except:
-    pass
+from bokeh.layouts import Column, Row
+from bokeh.models import Div, ToolbarBox, GlyphRenderer, Tabs, Panel, Spacer, GridBox, Title
+from bokeh.plotting import Figure
 
 from ...utils import LoggingComparisonTestCase
 from .test_plot import TestBokehPlot, bokeh_renderer

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -1,26 +1,15 @@
-from unittest import SkipTest
-
 import numpy as np
 
 from holoviews.core.spaces import DynamicMap
 from holoviews.element import Curve, Polygons, Table, Scatter, Path, Points
 from holoviews.plotting.links import (Link, RangeToolLink, DataLink)
 
-try:
-    from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
-    from bokeh.models import ColumnDataSource
-except:
-    pass
+from bokeh.models import ColumnDataSource
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
 
 class TestLinkCallbacks(TestBokehPlot):
-
-    def setUp(self):
-        if not bokeh_renderer or bokeh_version < LooseVersion('0.13'):
-            raise SkipTest('RangeTool requires bokeh version >= 0.13')
-        super().setUp()
 
     def test_range_tool_link_callback_single_axis(self):
         from bokeh.models import RangeTool

--- a/holoviews/tests/plotting/bokeh/test_overlayplot.py
+++ b/holoviews/tests/plotting/bokeh/test_overlayplot.py
@@ -10,10 +10,7 @@ from holoviews.util import Dynamic
 from ...utils import LoggingComparisonTestCase
 from .test_plot import TestBokehPlot, bokeh_renderer
 
-try:
-    from bokeh.models import FixedTicker, HoverTool, FactorRange, Span, Range1d
-except:
-    pass
+from bokeh.models import FixedTicker, HoverTool, FactorRange, Span, Range1d
 
 
 class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_pathplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pathplot.py
@@ -10,10 +10,7 @@ from holoviews.util.transform import dim
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
-try:
-    from bokeh.models import LinearColorMapper, CategoricalColorMapper
-except:
-    pass
+from bokeh.models import LinearColorMapper, CategoricalColorMapper
 
 
 class TestPathPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -1,5 +1,3 @@
-from unittest import SkipTest
-
 import pyviz_comms as comms
 
 from param import concrete_descendents
@@ -8,15 +6,12 @@ from holoviews.core.element import Element
 from holoviews.core.options import Store
 from holoviews.element.comparison import ComparisonTestCase
 
-try:
-    from bokeh.models import (
-        ColumnDataSource, LinearColorMapper, LogColorMapper, HoverTool
-    )
-    from holoviews.plotting.bokeh.callbacks import Callback
-    from holoviews.plotting.bokeh.element import ElementPlot
-    bokeh_renderer = Store.renderers['bokeh']
-except:
-    bokeh_renderer = None
+from bokeh.models import (
+    ColumnDataSource, LinearColorMapper, LogColorMapper, HoverTool
+)
+from holoviews.plotting.bokeh.callbacks import Callback
+from holoviews.plotting.bokeh.element import ElementPlot
+bokeh_renderer = Store.renderers['bokeh']
 
 from .. import option_intersections
 
@@ -36,8 +31,6 @@ class TestBokehPlot(ComparisonTestCase):
         self.previous_backend = Store.current_backend
         self.comm_manager = bokeh_renderer.comm_manager
         bokeh_renderer.comm_manager = comms.CommManager
-        if not bokeh_renderer:
-            raise SkipTest("Bokeh required to test plot instantiation")
         Store.set_current_backend('bokeh')
         self._padding = {}
         for plot in concrete_descendents(ElementPlot).values():

--- a/holoviews/tests/plotting/bokeh/test_pointplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pointplot.py
@@ -1,22 +1,18 @@
 import datetime as dt
-from unittest import SkipTest
 
 import numpy as np
+import pandas as pd
 
 from holoviews.core import NdOverlay
 from holoviews.core.options import Cycle
-from holoviews.core.util import pd
 from holoviews.element import Points
 from holoviews.streams import Stream
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 from ..utils import ParamLogStream
 
-try:
-    from bokeh.models import FactorRange, LinearColorMapper, CategoricalColorMapper
-    from bokeh.models import Scatter
-except:
-    pass
+from bokeh.models import FactorRange, LinearColorMapper, CategoricalColorMapper
+from bokeh.models import Scatter
 
 
 class TestPointPlot(TestBokehPlot):
@@ -132,8 +128,6 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(plot.handles['source'].data['color'], color)
 
     def test_points_overlay_datetime_hover(self):
-        if pd is None:
-            raise SkipTest("Test requires pandas")
         obj = NdOverlay({i: Points((list(pd.date_range('2016-01-01', '2016-01-31')), range(31))) for i in range(5)},
                         kdims=['Test'])
         opts = {'Points': {'tools': ['hover']}}

--- a/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
@@ -4,10 +4,7 @@ from holoviews.element import QuadMesh, Image
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
-try:
-    from bokeh.models import ColorBar
-except:
-    pass
+from bokeh.models import ColorBar
 
 
 class TestQuadMeshPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_radialheatmap.py
+++ b/holoviews/tests/plotting/bokeh/test_radialheatmap.py
@@ -5,11 +5,8 @@ import numpy as np
 from holoviews.core.spaces import HoloMap
 from holoviews.element.raster import HeatMap
 
-try:
-    from bokeh.models import ColorBar
-    from holoviews.plotting.bokeh import RadialHeatMapPlot
-except:
-    pass
+from bokeh.models import ColorBar
+from holoviews.plotting.bokeh import RadialHeatMapPlot
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 

--- a/holoviews/tests/plotting/bokeh/test_renderer.py
+++ b/holoviews/tests/plotting/bokeh/test_renderer.py
@@ -5,30 +5,25 @@ from unittest import SkipTest
 import numpy as np
 import param
 
-from holoviews import DynamicMap, HoloMap, Image, GridSpace, Table, Curve, Store
+from holoviews import DynamicMap, HoloMap, Image, GridSpace, Table, Curve
 from holoviews.streams import Stream
 from holoviews.plotting import Renderer
 from holoviews.element.comparison import ComparisonTestCase
 from pyviz_comms import CommManager
 
-try:
-    import panel as pn
+import panel as pn
 
-    from bokeh.io import curdoc
-    from holoviews.plotting.bokeh import BokehRenderer
-    from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
-    from bokeh.themes.theme import Theme
+from bokeh.io import curdoc
+from holoviews.plotting.bokeh import BokehRenderer
+from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
+from bokeh.themes.theme import Theme
 
-    from panel.widgets import DiscreteSlider, Player, FloatSlider
-except:
-    pn = None
+from panel.widgets import DiscreteSlider, Player, FloatSlider
 
 
 class BokehRendererTest(ComparisonTestCase):
 
     def setUp(self):
-        if 'bokeh' not in Store.renderers and pn is not None:
-            raise SkipTest("Bokeh and Panel required to test 'bokeh' renderer")
         self.image1 = Image(np.array([[0,1],[2,3]]), label='Image1')
         self.image2 = Image(np.array([[1,0],[4,-2]]), label='Image2')
         self.map1 = HoloMap({1:self.image1, 2:self.image2}, label='TestMap')

--- a/holoviews/tests/plotting/bokeh/test_server.py
+++ b/holoviews/tests/plotting/bokeh/test_server.py
@@ -1,7 +1,4 @@
-import sys
 import time
-
-from unittest import SkipTest
 
 import param
 
@@ -12,34 +9,26 @@ from holoviews.element.comparison import ComparisonTestCase
 from holoviews.plotting import Renderer
 from holoviews.streams import Stream, RangeXY, PlotReset
 
-try:
-    from bokeh.client import pull_session
-    from bokeh.document import Document
-    from bokeh.io.doc import curdoc, set_curdoc
-    from bokeh.models import ColumnDataSource
+from bokeh.client import pull_session
+from bokeh.document import Document
+from bokeh.io.doc import curdoc, set_curdoc
+from bokeh.models import ColumnDataSource
 
-    from holoviews.plotting.bokeh.callbacks import (
-        Callback, RangeXYCallback, ResetCallback
-    )
-    from holoviews.plotting.bokeh.renderer import BokehRenderer
-    from panel.widgets import DiscreteSlider, FloatSlider
-    from panel.io.state import state
-    from panel import serve
-    bokeh_renderer = BokehRenderer.instance(mode='server')
-except:
-    bokeh_renderer = None
+from holoviews.plotting.bokeh.callbacks import (
+    Callback, RangeXYCallback, ResetCallback
+)
+from holoviews.plotting.bokeh.renderer import BokehRenderer
+from panel.widgets import DiscreteSlider, FloatSlider
+from panel.io.state import state
+from panel import serve
 
-
-if sys.version_info.major == 3 and sys.version_info.minor == 6:
-    raise SkipTest('Skip Python 3.6 as Panel fixes were not backported to prevent tests hanging')
+bokeh_renderer = BokehRenderer.instance(mode='server')
 
 
 class TestBokehServerSetup(ComparisonTestCase):
 
     def setUp(self):
         self.previous_backend = Store.current_backend
-        if not bokeh_renderer:
-            raise SkipTest("Bokeh required to test plot instantiation")
         Store.current_backend = 'bokeh'
         self.doc = curdoc()
         set_curdoc(Document())
@@ -97,8 +86,6 @@ class TestBokehServer(ComparisonTestCase):
 
     def setUp(self):
         self.previous_backend = Store.current_backend
-        if not bokeh_renderer:
-            raise SkipTest("Bokeh required to test plot instantiation")
         Store.current_backend = 'bokeh'
         self._port = None
 

--- a/holoviews/tests/plotting/bokeh/test_tabular.py
+++ b/holoviews/tests/plotting/bokeh/test_tabular.py
@@ -1,30 +1,24 @@
 from datetime import datetime as dt
-from unittest import SkipTest
 
+from bokeh.models.widgets import (
+        NumberEditor, NumberFormatter, DateFormatter,
+    DateEditor, StringFormatter, StringEditor, IntEditor
+)
 from holoviews.core.options import Store
 from holoviews.core.spaces import DynamicMap
 from holoviews.element import Table
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.plotting.bokeh.callbacks import CDSCallback
+from holoviews.plotting.bokeh.renderer import BokehRenderer
 from holoviews.streams import CDSStream, Stream
 
-try:
-    from bokeh.models.widgets import (
-         NumberEditor, NumberFormatter, DateFormatter,
-        DateEditor, StringFormatter, StringEditor, IntEditor
-    )
-    from holoviews.plotting.bokeh.callbacks import CDSCallback
-    from holoviews.plotting.bokeh.renderer import BokehRenderer
-    bokeh_renderer = BokehRenderer.instance(mode='server')
-except:
-    bokeh_renderer = None
+bokeh_renderer = BokehRenderer.instance(mode='server')
 
 
 class TestBokehTablePlot(ComparisonTestCase):
 
     def setUp(self):
         self.previous_backend = Store.current_backend
-        if not bokeh_renderer:
-            raise SkipTest("Bokeh required to test plot instantiation")
         Store.current_backend = 'bokeh'
 
     def tearDown(self):

--- a/holoviews/tests/plotting/bokeh/test_utils.py
+++ b/holoviews/tests/plotting/bokeh/test_utils.py
@@ -1,19 +1,12 @@
-from unittest import SkipTest
 from holoviews.core import Store
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.plotting.bokeh.util import filter_batched_data, glyph_order
+from holoviews.plotting.bokeh.styles import expand_batched_style
 
-try:
-    from holoviews.plotting.bokeh.util import filter_batched_data, glyph_order
-    from holoviews.plotting.bokeh.styles import expand_batched_style
-    bokeh_renderer = Store.renderers['bokeh']
-except:
-    bokeh_renderer = None
+bokeh_renderer = Store.renderers['bokeh']
+
 
 class TestBokehUtilsInstantiation(ComparisonTestCase):
-
-    def setUp(self):
-        if not bokeh_renderer:
-            raise SkipTest("Bokeh required to test plot instantiation")
 
     def test_expand_style_opts_simple(self):
         style = {'line_width': 3}

--- a/holoviews/tests/plotting/bokeh/test_violinplot.py
+++ b/holoviews/tests/plotting/bokeh/test_violinplot.py
@@ -10,10 +10,7 @@ from holoviews.util.transform import dim
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
-try:
-    from bokeh.models import LinearColorMapper, CategoricalColorMapper
-except:
-    pass
+from bokeh.models import LinearColorMapper, CategoricalColorMapper
 
 
 class TestBokehViolinPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/matplotlib/test_curveplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_curveplot.py
@@ -1,16 +1,13 @@
 import datetime as dt
-from unittest import skipIf
 
 import numpy as np
+import pandas as pd
 
 from holoviews.core.overlay import NdOverlay
-from holoviews.core.util import pd
 from holoviews.element import Curve
 from holoviews.util.transform import dim
 
 from .test_plot import TestMPLPlot, mpl_renderer
-
-pd_skip = skipIf(pd is None, 'Pandas is not available')
 
 
 class TestCurvePlot(TestMPLPlot):
@@ -21,7 +18,6 @@ class TestCurvePlot(TestMPLPlot):
         plot = mpl_renderer.get_plot(curve)
         self.assertEqual(plot.handles['axis'].get_xlim(), (16801.0, 16810.0))
 
-    @pd_skip
     def test_curve_pandas_timestamps(self):
         dates = pd.date_range('2016-01-01', '2016-01-10', freq='D')
         curve = Curve((dates, np.random.rand(10)))
@@ -42,7 +38,6 @@ class TestCurvePlot(TestMPLPlot):
         plot = mpl_renderer.get_plot(curve_dt*curve_dt64)
         self.assertEqual(tuple(map(round, plot.handles['axis'].get_xlim())), (16801.0, 16811.0))
 
-    @pd_skip
     def test_curve_heterogeneous_datetime_types_with_pd_overlay(self):
         dates_pd = pd.date_range('2016-01-04', '2016-01-13', freq='D')
         dates64 = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]

--- a/holoviews/tests/plotting/matplotlib/test_elementplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_elementplot.py
@@ -6,10 +6,7 @@ from holoviews.streams import Stream
 
 from .test_plot import TestMPLPlot, mpl_renderer
 
-try:
-    from matplotlib.ticker import FormatStrFormatter, FuncFormatter, PercentFormatter
-except:
-    pass
+from matplotlib.ticker import FormatStrFormatter, FuncFormatter, PercentFormatter
 
 class TestElementPlot(TestMPLPlot):
 

--- a/holoviews/tests/plotting/matplotlib/test_graphplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_graphplot.py
@@ -6,12 +6,7 @@ from holoviews.core.spaces import HoloMap
 from holoviews.core.util import LooseVersion
 from holoviews.element import Graph, Nodes, TriMesh, Chord, circular_layout
 from holoviews.util.transform import dim
-
-# Standardize backend due to random inconsistencies
-try:
-    from matplotlib.collections import LineCollection, PolyCollection
-except:
-    pass
+from matplotlib.collections import LineCollection, PolyCollection
 
 from .test_plot import TestMPLPlot, mpl_renderer
 

--- a/holoviews/tests/plotting/matplotlib/test_plot.py
+++ b/holoviews/tests/plotting/matplotlib/test_plot.py
@@ -1,19 +1,14 @@
-from unittest import SkipTest
-
-from param import concrete_descendents
+import matplotlib.pyplot as plt
+import pyviz_comms as comms
 
 from holoviews.core.options import Store
 from holoviews.element.comparison import ComparisonTestCase
-import pyviz_comms as comms
-
-try:
-    from holoviews.plotting.mpl.element import ElementPlot
-    import matplotlib.pyplot as plt
-    mpl_renderer = Store.renderers['matplotlib']
-except:
-    mpl_renderer = None
+from holoviews.plotting.mpl.element import ElementPlot
+from param import concrete_descendents
 
 from .. import option_intersections
+
+mpl_renderer = Store.renderers['matplotlib']
 
 
 class TestPlotDefinitions(ComparisonTestCase):
@@ -30,8 +25,6 @@ class TestMPLPlot(ComparisonTestCase):
         self.previous_backend = Store.current_backend
         self.comm_manager = mpl_renderer.comm_manager
         mpl_renderer.comm_manager = comms.CommManager
-        if not mpl_renderer:
-            raise SkipTest("Matplotlib required to test plot instantiation")
         Store.set_current_backend('matplotlib')
         self._padding = {}
         for plot in concrete_descendents(ElementPlot).values():

--- a/holoviews/tests/plotting/matplotlib/test_pointplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pointplot.py
@@ -7,10 +7,7 @@ from holoviews.element import Points
 from .test_plot import TestMPLPlot, mpl_renderer
 from ..utils import ParamLogStream
 
-try:
-    from matplotlib import pyplot
-except:
-    pass
+from matplotlib import pyplot
 
 
 class TestPointPlot(TestMPLPlot):

--- a/holoviews/tests/plotting/matplotlib/test_rasterplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_rasterplot.py
@@ -4,10 +4,7 @@ from holoviews.element import Raster, Image
 
 from .test_plot import TestMPLPlot, mpl_renderer
 
-try:
-    from matplotlib.colors import ListedColormap
-except:
-    pass
+from matplotlib.colors import ListedColormap
 
 
 class TestRasterPlot(TestMPLPlot):

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -9,21 +9,16 @@ from unittest import SkipTest
 
 import numpy as np
 import param
+import panel as pn
 
-from holoviews import (DynamicMap, HoloMap, Image, ItemTable, Store,
+from holoviews import (DynamicMap, HoloMap, Image, ItemTable,
                        GridSpace, Table, Curve)
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import Stream
+from holoviews.plotting.mpl import MPLRenderer, CurvePlot
+from holoviews.plotting.renderer import Renderer
+from panel.widgets import DiscreteSlider, Player, FloatSlider
 from pyviz_comms import CommManager
-
-try:
-    import panel as pn
-
-    from holoviews.plotting.mpl import MPLRenderer, CurvePlot
-    from holoviews.plotting.renderer import Renderer
-    from panel.widgets import DiscreteSlider, Player, FloatSlider
-except:
-    pn = None
 
 
 class MPLRendererTest(ComparisonTestCase):
@@ -33,9 +28,6 @@ class MPLRendererTest(ComparisonTestCase):
     """
 
     def setUp(self):
-        if 'matplotlib' not in Store.renderers and pn is not None:
-            raise SkipTest("Matplotlib and Panel required to test rendering.")
-
         self.basename = 'no-file'
         self.image1 = Image(np.array([[0,1],[2,3]]), label='Image1')
         self.image2 = Image(np.array([[1,0],[4,-2]]), label='Image2')

--- a/holoviews/tests/plotting/plotly/test_callbacks.py
+++ b/holoviews/tests/plotting/plotly/test_callbacks.py
@@ -1,29 +1,19 @@
-from unittest import TestCase, SkipTest
-
-try:
-    from unittest.mock import Mock
-except:
-    from mock import Mock
-
 import uuid
-from holoviews import Tiles
-try:
-    import plotly.graph_objs as go
-except:
-    go = None
 
+from unittest import TestCase
+from unittest.mock import Mock
+
+import plotly.graph_objs as go
+
+from holoviews import Tiles
 from holoviews.streams import (
     BoundsXY, BoundsX, BoundsY, RangeXY, RangeX, RangeY, Selection1D
 )
-
-try:
-    from holoviews.plotting.plotly.callbacks import (
-        RangeXYCallback, RangeXCallback, RangeYCallback,
-        BoundsXYCallback, BoundsXCallback, BoundsYCallback,
-        Selection1DCallback
-    )
-except:
-    pass
+from holoviews.plotting.plotly.callbacks import (
+    RangeXYCallback, RangeXCallback, RangeYCallback,
+    BoundsXYCallback, BoundsXCallback, BoundsYCallback,
+    Selection1DCallback
+)
 
 
 def mock_plot(trace_uid=None):
@@ -69,8 +59,6 @@ def build_callback_set(callback_cls, trace_uids, stream_type, num_streams=2):
 class TestCallbacks(TestCase):
 
     def setUp(self):
-        if go is None:
-            raise SkipTest("Plotly required to test plotly callbacks")
         self.fig_dict = go.Figure({
             'data': [
                 {'type': 'scatter',

--- a/holoviews/tests/plotting/plotly/test_dash.py
+++ b/holoviews/tests/plotting/plotly/test_dash.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 from dash._callback_context import CallbackContext
 
 from .test_plot import TestPlotlyPlot
@@ -12,11 +14,6 @@ except ImportError:
     from dash.dcc import Store
 import plotly.io as pio
 pio.templates.default = None
-
-try:
-    from unittest.mock import MagicMock, patch
-except:
-    from mock import MagicMock, patch
 
 
 class TestHoloViewsDash(TestPlotlyPlot):

--- a/holoviews/tests/plotting/plotly/test_dynamic.py
+++ b/holoviews/tests/plotting/plotly/test_dynamic.py
@@ -1,7 +1,4 @@
-try:
-    from unittest.mock import Mock
-except:
-    from mock import Mock
+from unittest.mock import Mock
 
 import holoviews as hv
 import panel as pn

--- a/holoviews/tests/plotting/plotly/test_plot.py
+++ b/holoviews/tests/plotting/plotly/test_plot.py
@@ -1,28 +1,21 @@
-from unittest import SkipTest
-
 from param import concrete_descendents
+
+import plotly.graph_objs as go
+import pyviz_comms as comms
 
 from holoviews.core import Store
 from holoviews.element.comparison import ComparisonTestCase
-import pyviz_comms as comms
-
-try:
-    from holoviews.plotting.plotly.element import ElementPlot
-    plotly_renderer = Store.renderers['plotly']
-    from holoviews.plotting.plotly.util import figure_grid
-    import plotly.graph_objs as go
-except:
-    plotly_renderer = None
+from holoviews.plotting.plotly.element import ElementPlot
+from holoviews.plotting.plotly.util import figure_grid
 
 from .. import option_intersections
 
+plotly_renderer = Store.renderers['plotly']
 
 
 class TestPlotlyPlot(ComparisonTestCase):
 
     def setUp(self):
-        if not plotly_renderer:
-            raise SkipTest("Plotly required to test plot instantiation")
         self.previous_backend = Store.current_backend
         Store.set_current_backend('plotly')
         self.comm_manager = plotly_renderer.comm_manager

--- a/holoviews/tests/plotting/plotly/test_renderer.py
+++ b/holoviews/tests/plotting/plotly/test_renderer.py
@@ -3,31 +3,22 @@
 Test cases for rendering exporters
 """
 from collections import OrderedDict
-from unittest import SkipTest
 
+import panel as pn
 import param
 
 from holoviews import (DynamicMap, HoloMap, Store, Curve)
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.plotting.plotly import PlotlyRenderer
+from holoviews.plotting.renderer import Renderer
 from holoviews.streams import Stream
+from panel.widgets import DiscreteSlider, Player, FloatSlider
 from pyviz_comms import CommManager
-
-try:
-    import panel as pn
-
-    from holoviews.plotting.plotly import PlotlyRenderer
-    from holoviews.plotting.renderer import Renderer
-    from panel.widgets import DiscreteSlider, Player, FloatSlider
-except:
-    pn, PlotlyRenderer = None, None
 
 
 class PlotlyRendererTest(ComparisonTestCase):
 
     def setUp(self):
-        if 'plotly' not in Store.renderers or None in (pn, PlotlyRenderer):
-            raise SkipTest("Plotly and Panel required to test rendering.")
-
         self.previous_backend = Store.current_backend
         Store.current_backend = 'plotly'
         self.renderer = PlotlyRenderer.instance()

--- a/holoviews/tests/plotting/plotly/test_rgb.py
+++ b/holoviews/tests/plotting/plotly/test_rgb.py
@@ -2,12 +2,8 @@ import numpy as np
 
 import PIL.Image
 
-try:
-    import plotly.graph_objs as go
-except:
-    go = None
-
 from holoviews.element import RGB, Tiles
+import plotly.graph_objs as go
 
 from .test_plot import TestPlotlyPlot, plotly_renderer
 

--- a/holoviews/tests/plotting/test_plotutils.py
+++ b/holoviews/tests/plotting/test_plotutils.py
@@ -16,11 +16,8 @@ from holoviews.plotting.util import (
     get_range, get_axis_padding)
 from holoviews.streams import PointerX
 
-try:
-    from holoviews.plotting.bokeh import util
-    bokeh_renderer = Store.renderers['bokeh']
-except:
-    bokeh_renderer = None
+from holoviews.plotting.bokeh import util
+bokeh_renderer = Store.renderers['bokeh']
 
 
 class TestOverlayableZorders(ComparisonTestCase):
@@ -464,11 +461,7 @@ class TestPlotColorUtils(ComparisonTestCase):
 class TestMPLColormapUtils(ComparisonTestCase):
 
     def setUp(self):
-        try:
-            import matplotlib.cm # noqa
-            import holoviews.plotting.mpl # noqa
-        except:
-            raise SkipTest("Matplotlib needed to test matplotlib colormap instances")
+        import holoviews.plotting.mpl # noqa
 
     def test_mpl_colormap_fire(self):
         colors = process_cmap('fire', 3, provider='matplotlib')
@@ -524,11 +517,8 @@ class TestMPLColormapUtils(ComparisonTestCase):
 class TestBokehPaletteUtils(ComparisonTestCase):
 
     def setUp(self):
-        try:
-            import bokeh.palettes # noqa
-            import holoviews.plotting.bokeh # noqa
-        except:
-            raise SkipTest('Bokeh required to test bokeh palette utilities')
+        import bokeh.palettes # noqa
+        import holoviews.plotting.bokeh # noqa
 
     def test_bokeh_palette_categorical_palettes_not_interpolated(self):
         # Ensure categorical palettes are not expanded
@@ -665,8 +655,6 @@ class TestRangeUtilities(ComparisonTestCase):
 class TestBokehUtils(ComparisonTestCase):
 
     def setUp(self):
-        if not bokeh_renderer:
-            raise SkipTest("Bokeh required to test bokeh plot utils.")
         try:
             import pscript # noqa
         except:

--- a/holoviews/tests/test_selection.py
+++ b/holoviews/tests/test_selection.py
@@ -1,4 +1,4 @@
-from unittest import SkipTest, skip, skipIf
+from unittest import skip, skipIf
 
 import holoviews as hv
 import pandas as pd
@@ -702,10 +702,7 @@ class TestLinkSelectionsPlotly(TestLinkSelections):
     __test__ = True
 
     def setUp(self):
-        try:
-            import holoviews.plotting.plotly # noqa
-        except:
-            raise SkipTest("Plotly selection tests require plotly.")
+        import holoviews.plotting.plotly # noqa
         super().setUp()
         self._backend = Store.current_backend
         Store.set_current_backend('plotly')
@@ -733,10 +730,7 @@ class TestLinkSelectionsBokeh(TestLinkSelections):
     __test__ = True
 
     def setUp(self):
-        try:
-            import holoviews.plotting.bokeh # noqa
-        except:
-            raise SkipTest("Bokeh selection tests require bokeh.")
+        import holoviews.plotting.bokeh # noqa
         super().setUp()
         self._backend = Store.current_backend
         Store.set_current_backend('bokeh')

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -4,11 +4,12 @@ Unit test of the streams system
 from collections import defaultdict
 from unittest import SkipTest
 
+import pandas as pd
 import param
 from panel.widgets import IntSlider
 
 from holoviews.core.spaces import DynamicMap
-from holoviews.core.util import LooseVersion, pd
+from holoviews.core.util import LooseVersion
 from holoviews.element import Points, Scatter, Curve, Histogram, Polygons
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import * # noqa (Test all available streams)
@@ -898,11 +899,6 @@ class TestBufferDictionaryStream(ComparisonTestCase):
 
 
 class TestBufferDataFrameStream(ComparisonTestCase):
-
-    def setUp(self):
-        if pd is None:
-            raise SkipTest('Pandas not available')
-        super().setUp()
 
     def test_init_buffer_dframe(self):
         data = pd.DataFrame({'x': np.array([1]), 'y': np.array([2])})

--- a/holoviews/tests/util/test_utils.py
+++ b/holoviews/tests/util/test_utils.py
@@ -2,8 +2,6 @@
 """
 Unit tests of the helper functions in utils
 """
-from unittest import SkipTest
-
 from holoviews import notebook_extension
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews import Store
@@ -13,17 +11,10 @@ from holoviews.core import OrderedDict
 from holoviews.core.options import OptionTree
 from pyviz_comms import CommManager
 
-try:
-    from holoviews.plotting import mpl
-except:
-    mpl = None
+from holoviews.plotting import mpl
+from holoviews.plotting import bokeh
 
-try:
-    from holoviews.plotting import bokeh
-except:
-    bokeh = None
-
-BACKENDS = ['matplotlib'] + (['bokeh'] if bokeh else [])
+BACKENDS = ['matplotlib', 'bokeh']
 
 from ..utils import LoggingComparisonTestCase
 
@@ -34,16 +25,14 @@ class TestOutputUtil(ComparisonTestCase):
         notebook_extension(*BACKENDS)
         Store.current_backend = 'matplotlib'
         Store.renderers['matplotlib'] = mpl.MPLRenderer.instance()
-        if bokeh:
-            Store.renderers['bokeh'] = bokeh.BokehRenderer.instance()
+        Store.renderers['bokeh'] = bokeh.BokehRenderer.instance()
         OutputSettings.options =  OrderedDict(OutputSettings.defaults.items())
 
         super().setUp()
 
     def tearDown(self):
         Store.renderers['matplotlib'] = mpl.MPLRenderer.instance()
-        if bokeh:
-            Store.renderers['bokeh'] = bokeh.BokehRenderer.instance()
+        Store.renderers['bokeh'] = bokeh.BokehRenderer.instance()
         OutputSettings.options =  OrderedDict(OutputSettings.defaults.items())
         for renderer in Store.renderers.values():
             renderer.comm_manager = CommManager
@@ -60,15 +49,11 @@ class TestOutputUtil(ComparisonTestCase):
         self.assertEqual(OutputSettings.options.get('fig', None), 'png')
 
     def test_output_util_backend_string(self):
-        if bokeh is None:
-            raise SkipTest('Bokeh needed to test backend switch')
         self.assertEqual(OutputSettings.options.get('backend', None), None)
         output("backend='bokeh'")
         self.assertEqual(OutputSettings.options.get('backend', None), 'bokeh')
 
     def test_output_util_backend_kwargs(self):
-        if bokeh is None:
-            raise SkipTest('Bokeh needed to test backend switch')
         self.assertEqual(OutputSettings.options.get('backend', None), None)
         output(backend='bokeh')
         self.assertEqual(OutputSettings.options.get('backend', None), 'bokeh')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,7 @@
 [metadata]
 license_file = LICENSE.txt
+
+[tool:pyctdev.conda]
+namespace_map = 
+    ibis-framework=ibis-sqlite
+

--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ setup_args.update(
         long_description_content_type="text/markdown",
         author="Jean-Luc Stevens and Philipp Rudiger",
         author_email="holoviews@gmail.com",
-        maintainer="PyViz Developers",
+        maintainer="HoloViz Developers",
         maintainer_email="developers@pyviz.org",
         platforms=["Windows", "Mac OS X", "Linux"],
         license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ extras_require["extras"] = extras_require["examples"] + [
     "pscript ==0.7.1",
 ]
 
+# Not used in tox.ini or elsewhere, kept for backwards compatibility.
 extras_require["unit_tests"] = extras_require["examples"] + extras_require["tests"]
 
 extras_require['doc'] = extras_require['examples'] + [

--- a/setup.py
+++ b/setup.py
@@ -93,13 +93,15 @@ extras_require["examples"] = extras_require["recommended"] + [
     "pyarrow",
 ]
 
+extras_require["examples_tests"] = extras_require["examples"] + extras_require['tests_nb']
+
 # Extra third-party libraries
 extras_require["extras"] = extras_require["examples"] + [
     "pscript ==0.7.1",
 ]
 
 # Not used in tox.ini or elsewhere, kept for backwards compatibility.
-extras_require["unit_tests"] = extras_require["examples"] + extras_require["tests"]
+extras_require["unit_tests"] = extras_require["examples"] + extras_require["tests"] + extras_require['flakes']
 
 extras_require['doc'] = extras_require['examples'] + [
     'nbsite >=0.7.1',

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,7 @@ extras_require['tests_core'] = [
     'pytest',
     'pytest-cov',
     'matplotlib >=3',
-    # nbconvert: see https://github.com/holoviz/holoviews/issues/5167
-    'nbconvert <6',
+    'nbconvert',
     'bokeh',
     'pillow',
     'plotly >=4.0',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ extras_require['tests'] = extras_require['tests_core'] + [
     'ffmpeg',
     'cftime',
     'scipy',
-    'pscript ==0.7.1',
     'selenium',
     'ipython >=5.4.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,48 @@ install_requires = [
 
 extras_require = {}
 
+extras_require['flakes'] = [
+    'flake8',
+]
+
+# Test requirements
+extras_require['tests_core'] = [
+    'pytest',
+    'pytest-cov',
+    'matplotlib >=3',
+    # nbconvert: see https://github.com/holoviz/holoviews/issues/5167
+    'nbconvert <6',
+    'bokeh',
+    'pillow',
+    'plotly >=4.0',
+    'dash >=1.16',
+    'codecov',
+]
+
+# Optional tests dependencies, i.e. one should be able
+# to run and pass the test suite without installing any
+# of those.
+extras_require['tests'] = extras_require['tests_core'] + [
+    'dask',
+    'cudf',
+    'ibis-sqlite',
+    'spatialpandas',
+    'xarray >=0.10.4',
+    'networkx',
+    'datashader >=0.11.1',
+    'shapely',
+    'ffmpeg',
+    'cftime',
+    'scipy',
+    'pscript ==0.7.1',
+    'selenium',
+    'ipython >=5.4.0',
+]
+
+extras_require['tests_nb'] = [
+    'nbsmoke >=0.2.0',
+]
+
 # Notebook dependencies
 extras_require["notebook"] = ["ipython >=5.4.0", "notebook"]
 
@@ -55,35 +97,10 @@ extras_require["extras"] = extras_require["examples"] + [
     "pscript ==0.7.1",
 ]
 
-# Test requirements
-extras_require['tests'] = [
-    'pytest',
-    'pytest-cov',
-    'mock',
-    'flake8',
-    'path.py',
-    'matplotlib >=3',
-    'nbsmoke >=0.2.0',
-    'nbconvert',
-    'codecov',
-]
-
 extras_require["unit_tests"] = extras_require["examples"] + extras_require["tests"]
-
-if sys.version_info >= (3, 7):
-    extras_require["unit_tests"].append("ibis-sqlite")
-
-extras_require["basic_tests"] = (
-    extras_require["tests"]
-    + ["matplotlib >=3", "bokeh >=2.4.3", "pandas"]
-    + extras_require["notebook"]
-)
-
-extras_require["nbtests"] = extras_require["recommended"]
 
 extras_require['doc'] = extras_require['examples'] + [
     'nbsite >=0.7.1',
-    'sphinx',
     'mpl_sample_data >=3.1.3',
     'pscript',
     'graphviz',
@@ -93,16 +110,13 @@ extras_require['doc'] = extras_require['examples'] + [
     'pooch',
 ]
 
+extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
+
 extras_require["build"] = [
     "param >=1.7.0",
     "setuptools >=30.3.0",
     "pyct >=0.4.4",
 ]
-
-# Everything for examples and nosetests
-extras_require["all"] = list(
-    set(extras_require["unit_tests"]) | set(extras_require["nbtests"])
-)
 
 def get_setup_version(reponame):
     """

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,7 @@ extras_require['tests_core'] = [
 # of those.
 extras_require['tests'] = extras_require['tests_core'] + [
     'dask',
-    'cudf',
-    'ibis-sqlite',
+    'ibis-framework',  # Mapped to ibis-sqlite in setup.cfg for conda
     'spatialpandas',
     'xarray >=0.10.4',
     'networkx',
@@ -58,6 +57,10 @@ extras_require['tests'] = extras_require['tests_core'] + [
     'pscript ==0.7.1',
     'selenium',
     'ipython >=5.4.0',
+]
+
+extras_require['tests_gpu'] = extras_require['tests'] + [
+    'cudf',
 ]
 
 extras_require['tests_nb'] = [

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,11 @@ description = Run unit tests with coverage and all the optional test dependencie
 deps = .[tests]
 commands = pytest holoviews --cov=./holoviews
 
+[_unit_gpu]
+description = Run unit tests with coverage and all the optional test dependencies
+deps = .[tests_gpu]
+commands = pytest holoviews --cov=./holoviews
+
 [_examples]
 description = Test that default examples run
 deps = .[tests_nb, examples]
@@ -43,11 +48,15 @@ changedir = {envtmpdir}
 
 commands = examples-pkg: {[_pkg]commands}
            unit: {[_unit]commands}
+           unit_core: {[_unit_core]commands}
+           unit_gpu: {[_unit_gpu]commands}
            flakes: {[_flakes]commands}
            examples: {[_examples]commands}
            all_recommended: {[_all_recommended]commands}
 
 deps = unit: {[_unit]deps}
+       unit_core: {[_unit_core]deps}
+       unit_gpu: {[_unit_gpu]deps}
        flakes: {[_flakes]deps}
        examples: {[_examples]deps}
        all_recommended: {[_all_recommended]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -3,26 +3,31 @@
 
 [tox]
 #          python version             test group                  extra envs  extra commands
-envlist = {py36,py37,py38,py39,py310}-{flakes,unit,examples,all_recommended}-{default}-{dev,pkg}
+envlist = {py37,py38,py39,py310}-{flakes,unit,examples,all_recommended}-{default}-{dev,pkg}
 
 [_flakes]
 description = Flake check python
-deps = .[tests]
+deps = .[flakes]
 commands = flake8 holoviews
 
+[_unit_core]
+description = Run unit tests with coverage but no optional test dependency
+deps = .[tests_core]
+commands = pytest holoviews --cov=./holoviews
+
 [_unit]
-description = Run unit tests with coverage
-deps = .[unit_tests]
+description = Run unit tests with coverage and all the optional test dependencies
+deps = .[tests]
 commands = pytest holoviews --cov=./holoviews
 
 [_examples]
 description = Test that default examples run
-deps = .[tests]
+deps = .[tests_nb, examples]
 commands = pytest --nbsmoke-run -k ".ipynb" examples/reference/elements
 
 [_all_recommended]
 description = Run all recommended tests
-deps = .[unit_tests]
+deps = .[flakes, tests_extra, examples]
 commands = {[_flakes]commands}
            {[_unit]commands}
            {[_examples]commands}
@@ -44,6 +49,7 @@ commands = examples-pkg: {[_pkg]commands}
 
 deps = unit: {[_unit]deps}
        flakes: {[_flakes]deps}
+       examples: {[_examples]deps}
        all_recommended: {[_all_recommended]deps}
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -27,12 +27,12 @@ commands = pytest holoviews --cov=./holoviews
 
 [_examples]
 description = Test that default examples run
-deps = .[tests_nb, examples]
+deps = .[examples_tests]
 commands = pytest --nbsmoke-run -k ".ipynb" examples/reference/elements
 
 [_all_recommended]
 description = Run all recommended tests
-deps = .[flakes, tests_extra, examples]
+deps = .[flakes, tests, examples_tests]
 commands = {[_flakes]commands}
            {[_unit]commands}
            {[_examples]commands}


### PR DESCRIPTION
This turned into a bigger PR than I thought. My original intention was to fix the pip build that appeared to be broken when it last run on the scheduled jobs. I saw that the grouped dependencies in `setup.py` where not so clear, so started to re-organize them and checked in particular the ones required to run the tests (not the notebooks). That led me to simplify a lot of imports in the tests. For instance in many places `pandas` was assumed to be optional while it's now a required dependency of HoloViews, same for Panel. The tests also now need Bokeh, Matplotlib and Plotly to be installed to run. This made sense to me, they're so critical to HoloViews.