### PR TITLE
Test updates following release of datashader 0.14.1

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1227,6 +1227,13 @@ def is_number(obj):
     else: return False
 
 
+def is_float(obj):
+    """
+    Checks if the argument is a floating-point scalar.
+    """
+    return isinstance(obj, (float, np.floating))
+
+
 def is_int(obj, int_like=False):
     """
     Checks for int types including the native Python type and NumPy-like objects

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -28,7 +28,8 @@ from ..core import (Element, Empty, AdjointLayout, Overlay, Dimension,
                     HoloMap, Dimensioned, Layout, NdLayout, NdOverlay,
                     GridSpace, DynamicMap, GridMatrix, OrderedDict)
 from ..core.options import Options, Cycle
-from ..core.util import pd, cast_array_to_int64, datetime_types, dt_to_int
+from ..core.util import (pd, cast_array_to_int64, datetime_types, dt_to_int,
+                         is_float)
 
 
 class ComparisonInterface(object):
@@ -62,7 +63,7 @@ class ComparisonInterface(object):
         Classmethod equivalent to unittest.TestCase method
         """
         asserter = None
-        if type(first) is type(second):
+        if type(first) is type(second) or (is_float(first) and is_float(second)):
             asserter = cls.equality_type_funcs.get(type(first))
 
             if asserter is not None:

--- a/holoviews/tests/element/test_comparisonsimple.py
+++ b/holoviews/tests/element/test_comparisonsimple.py
@@ -44,19 +44,22 @@ class SimpleComparisonTest(ComparisonTestCase):
         try:
             self.assertEqual(np.float32(3.52),3.5)
         except AssertionError as e:
-            self.assertEqual(str(e), "3.52 != 3.5")
+            if not str(e).startswith("Floats not almost equal to 6 decimals"):
+                    raise self.failureException("Numpy float mismatch error not raised.")
 
     def test_float_heterogeneous_unequal2(self):
         try:
             self.assertEqual(np.float64(3.54),3.5)
         except AssertionError as e:
-            self.assertEqual(str(e), "3.54 != 3.5")
+            if not str(e).startswith("Floats not almost equal to 6 decimals"):
+                    raise self.failureException("Numpy float mismatch error not raised.")
 
     def test_float_heterogeneous_unequal3(self):
         try:
             self.assertEqual(np.float64(3.0), np.float32(4.0))
         except AssertionError as e:
