### PR TITLE
Checking for empty data ranges in raster elements

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -299,7 +299,7 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
             data_bounds = self.bounds.lbrt()
 
         non_finite_bounds = all(not util.isfinite(v) for v in bounds.lbrt())
-        data_ranges = self.interface.range(self, kdims[0]) + self.interface.range(self, kdims[1])
+        data_ranges = self.interface.range(self, self.kdims[0]) + self.interface.range(self, self.kdims[1])
         non_finite_data_ranges = all(not util.isfinite(v) for v in data_ranges)
         non_finite = non_finite_bounds or non_finite_data_ranges
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -298,7 +298,11 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
         if self.interface is ImageInterface and not isinstance(data, (np.ndarray, Image)):
             data_bounds = self.bounds.lbrt()
 
-        non_finite = all(not util.isfinite(v) for v in bounds.lbrt())
+        non_finite_bounds = all(not util.isfinite(v) for v in bounds.lbrt())
+        data_ranges = self.interface.range(self, kdims[0]) + self.interface.range(self, kdims[1])
+        non_finite_data_ranges = all(not util.isfinite(v) for v in data_ranges)
+        non_finite = non_finite_bounds or non_finite_data_ranges
+
         if non_finite:
             bounds = BoundingBox(points=((0, 0), (0, 0)))
             xdensity = xdensity or 1


### PR DESCRIPTION
PR to address https://github.com/holoviz/holoviews/issues/5255

The datashader operation was using `_empty_agg` to return an empty `Image` element which then failed to display with a `ZeroDivisionError` after attempting a bounds calculation. I'm not sure this is quite the right fix but now this element displays without error:

<img width="1212" alt="image" src="https://user-images.githubusercontent.com/890576/172663697-2e819dfe-7907-48d5-be4b-91c5e2386307.png">

Though I now notice that this isn't enough as both the matplotlib and plotly backends still have trouble: plotly complains with `Out of range float values are not JSON compliant` and matplotlib complains with `ValueError: zero-size array to reduction operation minimum which has no identity`.  

Looks like plotting libraries don't believe that empty images are a thing either! ;-p
