### PR TITLE
Enable Dimension to accept a dict spec

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -241,40 +241,40 @@ class Dimension(param.Parameterized):
         if 'name' in params:
             raise KeyError('Dimension name must only be passed as the positional argument')
 
-        existing_params = {}
+        all_params = {}
         if isinstance(spec, Dimension):
-            existing_params = dict(spec.param.get_param_values())
+            all_params.update(spec.param.get_param_values())
         elif isinstance(spec, str):
             if (spec, params.get('unit', None)) in self.presets.keys():
                 preset = self.presets[(str(spec), str(params['unit']))]
-                existing_params = dict(preset.param.get_param_values())
+                all_params.update(preset.param.get_param_values())
             elif spec in self.presets:
-                existing_params = dict(self.presets[spec].param.get_param_values())
+                all_params.update(self.presets[spec].param.get_param_values())
             elif (spec,) in self.presets:
-                existing_params = dict(self.presets[(spec,)].param.get_param_values())
-            existing_params['name'] = spec
-            existing_params['label'] = spec
+                all_params.update(self.presets[(spec,)].param.get_param_values())
+            all_params['name'] = spec
+            all_params['label'] = spec
         elif isinstance(spec, tuple):
             if not all(isinstance(s, str) for s in spec) or len(spec) != 2:
                 raise ValueError("Dimensions specified as a tuple must be a tuple "
                                  "consisting of the name and label not: %s" % str(spec))
             name, label = spec
-            existing_params['name'] = name
-            existing_params['label'] = label
+            all_params['name'] = name
+            all_params['label'] = label
             if 'label' in params and (label != params['label']):
                 if params['label'] != label:
                     self.param.warning(
                         'Using label as supplied by keyword ({!r}), ignoring '
                         'tuple value {!r}'.format(params['label'], label))
         elif isinstance(spec, dict):
-            existing_params.update(spec)
+            all_params.update(spec)
             try:
-                existing_params.setdefault('label', spec['name'])
+                all_params.setdefault('label', spec['name'])
             except KeyError as exc:
                 raise ValueError(
                     'Dimension specified as a dict must contain a "name" key'
                 ) from exc
-        all_params = dict(existing_params, **params)
+        all_params.update(params)
 
         if all_params['name'] == '':
             raise ValueError('Dimension name cannot be the empty string')

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -252,33 +252,29 @@ class Dimension(param.Parameterized):
                 existing_params = dict(self.presets[spec].param.get_param_values())
             elif (spec,) in self.presets:
                 existing_params = dict(self.presets[(spec,)].param.get_param_values())
-        elif isinstance(spec, dict):
-            existing_params = spec
-
-        all_params = dict(existing_params, **params)
-        if isinstance(spec, tuple):
+            existing_params['name'] = spec
+            existing_params['label'] = spec
+        elif isinstance(spec, tuple):
             if not all(isinstance(s, str) for s in spec) or len(spec) != 2:
                 raise ValueError("Dimensions specified as a tuple must be a tuple "
                                  "consisting of the name and label not: %s" % str(spec))
             name, label = spec
-            all_params['name'] = name
-            all_params['label'] = label
+            existing_params['name'] = name
+            existing_params['label'] = label
             if 'label' in params and (label != params['label']):
                 if params['label'] != label:
                     self.param.warning(
                         'Using label as supplied by keyword ({!r}), ignoring '
                         'tuple value {!r}'.format(params['label'], label))
-                all_params['label'] = params['label']
         elif isinstance(spec, dict):
+            existing_params.update(spec)
             try:
-                all_params.setdefault('label', spec['name'])
+                existing_params.setdefault('label', spec['name'])
             except KeyError as exc:
                 raise ValueError(
                     'Dimension specified as a dict must contain a "name" key'
                 ) from exc