-            self.assertEqual(str(e), "3.0 != 4.0")
+            if not str(e).startswith("Floats not almost equal to 6 decimals"):
+                    raise self.failureException("Numpy float mismatch error not raised.")
 
     def test_arrays_equal_int(self):
         self.assertEqual(np.array([[1,2],[3,4]]),

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -922,9 +922,9 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         trimesh = TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
         img = rasterize(trimesh, width=3, height=3, dynamic=False)
         array = np.array([
-            [   1.5,    1.5, np.NaN],
-            [   0.5,    1.5, np.NaN],
-            [np.NaN, np.NaN, np.NaN]
+            [0.5, 1.5, 1.5],
+            [0.5, 0.5, 1.5],
+            [0.5, 0.5, 0.5]
         ])
         image = Image(array, bounds=(0, 0, 1, 1))
         self.assertEqual(img, image)
@@ -937,9 +937,9 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         img = rasterize(trimesh, width=3, height=3, dynamic=False)
 
         array = np.array([
-            [    2.,     3., np.NaN],
-            [   1.5,    2.5, np.NaN],
-            [np.NaN, np.NaN, np.NaN]
+            [2.166667, 2.833333, 3.5     ],
+            [1.833333, 2.5,      3.166667],
+            [1.5,      2.166667, 2.833333]
         ])
         image = Image(array, bounds=(0, 0, 1, 1))
         self.assertEqual(img, image)
@@ -962,9 +962,9 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         self.assertIsInstance(cache[trimesh._plot_id]['mesh'], dd.DataFrame)
 
         array = np.array([
-            [    2.,     3., np.NaN],
-            [   1.5,    2.5, np.NaN],
-            [np.NaN, np.NaN, np.NaN]
+            [2.166667, 2.833333, 3.5     ],
+            [1.833333, 2.5,      3.166667],
+            [1.5,      2.166667, 2.833333]
         ])
         image = Image(array, bounds=(0, 0, 1, 1))
         self.assertEqual(img, image)
@@ -988,9 +988,9 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         self.assertIsInstance(cache[trimesh._plot_id]['mesh'], dd.DataFrame)
 
         array = np.array([
-            [   1.5,    1.5, np.NaN],
-            [   0.5,    1.5, np.NaN],
-            [np.NaN, np.NaN, np.NaN]
+            [0.5, 1.5, 1.5],
+            [0.5, 0.5, 1.5],
+            [0.5, 0.5, 0.5]
         ])
         image = Image(array, bounds=(0, 0, 1, 1))
         self.assertEqual(img, image)
@@ -1014,9 +1014,9 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         self.assertIsInstance(cache[trimesh._plot_id]['mesh'], dd.DataFrame)
 
         array = np.array([
-            [    2.,     3., np.NaN],
-            [   1.5,    2.5, np.NaN],
-            [np.NaN, np.NaN, np.NaN]
+            [2.166667, 2.833333, 3.5     ],
+            [1.833333, 2.5,      3.166667],
+            [1.5,      2.166667, 2.833333]
         ])
         image = Image(array, bounds=(0, 0, 1, 1))
         self.assertEqual(img, image)
@@ -1027,9 +1027,9 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         img = rasterize(trimesh, width=3, height=3, dynamic=False)
 
         array = np.array([
-            [    2.,     3., np.NaN],
-            [   1.5,    2.5, np.NaN],
-            [np.NaN, np.NaN, np.NaN]
+            [2.166667, 2.833333, 3.5     ],
+            [1.833333, 2.5,      3.166667],
+            [1.5,      2.166667, 2.833333]
         ])
         image = Image(array, bounds=(0, 0, 1, 1), vdims='node_z')
         self.assertEqual(img, image)
@@ -1040,9 +1040,9 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         img = rasterize(trimesh, width=3, height=3, dynamic=False, aggregator=ds.mean('z'))
 
         array = np.array([
-            [   1.5,    1.5, np.NaN],
-            [   0.5,    1.5, np.NaN],
-            [np.NaN, np.NaN, np.NaN]
+            [0.5, 1.5, 1.5],
+            [0.5, 0.5, 1.5],
+            [0.5, 0.5, 0.5]
         ])
         image = Image(array, bounds=(0, 0, 1, 1))
         self.assertEqual(img, image)
@@ -1059,17 +1059,22 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         vertices = [(0., 0., 1), (0., 1., 2), (1., 0., 3), (1., 1., 4)]
         trimesh = TriMesh((simplices, Points(vertices, vdims='z')))
         img = rasterize(trimesh, width=3, height=3, dynamic=False)
-        image = Image(np.array([[2., 3., np.NaN], [1.5, 2.5, np.NaN], [np.NaN, np.NaN, np.NaN]]),
-                      bounds=(0, 0, 1, 1), vdims='z')
+
+        array = np.array([
+            [2.166667, 2.833333, 3.5     ],
+            [1.833333, 2.5,      3.166667],
+            [1.5,      2.166667, 2.833333]
+        ])
+        image = Image(array, bounds=(0, 0, 1, 1), vdims='z')
         self.assertEqual(img, image)
 
     def test_rasterize_trimesh_ds_aggregator(self):
         trimesh = TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
         img = rasterize(trimesh, width=3, height=3, dynamic=False, aggregator=ds.mean('z'))
         array = np.array([
-            [   1.5,    1.5, np.NaN],
-            [   0.5,    1.5, np.NaN],
-            [np.NaN, np.NaN, np.NaN]
+            [0.5, 1.5, 1.5],
+            [0.5, 0.5, 1.5],
+            [0.5, 0.5, 0.5]
         ])
         image = Image(array, bounds=(0, 0, 1, 1))
         self.assertEqual(img, image)
@@ -1078,9 +1083,9 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         trimesh = TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
         img = rasterize(trimesh, width=3, height=3, dynamic=False, aggregator='mean')
         array = np.array([
-            [   1.5,    1.5, np.NaN],
-            [   0.5,    1.5, np.NaN],
-            [np.NaN, np.NaN, np.NaN]
+            [0.5, 1.5, 1.5],
+            [0.5, 0.5, 1.5],
+            [0.5, 0.5, 0.5]
         ])
         image = Image(array, bounds=(0, 0, 1, 1))
         self.assertEqual(img, image)

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -760,7 +760,7 @@ class DatashaderShadeTests(ComparisonTestCase):
                           'C': Image((xs, ys, np.array([[0, 0], [1, 0]], dtype='u4')),
                                      datatype=['xarray'], vdims=Dimension('z Count', nodata=0))},
                          kdims=['z'])
-        shaded = shade(data)
+        shaded = shade(data, rescale_discrete_levels=False)
         r = [[228, 120], [66, 120]]
         g = [[26, 109], [150, 109]]
         b = [[28, 95], [129, 95]]
@@ -778,7 +778,7 @@ class DatashaderShadeTests(ComparisonTestCase):
                           'C': Image((xs, ys, np.array([[0, 0], [1, 0]], dtype='u4')),
                                      datatype=['grid'], vdims=Dimension('z Count', nodata=0))},
                          kdims=['z'])
-        shaded = shade(data)
+        shaded = shade(data, rescale_discrete_levels=False)
         r = [[228, 120], [66, 120]]
         g = [[26, 109], [150, 109]]
         b = [[28, 95], [129, 95]]


### PR DESCRIPTION
This PR fixes the HoloViews test failures which were identified in PR #5343. There were two sets of failures, both relating to HoloViews tests needing to be updated following changes released in Datashader 0.14.1. They were:

1. Improved `trimesh` rendering.
2. The default setting of `rescale_discrete_levels=True` in `shade`.

The former required changing the comparison arrays; I have visually checked all of these. The latter required setting `rescale_discrete_levels=False` and then the tests pass.