-        elif isinstance(spec, str):
-            all_params['name'] = spec
-            all_params['label'] = params.get('label', spec)
+        all_params = dict(existing_params, **params)
 
         if all_params['name'] == '':
             raise ValueError('Dimension name cannot be the empty string')

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -254,7 +254,8 @@ class Dimension(param.Parameterized):
             if 'label' in params and params['label'] != all_params['label']:
                 self.param.warning(
                     'Using label as supplied by keyword ({!r}), ignoring '
-                    'tuple value {!r}'.format(params['label'], all_params['label']))
+                    'tuple value {!r}'.format(params['label'], all_params['label'])
+                )
         elif isinstance(spec, dict):
             all_params.update(spec)
             try:

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -241,19 +241,19 @@ class Dimension(param.Parameterized):
         if 'name' in params:
             raise KeyError('Dimension name must only be passed as the positional argument')
 
+        existing_params = {}
         if isinstance(spec, Dimension):
             existing_params = dict(spec.param.get_param_values())
-        elif (spec, params.get('unit', None)) in self.presets.keys():
-            preset = self.presets[(str(spec), str(params['unit']))]
-            existing_params = dict(preset.param.get_param_values())
+        elif isinstance(spec, str):
+            if (spec, params.get('unit', None)) in self.presets.keys():
+                preset = self.presets[(str(spec), str(params['unit']))]
+                existing_params = dict(preset.param.get_param_values())
+            elif spec in self.presets:
+                existing_params = dict(self.presets[spec].param.get_param_values())
+            elif (spec,) in self.presets:
+                existing_params = dict(self.presets[(spec,)].param.get_param_values())
         elif isinstance(spec, dict):
             existing_params = spec
-        elif spec in self.presets:
-            existing_params = dict(self.presets[spec].param.get_param_values())
-        elif (spec,) in self.presets:
-            existing_params = dict(self.presets[(spec,)].param.get_param_values())
-        else:
-            existing_params = {}
 
         all_params = dict(existing_params, **params)
         if isinstance(spec, tuple):

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -255,7 +255,7 @@ class Dimension(param.Parameterized):
             all_params['name'] = spec
             all_params['label'] = spec
         elif isinstance(spec, tuple):
-            if not all(isinstance(s, str) for s in spec) or len(spec) != 2:
+            if len(spec) != 2:
                 raise ValueError("Dimensions specified as a tuple must be a tuple "
                                  "consisting of the name and label not: %s" % str(spec))
             name, label = spec
@@ -276,10 +276,10 @@ class Dimension(param.Parameterized):
                 ) from exc
         all_params.update(params)
 
-        if all_params['name'] == '':
-            raise ValueError('Dimension name cannot be the empty string')
-        if all_params['label'] in ['', None]:
-            raise ValueError('Dimension label cannot be None or the empty string')
+        if not all_params['name']:
+            raise ValueError('Dimension name cannot be empty')
+        if not all_params['label']:
+            raise ValueError('Dimension label cannot be empty')
 
         values = params.get('values', [])
         if isinstance(values, str) and values == 'initial':

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -56,14 +56,8 @@ def asdim(dimension):
         A Dimension object constructed from the dimension spec. No
         copy is performed if the input is already a Dimension.
     """
-    if isinstance(dimension, Dimension):
-        return dimension
-    elif isinstance(dimension, (tuple, dict, str)):
-        return Dimension(dimension)
-    else:
-        raise ValueError('%s type could not be interpreted as Dimension. '
-                         'Dimensions must be declared as a string, tuple, '
-                         'dictionary or Dimension type.')
+    return dimension if isinstance(dimension, Dimension) else Dimension(dimension)
+
 
 def dimension_name(dimension):
     """Return the Dimension.name for a dimension-like object.
@@ -118,11 +112,6 @@ def process_dimensions(kdims, vdims):
                              "specified as tuples, strings, dictionaries or Dimension "
                              "instances, not a %s type. Ensure you passed the data as the "
                              "first argument." % (group, type(dims).__name__))
-        for dim in dims:
-            if not isinstance(dim, (tuple, str, Dimension, dict)):
-                raise ValueError('Dimensions must be defined as a tuple, '
-                                 'string, dictionary or Dimension instance, '
-                                 'found a %s type.' % type(dim).__name__)
         dimensions[group] = [asdim(d) for d in dims]
     return dimensions
 
@@ -274,6 +263,12 @@ class Dimension(param.Parameterized):
                 raise ValueError(
                     'Dimension specified as a dict must contain a "name" key'
                 ) from exc
+        else:
+            raise ValueError(
+                '%s type could not be interpreted as Dimension.  Dimensions must be '
+                'declared as a string, tuple, dictionary or Dimension type.'
+                % type(spec).__name__
+            )
         all_params.update(params)
 
         if not all_params['name']:

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -255,17 +255,17 @@ class Dimension(param.Parameterized):
             all_params['name'] = spec
             all_params['label'] = spec
         elif isinstance(spec, tuple):
-            if len(spec) != 2:
-                raise ValueError("Dimensions specified as a tuple must be a tuple "
-                                 "consisting of the name and label not: %s" % str(spec))
-            name, label = spec
-            all_params['name'] = name
-            all_params['label'] = label
-            if 'label' in params and (label != params['label']):
-                if params['label'] != label:
-                    self.param.warning(
-                        'Using label as supplied by keyword ({!r}), ignoring '
-                        'tuple value {!r}'.format(params['label'], label))
+            try:
+                all_params['name'], all_params['label'] = spec
+            except ValueError as exc:
+                raise ValueError(
+                    "Dimensions specified as a tuple must be a tuple "
+                    "consisting of the name and label not: %s" % str(spec)
+                ) from exc
+            if 'label' in params and params['label'] != all_params['label']:
+                self.param.warning(
+                    'Using label as supplied by keyword ({!r}), ignoring '
+                    'tuple value {!r}'.format(params['label'], all_params['label']))
         elif isinstance(spec, dict):
             all_params.update(spec)
             try:

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -269,6 +269,13 @@ class Dimension(param.Parameterized):
                         'Using label as supplied by keyword ({!r}), ignoring '
                         'tuple value {!r}'.format(params['label'], label))
                 all_params['label'] = params['label']
+        elif isinstance(spec, dict):
+            try:
+                all_params.setdefault('label', spec['name'])
+            except KeyError as exc:
+                raise ValueError(
+                    'Dimension specified as a dict must contain a "name" key'
+                ) from exc
         elif isinstance(spec, str):
             all_params['name'] = spec
             all_params['label'] = params.get('label', spec)

--- a/holoviews/tests/core/test_dimensions.py
+++ b/holoviews/tests/core/test_dimensions.py
@@ -53,7 +53,6 @@ class DimensionNameLabelTest(LoggingComparisonTestCase):
         self.assertEqual(dim.name, 'test')
         self.assertEqual(dim.label, 'test')
 
-    @pytest.mark.xfail()
     def test_dimension_dict_name_and_label(self):
         dim = Dimension(dict(name='test', label='A test'))
         self.assertEqual(dim.name, 'test')

--- a/holoviews/tests/core/test_dimensions.py
+++ b/holoviews/tests/core/test_dimensions.py
@@ -1,9 +1,6 @@
 """
 Test cases for Dimension and Dimensioned object behaviour.
 """
-
-import pytest
-
 from holoviews.core import Dimensioned, Dimension
 from holoviews.element.comparison import ComparisonTestCase
 from ..utils import LoggingComparisonTestCase
@@ -37,17 +34,14 @@ class DimensionNameLabelTest(LoggingComparisonTestCase):
         dim = Dimension('test', label='A test')
         self.assertEqual(dim.label, 'A test')
 
-    @pytest.mark.xfail()
     def test_dimension_dict_empty(self):
         with self.assertRaisesRegex(ValueError, 'must contain a "name" key'):
             Dimension(dict())
 
-    @pytest.mark.xfail()
     def test_dimension_dict_label(self):
         with self.assertRaisesRegex(ValueError, 'must contain a "name" key'):
             Dimension(dict(label='A test'))
 
-    @pytest.mark.xfail()
     def test_dimension_dict_name(self):
         dim = Dimension(dict(name='test'))
         self.assertEqual(dim.name, 'test')

--- a/holoviews/tests/core/test_dimensions.py
+++ b/holoviews/tests/core/test_dimensions.py
@@ -1,6 +1,9 @@
 """
 Test cases for Dimension and Dimensioned object behaviour.
 """
+
+import pytest
+
 from holoviews.core import Dimensioned, Dimension
 from holoviews.element.comparison import ComparisonTestCase
 from ..utils import LoggingComparisonTestCase
@@ -32,6 +35,28 @@ class DimensionNameLabelTest(LoggingComparisonTestCase):
 
     def test_dimension_label_kwarg(self):
         dim = Dimension('test', label='A test')
+        self.assertEqual(dim.label, 'A test')
+
+    @pytest.mark.xfail()
+    def test_dimension_dict_empty(self):
+        with self.assertRaisesRegex(ValueError, 'must contain a "name" key'):
+            Dimension(dict())
+
+    @pytest.mark.xfail()
+    def test_dimension_dict_label(self):
+        with self.assertRaisesRegex(ValueError, 'must contain a "name" key'):
+            Dimension(dict(label='A test'))
+
+    @pytest.mark.xfail()
+    def test_dimension_dict_name(self):
+        dim = Dimension(dict(name='test'))
+        self.assertEqual(dim.name, 'test')
+        self.assertEqual(dim.label, 'test')
+
+    @pytest.mark.xfail()
+    def test_dimension_dict_name_and_label(self):
+        dim = Dimension(dict(name='test', label='A test'))
+        self.assertEqual(dim.name, 'test')
         self.assertEqual(dim.label, 'A test')
 
     def test_dimension_label_kwarg_and_tuple(self):

--- a/holoviews/tests/core/test_ndmapping.py
+++ b/holoviews/tests/core/test_ndmapping.py
@@ -1,7 +1,5 @@
 from collections import OrderedDict
 
-import pytest
-
 from holoviews.core import Dimension
 from holoviews.core.ndmapping import (
     MultiDimensionalMapping, NdMapping, UniformNdMapping
@@ -58,7 +56,6 @@ class NdIndexableMappingTest(ComparisonTestCase):
     def test_idxmapping_init_dimstr(self):
         MultiDimensionalMapping(self.init_item_odict, kdims=self.dimension_labels)
 
-    @pytest.mark.xfail()
     def test_idxmapping_init_dimdict(self):
         MultiDimensionalMapping(
             self.init_item_odict,

--- a/holoviews/tests/core/test_ndmapping.py
+++ b/holoviews/tests/core/test_ndmapping.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 
+import pytest
+
 from holoviews.core import Dimension
 from holoviews.core.ndmapping import (
     MultiDimensionalMapping, NdMapping, UniformNdMapping
@@ -55,6 +57,13 @@ class NdIndexableMappingTest(ComparisonTestCase):
 
     def test_idxmapping_init_dimstr(self):
         MultiDimensionalMapping(self.init_item_odict, kdims=self.dimension_labels)
+
+    @pytest.mark.xfail()
+    def test_idxmapping_init_dimdict(self):
+        MultiDimensionalMapping(
+            self.init_item_odict,
+            kdims=[dict(name=label) for label in self.dimension_labels],
+        )
 
     def test_idxmapping_init_dimensions(self):
         MultiDimensionalMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])


### PR DESCRIPTION
This PR closes #5332 and is closely related to issue #2315 and PR #2332.  Its main changes are as follows:

*   Enable one to specify a `Dimension` with a `dict`.
*   When `spec` is a `dict` that lacks a "name" key, raise `ValueError`.
*   When `spec` has an invalid type, raise `ValueError`.  (Although `TypeError` would be customary, `ValueError` is backward-compatible with the behavior of helper functions around `Dimension`.)
*   Look up preset dimensions only when `spec` is a `str`.
*   Let the *param* system handle wrong types of parameters.

One could further refine this code as follows:

*   It's unclear whether the `Dimension.presets` mapping (of PR #644) should remain; it appears unused internally (including by tests) and undocumented.
*   I'd rather see checks for instances of `collections.abc.Mapping` instead of `dict`, but other related code in *Holoviews* uses `dict`.
*   When a caller calls the `Dimension` class, `dimension_name` function, or `process_dimensions` function with an invalid type, raise `TypeError` instead of the current `ValueError`.

This change might make it easier for *hvplot* to accept `kdims` specified as `dict`s instead of `Dimension`s.