### PR TITLE
Remove deprecated options and add new deprecation warnings

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -421,9 +421,6 @@ class DivPlot(BokehPlot, GenericElementPlot, AnnotationPlot):
           aspect ratio.
     """)
 
-    finalize_hooks = param.HookList(default=[], doc="""
-        Deprecated; use hooks options instead.""")
-
     hooks = param.HookList(default=[], doc="""
         Optional list of hooks called when finalizing a plot. The
         hook is passed the plot object and the displayed element, and

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -310,12 +310,7 @@ class BokehPlot(DimensionedPlot, CallbackPlot):
                 shared_sources.append(new_source)
                 source_cols[id(new_source)] = [c for c in new_source.data]
         for plot in plots:
-            if plot.hooks and plot.finalize_hooks:
-                self.param.warning(
-                    "Supply either hooks or finalize_hooks not both; "
-                    "using hooks and ignoring finalize_hooks.")
-            hooks = plot.hooks or plot.finalize_hooks
-            for hook in hooks:
+            for hook in plot.hooks:
                 hook(plot, plot.current_frame)
             for callback in plot.callbacks:
                 callback.initialize(plot_id=self.id)

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -17,9 +17,6 @@ from .selection import TabularSelectionDisplay
 
 class TablePlot(BokehPlot, GenericElementPlot):
 
-    finalize_hooks = param.HookList(default=[], doc="""
-        Deprecated; use hooks options instead.""")
-
     hooks = param.HookList(default=[], doc="""
         Optional list of hooks called when finalizing a plot. The
         hook is passed the plot object and the displayed element, and

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -678,7 +678,7 @@ class ColorbarPlot(ElementPlot):
         An explicit override of the color bar label, if set takes precedence
         over the title key in colorbar_opts.""")
 
-    clim = param.NumericTuple(default=(np.nan, np.nan), length=2, doc="""
+    clim = param.Tuple(default=(np.nan, np.nan), length=2, doc="""
         User-specified colorbar axis range limits for the plot, as a
         tuple (low,high). If specified, takes precedence over data
         and dimension ranges.""")
@@ -872,7 +872,7 @@ class ColorbarPlot(ElementPlot):
         clim = opts.pop(prefix+'clims', None)
 
         # check if there's an actual value (not np.nan)
-        if clim is None and util.isfinite(self.clim).all():
+        if clim is None and self.clim is not None and any(util.isfinite(cl) for cl in self.clim):
             clim = self.clim
 
         if clim is None:

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -227,7 +227,6 @@ class RasterGridPlot(GridPlot, OverlayPlot):
     data_aspect = param.Parameter(precedence=-1)
     default_span = param.Parameter(precedence=-1)
     hooks = param.Parameter(precedence=-1)
-    finalize_hooks = param.Parameter(precedence=-1)
     invert_axes = param.Parameter(precedence=-1)
     invert_xaxis = param.Parameter(precedence=-1)
     invert_yaxis = param.Parameter(precedence=-1)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -505,11 +505,7 @@ class DimensionedPlot(Plot):
         label, group, type_name, dim_title = self._format_title_components(
             key, dimensions=True, separator='\n'
         )
-
-        custom_title = (self.title != self.param['title'].default)
-        title_str = self.title
-
-        title = util.bytes_to_unicode(title_str).format(
+        title = util.bytes_to_unicode(self.title).format(
             label=util.bytes_to_unicode(label),
             group=util.bytes_to_unicode(group),
             type=type_name,

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -118,7 +118,7 @@ class TestTextPlot(TestBokehPlot):
         self.assertEqual(glyph.angle, np.pi/2.)
 
     def test_text_plot_rotation_style(self):
-        text = Text(0, 0, 'Test').options(angle=90)
+        text = Text(0, 0, 'Test').opts(angle=90)
         plot = bokeh_renderer.get_plot(text)
         glyph = plot.handles['glyph']
         self.assertEqual(glyph.angle, np.pi/2.)
@@ -177,7 +177,7 @@ class TestLabelsPlot(TestBokehPlot):
             self.assertEqual(col, data[c])
 
     def test_labels_plot_rotation_style(self):
-        text = Labels([(0, 0, 'Test')]).options(angle=90)
+        text = Labels([(0, 0, 'Test')]).opts(angle=90)
         plot = bokeh_renderer.get_plot(text)
         glyph = plot.handles['glyph']
         self.assertEqual(glyph.angle, np.pi/2.)

--- a/holoviews/tests/plotting/bokeh/test_areaplot.py
+++ b/holoviews/tests/plotting/bokeh/test_areaplot.py
@@ -49,7 +49,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(cds.data['y'], ys)
 
     def test_area_padding_square(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).options(padding=0.1)
+        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -58,7 +58,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_area_padding_square_per_axis(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).options(padding=((0, 0.1), (0.1, 0.2)))
+        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 1.0)
@@ -67,7 +67,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.4)
 
     def test_area_with_lower_vdim(self):
-        area = Area([(1, 0.5, 1), (2, 1.5, 2), (3, 2.5, 3)], vdims=['y', 'y2']).options(padding=0.1)
+        area = Area([(1, 0.5, 1), (2, 1.5, 2), (3, 2.5, 3)], vdims=['y', 'y2']).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -76,7 +76,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.25)
 
     def test_area_padding_negative(self):
-        area = Area([(1, -1), (2, -2), (3, -3)]).options(padding=0.1)
+        area = Area([(1, -1), (2, -2), (3, -3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -85,7 +85,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 0)
 
     def test_area_padding_mixed(self):
-        area = Area([(1, 1), (2, -2), (3, 3)]).options(padding=0.1)
+        area = Area([(1, 1), (2, -2), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -94,7 +94,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.5)
 
     def test_area_padding_hard_range(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).redim.range(y=(0, 4)).options(padding=0.1)
+        area = Area([(1, 1), (2, 2), (3, 3)]).redim.range(y=(0, 4)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -103,7 +103,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 4)
 
     def test_area_padding_soft_range(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).redim.soft_range(y=(0, 3.5)).options(padding=0.1)
+        area = Area([(1, 1), (2, 2), (3, 3)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -112,7 +112,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.5)
 
     def test_area_padding_nonsquare(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).options(padding=0.1, width=600)
+        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.9)
@@ -121,7 +121,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_area_padding_logx(self):
-        area = Area([(1, 1), (2, 2), (3,3)]).options(padding=0.1, logx=True)
+        area = Area([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.89595845984076228)
@@ -130,7 +130,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_area_padding_logy(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).options(padding=0.1, logy=True)
+        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -22,14 +22,14 @@ class TestBarPlot(TestBokehPlot):
         self._test_hover_info(obj, [('x', '@{x}'), ('Dim with spaces', '@{Dim_with_spaces}')])
 
     def test_bars_suppress_legend(self):
-        bars = Bars([('A', 1), ('B', 2)]).opts(plot=dict(show_legend=False))
+        bars = Bars([('A', 1), ('B', 2)]).opts(show_legend=False)
         plot = bokeh_renderer.get_plot(bars)
         plot.initialize_plot()
         fig = plot.state
         self.assertEqual(len(fig.legend), 0)
 
     def test_empty_bars(self):
-        bars = Bars([], kdims=['x', 'y'], vdims=['z']).opts(plot=dict(group_index=1))
+        bars = Bars([], kdims=['x', 'y'], vdims=['z'])
         plot = bokeh_renderer.get_plot(bars)
         plot.initialize_plot()
         source = plot.handles['source']
@@ -77,7 +77,7 @@ class TestBarPlot(TestBokehPlot):
     def test_bars_logy(self):
         bars = Bars([('A', 1), ('B', 2), ('C', 3)],
                     kdims=['Index'], vdims=['Value'])
-        plot = bokeh_renderer.get_plot(bars.opts(plot=dict(logy=True)))
+        plot = bokeh_renderer.get_plot(bars.opts(logy=True))
         source = plot.handles['source']
         glyph = plot.handles['glyph']
         y_range = plot.handles['y_range']
@@ -90,7 +90,7 @@ class TestBarPlot(TestBokehPlot):
     def test_bars_logy_explicit_range(self):
         bars = Bars([('A', 1), ('B', 2), ('C', 3)],
                     kdims=['Index'], vdims=['Value']).redim.range(Value=(0.001, 3))
-        plot = bokeh_renderer.get_plot(bars.opts(plot=dict(logy=True)))
+        plot = bokeh_renderer.get_plot(bars.opts(logy=True))
         source = plot.handles['source']
         glyph = plot.handles['glyph']
         y_range = plot.handles['y_range']
@@ -108,42 +108,42 @@ class TestBarPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 200)
 
     def test_bars_padding_square(self):
-        points = Bars([(1, 2), (2, -1), (3, 3)]).options(padding=0.1)
+        points = Bars([(1, 2), (2, -1), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         y_range = plot.handles['y_range']
         self.assertEqual(y_range.start, -1.4)
         self.assertEqual(y_range.end, 3.4)
 
     def test_bars_padding_square_positive(self):
-        points = Bars([(1, 2), (2, 1), (3, 3)]).options(padding=0.1)
+        points = Bars([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         y_range = plot.handles['y_range']
         self.assertEqual(y_range.start, 0)
         self.assertEqual(y_range.end, 3.2)
 
     def test_bars_padding_square_negative(self):
-        points = Bars([(1, -2), (2, -1), (3, -3)]).options(padding=0.1)
+        points = Bars([(1, -2), (2, -1), (3, -3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         y_range = plot.handles['y_range']
         self.assertEqual(y_range.start, -3.2)
         self.assertEqual(y_range.end, 0)
 
     def test_bars_padding_nonsquare(self):
-        bars = Bars([(1, 2), (2, 1), (3, 3)]).options(padding=0.1, width=600)
+        bars = Bars([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(bars)
         y_range = plot.handles['y_range']
         self.assertEqual(y_range.start, 0)
         self.assertEqual(y_range.end, 3.2)
 
     def test_bars_padding_logx(self):
-        bars = Bars([(1, 1), (2, 2), (3,3)]).options(padding=0.1, logx=True)
+        bars = Bars([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(bars)
         y_range = plot.handles['y_range']
         self.assertEqual(y_range.start, 0)
         self.assertEqual(y_range.end, 3.2)
 
     def test_bars_padding_logy(self):
-        bars = Bars([(1, 2), (2, 1), (3, 3)]).options(padding=0.1, logy=True)
+        bars = Bars([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(bars)
         y_range = plot.handles['y_range']
         self.assertEqual(y_range.start, 0.01)
@@ -155,7 +155,7 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_color_op(self):
         bars = Bars([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -165,7 +165,7 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_linear_color_op(self):
         bars = Bars([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -179,7 +179,7 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_categorical_color_op(self):
         bars = Bars([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -192,7 +192,7 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_line_color_op(self):
         bars = Bars([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                              vdims=['y', 'color']).options(line_color='color')
+                              vdims=['y', 'color']).opts(line_color='color')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -202,7 +202,7 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_fill_color_op(self):
         bars = Bars([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                              vdims=['y', 'color']).options(fill_color='color')
+                              vdims=['y', 'color']).opts(fill_color='color')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -212,7 +212,7 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_alpha_op(self):
         bars = Bars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                              vdims=['y', 'alpha']).options(alpha='alpha')
+                              vdims=['y', 'alpha']).opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -221,7 +221,7 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_line_alpha_op(self):
         bars = Bars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                              vdims=['y', 'alpha']).options(line_alpha='alpha')
+                              vdims=['y', 'alpha']).opts(line_alpha='alpha')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -231,7 +231,7 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_fill_alpha_op(self):
         bars = Bars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                              vdims=['y', 'alpha']).options(fill_alpha='alpha')
+                              vdims=['y', 'alpha']).opts(fill_alpha='alpha')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -241,7 +241,7 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_line_width_op(self):
         bars = Bars([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
-                              vdims=['y', 'line_width']).options(line_width='line_width')
+                              vdims=['y', 'line_width']).opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -250,17 +250,20 @@ class TestBarPlot(TestBokehPlot):
 
     def test_op_ndoverlay_value(self):
         colors = ['blue', 'red']
-        overlay = NdOverlay({color: Bars(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').options('Bars', fill_color='Color')
+        overlay = NdOverlay({color: Bars(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Bars', fill_color='Color')
         plot = bokeh_renderer.get_plot(overlay)
         for subplot, color in zip(plot.subplots.values(),  colors):
             self.assertEqual(subplot.handles['glyph'].fill_color, color)
 
     def test_bars_color_index_color_clash(self):
         bars = Bars([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                    vdims=['y', 'color']).options(color='color', color_index='color')
+                    vdims=['y', 'color']).opts(color='color', color_index='color')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(bars)
         log_msg = log.stream.read()
-        warning = ("Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n")
+        warning = (
+            "The `color_index` parameter is deprecated in favor of color style mapping, "
+            "e.g. `color=dim('color')` or `line_color=dim('color')`\nCannot declare style "
+            "mapping for 'color' option and declare a color_index; ignoring the color_index.\n"
+        )
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/bokeh/test_boxwhiskerplot.py
+++ b/holoviews/tests/plotting/bokeh/test_boxwhiskerplot.py
@@ -23,7 +23,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
 
     def test_box_whisker_hover(self):
         xs, ys = np.random.randint(0, 5, 100), np.random.randn(100)
-        box = BoxWhisker((xs, ys), 'A').sort().opts(plot=dict(tools=['hover']))
+        box = BoxWhisker((xs, ys), 'A').sort().opts(tools=['hover'])
         plot = bokeh_renderer.get_plot(box)
         src = plot.handles['vbar_1_source']
         ys = box.aggregate(function=np.median).dimension_values('y')
@@ -42,7 +42,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
             ('A', '1'), ('A', '3'), ('A', '10'), ('B', '1'), ('B', '3'), ('B', '10')])
 
     def test_box_whisker_padding_square(self):
-        curve = BoxWhisker([1, 2, 3]).options(padding=0.1)
+        curve = BoxWhisker([1, 2, 3]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(curve)
         y_range = plot.handles['y_range']
         self.assertEqual(y_range.start, 0.8)
@@ -55,7 +55,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
     def test_box_whisker_linear_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').options(box_color='b')
+        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
         plot = bokeh_renderer.get_plot(box)
         source = plot.handles['vbar_1_source']
         cmapper = plot.handles['box_color_color_mapper']
@@ -69,7 +69,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
     def test_box_whisker_categorical_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(['A', 'B', 'C', 'D', 'E'], 5)
-        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').options(box_color='b')
+        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
         plot = bokeh_renderer.get_plot(box)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']
@@ -82,7 +82,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
     def test_box_whisker_alpha_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5)/10., 5)
-        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').options(box_alpha='b')
+        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_alpha='b')
         plot = bokeh_renderer.get_plot(box)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']
@@ -92,7 +92,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
     def test_box_whisker_line_width_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').options(box_line_width='b')
+        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_line_width='b')
         plot = bokeh_renderer.get_plot(box)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -328,7 +328,7 @@ class TestEditToolCallbacks(CallbackTestCase):
     def test_point_draw_shared_datasource_callback(self):
         points = Points([1, 2, 3])
         table = Table(points.data, ['x', 'y'])
-        layout = (points + table).options(shared_datasource=True, clone=False)
+        layout = (points + table).opts(shared_datasource=True, clone=False)
         PointDraw(source=points)
         self.assertIs(points.data, table.data)
         plot = bokeh_renderer.get_plot(layout)

--- a/holoviews/tests/plotting/bokeh/test_curveplot.py
+++ b/holoviews/tests/plotting/bokeh/test_curveplot.py
@@ -20,8 +20,8 @@ class TestCurvePlot(TestBokehPlot):
 
     def test_batched_curve_subscribers_correctly_attached(self):
         posx = PointerX()
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Curve': dict(style=dict(line_color=Cycle(values=['red', 'blue'])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Curve': dict(line_color=Cycle(values=['red', 'blue']))}
         overlay = DynamicMap(lambda x: NdOverlay({i: Curve([(i, j) for j in range(2)])
                                                   for i in range(2)}).opts(opts), kdims=[],
                              streams=[posx])
@@ -33,8 +33,8 @@ class TestCurvePlot(TestBokehPlot):
         # Checks if a stream callback is created to link batched plot
         # to the stream
         posx = PointerX()
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Curve': dict(style=dict(line_color=Cycle(values=['red', 'blue'])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Curve': dict(line_color=Cycle(values=['red', 'blue']))}
         overlay = DynamicMap(lambda x: NdOverlay({i: Curve([(i, j) for j in range(2)])
                                                   for i in range(2)}).opts(opts), kdims=[],
                              streams=[posx])
@@ -56,8 +56,8 @@ class TestCurvePlot(TestBokehPlot):
             self.assertEqual(subp.handles['glyph'].line_color, color)
 
     def test_batched_curve_line_color_and_color(self):
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Curve': dict(style=dict(line_color=Cycle(values=['red', 'blue'])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Curve': dict(line_color=Cycle(values=['red', 'blue']))}
         overlay = NdOverlay({i: Curve([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
@@ -65,8 +65,8 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(plot.handles['source'].data['line_color'], line_color)
 
     def test_batched_curve_alpha_and_color(self):
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Curve': dict(style=dict(alpha=Cycle(values=[0.5, 1])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Curve': dict(alpha=Cycle(values=[0.5, 1]))}
         overlay = NdOverlay({i: Curve([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
@@ -76,8 +76,8 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(plot.handles['source'].data['color'], color)
 
     def test_batched_curve_line_width_and_color(self):
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Curve': dict(style=dict(line_width=Cycle(values=[0.5, 1])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Curve': dict(line_width=Cycle(values=[0.5, 1]))}
         overlay = NdOverlay({i: Curve([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
@@ -90,7 +90,7 @@ class TestCurvePlot(TestBokehPlot):
         obj = NdOverlay({i: Curve([(dt.datetime(2016, 1, j+1), j) for j in range(31)]) for i in range(5)},
                         kdims=['Test'])
         opts = {'Curve': {'tools': ['hover']}}
-        obj = obj.opts(plot=opts)
+        obj = obj.opts(opts)
         self._test_hover_info(obj, [('Test', '@{Test}'), ('x', '@{x}{%F %T}'), ('y', '@{y}')],
                               formatters={'@{x}': "datetime"})
 
@@ -99,7 +99,7 @@ class TestCurvePlot(TestBokehPlot):
                         kdims=['Test'])
         opts = {'Curve': {'tools': ['hover']},
                 'NdOverlay': {'legend_limit': 0}}
-        obj = obj.opts(plot=opts)
+        obj = obj.opts(opts)
         self._test_hover_info(obj, [('Test', '@{Test}')], 'prev')
 
     def test_curve_overlay_hover(self):
@@ -117,7 +117,7 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(x_range.factors, ['A', 'B', 'C'])
 
     def test_curve_categorical_xaxis_invert_axes(self):
-        curve = Curve((['A', 'B', 'C'], (1,2,3))).opts(plot=dict(invert_axes=True))
+        curve = Curve((['A', 'B', 'C'], (1,2,3))).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(curve)
         y_range = plot.handles['y_range']
         self.assertIsInstance(y_range, FactorRange)
@@ -165,19 +165,19 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(plot.handles['x_range'].end, np.datetime64(dt.datetime(2016, 1, 13)))
 
     def test_curve_fontsize_xlabel(self):
-        curve = Curve(range(10)).opts(plot=dict(fontsize={'xlabel': '14pt'}))
+        curve = Curve(range(10)).opts(fontsize={'xlabel': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         self.assertEqual(plot.handles['xaxis'].axis_label_text_font_size,
                          '14pt')
 
     def test_curve_fontsize_ylabel(self):
-        curve = Curve(range(10)).opts(plot=dict(fontsize={'ylabel': '14pt'}))
+        curve = Curve(range(10)).opts(fontsize={'ylabel': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         self.assertEqual(plot.handles['yaxis'].axis_label_text_font_size,
                          '14pt')
 
     def test_curve_fontsize_both_labels(self):
-        curve = Curve(range(10)).opts(plot=dict(fontsize={'labels': '14pt'}))
+        curve = Curve(range(10)).opts(fontsize={'labels': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         self.assertEqual(plot.handles['xaxis'].axis_label_text_font_size,
                          '14pt')
@@ -185,19 +185,19 @@ class TestCurvePlot(TestBokehPlot):
                          '14pt')
 
     def test_curve_fontsize_xticks(self):
-        curve = Curve(range(10)).opts(plot=dict(fontsize={'xticks': '14pt'}))
+        curve = Curve(range(10)).opts(fontsize={'xticks': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         self.assertEqual(plot.handles['xaxis'].major_label_text_font_size,
                          '14pt')
 
     def test_curve_fontsize_yticks(self):
-        curve = Curve(range(10)).opts(plot=dict(fontsize={'yticks': '14pt'}))
+        curve = Curve(range(10)).opts(fontsize={'yticks': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         self.assertEqual(plot.handles['yaxis'].major_label_text_font_size,
                          '14pt')
 
     def test_curve_fontsize_both_ticks(self):
-        curve = Curve(range(10)).opts(plot=dict(fontsize={'ticks': '14pt'}))
+        curve = Curve(range(10)).opts(fontsize={'ticks': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         self.assertEqual(plot.handles['xaxis'].major_label_text_font_size,
                          '14pt')
@@ -205,7 +205,7 @@ class TestCurvePlot(TestBokehPlot):
                          '14pt')
 
     def test_curve_fontsize_xticks_and_both_ticks(self):
-        curve = Curve(range(10)).opts(plot=dict(fontsize={'xticks': '18pt', 'ticks': '14pt'}))
+        curve = Curve(range(10)).opts(fontsize={'xticks': '18pt', 'ticks': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         self.assertEqual(plot.handles['xaxis'].major_label_text_font_size,
                          '18pt')
@@ -213,33 +213,33 @@ class TestCurvePlot(TestBokehPlot):
                          '14pt')
 
     def test_curve_xticks_list(self):
-        curve = Curve(range(10)).opts(plot=dict(xticks=[0, 5, 10]))
+        curve = Curve(range(10)).opts(xticks=[0, 5, 10])
         plot = bokeh_renderer.get_plot(curve).state
         self.assertIsInstance(plot.xaxis[0].ticker, FixedTicker)
         self.assertEqual(plot.xaxis[0].ticker.ticks, [0, 5, 10])
 
     def test_curve_xticks_list_of_tuples_xaxis(self):
         ticks = [(0, 'zero'), (5, 'five'), (10, 'ten')]
-        curve = Curve(range(10)).opts(plot=dict(xticks=ticks))
+        curve = Curve(range(10)).opts(xticks=ticks)
         plot = bokeh_renderer.get_plot(curve).state
         self.assertIsInstance(plot.xaxis[0].ticker, FixedTicker)
         self.assertEqual(plot.xaxis[0].major_label_overrides, dict(ticks))
 
     def test_curve_yticks_list(self):
-        curve = Curve(range(10)).opts(plot=dict(yticks=[0, 5, 10]))
+        curve = Curve(range(10)).opts(yticks=[0, 5, 10])
         plot = bokeh_renderer.get_plot(curve).state
         self.assertIsInstance(plot.yaxis[0].ticker, FixedTicker)
         self.assertEqual(plot.yaxis[0].ticker.ticks, [0, 5, 10])
 
     def test_curve_xticks_list_of_tuples_yaxis(self):
         ticks = [(0, 'zero'), (5, 'five'), (10, 'ten')]
-        curve = Curve(range(10)).opts(plot=dict(yticks=ticks))
+        curve = Curve(range(10)).opts(yticks=ticks)
         plot = bokeh_renderer.get_plot(curve).state
         self.assertIsInstance(plot.yaxis[0].ticker, FixedTicker)
         self.assertEqual(plot.yaxis[0].major_label_overrides, dict(ticks))
 
     def test_curve_padding_square(self):
-        curve = Curve([1, 2, 3]).options(padding=0.1)
+        curve = Curve([1, 2, 3]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, -0.2)
@@ -248,7 +248,7 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_curve_padding_square_per_axis(self):
-        curve = Curve([1, 2, 3]).options(padding=((0, 0.1), (0.1, 0.2)))
+        curve = Curve([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0)
@@ -257,7 +257,7 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.4)
 
     def test_curve_padding_hard_xrange(self):
-        curve = Curve([1, 2, 3]).redim.range(x=(0, 3)).options(padding=0.1)
+        curve = Curve([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0)
@@ -266,7 +266,7 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_curve_padding_soft_xrange(self):
-        curve = Curve([1, 2, 3]).redim.soft_range(x=(0, 3)).options(padding=0.1)
+        curve = Curve([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0)
@@ -275,7 +275,7 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_curve_padding_unequal(self):
-        curve = Curve([1, 2, 3]).options(padding=(0.05, 0.1))
+        curve = Curve([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, -0.1)
@@ -284,7 +284,7 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_curve_padding_nonsquare(self):
-        curve = Curve([1, 2, 3]).options(padding=0.1, width=600)
+        curve = Curve([1, 2, 3]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, -0.1)
@@ -293,7 +293,7 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_curve_padding_logx(self):
-        curve = Curve([(1, 1), (2, 2), (3,3)]).options(padding=0.1, logx=True)
+        curve = Curve([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.89595845984076228)
@@ -302,7 +302,7 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_curve_padding_logy(self):
-        curve = Curve([1, 2, 3]).options(padding=0.1, logy=True)
+        curve = Curve([1, 2, 3]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, -0.2)
@@ -311,7 +311,7 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.3483695221017129)
 
     def test_curve_padding_datetime_square(self):
-        curve = Curve([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).options(
+        curve = Curve([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = bokeh_renderer.get_plot(curve)
@@ -322,7 +322,7 @@ class TestCurvePlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_curve_padding_datetime_nonsquare(self):
-        curve = Curve([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).options(
+        curve = Curve([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).opts(
             padding=0.1, width=600
         )
         plot = bokeh_renderer.get_plot(curve)
@@ -338,7 +338,7 @@ class TestCurvePlot(TestBokehPlot):
 
     def test_curve_scalar_color_op(self):
         curve = Curve([(0, 0, 'red'), (0, 1, 'red'), (0, 2, 'red')],
-                       vdims=['y', 'color']).options(color='color')
+                       vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(curve)
         glyph = plot.handles['glyph']
         self.assertEqual(glyph.line_color, 'red')
@@ -347,7 +347,7 @@ class TestCurvePlot(TestBokehPlot):
         colors = ['blue', 'red']
         overlay = NdOverlay({color: Curve(np.arange(i))
                              for i, color in enumerate(colors)},
-                            'color').options('Curve', color='color')
+                            'color').opts('Curve', color='color')
         plot = bokeh_renderer.get_plot(overlay)
         for subplot, color in zip(plot.subplots.values(), colors):
             style = dict(subplot.style[subplot.cyclic_index])
@@ -356,19 +356,19 @@ class TestCurvePlot(TestBokehPlot):
 
     def test_curve_color_op(self):
         curve = Curve([(0, 0, 'red'), (0, 1, 'blue'), (0, 2, 'red')],
-                       vdims=['y', 'color']).options(color='color')
+                       vdims=['y', 'color']).opts(color='color')
         with self.assertRaises(Exception):
             bokeh_renderer.get_plot(curve)
 
     def test_curve_alpha_op(self):
         curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
-                       vdims=['y', 'alpha']).options(alpha='alpha')
+                       vdims=['y', 'alpha']).opts(alpha='alpha')
         with self.assertRaises(Exception):
             bokeh_renderer.get_plot(curve)
 
     def test_curve_line_width_op(self):
         curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
-                       vdims=['y', 'linewidth']).options(line_width='linewidth')
+                       vdims=['y', 'linewidth']).opts(line_width='linewidth')
         with self.assertRaises(Exception):
             bokeh_renderer.get_plot(curve)
 

--- a/holoviews/tests/plotting/bokeh/test_divplot.py
+++ b/holoviews/tests/plotting/bokeh/test_divplot.py
@@ -14,7 +14,7 @@ class TestDivPlot(TestBokehPlot):
 
     def test_div_plot_width(self):
         html = '<h1>Test</h1>'
-        div = Div(html).options(width=342, height=432, backend='bokeh')
+        div = Div(html).opts(width=342, height=432, backend='bokeh')
         plot = bokeh_renderer.get_plot(div)
         bkdiv = plot.handles['plot']
         self.assertEqual(bkdiv.width, 342)

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -28,12 +28,12 @@ from holoviews.plotting.bokeh.util import LooseVersion, bokeh_version
 class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_element_show_frame_disabled(self):
-        curve = Curve(range(10)).opts(plot=dict(show_frame=False))
+        curve = Curve(range(10)).opts(show_frame=False)
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.outline_line_alpha, 0)
 
     def test_element_font_scaling(self):
-        curve = Curve(range(10)).options(fontscale=2, title='A title')
+        curve = Curve(range(10)).opts(fontscale=2, title='A title')
         plot = bokeh_renderer.get_plot(curve)
         fig = plot.state
         xaxis = plot.handles['xaxis']
@@ -54,7 +54,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
             self.assertEqual(yaxis.major_label_text_font_size, '22px')
 
     def test_element_font_scaling_fontsize_override_common(self):
-        curve = Curve(range(10)).options(fontscale=2, fontsize='14pt', title='A title')
+        curve = Curve(range(10)).opts(fontscale=2, fontsize='14pt', title='A title')
         plot = bokeh_renderer.get_plot(curve)
         fig = plot.state
         xaxis = plot.handles['xaxis']
@@ -73,7 +73,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
             self.assertEqual(yaxis.major_label_text_font_size, '22px')
 
     def test_element_font_scaling_fontsize_override_specific(self):
-        curve = Curve(range(10)).options(
+        curve = Curve(range(10)).opts(
             fontscale=2, fontsize={'title': '100%', 'xlabel': '12pt', 'xticks': '1.2em'},
             title='A title')
         plot = bokeh_renderer.get_plot(curve)
@@ -94,13 +94,13 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
             self.assertEqual(yaxis.major_label_text_font_size, '22px')
 
     def test_element_xaxis_top(self):
-        curve = Curve(range(10)).options(xaxis='top')
+        curve = Curve(range(10)).opts(xaxis='top')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         self.assertTrue(xaxis in plot.state.above)
 
     def test_element_xaxis_bare(self):
-        curve = Curve(range(10)).options(xaxis='bare')
+        curve = Curve(range(10)).opts(xaxis='bare')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         self.assertEqual(xaxis.axis_label_text_font_size, '0pt')
@@ -110,7 +110,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertTrue(xaxis in plot.state.below)
 
     def test_element_xaxis_bottom_bare(self):
-        curve = Curve(range(10)).options(xaxis='bottom-bare')
+        curve = Curve(range(10)).opts(xaxis='bottom-bare')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         self.assertEqual(xaxis.axis_label_text_font_size, '0pt')
@@ -120,7 +120,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertTrue(xaxis in plot.state.below)
 
     def test_element_xaxis_top_bare(self):
-        curve = Curve(range(10)).options(xaxis='top-bare')
+        curve = Curve(range(10)).opts(xaxis='top-bare')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         self.assertEqual(xaxis.axis_label_text_font_size, '0pt')
@@ -130,13 +130,13 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertTrue(xaxis in plot.state.above)
 
     def test_element_yaxis_right(self):
-        curve = Curve(range(10)).options(yaxis='right')
+        curve = Curve(range(10)).opts(yaxis='right')
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         self.assertTrue(yaxis in plot.state.right)
 
     def test_element_yaxis_bare(self):
-        curve = Curve(range(10)).options(yaxis='bare')
+        curve = Curve(range(10)).opts(yaxis='bare')
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         self.assertEqual(yaxis.axis_label_text_font_size, '0pt')
@@ -146,7 +146,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertTrue(yaxis in plot.state.left)
 
     def test_element_yaxis_left_bare(self):
-        curve = Curve(range(10)).options(yaxis='left-bare')
+        curve = Curve(range(10)).opts(yaxis='left-bare')
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         self.assertEqual(yaxis.axis_label_text_font_size, '0pt')
@@ -156,7 +156,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertTrue(yaxis in plot.state.left)
 
     def test_element_yaxis_right_bare(self):
-        curve = Curve(range(10)).options(yaxis='right-bare')
+        curve = Curve(range(10)).opts(yaxis='right-bare')
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         self.assertEqual(yaxis.axis_label_text_font_size, '0pt')
@@ -194,14 +194,14 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         assert plot.handles['glyph_renderer'].visible
         
     def test_element_xformatter_string(self):
-        curve = Curve(range(10)).options(xformatter='%d')
+        curve = Curve(range(10)).opts(xformatter='%d')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         self.assertIsInstance(xaxis.formatter, PrintfTickFormatter)
         self.assertEqual(xaxis.formatter.format, '%d')
 
     def test_element_yformatter_string(self):
-        curve = Curve(range(10)).options(yformatter='%d')
+        curve = Curve(range(10)).opts(yformatter='%d')
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         self.assertIsInstance(yaxis.formatter, PrintfTickFormatter)
@@ -214,7 +214,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
             raise SkipTest('Test requires pscript')
         def formatter(value):
             return str(value) + ' %'
-        curve = Curve(range(10)).options(xformatter=formatter)
+        curve = Curve(range(10)).opts(xformatter=formatter)
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         self.assertIsInstance(xaxis.formatter, FuncTickFormatter)
@@ -226,21 +226,21 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
             raise SkipTest('Test requires pscript')
         def formatter(value):
             return str(value) + ' %'
-        curve = Curve(range(10)).options(yformatter=formatter)
+        curve = Curve(range(10)).opts(yformatter=formatter)
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         self.assertIsInstance(yaxis.formatter, FuncTickFormatter)
 
     def test_element_xformatter_instance(self):
         formatter = NumeralTickFormatter()
-        curve = Curve(range(10)).options(xformatter=formatter)
+        curve = Curve(range(10)).opts(xformatter=formatter)
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         self.assertIs(xaxis.formatter, formatter)
 
     def test_element_yformatter_instance(self):
         formatter = NumeralTickFormatter()
-        curve = Curve(range(10)).options(yformatter=formatter)
+        curve = Curve(range(10)).opts(yformatter=formatter)
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         self.assertIs(yaxis.formatter, formatter)
@@ -251,49 +251,49 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertTrue(plot.handles['glyph_renderer'].visible)
 
     def test_element_no_xaxis(self):
-        curve = Curve(range(10)).opts(plot=dict(xaxis=None))
+        curve = Curve(range(10)).opts(xaxis=None)
         plot = bokeh_renderer.get_plot(curve).state
         self.assertFalse(plot.xaxis[0].visible)
 
     def test_element_no_yaxis(self):
-        curve = Curve(range(10)).opts(plot=dict(yaxis=None))
+        curve = Curve(range(10)).opts(yaxis=None)
         plot = bokeh_renderer.get_plot(curve).state
         self.assertFalse(plot.yaxis[0].visible)
 
     def test_element_xrotation(self):
-        curve = Curve(range(10)).opts(plot=dict(xrotation=90))
+        curve = Curve(range(10)).opts(xrotation=90)
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.xaxis[0].major_label_orientation, np.pi/2)
 
     def test_element_yrotation(self):
-        curve = Curve(range(10)).opts(plot=dict(yrotation=90))
+        curve = Curve(range(10)).opts(yrotation=90)
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.yaxis[0].major_label_orientation, np.pi/2)
 
     def test_element_xlabel_override(self):
-        curve = Curve(range(10)).options(xlabel='custom x-label')
+        curve = Curve(range(10)).opts(xlabel='custom x-label')
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.xaxis[0].axis_label, 'custom x-label')
 
     def test_element_ylabel_override(self):
-        curve = Curve(range(10)).options(ylabel='custom y-label')
+        curve = Curve(range(10)).opts(ylabel='custom y-label')
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.yaxis[0].axis_label, 'custom y-label')
 
     def test_element_labelled_x_disabled(self):
-        curve = Curve(range(10)).options(labelled=['y'])
+        curve = Curve(range(10)).opts(labelled=['y'])
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.xaxis[0].axis_label, '')
         self.assertEqual(plot.yaxis[0].axis_label, 'y')
 
     def test_element_labelled_y_disabled(self):
-        curve = Curve(range(10)).options(labelled=['x'])
+        curve = Curve(range(10)).opts(labelled=['x'])
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.xaxis[0].axis_label, 'x')
         self.assertEqual(plot.yaxis[0].axis_label, '')
 
     def test_element_labelled_both_disabled(self):
-        curve = Curve(range(10)).options(labelled=[])
+        curve = Curve(range(10)).opts(labelled=[])
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.xaxis[0].axis_label, '')
         self.assertEqual(plot.yaxis[0].axis_label, '')
@@ -374,7 +374,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_element_grid_options(self):
         grid_style = {'grid_line_color': 'blue', 'grid_line_width': 1.5, 'ygrid_bounds': (0.3, 0.7),
                       'minor_xgrid_line_color': 'lightgray', 'xgrid_line_dash': [4, 4]}
-        curve = Curve(range(10)).options(show_grid=True, gridstyle=grid_style)
+        curve = Curve(range(10)).opts(show_grid=True, gridstyle=grid_style)
         plot = bokeh_renderer.get_plot(curve)
         self.assertEqual(plot.state.xgrid[0].grid_line_color, 'blue')
         self.assertEqual(plot.state.xgrid[0].grid_line_width, 1.5)
@@ -404,14 +404,14 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(plot.state.xaxis[0].axis_label, 'b')
 
     def test_categorical_axis_fontsize(self):
-        curve = Curve([('A', 1), ('B', 2)]).options(fontsize={'minor_xticks': '6pt', 'xticks': 18})
+        curve = Curve([('A', 1), ('B', 2)]).opts(fontsize={'minor_xticks': '6pt', 'xticks': 18})
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         self.assertEqual(xaxis.major_label_text_font_size, '6pt')
         self.assertEqual(xaxis.group_text_font_size, '18pt')
 
     def test_categorical_axis_fontsize_both(self):
-        curve = Curve([('A', 1), ('B', 2)]).options(fontsize={'xticks': 18})
+        curve = Curve([('A', 1), ('B', 2)]).opts(fontsize={'xticks': 18})
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         self.assertEqual(xaxis.major_label_text_font_size, '18pt')
@@ -452,25 +452,25 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.log_handler.assertEndsWith('WARNING', substr)
 
     def test_active_tools_drag(self):
-        curve = Curve([1, 2, 3]).options(active_tools=['box_zoom'])
+        curve = Curve([1, 2, 3]).opts(active_tools=['box_zoom'])
         plot = bokeh_renderer.get_plot(curve)
         toolbar = plot.state.toolbar
         self.assertIsInstance(toolbar.active_drag, tools.BoxZoomTool)
 
     def test_active_tools_scroll(self):
-        curve = Curve([1, 2, 3]).options(active_tools=['wheel_zoom'])
+        curve = Curve([1, 2, 3]).opts(active_tools=['wheel_zoom'])
         plot = bokeh_renderer.get_plot(curve)
         toolbar = plot.state.toolbar
         self.assertIsInstance(toolbar.active_scroll, tools.WheelZoomTool)
 
     def test_active_tools_tap(self):
-        curve = Curve([1, 2, 3]).options(active_tools=['tap'], tools=['tap'])
+        curve = Curve([1, 2, 3]).opts(active_tools=['tap'], tools=['tap'])
         plot = bokeh_renderer.get_plot(curve)
         toolbar = plot.state.toolbar
         self.assertIsInstance(toolbar.active_tap, tools.TapTool)
 
     def test_active_tools_draw_stream(self):
-        scatter = Scatter([1, 2, 3]).options(active_tools=['point_draw'])
+        scatter = Scatter([1, 2, 3]).opts(active_tools=['point_draw'])
         PointDraw(source=scatter)
         plot = bokeh_renderer.get_plot(scatter)
         toolbar = plot.state.toolbar
@@ -811,21 +811,21 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
 class TestColorbarPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_colormapper_symmetric(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(symmetric=True)
+        img = Image(np.array([[0, 1], [2, 3]])).opts(symmetric=True)
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         self.assertEqual(cmapper.low, -3)
         self.assertEqual(cmapper.high, 3)
 
     def test_colormapper_logz_int_zero_bound(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(logz=True)
+        img = Image(np.array([[0, 1], [2, 3]])).opts(logz=True)
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         self.assertEqual(cmapper.low, 1)
         self.assertEqual(cmapper.high, 3)
 
     def test_colormapper_logz_float_zero_bound(self):
-        img = Image(np.array([[0, 1], [2, 3.]])).options(logz=True)
+        img = Image(np.array([[0, 1], [2, 3.]])).opts(logz=True)
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         self.assertEqual(cmapper.low, 0)
@@ -834,26 +834,26 @@ class TestColorbarPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_colormapper_color_levels(self):
         cmap = process_cmap('viridis', provider='bokeh')
-        img = Image(np.array([[0, 1], [2, 3]])).options(color_levels=5, cmap=cmap)
+        img = Image(np.array([[0, 1], [2, 3]])).opts(color_levels=5, cmap=cmap)
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         self.assertEqual(len(cmapper.palette), 5)
         self.assertEqual(cmapper.palette, ['#440154', '#440255', '#440357', '#450558', '#45065A'])
 
     def test_colormapper_transparent_nan(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(clipping_colors={'NaN': 'transparent'})
+        img = Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'NaN': 'transparent'})
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         self.assertEqual(cmapper.nan_color, 'rgba(0, 0, 0, 0)')
 
     def test_colormapper_cnorm_linear(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(cnorm='linear')
+        img = Image(np.array([[0, 1], [2, 3]])).opts(cnorm='linear')
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         self.assertTrue(cmapper, LinearColorMapper)
 
     def test_colormapper_cnorm_log(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(cnorm='log')
+        img = Image(np.array([[0, 1], [2, 3]])).opts(cnorm='log')
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         self.assertTrue(cmapper, LogColorMapper)
@@ -863,14 +863,14 @@ class TestColorbarPlot(LoggingComparisonTestCase, TestBokehPlot):
             from bokeh.models import EqHistColorMapper
         except:
             raise SkipTest("Option cnorm='eq_hist' requires EqHistColorMapper")
-        img = Image(np.array([[0, 1], [2, 3]])).options(cnorm='eq_hist')
+        img = Image(np.array([[0, 1], [2, 3]])).opts(cnorm='eq_hist')
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         self.assertTrue(cmapper, EqHistColorMapper)
 
 
     def test_colormapper_min_max_colors(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(clipping_colors={'min': 'red', 'max': 'blue'})
+        img = Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'min': 'red', 'max': 'blue'})
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         self.assertEqual(cmapper.low_color, 'red')
@@ -878,7 +878,7 @@ class TestColorbarPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_custom_colorbar_ticker(self):
         ticker = LogTicker()
-        img = Image(np.array([[0, 1], [2, 3]])).options(colorbar=True, colorbar_opts=dict(ticker=ticker))
+        img = Image(np.array([[0, 1], [2, 3]])).opts(colorbar=True, colorbar_opts=dict(ticker=ticker))
         plot = bokeh_renderer.get_plot(img)
         colorbar = plot.handles['colorbar']
         self.assertIs(colorbar.ticker, ticker)
@@ -896,7 +896,7 @@ class TestColorbarPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_explicit_categorical_cmap_on_integer_data(self):
         explicit_mapping = OrderedDict([(0, 'blue'), (1, 'red'), (2, 'green'), (3, 'purple')])
-        points = Scatter(([0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]), vdims=['y', 'Category']).options(
+        points = Scatter(([0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]), vdims=['y', 'Category']).opts(
             color_index='Category', cmap=explicit_mapping
         )
         plot = bokeh_renderer.get_plot(points)
@@ -910,12 +910,12 @@ class TestColorbarPlot(LoggingComparisonTestCase, TestBokehPlot):
 class TestOverlayPlot(TestBokehPlot):
 
     def test_overlay_projection_clashing(self):
-        overlay = Curve([]).options(projection='polar') * Curve([]).options(projection='custom')
+        overlay = Curve([]).opts(projection='polar') * Curve([]).opts(projection='custom')
         with self.assertRaises(Exception):
             bokeh_renderer.get_plot(overlay)
 
     def test_overlay_projection_propagates(self):
-        overlay = Curve([]) * Curve([]).options(projection='custom')
+        overlay = Curve([]) * Curve([]).opts(projection='custom')
         plot = bokeh_renderer.get_plot(overlay)
         self.assertEqual([p.projection for p in plot.subplots.values()], ['custom', 'custom'])
 
@@ -928,21 +928,21 @@ class TestOverlayPlot(TestBokehPlot):
 
     def test_overlay_gridstyle_applies(self):
         grid_style = {'grid_line_color': 'blue', 'grid_line_width': 2}
-        overlay = (Scatter([(10,10)]).options(gridstyle=grid_style, show_grid=True, size=20)
+        overlay = (Scatter([(10,10)]).opts(gridstyle=grid_style, show_grid=True, size=20)
                    * Labels([(10, 10, 'A')]))
         plot = bokeh_renderer.get_plot(overlay)
         self.assertEqual(plot.state.xgrid[0].grid_line_color, 'blue')
         self.assertEqual(plot.state.xgrid[0].grid_line_width, 2)
 
     def test_ndoverlay_legend_muted(self):
-        overlay = NdOverlay({i: Curve(np.random.randn(10).cumsum()) for i in range(5)}).options(legend_muted=True)
+        overlay = NdOverlay({i: Curve(np.random.randn(10).cumsum()) for i in range(5)}).opts(legend_muted=True)
         plot = bokeh_renderer.get_plot(overlay)
         for sp in plot.subplots.values():
             self.assertTrue(sp.handles['glyph_renderer'].muted)
 
     def test_overlay_legend_muted(self):
         overlay = (Curve(np.random.randn(10).cumsum(), label='A') *
-                   Curve(np.random.randn(10).cumsum(), label='B')).options(legend_muted=True)
+                   Curve(np.random.randn(10).cumsum(), label='B')).opts(legend_muted=True)
         plot = bokeh_renderer.get_plot(overlay)
         for sp in plot.subplots.values():
             self.assertTrue(sp.handles['glyph_renderer'].muted)
@@ -951,7 +951,7 @@ class TestOverlayPlot(TestBokehPlot):
         overlay = (
             Curve(np.random.randn(10).cumsum(), label='A') *
             Curve(np.random.randn(10).cumsum(), label='B')
-        ).options(legend_opts={'background_fill_alpha': 0.5, 'background_fill_color': 'red'})
+        ).opts(legend_opts={'background_fill_alpha': 0.5, 'background_fill_color': 'red'})
         plot = bokeh_renderer.get_plot(overlay)
         legend = plot.state.legend
         self.assertEqual(legend.background_fill_alpha, 0.5)
@@ -960,7 +960,7 @@ class TestOverlayPlot(TestBokehPlot):
     def test_active_tools_drag(self):
         curve = Curve([1, 2, 3])
         scatter = Scatter([1, 2, 3])
-        overlay = (scatter * curve).options(active_tools=['box_zoom'])
+        overlay = (scatter * curve).opts(active_tools=['box_zoom'])
         plot = bokeh_renderer.get_plot(overlay)
         toolbar = plot.state.toolbar
         self.assertIsInstance(toolbar.active_drag, tools.BoxZoomTool)
@@ -968,22 +968,22 @@ class TestOverlayPlot(TestBokehPlot):
     def test_active_tools_scroll(self):
         curve = Curve([1, 2, 3])
         scatter = Scatter([1, 2, 3])
-        overlay = (scatter * curve).options(active_tools=['wheel_zoom'])
+        overlay = (scatter * curve).opts(active_tools=['wheel_zoom'])
         plot = bokeh_renderer.get_plot(overlay)
         toolbar = plot.state.toolbar
         self.assertIsInstance(toolbar.active_scroll, tools.WheelZoomTool)
 
     def test_active_tools_tap(self):
         curve = Curve([1, 2, 3])
-        scatter = Scatter([1, 2, 3]).options(tools=['tap'])
-        overlay = (scatter * curve).options(active_tools=['tap'])
+        scatter = Scatter([1, 2, 3]).opts(tools=['tap'])
+        overlay = (scatter * curve).opts(active_tools=['tap'])
         plot = bokeh_renderer.get_plot(overlay)
         toolbar = plot.state.toolbar
         self.assertIsInstance(toolbar.active_tap, tools.TapTool)
 
     def test_active_tools_draw_stream(self):
         curve = Curve([1, 2, 3])
-        scatter = Scatter([1, 2, 3]).options(active_tools=['point_draw'])
+        scatter = Scatter([1, 2, 3]).opts(active_tools=['point_draw'])
         PointDraw(source=scatter)
         overlay = (scatter * curve)
         plot = bokeh_renderer.get_plot(overlay)

--- a/holoviews/tests/plotting/bokeh/test_errorbarplot.py
+++ b/holoviews/tests/plotting/bokeh/test_errorbarplot.py
@@ -10,7 +10,7 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestErrorBarsPlot(TestBokehPlot):
 
     def test_errorbars_padding_square(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).options(padding=0.1)
+        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -19,7 +19,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.8)
 
     def test_errorbars_padding_hard_range(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.range(y=(0, 4)).options(padding=0.1)
+        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.range(y=(0, 4)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -28,7 +28,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 4)
 
     def test_errorbars_padding_soft_range(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.soft_range(y=(0, 3.5)).options(padding=0.1)
+        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -37,7 +37,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.5)
 
     def test_errorbars_padding_nonsquare(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).options(padding=0.1, width=600)
+        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.9)
@@ -46,7 +46,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.8)
 
     def test_errorbars_padding_logx(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3,3, 0.5)]).options(padding=0.1, logx=True)
+        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3,3, 0.5)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.89595845984076228)
@@ -55,7 +55,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.8)
 
     def test_errorbars_padding_logy(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).options(padding=0.1, logy=True)
+        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -69,7 +69,7 @@ class TestErrorBarsPlot(TestBokehPlot):
 
     def test_errorbars_color_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, '#000'), (0, 1, 0.2, 0.4, '#F00'), (0, 2, 0.6, 1.2, '#0F0')],
-                              vdims=['y', 'perr', 'nerr', 'color']).options(color='color')
+                              vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -78,7 +78,7 @@ class TestErrorBarsPlot(TestBokehPlot):
 
     def test_errorbars_linear_color_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 1), (0, 2, 0.6, 1.2, 2)],
-                              vdims=['y', 'perr', 'nerr', 'color']).options(color='color')
+                              vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -91,7 +91,7 @@ class TestErrorBarsPlot(TestBokehPlot):
 
     def test_errorbars_categorical_color_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, 'A'), (0, 1, 0.2, 0.4, 'B'), (0, 2, 0.6, 1.2, 'C')],
-                              vdims=['y', 'perr', 'nerr', 'color']).options(color='color')
+                              vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -103,7 +103,7 @@ class TestErrorBarsPlot(TestBokehPlot):
 
     def test_errorbars_line_color_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, '#000'), (0, 1, 0.2, 0.4, '#F00'), (0, 2, 0.6, 1.2, '#0F0')],
-                              vdims=['y', 'perr', 'nerr', 'color']).options(line_color='color')
+                              vdims=['y', 'perr', 'nerr', 'color']).opts(line_color='color')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -112,7 +112,7 @@ class TestErrorBarsPlot(TestBokehPlot):
 
     def test_errorbars_alpha_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 0.2), (0, 2, 0.6, 1.2, 0.7)],
-                              vdims=['y', 'perr', 'nerr', 'alpha']).options(alpha='alpha')
+                              vdims=['y', 'perr', 'nerr', 'alpha']).opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -121,7 +121,7 @@ class TestErrorBarsPlot(TestBokehPlot):
 
     def test_errorbars_line_alpha_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 0.2), (0, 2, 0.6, 1.2, 0.7)],
-                              vdims=['y', 'perr', 'nerr', 'alpha']).options(line_alpha='alpha')
+                              vdims=['y', 'perr', 'nerr', 'alpha']).opts(line_alpha='alpha')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -130,7 +130,7 @@ class TestErrorBarsPlot(TestBokehPlot):
 
     def test_errorbars_line_width_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, 1), (0, 1, 0.2, 0.4, 4), (0, 2, 0.6, 1.2, 8)],
-                              vdims=['y', 'perr', 'nerr', 'line_width']).options(line_width='line_width')
+                              vdims=['y', 'perr', 'nerr', 'line_width']).opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']

--- a/holoviews/tests/plotting/bokeh/test_graphplot.py
+++ b/holoviews/tests/plotting/bokeh/test_graphplot.py
@@ -71,7 +71,7 @@ class TestBokehGraphPlot(TestBokehPlot):
         self.assertIn(renderer, hover.renderers)
 
     def test_graph_inspection_policy_edges(self):
-        plot = bokeh_renderer.get_plot(self.graph.opts(plot=dict(inspection_policy='edges')))
+        plot = bokeh_renderer.get_plot(self.graph.opts(inspection_policy='edges'))
         renderer = plot.handles['glyph_renderer']
         hover = plot.handles['hover']
         self.assertIsInstance(renderer.inspection_policy, EdgesAndLinkedNodes)
@@ -80,7 +80,7 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_inspection_policy_edges_non_default_names(self):
         graph = self.graph.redim(start='source', end='target')
-        plot = bokeh_renderer.get_plot(graph.opts(plot=dict(inspection_policy='edges')))
+        plot = bokeh_renderer.get_plot(graph.opts(inspection_policy='edges'))
         renderer = plot.handles['glyph_renderer']
         hover = plot.handles['hover']
         self.assertIsInstance(renderer.inspection_policy, EdgesAndLinkedNodes)
@@ -88,7 +88,7 @@ class TestBokehGraphPlot(TestBokehPlot):
         self.assertIn(renderer, hover.renderers)
 
     def test_graph_inspection_policy_none(self):
-        plot = bokeh_renderer.get_plot(self.graph.opts(plot=dict(inspection_policy=None)))
+        plot = bokeh_renderer.get_plot(self.graph.opts(inspection_policy=None))
         renderer = plot.handles['glyph_renderer']
         self.assertIsInstance(renderer.inspection_policy, NodesOnly)
 
@@ -100,19 +100,19 @@ class TestBokehGraphPlot(TestBokehPlot):
         self.assertIn(renderer, hover.renderers)
 
     def test_graph_selection_policy_edges(self):
-        plot = bokeh_renderer.get_plot(self.graph.opts(plot=dict(selection_policy='edges')))
+        plot = bokeh_renderer.get_plot(self.graph.opts(selection_policy='edges'))
         renderer = plot.handles['glyph_renderer']
         hover = plot.handles['hover']
         self.assertIsInstance(renderer.selection_policy, EdgesAndLinkedNodes)
         self.assertIn(renderer, hover.renderers)
 
     def test_graph_selection_policy_none(self):
-        plot = bokeh_renderer.get_plot(self.graph.opts(plot=dict(selection_policy=None)))
+        plot = bokeh_renderer.get_plot(self.graph.opts(selection_policy=None))
         renderer = plot.handles['glyph_renderer']
         self.assertIsInstance(renderer.selection_policy, NodesOnly)
 
     def test_graph_nodes_categorical_colormapped(self):
-        g = self.graph2.opts(plot=dict(color_index='Label'), style=dict(cmap='Set1'))
+        g = self.graph2.opts(color_index='Label', cmap='Set1')
         plot = bokeh_renderer.get_plot(g)
         cmapper = plot.handles['color_mapper']
         node_source = plot.handles['scatter_1_source']
@@ -123,7 +123,7 @@ class TestBokehGraphPlot(TestBokehPlot):
         self.assertEqual(glyph.fill_color, {'field': 'Label', 'transform': cmapper})
 
     def test_graph_nodes_numerically_colormapped(self):
-        g = self.graph3.opts(plot=dict(color_index='Weight'), style=dict(cmap='viridis'))
+        g = self.graph3.opts(color_index='Weight', cmap='viridis')
         plot = bokeh_renderer.get_plot(g)
         cmapper = plot.handles['color_mapper']
         node_source = plot.handles['scatter_1_source']
@@ -135,8 +135,7 @@ class TestBokehGraphPlot(TestBokehPlot):
         self.assertEqual(glyph.fill_color, {'field': 'Weight', 'transform': cmapper})
 
     def test_graph_edges_categorical_colormapped(self):
-        g = self.graph3.opts(plot=dict(edge_color_index='start'),
-                             style=dict(edge_cmap=['#FFFFFF', '#000000']))
+        g = self.graph3.opts(edge_color_index='start', edge_cmap=['#FFFFFF', '#000000'])
         plot = bokeh_renderer.get_plot(g)
         cmapper = plot.handles['edge_colormapper']
         edge_source = plot.handles['multi_line_1_source']
@@ -148,8 +147,7 @@ class TestBokehGraphPlot(TestBokehPlot):
         self.assertEqual(glyph.line_color, {'field': 'start_str__', 'transform': cmapper})
 
     def test_graph_edges_numerically_colormapped(self):
-        g = self.graph4.opts(plot=dict(edge_color_index='Weight'),
-                             style=dict(edge_cmap=['#FFFFFF', '#000000']))
+        g = self.graph4.opts(edge_color_index='Weight', edge_cmap=['#FFFFFF', '#000000'])
         plot = bokeh_renderer.get_plot(g)
         cmapper = plot.handles['edge_colormapper']
         edge_source = plot.handles['multi_line_1_source']
@@ -168,7 +166,7 @@ class TestBokehGraphPlot(TestBokehPlot):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 'red'), (0, 1, 1, 'green'), (1, 1, 2, 'blue')],
                       vdims='color')
-        graph = Graph((edges, nodes)).options(node_color='color')
+        graph = Graph((edges, nodes)).opts(node_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -180,7 +178,7 @@ class TestBokehGraphPlot(TestBokehPlot):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 0.5), (0, 1, 1, 1.5), (1, 1, 2, 2.5)],
                       vdims='color')
-        graph = Graph((edges, nodes)).options(node_color='color')
+        graph = Graph((edges, nodes)).opts(node_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -193,7 +191,7 @@ class TestBokehGraphPlot(TestBokehPlot):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 'A'), (0, 1, 1, 'B'), (1, 1, 2, 'C')],
                       vdims='color')
-        graph = Graph((edges, nodes)).options(node_color='color')
+        graph = Graph((edges, nodes)).opts(node_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -206,7 +204,7 @@ class TestBokehGraphPlot(TestBokehPlot):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 6)],
                       vdims='size')
-        graph = Graph((edges, nodes)).options(node_size='size')
+        graph = Graph((edges, nodes)).opts(node_size='size')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -216,7 +214,7 @@ class TestBokehGraphPlot(TestBokehPlot):
     def test_graph_op_node_alpha(self):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 0.2), (0, 1, 1, 0.6), (1, 1, 2, 1)], vdims='alpha')
-        graph = Graph((edges, nodes)).options(node_alpha='alpha')
+        graph = Graph((edges, nodes)).opts(node_alpha='alpha')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -227,7 +225,7 @@ class TestBokehGraphPlot(TestBokehPlot):
     def test_graph_op_node_line_width(self):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 6)], vdims='line_width')
-        graph = Graph((edges, nodes)).options(node_line_width='line_width')
+        graph = Graph((edges, nodes)).opts(node_line_width='line_width')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -236,7 +234,7 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_edge_color(self):
         edges = [(0, 1, 'red'), (0, 2, 'green'), (1, 3, 'blue')]
-        graph = Graph(edges, vdims='color').options(edge_color='color')
+        graph = Graph(edges, vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -245,7 +243,7 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_edge_color_linear(self):
         edges = [(0, 1, 2), (0, 2, 0.5), (1, 3, 3)]
-        graph = Graph(edges, vdims='color').options(edge_color='color')
+        graph = Graph(edges, vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -255,7 +253,7 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_edge_color_categorical(self):
         edges = [(0, 1, 'C'), (0, 2, 'B'), (1, 3, 'A')]
-        graph = Graph(edges, vdims='color').options(edge_color='color')
+        graph = Graph(edges, vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -265,7 +263,7 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_edge_alpha(self):
         edges = [(0, 1, 0.1), (0, 2, 0.5), (1, 3, 0.3)]
-        graph = Graph(edges, vdims='alpha').options(edge_alpha='alpha')
+        graph = Graph(edges, vdims='alpha').opts(edge_alpha='alpha')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -274,7 +272,7 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_edge_line_width(self):
         edges = [(0, 1, 2), (0, 2, 10), (1, 3, 6)]
-        graph = Graph(edges, vdims='line_width').options(edge_line_width='line_width')
+        graph = Graph(edges, vdims='line_width').opts(edge_line_width='line_width')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -304,7 +302,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
         self.assertEqual(layout_source.graph_layout, layout)
 
     def test_plot_simple_trimesh_filled(self):
-        plot = bokeh_renderer.get_plot(self.trimesh.opts(plot=dict(filled=True)))
+        plot = bokeh_renderer.get_plot(self.trimesh.opts(filled=True))
         node_source = plot.handles['scatter_1_source']
         edge_source = plot.handles['patches_1_source']
         layout_source = plot.handles['layout_source']
@@ -316,10 +314,10 @@ class TestBokehTriMeshPlot(TestBokehPlot):
         self.assertEqual(layout_source.graph_layout, layout)
 
     def test_trimesh_edges_categorical_colormapped(self):
-        g = self.trimesh.opts(plot=dict(edge_color_index='node1'),
-                              style=dict(edge_cmap=['#FFFFFF', '#000000']))
+        g = self.trimesh.opts(
+            edge_color_index='node1', edge_cmap=['#FFFFFF', '#000000']
+        )
         plot = bokeh_renderer.get_plot(g)
-        print(plot.handles)
         cmapper = plot.handles['edge_colormapper']
         edge_source = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -330,8 +328,9 @@ class TestBokehTriMeshPlot(TestBokehPlot):
         self.assertEqual(glyph.line_color, {'field': 'node1_str__', 'transform': cmapper})
 
     def test_trimesh_nodes_numerically_colormapped(self):
-        g = self.trimesh_weighted.opts(plot=dict(edge_color_index='weight'),
-                                       style=dict(edge_cmap=['#FFFFFF', '#000000']))
+        g = self.trimesh_weighted.opts(
+            edge_color_index='weight', edge_cmap=['#FFFFFF', '#000000']
+        )
         plot = bokeh_renderer.get_plot(g)
         cmapper = plot.handles['edge_colormapper']
         edge_source = plot.handles['multi_line_1_source']
@@ -349,7 +348,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_color(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 'red'), (0, 0, 1, 'green'), (0, 1, 2, 'blue'), (1, 0, 3, 'black')]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).options(node_color='color')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -360,7 +359,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_color_linear(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 2), (0, 0, 1, 1), (0, 1, 2, 3), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).options(node_color='color')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -374,7 +373,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_color_categorical(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 'B'), (0, 0, 1, 'C'), (0, 1, 2, 'A'), (1, 0, 3, 'B')]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).options(node_color='color')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -386,7 +385,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_size(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 3), (0, 0, 1, 2), (0, 1, 2, 8), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='size'))).options(node_size='size')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='size'))).opts(node_size='size')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -396,7 +395,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_alpha(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 0.2), (0, 0, 1, 0.6), (0, 1, 2, 1), (1, 0, 3, 0.3)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='alpha'))).options(node_alpha='alpha')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='alpha'))).opts(node_alpha='alpha')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -407,7 +406,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_line_width(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 0.2), (0, 0, 1, 0.6), (0, 1, 2, 1), (1, 0, 3, 0.3)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='line_width'))).options(node_line_width='line_width')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='line_width'))).opts(node_line_width='line_width')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -417,7 +416,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_color_linear_mean_node(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 2), (0, 0, 1, 1), (0, 1, 2, 3), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).options(edge_color='color')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(edge_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -430,7 +429,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_color(self):
         edges = [(0, 1, 2, 'red'), (1, 2, 3, 'blue')]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').options(edge_color='color')
+        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -440,7 +439,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_color_linear(self):
         edges = [(0, 1, 2, 2.4), (1, 2, 3, 3.6)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').options(edge_color='color')
+        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -453,7 +452,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_color_linear_filled(self):
         edges = [(0, 1, 2, 2.4), (1, 2, 3, 3.6)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').options(edge_color='color', filled=True)
+        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color', filled=True)
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['patches_1_source']
         glyph = plot.handles['patches_1_glyph']
@@ -467,7 +466,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_color_categorical(self):
         edges = [(0, 1, 2, 'A'), (1, 2, 3, 'B')]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').options(edge_color='color')
+        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -479,7 +478,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_alpha(self):
         edges = [(0, 1, 2, 0.7), (1, 2, 3, 0.3)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='alpha').options(edge_alpha='alpha')
+        trimesh = TriMesh((edges, nodes), vdims='alpha').opts(edge_alpha='alpha')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -489,7 +488,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_line_width(self):
         edges = [(0, 1, 2, 7), (1, 2, 3, 3)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='line_width').options(edge_line_width='line_width')
+        trimesh = TriMesh((edges, nodes), vdims='line_width').opts(edge_line_width='line_width')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -513,7 +512,7 @@ class TestBokehChordPlot(TestBokehPlot):
         self.assertTrue(renderers.index(arc_renderer)<renderers.index(graph_renderer))
 
     def test_chord_label_draw_order(self):
-        g = self.chord.options(labels='Label')
+        g = self.chord.opts(labels='Label')
         plot = bokeh_renderer.get_plot(g)
         renderers = plot.state.renderers
         graph_renderer = plot.handles['glyph_renderer']
@@ -521,20 +520,21 @@ class TestBokehChordPlot(TestBokehPlot):
         self.assertTrue(renderers.index(graph_renderer)<renderers.index(label_renderer))
 
     def test_chord_nodes_label_text(self):
-        g = self.chord.opts(plot=dict(label_index='Label'))
+        g = self.chord.opts(label_index='Label')
         plot = bokeh_renderer.get_plot(g)
         source = plot.handles['text_1_source']
         self.assertEqual(source.data['text'], ['A', 'B', 'C'])
 
     def test_chord_nodes_labels_mapping(self):
-        g = self.chord.opts(plot=dict(labels='Label'))
+        g = self.chord.opts(labels='Label')
         plot = bokeh_renderer.get_plot(g)
         source = plot.handles['text_1_source']
         self.assertEqual(source.data['text'], ['A', 'B', 'C'])
 
     def test_chord_nodes_categorically_colormapped(self):
-        g = self.chord.opts(plot=dict(color_index='Label', label_index='Label'),
-                            style=dict(cmap=['#FFFFFF', '#888888', '#000000']))
+        g = self.chord.opts(
+            color_index='Label', label_index='Label', cmap=['#FFFFFF', '#888888', '#000000']
+        )
         plot = bokeh_renderer.get_plot(g)
         cmapper = plot.handles['color_mapper']
         source = plot.handles['scatter_1_source']
@@ -548,8 +548,9 @@ class TestBokehChordPlot(TestBokehPlot):
         self.assertEqual(glyph.fill_color, {'field': 'Label', 'transform': cmapper})
 
     def test_chord_nodes_style_map_node_color_colormapped(self):
-        g = self.chord.opts(plot=dict(labels='Label'),
-                            style=dict(node_color='Label', cmap=['#FFFFFF', '#888888', '#000000']))
+        g = self.chord.opts(
+            labels='Label', node_color='Label', cmap=['#FFFFFF', '#888888', '#000000']
+        )
         plot = bokeh_renderer.get_plot(g)
         cmapper = plot.handles['node_color_color_mapper']
         source = plot.handles['scatter_1_source']
@@ -565,8 +566,9 @@ class TestBokehChordPlot(TestBokehPlot):
         self.assertEqual(arc_glyph.line_color, {'field': 'node_color', 'transform': cmapper})
 
     def test_chord_edges_categorically_colormapped(self):
-        g = self.chord.opts(plot=dict(edge_color_index='start'),
-                            style=dict(edge_cmap=['#FFFFFF', '#000000']))
+        g = self.chord.opts(
+            edge_color_index='start', edge_cmap=['#FFFFFF', '#000000']
+        )
         plot = bokeh_renderer.get_plot(g)
         cmapper = plot.handles['edge_colormapper']
         edge_source = plot.handles['multi_line_1_source']
@@ -578,7 +580,9 @@ class TestBokehChordPlot(TestBokehPlot):
         self.assertEqual(glyph.line_color, {'field': 'start_str__', 'transform': cmapper})
 
     def test_chord_edge_color_style_mapping(self):
-        g = self.chord.opts(style=dict(edge_color=dim('start').astype(str), edge_cmap=['#FFFFFF', '#000000']))
+        g = self.chord.opts(
+            edge_color=dim('start').astype(str), edge_cmap=['#FFFFFF', '#000000']
+        )
         plot = bokeh_renderer.get_plot(g)
         cmapper = plot.handles['edge_color_color_mapper']
         edge_source = plot.handles['multi_line_1_source']

--- a/holoviews/tests/plotting/bokeh/test_gridplot.py
+++ b/holoviews/tests/plotting/bokeh/test_gridplot.py
@@ -106,13 +106,13 @@ class TestGridPlot(TestBokehPlot):
         self.assertEqual(data['D'], np.full_like(hmap1[1].dimension_values(0), np.NaN))
 
     def test_grid_set_toolbar_location(self):
-        grid = GridSpace({0: Curve([]), 1: Points([])}, 'X').options(toolbar='left')
+        grid = GridSpace({0: Curve([]), 1: Points([])}, 'X').opts(toolbar='left')
         plot = bokeh_renderer.get_plot(grid)
         self.assertIsInstance(plot.state, Column)
         self.assertIsInstance(plot.state.children[0].children[0], ToolbarBox)
 
     def test_grid_disable_toolbar(self):
-        grid = GridSpace({0: Curve([]), 1: Points([])}, 'X').options(toolbar=None)
+        grid = GridSpace({0: Curve([]), 1: Points([])}, 'X').opts(toolbar=None)
         plot = bokeh_renderer.get_plot(grid)
         self.assertIsInstance(plot.state, Column)
         self.assertEqual([p for p in plot.state.children if isinstance(p, ToolbarBox)], [])

--- a/holoviews/tests/plotting/bokeh/test_heatmapplot.py
+++ b/holoviews/tests/plotting/bokeh/test_heatmapplot.py
@@ -20,7 +20,7 @@ class TestHeatMapPlot(TestBokehPlot):
         tooltips = "<div><h1>Test</h1></div>"
         custom_hover = HoverTool(tooltips=tooltips)
         hm = HeatMap([(1,1,1), (2,2,0)], kdims=['x with space', 'y with $pecial symbol'])
-        hm = hm.options(tools=[custom_hover])
+        hm = hm.opts(tools=[custom_hover])
         plot = bokeh_renderer.get_plot(hm)
         hover = plot.handles['hover']
         self.assertEqual(hover.tooltips, tooltips)
@@ -104,7 +104,7 @@ class TestHeatMapPlot(TestBokehPlot):
         self.assertEqual(source.data['y'], hm.dimension_values(0))
 
     def test_heatmap_dilate(self):
-        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).options(dilate=True)
+        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).opts(dilate=True)
         plot = bokeh_renderer.get_plot(hmap)
         glyph = plot.handles['glyph']
         self.assertTrue(glyph.dilate)

--- a/holoviews/tests/plotting/bokeh/test_hextilesplot.py
+++ b/holoviews/tests/plotting/bokeh/test_hextilesplot.py
@@ -43,47 +43,47 @@ class TestHexTilesPlot(TestBokehPlot):
         self.assertEqual(plot.handles['source'].data, {'q': [], 'r': []})
 
     def test_hex_tiles_zero_min_count(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).options(min_count=0)
+        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(min_count=0)
         plot = bokeh_renderer.get_plot(tiles)
         cmapper = plot.handles['color_mapper']
         self.assertEqual(cmapper.low, 0)
         self.assertEqual(plot.state.background_fill_color, cmapper.palette[0])
 
     def test_hex_tiles_gridsize_tuple(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).options(gridsize=(5, 10))
+        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(gridsize=(5, 10))
         plot = bokeh_renderer.get_plot(tiles)
         glyph = plot.handles['glyph']
         self.assertEqual(glyph.size, 0.066666666666666666)
         self.assertEqual(glyph.aspect_scale, 0.5)
 
     def test_hex_tiles_gridsize_tuple_flat_orientation(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).options(gridsize=(5, 10), orientation='flat')
+        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(gridsize=(5, 10), orientation='flat')
         plot = bokeh_renderer.get_plot(tiles)
         glyph = plot.handles['glyph']
         self.assertEqual(glyph.size, 0.13333333333333333)
         self.assertEqual(glyph.aspect_scale, 0.5)
 
     def test_hex_tiles_scale(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).options(size_index=2, gridsize=3)
+        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(size_index=2, gridsize=3)
         plot = bokeh_renderer.get_plot(tiles)
         source = plot.handles['source']
         self.assertEqual(source.data['scale'], np.array([0.45, 0.45, 0.9]))
 
     def test_hex_tiles_scale_all_equal(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).options(size_index=2)
+        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(size_index=2)
         plot = bokeh_renderer.get_plot(tiles)
         source = plot.handles['source']
         self.assertEqual(source.data['scale'], np.array([0.9, 0.9, 0.9, 0.9]))
 
     def test_hex_tiles_hover_count(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).options(tools=['hover'])
+        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(tools=['hover'])
         plot = bokeh_renderer.get_plot(tiles)
         dims, opts = plot._hover_opts(tiles)
         self.assertEqual(dims, [Dimension('Count')])
         self.assertEqual(opts, {})
 
     def test_hex_tiles_hover_weighted(self):
-        tiles = HexTiles([(0, 0, 0.1), (0.5, 0.5, 0.2), (-0.5, -0.5, 0.3)], vdims='z').options(aggregator=np.mean)
+        tiles = HexTiles([(0, 0, 0.1), (0.5, 0.5, 0.2), (-0.5, -0.5, 0.3)], vdims='z').opts(aggregator=np.mean)
         plot = bokeh_renderer.get_plot(tiles)
         dims, opts = plot._hover_opts(tiles)
         self.assertEqual(dims, [Dimension('z')])
@@ -94,19 +94,19 @@ class TestHexTilesPlot(TestBokehPlot):
     ###########################
 
     def test_hex_tile_line_width_op(self):
-        hextiles = HexTiles(np.random.randn(1000, 2)).options(line_width='Count')
+        hextiles = HexTiles(np.random.randn(1000, 2)).opts(line_width='Count')
         plot = bokeh_renderer.get_plot(hextiles)
         glyph = plot.handles['glyph']
         self.assertEqual(glyph.line_width, {'field': 'line_width'})
 
     def test_hex_tile_alpha_op(self):
-        hextiles = HexTiles(np.random.randn(1000, 2)).options(alpha='Count')
+        hextiles = HexTiles(np.random.randn(1000, 2)).opts(alpha='Count')
         plot = bokeh_renderer.get_plot(hextiles)
         glyph = plot.handles['glyph']
         self.assertEqual(glyph.fill_alpha, {'field': 'alpha'})
 
     def test_hex_tile_scale_op(self):
-        hextiles = HexTiles(np.random.randn(1000, 2)).options(scale='Count')
+        hextiles = HexTiles(np.random.randn(1000, 2)).opts(scale='Count')
         plot = bokeh_renderer.get_plot(hextiles)
         glyph = plot.handles['glyph']
         self.assertEqual(glyph.scale, {'field': 'scale'})

--- a/holoviews/tests/plotting/bokeh/test_histogramplot.py
+++ b/holoviews/tests/plotting/bokeh/test_histogramplot.py
@@ -80,7 +80,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(range_x.end, np.datetime64('2017-01-04T00:00:00.000000', 'us'))
 
     def test_histogram_padding_square(self):
-        points = Histogram([(1, 2), (2, -1), (3, 3)]).options(padding=0.1)
+        points = Histogram([(1, 2), (2, -1), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.19999999999999996)
@@ -89,7 +89,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.4)
 
     def test_histogram_padding_square_positive(self):
-        points = Histogram([(1, 2), (2, 1), (3, 3)]).options(padding=0.1)
+        points = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.19999999999999996)
@@ -98,7 +98,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_histogram_padding_square_negative(self):
-        points = Histogram([(1, -2), (2, -1), (3, -3)]).options(padding=0.1)
+        points = Histogram([(1, -2), (2, -1), (3, -3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.19999999999999996)
@@ -107,7 +107,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 0)
 
     def test_histogram_padding_nonsquare(self):
-        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).options(padding=0.1, width=600)
+        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.35)
@@ -116,7 +116,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_histogram_padding_logx(self):
-        histogram = Histogram([(1, 1), (2, 2), (3,3)]).options(padding=0.1, logx=True)
+        histogram = Histogram([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.41158562699652224)
@@ -125,7 +125,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_histogram_padding_logy(self):
-        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).options(padding=0.1, logy=True)
+        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.19999999999999996)
@@ -135,7 +135,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.log_handler.assertContains('WARNING', 'Logarithmic axis range encountered value less than')
 
     def test_histogram_padding_datetime_square(self):
-        histogram = Histogram([(np.datetime64('2016-04-0%d' % i, 'ns'), i) for i in range(1, 4)]).options(
+        histogram = Histogram([(np.datetime64('2016-04-0%d' % i, 'ns'), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = bokeh_renderer.get_plot(histogram)
@@ -146,7 +146,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_histogram_padding_datetime_nonsquare(self):
-        histogram = Histogram([(np.datetime64('2016-04-0%d' % i, 'ns'), i) for i in range(1, 4)]).options(
+        histogram = Histogram([(np.datetime64('2016-04-0%d' % i, 'ns'), i) for i in range(1, 4)]).opts(
             padding=0.1, width=600
         )
         plot = bokeh_renderer.get_plot(histogram)
@@ -162,7 +162,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_histogram_color_op(self):
         histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -172,7 +172,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_histogram_linear_color_op(self):
         histogram = Histogram([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -186,7 +186,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_histogram_categorical_color_op(self):
         histogram = Histogram([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -199,7 +199,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_histogram_line_color_op(self):
         histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                              vdims=['y', 'color']).options(line_color='color')
+                              vdims=['y', 'color']).opts(line_color='color')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -209,7 +209,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_histogram_fill_color_op(self):
         histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                              vdims=['y', 'color']).options(fill_color='color')
+                              vdims=['y', 'color']).opts(fill_color='color')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -219,7 +219,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_histogram_alpha_op(self):
         histogram = Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                              vdims=['y', 'alpha']).options(alpha='alpha')
+                              vdims=['y', 'alpha']).opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -228,7 +228,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_histogram_line_alpha_op(self):
         histogram = Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                              vdims=['y', 'alpha']).options(line_alpha='alpha')
+                              vdims=['y', 'alpha']).opts(line_alpha='alpha')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -238,7 +238,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_histogram_fill_alpha_op(self):
         histogram = Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                              vdims=['y', 'alpha']).options(fill_alpha='alpha')
+                              vdims=['y', 'alpha']).opts(fill_alpha='alpha')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -248,7 +248,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_histogram_line_width_op(self):
         histogram = Histogram([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
-                              vdims=['y', 'line_width']).options(line_width='line_width')
+                              vdims=['y', 'line_width']).opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -257,7 +257,7 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_op_ndoverlay_value(self):
         colors = ['blue', 'red']
-        overlay = NdOverlay({color: Histogram(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').options('Histogram', fill_color='Color')
+        overlay = NdOverlay({color: Histogram(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Histogram', fill_color='Color')
         plot = bokeh_renderer.get_plot(overlay)
         for subplot, color in zip(plot.subplots.values(),  colors):
             self.assertEqual(subplot.handles['glyph'].fill_color, color)

--- a/holoviews/tests/plotting/bokeh/test_labels.py
+++ b/holoviews/tests/plotting/bokeh/test_labels.py
@@ -51,7 +51,7 @@ class TestLabelsPlot(TestBokehPlot):
         self.assertEqual(glyph.text, 'text')
 
     def test_labels_inverted(self):
-        labels = Labels([(0, 1, 'A'), (1, 0, 'B')]).options(invert_axes=True)
+        labels = Labels([(0, 1, 'A'), (1, 0, 'B')]).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(labels)
         source = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -63,7 +63,7 @@ class TestLabelsPlot(TestBokehPlot):
         self.assertEqual(glyph.text, 'Label')
 
     def test_labels_color_mapped_text_vals(self):
-        labels = Labels([(0, 1, 0.33333), (1, 0, 0.66666)]).options(color_index=2)
+        labels = Labels([(0, 1, 0.33333), (1, 0, 0.66666)]).opts(color_index=2)
         plot = bokeh_renderer.get_plot(labels)
         source = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -81,7 +81,7 @@ class TestLabelsPlot(TestBokehPlot):
         self.assertEqual(cmapper.high, 0.66666)
 
     def test_labels_color_mapped(self):
-        labels = Labels([(0, 1, 0.33333, 2), (1, 0, 0.66666, 1)], vdims=['text', 'color']).options(color_index=3)
+        labels = Labels([(0, 1, 0.33333, 2), (1, 0, 0.66666, 1)], vdims=['text', 'color']).opts(color_index=3)
         plot = bokeh_renderer.get_plot(labels)
         source = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -104,7 +104,7 @@ class TestLabelsPlot(TestBokehPlot):
 
     def test_label_color_op(self):
         labels = Labels([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                        vdims='color').options(text_color='color')
+                        vdims='color').opts(text_color='color')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -113,7 +113,7 @@ class TestLabelsPlot(TestBokehPlot):
 
     def test_label_linear_color_op(self):
         labels = Labels([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims='color').options(text_color='color')
+                        vdims='color').opts(text_color='color')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -126,7 +126,7 @@ class TestLabelsPlot(TestBokehPlot):
 
     def test_label_categorical_color_op(self):
         labels = Labels([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
-                        vdims='color').options(text_color='color')
+                        vdims='color').opts(text_color='color')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -138,7 +138,7 @@ class TestLabelsPlot(TestBokehPlot):
 
     def test_label_angle_op(self):
         labels = Labels([(0, 0, 0), (0, 1, 45), (0, 2, 90)],
-                        vdims='angle').options(angle='angle')
+                        vdims='angle').opts(angle='angle')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -147,7 +147,7 @@ class TestLabelsPlot(TestBokehPlot):
 
     def test_label_alpha_op(self):
         labels = Labels([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                        vdims='alpha').options(text_alpha='alpha')
+                        vdims='alpha').opts(text_alpha='alpha')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -156,7 +156,7 @@ class TestLabelsPlot(TestBokehPlot):
 
     def test_label_font_size_op_strings(self):
         labels = Labels([(0, 0, '10pt'), (0, 1, '4pt'), (0, 2, '8pt')],
-                        vdims='size').options(text_font_size='size')
+                        vdims='size').opts(text_font_size='size')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -165,7 +165,7 @@ class TestLabelsPlot(TestBokehPlot):
 
     def test_label_font_size_op_ints(self):
         labels = Labels([(0, 0, 10), (0, 1, 4), (0, 2, 8)],
-                        vdims='size').options(text_font_size='size')
+                        vdims='size').opts(text_font_size='size')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -174,10 +174,14 @@ class TestLabelsPlot(TestBokehPlot):
 
     def test_labels_color_index_color_clash(self):
         labels = Labels([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims='color').options(text_color='color', color_index='color')
+                        vdims='color').opts(text_color='color', color_index='color')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(labels)
         log_msg = log.stream.read()
-        warning = ("Cannot declare style mapping for 'text_color' option "
-                   "and declare a color_index; ignoring the color_index.\n")
+        warning = (
+            "The `color_index` parameter is deprecated in favor of color style mapping, "
+            "e.g. `color=dim('color')` or `line_color=dim('color')`\nCannot declare style "
+            "mapping for 'text_color' option and declare a color_index; ignoring the "
+            "color_index.\n"
+        )
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/bokeh/test_layoutplot.py
+++ b/holoviews/tests/plotting/bokeh/test_layoutplot.py
@@ -136,7 +136,7 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_layout_title_fontsize(self):
         hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
         hmap2 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
-        layout = Layout([hmap1, hmap2]).opts(plot=dict(fontsize={'title': '12pt'}))
+        layout = Layout([hmap1, hmap2]).opts(fontsize={'title': '12pt'})
         plot = bokeh_renderer.get_plot(layout)
         title = plot.handles['title']
         self.assertIsInstance(title, Div)
@@ -147,7 +147,7 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_layout_title_show_title_false(self):
         hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
         hmap2 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
-        layout = Layout([hmap1, hmap2]).opts(plot=dict(show_title=False))
+        layout = Layout([hmap1, hmap2]).opts(show_title=False)
         plot = bokeh_renderer.get_plot(layout)
         self.assertTrue('title' not in plot.handles)
 
@@ -240,7 +240,7 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
                          for (f, _, _) in grid.children], [1, 1, 1])
 
     def test_layout_plot_tabs_with_adjoints(self):
-        layout = (Curve([]) + Curve([]).hist()).options(tabs=True)
+        layout = (Curve([]) + Curve([]).hist()).opts(tabs=True)
         plot = bokeh_renderer.get_plot(layout)
         self.assertIsInstance(plot.state, Tabs)
         panel1, panel2 = plot.state.tabs
@@ -260,7 +260,7 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
 
         # Pop key (1,) for one of the HoloMaps and make Layout
         hmap2.pop((1,))
-        layout = (hmap1 + hmap2).opts(plot=dict(shared_datasource=True))
+        layout = (hmap1 + hmap2).opts(shared_datasource=True)
 
         # Get plot
         plot = bokeh_renderer.get_plot(layout)
@@ -297,7 +297,7 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_shared_axes_disable(self):
         curve = Curve(range(10))
-        img = Image(np.random.rand(10,10)).opts(plot=dict(shared_axes=False))
+        img = Image(np.random.rand(10,10)).opts(shared_axes=False)
         plot = bokeh_renderer.get_plot(curve+img)
         plot = plot.subplots[(0, 1)].subplots['main']
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
@@ -312,19 +312,19 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.log_handler.assertContains('WARNING', 'skipping subplot')
 
     def test_layout_set_toolbar_location(self):
-        layout = (Curve([]) + Points([])).options(toolbar='left')
+        layout = (Curve([]) + Points([])).opts(toolbar='left')
         plot = bokeh_renderer.get_plot(layout)
         self.assertIsInstance(plot.state, Row)
         self.assertIsInstance(plot.state.children[0], ToolbarBox)
 
     def test_layout_disable_toolbar(self):
-        layout = (Curve([]) + Points([])).options(toolbar=None)
+        layout = (Curve([]) + Points([])).opts(toolbar=None)
         plot = bokeh_renderer.get_plot(layout)
         self.assertIsInstance(plot.state, GridBox)
         self.assertEqual(len(plot.state.children), 2)
 
     def test_layout_shared_inverted_yaxis(self):
-        layout = (Curve([]) + Curve([])).options('Curve', invert_yaxis=True)
+        layout = (Curve([]) + Curve([])).opts('Curve', invert_yaxis=True)
         plot = bokeh_renderer.get_plot(layout)
         subplot = list(plot.subplots.values())[0].subplots['main']
         self.assertEqual(subplot.handles['y_range'].start, 1)

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -100,7 +100,7 @@ class TestLinkCallbacks(TestBokehPlot):
             bokeh_renderer.get_plot(layout)
 
     def test_data_link_list(self):
-        path = Path([[(0, 0, 0), (1, 1, 1), (2, 2, 2)]], vdims='color').options(color='color')
+        path = Path([[(0, 0, 0), (1, 1, 1), (2, 2, 2)]], vdims='color').opts(color='color')
         table = Table([('A', 1), ('B', 2)], 'A', 'B')
         DataLink(path, table)
         layout = path + table

--- a/holoviews/tests/plotting/bokeh/test_overlayplot.py
+++ b/holoviews/tests/plotting/bokeh/test_overlayplot.py
@@ -16,7 +16,7 @@ from bokeh.models import FixedTicker, HoverTool, FactorRange, Span, Range1d
 class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_overlay_apply_ranges_disabled(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).options('Curve', apply_ranges=False)
+        overlay = (Curve(range(10)) * Curve(range(10))).opts('Curve', apply_ranges=False)
         plot = bokeh_renderer.get_plot(overlay)
         self.assertTrue(all(np.isnan(e) for e in plot.get_extents(overlay, {})))
 
@@ -66,8 +66,7 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_hover_tool_instance_renderer_association(self):
         tooltips = [("index", "$index")]
         hover = HoverTool(tooltips=tooltips)
-        opts = dict(tools=[hover])
-        overlay = Curve(np.random.rand(10,2)).opts(plot=opts) * Points(np.random.rand(10,2))
+        overlay = Curve(np.random.rand(10,2)).opts(tools=[hover]) * Points(np.random.rand(10,2))
         plot = bokeh_renderer.get_plot(overlay)
         curve_plot = plot.subplots[('Curve', 'I')]
         self.assertEqual(len(curve_plot.handles['hover'].renderers), 1)
@@ -83,7 +82,7 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):
     def test_hover_tool_nested_overlay_renderers(self):
         overlay1 = NdOverlay({0: Curve(range(2)), 1: Curve(range(3))}, kdims=['Test'])
         overlay2 = NdOverlay({0: Curve(range(4)), 1: Curve(range(5))}, kdims=['Test'])
-        nested_overlay = (overlay1 * overlay2).opts(plot={'Curve': dict(tools=['hover'])})
+        nested_overlay = (overlay1 * overlay2).opts('Curve', tools=['hover'])
         plot = bokeh_renderer.get_plot(nested_overlay)
         self.assertEqual(len(plot.handles['hover'].renderers), 4)
         self.assertEqual(plot.handles['hover'].tooltips,
@@ -96,66 +95,66 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.log_handler.assertContains('WARNING', 'is empty and will be skipped during plotting')
 
     def test_overlay_show_frame_disabled(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(plot=dict(show_frame=False))
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(show_frame=False)
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertEqual(plot.outline_line_alpha, 0)
 
     def test_overlay_no_xaxis(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(plot=dict(xaxis=None))
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(xaxis=None)
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertFalse(plot.xaxis[0].visible)
 
     def test_overlay_no_yaxis(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(plot=dict(yaxis=None))
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(yaxis=None)
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertFalse(plot.yaxis[0].visible)
 
     def test_overlay_xlabel_override(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).options(xlabel='custom x-label')
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(xlabel='custom x-label')
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertEqual(plot.xaxis[0].axis_label, 'custom x-label')
 
     def test_overlay_ylabel_override(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).options(ylabel='custom y-label')
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(ylabel='custom y-label')
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertEqual(plot.yaxis[0].axis_label, 'custom y-label')
 
     def test_overlay_xlabel_override_propagated(self):
-        overlay = (Curve(range(10)).options(xlabel='custom x-label') * Curve(range(10)))
+        overlay = (Curve(range(10)).opts(xlabel='custom x-label') * Curve(range(10)))
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertEqual(plot.xaxis[0].axis_label, 'custom x-label')
 
     def test_overlay_ylabel_override_propagated(self):
-        overlay = (Curve(range(10)).options(ylabel='custom y-label') * Curve(range(10)))
+        overlay = (Curve(range(10)).opts(ylabel='custom y-label') * Curve(range(10)))
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertEqual(plot.yaxis[0].axis_label, 'custom y-label')
 
     def test_overlay_xrotation(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(plot=dict(xrotation=90))
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(xrotation=90)
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertEqual(plot.xaxis[0].major_label_orientation, np.pi/2)
 
     def test_overlay_yrotation(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(plot=dict(yrotation=90))
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(yrotation=90)
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertEqual(plot.yaxis[0].major_label_orientation, np.pi/2)
 
     def test_overlay_xticks_list(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(plot=dict(xticks=[0, 5, 10]))
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(xticks=[0, 5, 10])
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertIsInstance(plot.xaxis[0].ticker, FixedTicker)
         self.assertEqual(plot.xaxis[0].ticker.ticks, [0, 5, 10])
 
     def test_overlay_yticks_list(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(plot=dict(yticks=[0, 5, 10]))
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(yticks=[0, 5, 10])
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertIsInstance(plot.yaxis[0].ticker, FixedTicker)
         self.assertEqual(plot.yaxis[0].ticker.ticks, [0, 5, 10])
 
     def test_overlay_update_plot_opts(self):
         hmap = HoloMap(
-            {0: (Curve([]) * Curve([])).options(title='A'),
-             1: (Curve([]) * Curve([])).options(title='B')}
+            {0: (Curve([]) * Curve([])).opts(title='A'),
+             1: (Curve([]) * Curve([])).opts(title='B')}
         )
         plot = bokeh_renderer.get_plot(hmap)
         self.assertEqual(plot.state.title.text, 'A')
@@ -164,8 +163,8 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):
 
     def test_overlay_update_plot_opts_inherited(self):
         hmap = HoloMap(
-            {0: (Curve([]).options(title='A') * Curve([])),
-             1: (Curve([]).options(title='B') * Curve([]))}
+            {0: (Curve([]).opts(title='A') * Curve([])),
+             1: (Curve([]).opts(title='B') * Curve([]))}
         )
         plot = bokeh_renderer.get_plot(hmap)
         self.assertEqual(plot.state.title.text, 'A')
@@ -203,7 +202,7 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):
         overlay = NdOverlay({i: Points(([chr(65+i)]*10,np.random.randn(10)))
                              for i in range(5)})
         error = ErrorBars([(el['x'][0], np.mean(el['y']), np.std(el['y']))
-                           for el in overlay]).opts(plot=dict(invert_axes=True))
+                           for el in overlay]).opts(invert_axes=True)
         text = Text('C', 0, 'Test')
         plot = bokeh_renderer.get_plot(overlay*error*text)
         x_range = plot.handles['x_range']

--- a/holoviews/tests/plotting/bokeh/test_pathplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pathplot.py
@@ -16,8 +16,8 @@ from bokeh.models import LinearColorMapper, CategoricalColorMapper
 class TestPathPlot(TestBokehPlot):
 
     def test_batched_path_line_color_and_color(self):
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Path': dict(style=dict(line_color=Cycle(values=['red', 'blue'])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Path': dict(line_color=Cycle(values=['red', 'blue']))}
         overlay = NdOverlay({i: Path([[(i, j) for j in range(2)]])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
@@ -25,8 +25,8 @@ class TestPathPlot(TestBokehPlot):
         self.assertEqual(plot.handles['source'].data['line_color'], line_color)
 
     def test_batched_path_alpha_and_color(self):
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Path': dict(style=dict(alpha=Cycle(values=[0.5, 1])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Path': dict(alpha=Cycle(values=[0.5, 1]))}
         overlay = NdOverlay({i: Path([[(i, j) for j in range(2)]])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
@@ -36,8 +36,8 @@ class TestPathPlot(TestBokehPlot):
         self.assertEqual(plot.handles['source'].data['color'], color)
 
     def test_batched_path_line_width_and_color(self):
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Path': dict(style=dict(line_width=Cycle(values=[0.5, 1])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Path': dict(line_width=Cycle(values=[0.5, 1]))}
         overlay = NdOverlay({i: Path([[(i, j) for j in range(2)]])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
@@ -51,7 +51,7 @@ class TestPathPlot(TestBokehPlot):
                         kdims=['Test'])
         opts = {'Path': {'tools': ['hover']},
                 'NdOverlay': {'legend_limit': 0}}
-        obj = obj.opts(plot=opts)
+        obj = obj.opts(opts)
         self._test_hover_info(obj, [('Test', '@{Test}')])
 
     def test_path_colored_and_split_with_extra_vdims(self):
@@ -60,7 +60,9 @@ class TestPathPlot(TestBokehPlot):
         color = [0, 0.25, 0.5, 0.75]
         other = ['A', 'B', 'C', 'D']
         data = {'x': xs, 'y': ys, 'color': color, 'other': other}
-        path = Path([data], vdims=['color','other']).options(color_index='color', tools=['hover'])
+        path = Path([data], vdims=['color','other']).opts(
+            color_index='color', tools=['hover']
+        )
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
 
@@ -75,7 +77,9 @@ class TestPathPlot(TestBokehPlot):
         color = [0, 0.25, 0.5, 0.75]
         other = ['A', 'B', 'C', 'D']
         data = {'x': xs, 'y': ys, 'color': color, 'other': other}
-        path = Path([data], vdims=['color','other']).options(color=dim('color')*2, tools=['hover'])
+        path = Path([data], vdims=['color','other']).opts(
+            color=dim('color')*2, tools=['hover']
+        )
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
 
@@ -92,7 +96,7 @@ class TestPathPlot(TestBokehPlot):
         data = {'x': xs, 'y': ys, 'color': color, 'date': date}
         levels = [0, 38, 73, 95, 110, 130, 156, 999]
         colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']
-        path = Path([data], vdims=['color', 'date']).options(
+        path = Path([data], vdims=['color', 'date']).opts(
             color_index='color', color_levels=levels, cmap=colors, tools=['hover'])
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
@@ -114,7 +118,7 @@ class TestPathPlot(TestBokehPlot):
         data = {'x': xs, 'y': ys, 'color': color, 'date': date}
         levels = [0, 38, 73, 95, 110, 130, 156, 999]
         colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']
-        path = Path([data], vdims=['color', 'date']).options(
+        path = Path([data], vdims=['color', 'date']).opts(
             color='color', color_levels=levels, cmap=colors, tools=['hover'])
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
@@ -133,7 +137,7 @@ class TestPathPlot(TestBokehPlot):
         ys = xs[::-1]
         alpha = [0.1, 0.7, 0.3, 0.2]
         data = {'x': xs, 'y': ys, 'alpha': alpha}
-        path = Path([data], vdims='alpha').options(alpha='alpha')
+        path = Path([data], vdims='alpha').opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
         self.assertEqual(source.data['xs'], [np.array([1, 2]), np.array([2, 3]), np.array([3, 4])])
@@ -145,7 +149,7 @@ class TestPathPlot(TestBokehPlot):
         ys = xs[::-1]
         line_width = [1, 7, 3, 2]
         data = {'x': xs, 'y': ys, 'line_width': line_width}
-        path = Path([data], vdims='line_width').options(line_width='line_width')
+        path = Path([data], vdims='line_width').opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
         self.assertEqual(source.data['xs'], [np.array([1, 2]), np.array([2, 3]), np.array([3, 4])])
@@ -272,7 +276,7 @@ class TestPolygonPlot(TestBokehPlot):
         polygons = Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
-        ], vdims='color').options(fill_color='color', tools=['hover'])
+        ], vdims='color').opts(fill_color='color', tools=['hover'])
         plot = bokeh_renderer.get_plot(polygons)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -285,7 +289,7 @@ class TestPolygonPlot(TestBokehPlot):
         polygons = Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(polygons)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -297,7 +301,7 @@ class TestPolygonPlot(TestBokehPlot):
         polygons = Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 3}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(polygons)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -313,7 +317,7 @@ class TestPolygonPlot(TestBokehPlot):
         polygons = Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'b'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'a'}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(polygons)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -328,7 +332,7 @@ class TestPolygonPlot(TestBokehPlot):
         polygons = Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'alpha': 0.7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'alpha': 0.3}
-        ], vdims='alpha').options(alpha='alpha')
+        ], vdims='alpha').opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(polygons)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -340,7 +344,7 @@ class TestPolygonPlot(TestBokehPlot):
         polygons = Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'line_width': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'line_width': 3}
-        ], vdims='line_width').options(line_width='line_width')
+        ], vdims='line_width').opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(polygons)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -394,7 +398,7 @@ class TestContoursPlot(TestBokehPlot):
         contours = Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(contours)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -405,7 +409,7 @@ class TestContoursPlot(TestBokehPlot):
         contours = Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 3}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(contours)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -440,7 +444,7 @@ class TestContoursPlot(TestBokehPlot):
             1: Contours([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 5},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 2}
-            ], vdims='color')}).options(color='color', framewise=True)
+            ], vdims='color')}).opts(color='color', framewise=True)
         plot = bokeh_renderer.get_plot(contours)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -459,7 +463,7 @@ class TestContoursPlot(TestBokehPlot):
         contours = Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'b'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'a'}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(contours)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -473,7 +477,7 @@ class TestContoursPlot(TestBokehPlot):
         contours = Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'alpha': 0.7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'alpha': 0.3}
-        ], vdims='alpha').options(alpha='alpha')
+        ], vdims='alpha').opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(contours)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -484,7 +488,7 @@ class TestContoursPlot(TestBokehPlot):
         contours = Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'line_width': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'line_width': 3}
-        ], vdims='line_width').options(line_width='line_width')
+        ], vdims='line_width').opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(contours)
         cds = plot.handles['source']
         glyph = plot.handles['glyph']

--- a/holoviews/tests/plotting/bokeh/test_pointplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pointplot.py
@@ -18,18 +18,17 @@ from bokeh.models import Scatter
 class TestPointPlot(TestBokehPlot):
 
     def test_points_colormapping(self):
-        points = Points(np.random.rand(10, 4), vdims=['a', 'b']).opts(plot=dict(color_index=3))
+        points = Points(np.random.rand(10, 4), vdims=['a', 'b']).opts(color_index=3)
         self._test_colormapping(points, 3)
 
     def test_points_colormapping_with_nonselection(self):
-        opts = dict(plot=dict(color_index=3),
-                    style=dict(nonselection_color='red'))
+        opts = dict(color_index=3, nonselection_color='red')
         points = Points(np.random.rand(10, 4), vdims=['a', 'b']).opts(**opts)
         self._test_colormapping(points, 3)
 
     def test_points_colormapping_categorical(self):
         points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
-                         vdims=['a', 'b']).opts(plot=dict(color_index='b'))
+                         vdims=['a', 'b']).opts(color_index='b')
         plot = bokeh_renderer.get_plot(points)
         plot.initialize_plot()
         cmapper = plot.handles['color_mapper']
@@ -39,7 +38,7 @@ class TestPointPlot(TestBokehPlot):
     def test_points_color_selection_nonselection(self):
         opts = dict(color='green', selection_color='red', nonselection_color='blue')
         points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
-                         vdims=['a', 'b']).opts(style=opts)
+                         vdims=['a', 'b']).opts(**opts)
         plot = bokeh_renderer.get_plot(points)
         glyph_renderer = plot.handles['glyph_renderer']
         self.assertEqual(glyph_renderer.glyph.fill_color, 'green')
@@ -52,7 +51,7 @@ class TestPointPlot(TestBokehPlot):
     def test_points_alpha_selection_nonselection(self):
         opts = dict(alpha=0.8, selection_alpha=1.0, nonselection_alpha=0.2)
         points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
-                         vdims=['a', 'b']).opts(style=opts)
+                         vdims=['a', 'b']).opts(**opts)
         plot = bokeh_renderer.get_plot(points)
         glyph_renderer = plot.handles['glyph_renderer']
         self.assertEqual(glyph_renderer.glyph.fill_alpha, 0.8)
@@ -65,7 +64,7 @@ class TestPointPlot(TestBokehPlot):
     def test_points_alpha_selection_partial(self):
         opts = dict(selection_alpha=1.0, selection_fill_alpha=0.2)
         points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
-                         vdims=['a', 'b']).opts(style=opts)
+                         vdims=['a', 'b']).opts(**opts)
         plot = bokeh_renderer.get_plot(points)
         glyph_renderer = plot.handles['glyph_renderer']
         self.assertEqual(glyph_renderer.glyph.fill_alpha, 1.0)
@@ -80,8 +79,8 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(extents, (0, 0, 98, 98))
 
     def test_batched_points_size_and_color(self):
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Points': dict(style=dict(size=Cycle(values=[1, 2])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Points': dict(size=Cycle(values=[1, 2]))}
         overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
@@ -92,8 +91,8 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(plot.handles['source'].data['size'], size)
 
     def test_batched_points_line_color_and_color(self):
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Points': dict(style=dict(line_color=Cycle(values=['red', 'blue'])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Points': dict(line_color=Cycle(values=['red', 'blue']))}
         overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
@@ -104,8 +103,8 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(plot.handles['source'].data['line_color'], line_color)
 
     def test_batched_points_alpha_and_color(self):
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Points': dict(style=dict(alpha=Cycle(values=[0.5, 1])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Points': dict(alpha=Cycle(values=[0.5, 1]))}
         overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
@@ -116,8 +115,8 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(plot.handles['source'].data['color'], color)
 
     def test_batched_points_line_width_and_color(self):
-        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
-                'Points': dict(style=dict(line_width=Cycle(values=[0.5, 1])))}
+        opts = {'NdOverlay': dict(legend_limit=0),
+                'Points': dict(line_width=Cycle(values=[0.5, 1]))}
         overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
@@ -131,7 +130,7 @@ class TestPointPlot(TestBokehPlot):
         obj = NdOverlay({i: Points((list(pd.date_range('2016-01-01', '2016-01-31')), range(31))) for i in range(5)},
                         kdims=['Test'])
         opts = {'Points': {'tools': ['hover']}}
-        obj = obj.opts(plot=opts)
+        obj = obj.opts(opts)
         self._test_hover_info(obj, [('Test', '@{Test}'), ('x', '@{x}{%F %T}'), ('y', '@{y}')],
                               formatters={'@{x}': "datetime"})
 
@@ -140,7 +139,7 @@ class TestPointPlot(TestBokehPlot):
                         kdims=['Test'])
         opts = {'Points': {'tools': ['hover']},
                 'NdOverlay': {'legend_limit': 0}}
-        obj = obj.opts(plot=opts)
+        obj = obj.opts(opts)
         self._test_hover_info(obj, [('Test', '@{Test}'), ('x', '@{x}'), ('y', '@{y}')])
 
     def test_points_overlay_hover(self):
@@ -148,7 +147,7 @@ class TestPointPlot(TestBokehPlot):
                         kdims=['Test'])
         opts = {'Points': {'tools': ['hover']},
                 'NdOverlay': {'legend_limit': 0}}
-        obj = obj.opts(plot=opts)
+        obj = obj.opts(opts)
         self._test_hover_info(obj, [('Test', '@{Test}'), ('x', '@{x}'),
                                     ('y', '@{y}')])
 
@@ -165,8 +164,10 @@ class TestPointPlot(TestBokehPlot):
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ('z dimension is not numeric, '
-                   'cannot use to scale Points size.\n')
+        warning = (
+            "The `size_index` parameter is deprecated in favor of size style mapping, e.g. "
+            "`size=dim('size')**2`.\nz dimension is not numeric, cannot use to scale Points size.\n"
+        )
         self.assertEqual(log_msg, warning)
 
     def test_points_categorical_xaxis(self):
@@ -185,7 +186,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(x_range.factors, list(map(str, range(10))) + ['A', 'B', 'C', '2.0'])
 
     def test_points_categorical_xaxis_invert_axes(self):
-        points = Points((['A', 'B', 'C'], (1,2,3))).opts(plot=dict(invert_axes=True))
+        points = Points((['A', 'B', 'C'], (1,2,3))).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(points)
         y_range = plot.handles['y_range']
         self.assertIsInstance(y_range, FactorRange)
@@ -200,7 +201,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(x_range.factors, ['A', 'B', 'C', 'D'])
 
     def test_points_overlay_categorical_xaxis_invert_axis(self):
-        points = Points((['A', 'B', 'C'], (1,2,3))).opts(plot=dict(invert_xaxis=True))
+        points = Points((['A', 'B', 'C'], (1,2,3))).opts(invert_xaxis=True)
         points2 = Points((['B', 'C', 'D'], (1,2,3)))
         plot = bokeh_renderer.get_plot(points*points2)
         x_range = plot.handles['x_range']
@@ -208,7 +209,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(x_range.factors, ['A', 'B', 'C', 'D'][::-1])
 
     def test_points_overlay_categorical_xaxis_invert_axes(self):
-        points = Points((['A', 'B', 'C'], (1,2,3))).opts(plot=dict(invert_axes=True))
+        points = Points((['A', 'B', 'C'], (1,2,3))).opts(invert_axes=True)
         points2 = Points((['B', 'C', 'D'], (1,2,3)))
         plot = bokeh_renderer.get_plot(points*points2)
         y_range = plot.handles['y_range']
@@ -216,7 +217,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(y_range.factors, ['A', 'B', 'C', 'D'])
 
     def test_points_padding_square(self):
-        points = Points([1, 2, 3]).options(padding=0.1)
+        points = Points([1, 2, 3]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, -0.2)
@@ -225,7 +226,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_curve_padding_square_per_axis(self):
-        curve = Points([1, 2, 3]).options(padding=((0, 0.1), (0.1, 0.2)))
+        curve = Points([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0)
@@ -234,7 +235,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.4)
 
     def test_points_padding_unequal(self):
-        points = Points([1, 2, 3]).options(padding=(0.05, 0.1))
+        points = Points([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, -0.1)
@@ -243,7 +244,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_points_padding_nonsquare(self):
-        points = Points([1, 2, 3]).options(padding=0.1, width=600)
+        points = Points([1, 2, 3]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, -0.1)
@@ -252,7 +253,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_points_padding_logx(self):
-        points = Points([(1, 1), (2, 2), (3,3)]).options(padding=0.1, logx=True)
+        points = Points([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.89595845984076228)
@@ -261,7 +262,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_points_padding_logy(self):
-        points = Points([1, 2, 3]).options(padding=0.1, logy=True)
+        points = Points([1, 2, 3]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, -0.2)
@@ -270,7 +271,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.3483695221017129)
 
     def test_points_padding_datetime_square(self):
-        points = Points([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).options(
+        points = Points([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = bokeh_renderer.get_plot(points)
@@ -281,7 +282,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_points_padding_datetime_nonsquare(self):
-        points = Points([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).options(
+        points = Points([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).opts(
             padding=0.1, width=600
         )
         plot = bokeh_renderer.get_plot(points)
@@ -292,7 +293,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_points_padding_hard_xrange(self):
-        points = Points([1, 2, 3]).redim.range(x=(0, 3)).options(padding=0.1)
+        points = Points([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0)
@@ -301,7 +302,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_points_padding_soft_xrange(self):
-        points = Points([1, 2, 3]).redim.soft_range(x=(0, 3)).options(padding=0.1)
+        points = Points([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0)
@@ -310,7 +311,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_points_datetime_hover(self):
-        points = Points([(0, 1, dt.datetime(2017, 1, 1))], vdims='date').options(tools=['hover'])
+        points = Points([(0, 1, dt.datetime(2017, 1, 1))], vdims='date').opts(tools=['hover'])
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         self.assertEqual(cds.data['date'].astype('datetime64'), np.array([1483228800000000000]))
@@ -339,7 +340,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_color_op(self):
         points = Points([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                        vdims='color').options(color='color')
+                        vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -349,7 +350,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_linear_color_op(self):
         points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims='color').options(color='color')
+                        vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -363,7 +364,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_categorical_color_op(self):
         points = Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
-                        vdims='color').options(color='color')
+                        vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -399,7 +400,7 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(glyph.line_color, {'field': 'color', 'transform': cmapper})
 
     def test_point_explicit_cmap_color_op(self):
-        points = Points([(0, 0), (0, 1), (0, 2)]).options(
+        points = Points([(0, 0), (0, 1), (0, 2)]).opts(
             color='y', cmap={0: 'red', 1: 'green', 2: 'blue'})
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -414,7 +415,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_line_color_op(self):
         points = Points([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                        vdims='color').options(line_color='color')
+                        vdims='color').opts(line_color='color')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -424,7 +425,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_fill_color_op(self):
         points = Points([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                        vdims='color').options(fill_color='color')
+                        vdims='color').opts(fill_color='color')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -434,7 +435,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_angle_op(self):
         points = Points([(0, 0, 0), (0, 1, 45), (0, 2, 90)],
-                        vdims='angle').options(angle='angle')
+                        vdims='angle').opts(angle='angle')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -443,7 +444,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_alpha_op(self):
         points = Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                        vdims='alpha').options(alpha='alpha')
+                        vdims='alpha').opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -452,7 +453,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_line_alpha_op(self):
         points = Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                        vdims='alpha').options(line_alpha='alpha')
+                        vdims='alpha').opts(line_alpha='alpha')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -462,7 +463,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_fill_alpha_op(self):
         points = Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                        vdims='alpha').options(fill_alpha='alpha')
+                        vdims='alpha').opts(fill_alpha='alpha')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -472,7 +473,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_size_op(self):
         points = Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
-                        vdims='size').options(size='size')
+                        vdims='size').opts(size='size')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -481,7 +482,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_line_width_op(self):
         points = Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
-                        vdims='line_width').options(line_width='line_width')
+                        vdims='line_width').opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -490,7 +491,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_marker_op(self):
         points = Points([(0, 0, 'circle'), (0, 1, 'triangle'), (0, 2, 'square')],
-                        vdims='marker').options(marker='marker')
+                        vdims='marker').opts(marker='marker')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -499,7 +500,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_op_ndoverlay_value(self):
         markers = ['circle', 'triangle']
-        overlay = NdOverlay({marker: Points(np.arange(i)) for i, marker in enumerate(markers)}, 'Marker').options('Points', marker='Marker')
+        overlay = NdOverlay({marker: Points(np.arange(i)) for i, marker in enumerate(markers)}, 'Marker').opts('Points', marker='Marker')
         plot = bokeh_renderer.get_plot(overlay)
         for subplot, glyph_type, marker in zip(plot.subplots.values(), [Scatter, Scatter], markers):
             self.assertIsInstance(subplot.handles['glyph'], glyph_type)
@@ -507,17 +508,20 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_color_index_color_clash(self):
         points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims='color').options(color='color', color_index='color')
+                        vdims='color').opts(color='color', color_index='color')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ("Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n")
+        warning = (
+            "The `color_index` parameter is deprecated in favor of color style mapping, e.g. "
+            "`color=dim('color')` or `line_color=dim('color')`\nCannot declare style mapping "
+            "for 'color' option and declare a color_index; ignoring the color_index.\n"
+        )
         self.assertEqual(log_msg, warning)
 
     def test_point_color_index_color_no_clash(self):
         points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims='color').options(fill_color='color', color_index='color')
+                        vdims='color').opts(fill_color='color', color_index='color')
         plot = bokeh_renderer.get_plot(points)
         glyph = plot.handles['glyph']
         cmapper = plot.handles['fill_color_color_mapper']
@@ -527,10 +531,13 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_size_index_size_clash(self):
         points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims='size').options(size='size', size_index='size')
+                        vdims='size').opts(size='size', size_index='size')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ("Cannot declare style mapping for 'size' option "
-                   "and declare a size_index; ignoring the size_index.\n")
+        warning = (
+            "The `size_index` parameter is deprecated in favor of size style mapping, e.g. "
+            "`size=dim('size')**2`.\nCannot declare style mapping for 'size' option and declare a "
+            "size_index; ignoring the size_index.\n"
+        )
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
@@ -18,7 +18,7 @@ class TestQuadMeshPlot(TestBokehPlot):
 
     def test_quadmesh_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
-        qmesh = QuadMesh(Image(arr)).opts(plot=dict(invert_axes=True, tools=['hover']))
+        qmesh = QuadMesh(Image(arr)).opts(invert_axes=True, tools=['hover'])
         plot = bokeh_renderer.get_plot(qmesh)
         source = plot.handles['source']
         self.assertEqual(source.data['z'], qmesh.dimension_values(2, flat=False).flatten())
@@ -29,7 +29,7 @@ class TestQuadMeshPlot(TestBokehPlot):
         n = 21
         xs = np.logspace(1, 3, n)
         ys = np.linspace(1, 10, n)
-        qmesh = QuadMesh((xs, ys, np.random.rand(n-1, n-1))).options(colorbar=True)
+        qmesh = QuadMesh((xs, ys, np.random.rand(n-1, n-1))).opts(colorbar=True)
         plot = bokeh_renderer.get_plot(qmesh)
         self.assertIsInstance(plot.handles['colorbar'], ColorBar)
         self.assertIs(plot.handles['colorbar'].color_mapper, plot.handles['color_mapper'])

--- a/holoviews/tests/plotting/bokeh/test_radialheatmap.py
+++ b/holoviews/tests/plotting/bokeh/test_radialheatmap.py
@@ -276,16 +276,16 @@ class BokehRadialHeatMapPlotTests(TestBokehPlot):
     def test_heatmap_holomap(self):
         hm = HoloMap({'A': HeatMap(np.random.randint(0, 10, (100, 3))),
                       'B': HeatMap(np.random.randint(0, 10, (100, 3)))})
-        plot = bokeh_renderer.get_plot(hm.options(radial=True))
+        plot = bokeh_renderer.get_plot(hm.opts(radial=True))
         self.assertIsInstance(plot, RadialHeatMapPlot)
 
     def test_radial_heatmap_colorbar(self):
-        hm = HeatMap([(0, 0, 1), (0, 1, 2), (1, 0, 3)]).options(radial=True, colorbar=True)
+        hm = HeatMap([(0, 0, 1), (0, 1, 2), (1, 0, 3)]).opts(radial=True, colorbar=True)
         plot = bokeh_renderer.get_plot(hm)
         self.assertIsInstance(plot.handles.get('colorbar'), ColorBar)
 
     def test_radial_heatmap_ranges(self):
-        hm = HeatMap([(0, 0, 1), (0, 1, 2), (1, 0, 3)]).options(radial=True, colorbar=True)
+        hm = HeatMap([(0, 0, 1), (0, 1, 2), (1, 0, 3)]).opts(radial=True, colorbar=True)
         plot = bokeh_renderer.get_plot(hm)
         self.assertEqual(plot.handles['x_range'].start, -0.05)
         self.assertEqual(plot.handles['x_range'].end, 1.05)

--- a/holoviews/tests/plotting/bokeh/test_rasterplot.py
+++ b/holoviews/tests/plotting/bokeh/test_rasterplot.py
@@ -8,7 +8,7 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestRasterPlot(TestBokehPlot):
 
     def test_image_colormapping(self):
-        img = Image(np.random.rand(10, 10)).opts(plot=dict(logz=True))
+        img = Image(np.random.rand(10, 10)).opts(logz=True)
         self._test_colormapping(img, 2, True)
 
     def test_image_boolean_array(self):
@@ -43,7 +43,7 @@ class TestRasterPlot(TestBokehPlot):
 
     def test_raster_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4,  5]])
-        raster = Raster(arr).opts(plot=dict(invert_axes=True))
+        raster = Raster(arr).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(raster)
         source = plot.handles['source']
         self.assertEqual(source.data['image'][0], np.rot90(arr))
@@ -54,7 +54,7 @@ class TestRasterPlot(TestBokehPlot):
 
     def test_image_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4,  5]])
-        raster = Image(arr).opts(plot=dict(invert_axes=True))
+        raster = Image(arr).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(raster)
         source = plot.handles['source']
         self.assertEqual(source.data['image'][0], np.rot90(arr)[::-1, ::-1])
@@ -65,7 +65,7 @@ class TestRasterPlot(TestBokehPlot):
 
     def test_image_invert_xaxis(self):
         arr = np.random.rand(10, 10)
-        img = Image(arr).opts(plot=dict(invert_xaxis=True))
+        img = Image(arr).opts(invert_xaxis=True)
         plot = bokeh_renderer.get_plot(img)
         x_range = plot.handles['x_range']
         self.assertEqual(x_range.start, 0.5)
@@ -79,7 +79,7 @@ class TestRasterPlot(TestBokehPlot):
 
     def test_image_invert_yaxis(self):
         arr = np.random.rand(10, 10)
-        img = Image(arr).opts(plot=dict(invert_yaxis=True))
+        img = Image(arr).opts(invert_yaxis=True)
         plot = bokeh_renderer.get_plot(img)
         y_range = plot.handles['y_range']
         self.assertEqual(y_range.start, 0.5)
@@ -92,7 +92,7 @@ class TestRasterPlot(TestBokehPlot):
         self.assertEqual(cdata['image'][0], arr)
 
     def test_rgb_invert_xaxis(self):
-        rgb = RGB(np.random.rand(10, 10, 3)).opts(plot=dict(invert_xaxis=True))
+        rgb = RGB(np.random.rand(10, 10, 3)).opts(invert_xaxis=True)
         plot = bokeh_renderer.get_plot(rgb)
         x_range = plot.handles['x_range']
         self.assertEqual(x_range.start, 0.5)
@@ -104,7 +104,7 @@ class TestRasterPlot(TestBokehPlot):
         self.assertEqual(cdata['dw'], [1.0])
 
     def test_rgb_invert_yaxis(self):
-        rgb = RGB(np.random.rand(10, 10, 3)).opts(plot=dict(invert_yaxis=True))
+        rgb = RGB(np.random.rand(10, 10, 3)).opts(invert_yaxis=True)
         plot = bokeh_renderer.get_plot(rgb)
         y_range = plot.handles['y_range']
         self.assertEqual(y_range.start, 0.5)

--- a/holoviews/tests/plotting/bokeh/test_sankey.py
+++ b/holoviews/tests/plotting/bokeh/test_sankey.py
@@ -53,7 +53,7 @@ class TestSankeyPlot(TestBokehPlot):
             (0, 2, 5), (0, 3, 7), (0, 4, 6),
             (1, 2, 2), (1, 3, 9), (1, 4, 4)],
             Dataset(enumerate('ABXYZ'), 'index', 'label'))
-        ).options(label_index='label', tools=['hover'])
+        ).opts(label_index='label', tools=['hover'])
         plot = bokeh_renderer.get_plot(sankey)
 
         scatter_source = plot.handles['scatter_1_source']

--- a/holoviews/tests/plotting/bokeh/test_spikesplot.py
+++ b/holoviews/tests/plotting/bokeh/test_spikesplot.py
@@ -14,7 +14,7 @@ class TestSpikesPlot(TestBokehPlot):
 
     def test_spikes_colormapping(self):
         spikes = Spikes(np.random.rand(20, 2), vdims=['Intensity'])
-        color_spikes = spikes.opts(plot=dict(color_index=1))
+        color_spikes = spikes.opts(color_index=1)
         self._test_colormapping(color_spikes, 1)
 
     def test_empty_spikes_plot(self):
@@ -26,22 +26,24 @@ class TestSpikesPlot(TestBokehPlot):
         self.assertEqual(len(source.data['y1']), 0)
 
     def test_batched_spike_plot(self):
-        overlay = NdOverlay({i: Spikes([i], kdims=['Time']).opts(
-            plot=dict(position=0.1*i, spike_length=0.1, show_legend=False))
-                             for i in range(10)})
+        overlay = NdOverlay({
+            i: Spikes([i], kdims=['Time']).opts(
+                position=0.1*i, spike_length=0.1, show_legend=False)
+            for i in range(10)
+        })
         plot = bokeh_renderer.get_plot(overlay)
         extents = plot.get_extents(overlay, {})
         self.assertEqual(extents, (0, 0, 9, 1))
 
     def test_spikes_padding_square(self):
-        spikes = Spikes([1, 2, 3]).options(padding=0.1)
+        spikes = Spikes([1, 2, 3]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         self.assertEqual(x_range.start, 0.8)
         self.assertEqual(x_range.end, 3.2)
 
     def test_spikes_padding_square_heights(self):
-        spikes = Spikes([(1, 1), (2, 2), (3, 3)], vdims=['Height']).options(padding=0.1)
+        spikes = Spikes([(1, 1), (2, 2), (3, 3)], vdims=['Height']).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spikes)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -50,42 +52,42 @@ class TestSpikesPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_spikes_padding_hard_xrange(self):
-        spikes = Spikes([1, 2, 3]).redim.range(x=(0, 3)).options(padding=0.1)
+        spikes = Spikes([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         self.assertEqual(x_range.start, 0)
         self.assertEqual(x_range.end, 3)
 
     def test_spikes_padding_soft_xrange(self):
-        spikes = Spikes([1, 2, 3]).redim.soft_range(x=(0, 3)).options(padding=0.1)
+        spikes = Spikes([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         self.assertEqual(x_range.start, 0)
         self.assertEqual(x_range.end, 3)
 
     def test_spikes_padding_unequal(self):
-        spikes = Spikes([1, 2, 3]).options(padding=(0.05, 0.1))
+        spikes = Spikes([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         self.assertEqual(x_range.start, 0.9)
         self.assertEqual(x_range.end, 3.1)
 
     def test_spikes_padding_nonsquare(self):
-        spikes = Spikes([1, 2, 3]).options(padding=0.1, width=600)
+        spikes = Spikes([1, 2, 3]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         self.assertEqual(x_range.start, 0.9)
         self.assertEqual(x_range.end, 3.1)
 
     def test_spikes_padding_logx(self):
-        spikes = Spikes([(1, 1), (2, 2), (3,3)]).options(padding=0.1, logx=True)
+        spikes = Spikes([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         self.assertEqual(x_range.start, 0.89595845984076228)
         self.assertEqual(x_range.end, 3.3483695221017129)
 
     def test_spikes_padding_datetime_square(self):
-        spikes = Spikes([np.datetime64('2016-04-0%d' % i) for i in range(1, 4)]).options(
+        spikes = Spikes([np.datetime64('2016-04-0%d' % i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = bokeh_renderer.get_plot(spikes)
@@ -94,7 +96,7 @@ class TestSpikesPlot(TestBokehPlot):
         self.assertEqual(x_range.end, np.datetime64('2016-04-03T04:48:00.000000000'))
 
     def test_spikes_padding_datetime_square_heights(self):
-        spikes = Spikes([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)], vdims=['Height']).options(
+        spikes = Spikes([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)], vdims=['Height']).opts(
             padding=0.1
         )
         plot = bokeh_renderer.get_plot(spikes)
@@ -105,7 +107,7 @@ class TestSpikesPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.2)
 
     def test_spikes_padding_datetime_nonsquare(self):
-        spikes = Spikes([np.datetime64('2016-04-0%d' % i) for i in range(1, 4)]).options(
+        spikes = Spikes([np.datetime64('2016-04-0%d' % i) for i in range(1, 4)]).opts(
             padding=0.1, width=600
         )
         plot = bokeh_renderer.get_plot(spikes)
@@ -114,7 +116,7 @@ class TestSpikesPlot(TestBokehPlot):
         self.assertEqual(x_range.end, np.datetime64('2016-04-03T02:24:00.000000000'))
 
     def test_spikes_datetime_vdim_hover(self):
-        points = Spikes([(0, 1, dt.datetime(2017, 1, 1))], vdims=['value', 'date']).options(tools=['hover'])
+        points = Spikes([(0, 1, dt.datetime(2017, 1, 1))], vdims=['value', 'date']).opts(tools=['hover'])
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         self.assertEqual(cds.data['date'].astype('datetime64'), np.array([1483228800000000000]))
@@ -123,7 +125,7 @@ class TestSpikesPlot(TestBokehPlot):
         self.assertEqual(hover.formatters, {'@{date}': "datetime"})
 
     def test_spikes_datetime_kdim_hover(self):
-        points = Spikes([(dt.datetime(2017, 1, 1), 1)], 'x', 'y').options(tools=['hover'])
+        points = Spikes([(dt.datetime(2017, 1, 1), 1)], 'x', 'y').opts(tools=['hover'])
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         self.assertEqual(cds.data['x'].astype('datetime64'), np.array([1483228800000000000]))
@@ -135,7 +137,7 @@ class TestSpikesPlot(TestBokehPlot):
         self.assertEqual(hover.formatters, {'@{x}': "datetime"})
 
     def test_spikes_datetime_kdim_hover_spike_length_override(self):
-        points = Spikes([(dt.datetime(2017, 1, 1), 1)], 'x', 'y').options(
+        points = Spikes([(dt.datetime(2017, 1, 1), 1)], 'x', 'y').opts(
             tools=['hover'], spike_length=0.75)
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -152,7 +154,7 @@ class TestSpikesPlot(TestBokehPlot):
 
     def test_spikes_color_op(self):
         spikes = Spikes([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -161,7 +163,7 @@ class TestSpikesPlot(TestBokehPlot):
 
     def test_spikes_linear_color_op(self):
         spikes = Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -174,7 +176,7 @@ class TestSpikesPlot(TestBokehPlot):
 
     def test_spikes_categorical_color_op(self):
         spikes = Spikes([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -186,7 +188,7 @@ class TestSpikesPlot(TestBokehPlot):
 
     def test_spikes_line_color_op(self):
         spikes = Spikes([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                              vdims=['y', 'color']).options(line_color='color')
+                              vdims=['y', 'color']).opts(line_color='color')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -195,7 +197,7 @@ class TestSpikesPlot(TestBokehPlot):
 
     def test_spikes_alpha_op(self):
         spikes = Spikes([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                              vdims=['y', 'alpha']).options(alpha='alpha')
+                              vdims=['y', 'alpha']).opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -204,7 +206,7 @@ class TestSpikesPlot(TestBokehPlot):
 
     def test_spikes_line_alpha_op(self):
         spikes = Spikes([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                              vdims=['y', 'alpha']).options(line_alpha='alpha')
+                              vdims=['y', 'alpha']).opts(line_alpha='alpha')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -213,7 +215,7 @@ class TestSpikesPlot(TestBokehPlot):
 
     def test_spikes_line_width_op(self):
         spikes = Spikes([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
-                              vdims=['y', 'line_width']).options(line_width='line_width')
+                              vdims=['y', 'line_width']).opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -222,17 +224,20 @@ class TestSpikesPlot(TestBokehPlot):
 
     def test_op_ndoverlay_value(self):
         colors = ['blue', 'red']
-        overlay = NdOverlay({color: Spikes(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').options('Spikes', color='Color')
+        overlay = NdOverlay({color: Spikes(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Spikes', color='Color')
         plot = bokeh_renderer.get_plot(overlay)
         for subplot, color in zip(plot.subplots.values(),  colors):
             self.assertEqual(subplot.handles['glyph'].line_color, color)
 
     def test_spikes_color_index_color_clash(self):
         spikes = Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                    vdims=['y', 'color']).options(color='color', color_index='color')
+                    vdims=['y', 'color']).opts(color='color', color_index='color')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(spikes)
         log_msg = log.stream.read()
-        warning = ("Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n")
+        warning = (
+            "The `color_index` parameter is deprecated in favor of color style mapping, e.g. "
+            "`color=dim('color')` or `line_color=dim('color')`\nCannot declare style mapping "
+            "for 'color' option and declare a color_index; ignoring the color_index.\n"
+        )
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/bokeh/test_spreadplot.py
+++ b/holoviews/tests/plotting/bokeh/test_spreadplot.py
@@ -36,7 +36,7 @@ class TestSpreadPlot(TestBokehPlot):
         self.assertEqual(cds.data['y'], [])
 
     def test_spread_padding_square(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).options(padding=0.1)
+        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -45,7 +45,7 @@ class TestSpreadPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.8)
 
     def test_spread_padding_hard_range(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.range(y=(0, 4)).options(padding=0.1)
+        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.range(y=(0, 4)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -54,7 +54,7 @@ class TestSpreadPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 4)
 
     def test_spread_padding_soft_range(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.soft_range(y=(0, 3.5)).options(padding=0.1)
+        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)
@@ -63,7 +63,7 @@ class TestSpreadPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.5)
 
     def test_spread_padding_nonsquare(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).options(padding=0.1, width=600)
+        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.9)
@@ -72,7 +72,7 @@ class TestSpreadPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.8)
 
     def test_spread_padding_logx(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3,3, 0.5)]).options(padding=0.1, logx=True)
+        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3,3, 0.5)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.89595845984076228)
@@ -81,7 +81,7 @@ class TestSpreadPlot(TestBokehPlot):
         self.assertEqual(y_range.end, 3.8)
 
     def test_spread_padding_logy(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).options(padding=0.1, logy=True)
+        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual(x_range.start, 0.8)

--- a/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
@@ -19,7 +19,7 @@ class TestVectorFieldPlot(TestBokehPlot):
 
     def test_vectorfield_color_op(self):
         vectorfield = VectorField([(0, 0, 0, 1, '#000'), (0, 1, 0, 1,'#F00'), (0, 2, 0, 1,'#0F0')],
-                                  vdims=['A', 'M', 'color']).options(color='color')
+                                  vdims=['A', 'M', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(vectorfield)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -29,7 +29,7 @@ class TestVectorFieldPlot(TestBokehPlot):
 
     def test_vectorfield_linear_color_op(self):
         vectorfield = VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 1), (0, 2, 0, 1, 2)],
-                                  vdims=['A', 'M', 'color']).options(color='color')
+                                  vdims=['A', 'M', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(vectorfield)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -42,7 +42,7 @@ class TestVectorFieldPlot(TestBokehPlot):
 
     def test_vectorfield_categorical_color_op(self):
         vectorfield = VectorField([(0, 0, 0, 1, 'A'), (0, 1, 0, 1, 'B'), (0, 2, 0, 1, 'C')],
-                                  vdims=['A', 'M', 'color']).options(color='color')
+                                  vdims=['A', 'M', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(vectorfield)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -54,7 +54,7 @@ class TestVectorFieldPlot(TestBokehPlot):
 
     def test_vectorfield_alpha_op(self):
         vectorfield = VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 0.2), (0, 2, 0, 1, 0.7)],
-                                  vdims=['A', 'M', 'alpha']).options(alpha='alpha')
+                                  vdims=['A', 'M', 'alpha']).opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(vectorfield)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -63,7 +63,7 @@ class TestVectorFieldPlot(TestBokehPlot):
 
     def test_vectorfield_line_width_op(self):
         vectorfield = VectorField([(0, 0, 0, 1, 1), (0, 1, 0, 1, 4), (0, 2, 0, 1, 8)],
-                                  vdims=['A', 'M', 'line_width']).options(line_width='line_width')
+                                  vdims=['A', 'M', 'line_width']).opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(vectorfield)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -72,10 +72,13 @@ class TestVectorFieldPlot(TestBokehPlot):
 
     def test_vectorfield_color_index_color_clash(self):
         vectorfield = VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims='color').options(line_color='color', color_index='color')
+                        vdims='color').opts(line_color='color', color_index='color')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(vectorfield)
         log_msg = log.stream.read()
-        warning = ("Cannot declare style mapping for 'line_color' option "
-                   "and declare a color_index; ignoring the color_index.\n")
+        warning = (
+            "The `color_index` parameter is deprecated in favor of color style mapping, e.g. "
+            "`color=dim('color')` or `line_color=dim('color')`\nCannot declare style mapping "
+            "for 'line_color' option and declare a color_index; ignoring the color_index.\n"
+        )
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/bokeh/test_violinplot.py
+++ b/holoviews/tests/plotting/bokeh/test_violinplot.py
@@ -24,7 +24,7 @@ class TestBokehViolinPlot(TestBokehPlot):
 
     def test_violin_simple(self):
         values = np.random.rand(100)
-        violin = Violin(values).opts(plot=dict(violin_width=0.7))
+        violin = Violin(values).opts(violin_width=0.7)
         qmin, q1, q2, q3, qmax = (np.percentile(values, q=q)
                                   for q in range(0,125,25))
         iqr = q3 - q1
@@ -64,7 +64,7 @@ class TestBokehViolinPlot(TestBokehPlot):
 
     def test_violin_inner_quartiles(self):
         values = np.random.rand(100)
-        violin = Violin(values).opts(plot=dict(inner='quartiles'))
+        violin = Violin(values).opts(inner='quartiles')
         kde = univariate_kde(violin, cut=5)
         xs = kde.dimension_values(0)
         plot = bokeh_renderer.get_plot(violin)
@@ -76,7 +76,7 @@ class TestBokehViolinPlot(TestBokehPlot):
 
     def test_violin_inner_stick(self):
         values = np.random.rand(100)
-        violin = Violin(values).opts(plot=dict(inner='stick'))
+        violin = Violin(values).opts(inner='stick')
         kde = univariate_kde(violin, cut=5)
         xs = kde.dimension_values(0)
         plot = bokeh_renderer.get_plot(violin)
@@ -100,7 +100,7 @@ class TestBokehViolinPlot(TestBokehPlot):
 
     def test_violin_single_point(self):
         data = {'x': [1], 'y': [1]}
-        violin = Violin(data=data, kdims='x', vdims='y').opts(plot=dict(inner='box'))
+        violin = Violin(data=data, kdims='x', vdims='y').opts(inner='box')
 
         plot = bokeh_renderer.get_plot(violin)
         self.assertEqual(plot.handles['x_range'].factors, ['1'])
@@ -112,7 +112,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_linear_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').options(violin_color='b')
+        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_color='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['patches_1_source']
         cmapper = plot.handles['violin_color_color_mapper']
@@ -126,7 +126,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_categorical_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(['A', 'B', 'C', 'D', 'E'], 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').options(violin_color='b')
+        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_color='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['patches_1_source']
         glyph = plot.handles['patches_1_glyph']
@@ -139,7 +139,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_alpha_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5)/10., 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').options(violin_alpha='b')
+        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_alpha='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['patches_1_source']
         glyph = plot.handles['patches_1_glyph']
@@ -149,7 +149,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_line_width_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').options(violin_line_width='b')
+        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_line_width='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -159,7 +159,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_split_op_multi(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').options(split=dim('b')>2)
+        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(split=dim('b')>2)
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['patches_1_source']
         glyph = plot.handles['patches_1_glyph']
@@ -170,7 +170,7 @@ class TestBokehViolinPlot(TestBokehPlot):
 
     def test_violin_split_op_single(self):
         a = np.repeat(np.arange(2), 5)
-        violin = Violin((a, np.arange(10)), ['a'], 'd').options(split='a')
+        violin = Violin((a, np.arange(10)), ['a'], 'd').opts(split='a')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['patches_1_source']
         glyph = plot.handles['patches_1_glyph']
@@ -181,7 +181,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_box_linear_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').options(box_color='b')
+        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['vbar_1_source']
         cmapper = plot.handles['box_color_color_mapper']
@@ -195,7 +195,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_box_categorical_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(['A', 'B', 'C', 'D', 'E'], 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').options(box_color='b')
+        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']
@@ -208,7 +208,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_box_alpha_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5)/10., 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').options(box_alpha='b')
+        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_alpha='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']
@@ -218,7 +218,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_box_line_width_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').options(box_line_width='b')
+        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_line_width='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']

--- a/holoviews/tests/plotting/matplotlib/test_areaplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_areaplot.py
@@ -7,7 +7,7 @@ from .test_plot import TestMPLPlot, mpl_renderer
 class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
 
     def test_area_padding_square(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).options(padding=0.1)
+        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.8)
@@ -16,7 +16,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_area_padding_square_per_axis(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).options(padding=((0, 0.1), (0.1, 0.2)))
+        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 1)
@@ -25,7 +25,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.4)
 
     def test_area_with_lower_vdim(self):
-        area = Area([(1, 0.5, 1), (2, 1.5, 2), (3, 2.5, 3)], vdims=['y', 'y2']).options(padding=0.1)
+        area = Area([(1, 0.5, 1), (2, 1.5, 2), (3, 2.5, 3)], vdims=['y', 'y2']).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.8)
@@ -34,7 +34,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.25)
 
     def test_area_padding_negative(self):
-        area = Area([(1, -1), (2, -2), (3, -3)]).options(padding=0.1)
+        area = Area([(1, -1), (2, -2), (3, -3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.8)
@@ -43,7 +43,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 0)
 
     def test_area_padding_mixed(self):
-        area = Area([(1, 1), (2, -2), (3, 3)]).options(padding=0.1)
+        area = Area([(1, 1), (2, -2), (3, 3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.8)
@@ -52,7 +52,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.5)
 
     def test_area_padding_hard_range(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).redim.range(y=(0, 4)).options(padding=0.1)
+        area = Area([(1, 1), (2, 2), (3, 3)]).redim.range(y=(0, 4)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.8)
@@ -61,7 +61,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 4)
 
     def test_area_padding_soft_range(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).redim.soft_range(y=(0, 3.5)).options(padding=0.1)
+        area = Area([(1, 1), (2, 2), (3, 3)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.8)
@@ -70,7 +70,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.5)
 
     def test_area_padding_nonsquare(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).options(padding=0.1, aspect=2)
+        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.9)
@@ -79,7 +79,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_area_padding_logx(self):
-        area = Area([(1, 1), (2, 2), (3,3)]).options(padding=0.1, logx=True)
+        area = Area([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.89595845984076228)
@@ -88,7 +88,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_area_padding_logy(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).options(padding=0.1, logy=True)
+        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, logy=True)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.8)

--- a/holoviews/tests/plotting/matplotlib/test_boxwhisker.py
+++ b/holoviews/tests/plotting/matplotlib/test_boxwhisker.py
@@ -24,7 +24,7 @@ class TestMPLBoxWhiskerPlot(TestMPLPlot):
                          p2.handles['boxes'][0].get_path().vertices)
 
     def test_box_whisker_padding_square(self):
-        curve = BoxWhisker([1, 2, 3]).options(padding=0.1)
+        curve = BoxWhisker([1, 2, 3]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(curve)
         y_range = plot.handles['axis'].get_ylim()
         self.assertEqual(y_range[0], 0.8)

--- a/holoviews/tests/plotting/matplotlib/test_curveplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_curveplot.py
@@ -49,7 +49,7 @@ class TestCurvePlot(TestMPLPlot):
         self.assertEqual(plot.handles['axis'].get_xlim(), (16801.0, 16813.0))
 
     def test_curve_padding_square(self):
-        curve = Curve([1, 2, 3]).options(padding=0.1)
+        curve = Curve([1, 2, 3]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], -0.2)
@@ -58,7 +58,7 @@ class TestCurvePlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_curve_padding_square_per_axis(self):
-        curve = Curve([1, 2, 3]).options(padding=((0, 0.1), (0.1, 0.2)))
+        curve = Curve([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0)
@@ -67,7 +67,7 @@ class TestCurvePlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.4)
 
     def test_curve_padding_hard_xrange(self):
-        curve = Curve([1, 2, 3]).redim.range(x=(0, 3)).options(padding=0.1)
+        curve = Curve([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0)
@@ -76,7 +76,7 @@ class TestCurvePlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_curve_padding_soft_xrange(self):
-        curve = Curve([1, 2, 3]).redim.soft_range(x=(0, 3)).options(padding=0.1)
+        curve = Curve([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0)
@@ -85,7 +85,7 @@ class TestCurvePlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_curve_padding_unequal(self):
-        curve = Curve([1, 2, 3]).options(padding=(0.05, 0.1))
+        curve = Curve([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], -0.1)
@@ -94,7 +94,7 @@ class TestCurvePlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_curve_padding_nonsquare(self):
-        curve = Curve([1, 2, 3]).options(padding=0.1, aspect=2)
+        curve = Curve([1, 2, 3]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], -0.1)
@@ -103,7 +103,7 @@ class TestCurvePlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_curve_padding_logx(self):
-        curve = Curve([(1, 1), (2, 2), (3,3)]).options(padding=0.1, logx=True)
+        curve = Curve([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.89595845984076228)
@@ -112,7 +112,7 @@ class TestCurvePlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_curve_padding_logy(self):
-        curve = Curve([1, 2, 3]).options(padding=0.1, logy=True)
+        curve = Curve([1, 2, 3]).opts(padding=0.1, logy=True)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], -0.2)
@@ -121,7 +121,7 @@ class TestCurvePlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.3483695221017129)
 
     def test_curve_padding_datetime_square(self):
-        curve = Curve([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).options(
+        curve = Curve([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = mpl_renderer.get_plot(curve)
@@ -132,7 +132,7 @@ class TestCurvePlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_curve_padding_datetime_nonsquare(self):
-        curve = Curve([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).options(
+        curve = Curve([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).opts(
             padding=0.1, aspect=2
         )
         plot = mpl_renderer.get_plot(curve)
@@ -148,7 +148,7 @@ class TestCurvePlot(TestMPLPlot):
 
     def test_curve_scalar_color_op(self):
         curve = Curve([(0, 0, 'red'), (0, 1, 'red'), (0, 2, 'red')],
-                       vdims=['y', 'color']).options(color='color')
+                       vdims=['y', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(curve)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_color(), 'red')
@@ -157,7 +157,7 @@ class TestCurvePlot(TestMPLPlot):
         colors = ['blue', 'red']
         overlay = NdOverlay({color: Curve(np.arange(i))
                              for i, color in enumerate(colors)},
-                            'color').options('Curve', color='color')
+                            'color').opts('Curve', color='color')
         plot = mpl_renderer.get_plot(overlay)
         for subplot, color in zip(plot.subplots.values(), colors):
             style = dict(subplot.style[subplot.cyclic_index])
@@ -166,19 +166,19 @@ class TestCurvePlot(TestMPLPlot):
 
     def test_curve_color_op(self):
         curve = Curve([(0, 0, 'red'), (0, 1, 'blue'), (0, 2, 'red')],
-                       vdims=['y', 'color']).options(color='color')
+                       vdims=['y', 'color']).opts(color='color')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(curve)
 
     def test_curve_alpha_op(self):
         curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
-                       vdims=['y', 'alpha']).options(alpha='alpha')
+                       vdims=['y', 'alpha']).opts(alpha='alpha')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(curve)
 
     def test_curve_linewidth_op(self):
         curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
-                       vdims=['y', 'linewidth']).options(linewidth='linewidth')
+                       vdims=['y', 'linewidth']).opts(linewidth='linewidth')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(curve)
 

--- a/holoviews/tests/plotting/matplotlib/test_elementplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_elementplot.py
@@ -26,7 +26,7 @@ class TestElementPlot(TestMPLPlot):
         self.assertEqual(plot.handles['title'].get_text(), 'Called')
 
     def test_element_font_scaling(self):
-        curve = Curve(range(10)).options(fontscale=2, title='A title')
+        curve = Curve(range(10)).opts(fontscale=2, title='A title')
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         self.assertEqual(ax.title.get_fontsize(), 24)
@@ -36,7 +36,7 @@ class TestElementPlot(TestMPLPlot):
         self.assertEqual(ax.yaxis._major_tick_kw['labelsize'], 20)
 
     def test_element_font_scaling_fontsize_override_common(self):
-        curve = Curve(range(10)).options(fontscale=2, fontsize=14, title='A title')
+        curve = Curve(range(10)).opts(fontscale=2, fontsize=14, title='A title')
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         self.assertEqual(ax.title.get_fontsize(), 28)
@@ -46,7 +46,7 @@ class TestElementPlot(TestMPLPlot):
         self.assertEqual(ax.yaxis._major_tick_kw['labelsize'], 20)
 
     def test_element_font_scaling_fontsize_override_specific(self):
-        curve = Curve(range(10)).options(
+        curve = Curve(range(10)).opts(
             fontscale=2, fontsize={'title': 16, 'xticks': 12, 'xlabel': 6}, title='A title')
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
@@ -57,7 +57,7 @@ class TestElementPlot(TestMPLPlot):
         self.assertEqual(ax.yaxis._major_tick_kw['labelsize'], 20)
 
     def test_element_no_xaxis_yaxis(self):
-        element = Curve(range(10)).options(xaxis=None, yaxis=None)
+        element = Curve(range(10)).opts(xaxis=None, yaxis=None)
         axes = mpl_renderer.get_plot(element).handles['axis']
         xaxis = axes.get_xaxis()
         yaxis = axes.get_yaxis()
@@ -65,17 +65,17 @@ class TestElementPlot(TestMPLPlot):
         self.assertEqual(yaxis.get_visible(), False)
 
     def test_element_xlabel(self):
-        element = Curve(range(10)).options(xlabel='custom x-label')
+        element = Curve(range(10)).opts(xlabel='custom x-label')
         axes = mpl_renderer.get_plot(element).handles['axis']
         self.assertEqual(axes.get_xlabel(), 'custom x-label')
 
     def test_element_ylabel(self):
-        element = Curve(range(10)).options(ylabel='custom y-label')
+        element = Curve(range(10)).opts(ylabel='custom y-label')
         axes = mpl_renderer.get_plot(element).handles['axis']
         self.assertEqual(axes.get_ylabel(), 'custom y-label')
 
     def test_element_xformatter_string(self):
-        curve = Curve(range(10)).options(xformatter='%d')
+        curve = Curve(range(10)).opts(xformatter='%d')
         plot = mpl_renderer.get_plot(curve)
         xaxis = plot.handles['axis'].xaxis
         xformatter = xaxis.get_major_formatter()
@@ -83,7 +83,7 @@ class TestElementPlot(TestMPLPlot):
         self.assertEqual(xformatter.fmt, '%d')
 
     def test_element_yformatter_string(self):
-        curve = Curve(range(10)).options(yformatter='%d')
+        curve = Curve(range(10)).opts(yformatter='%d')
         plot = mpl_renderer.get_plot(curve)
         yaxis = plot.handles['axis'].yaxis
         yformatter = yaxis.get_major_formatter()
@@ -91,7 +91,7 @@ class TestElementPlot(TestMPLPlot):
         self.assertEqual(yformatter.fmt, '%d')
 
     def test_element_zformatter_string(self):
-        curve = Scatter3D([]).options(zformatter='%d')
+        curve = Scatter3D([]).opts(zformatter='%d')
         plot = mpl_renderer.get_plot(curve)
         zaxis = plot.handles['axis'].zaxis
         zformatter = zaxis.get_major_formatter()
@@ -101,7 +101,7 @@ class TestElementPlot(TestMPLPlot):
     def test_element_xformatter_function(self):
         def formatter(value):
             return str(value) + ' %'
-        curve = Curve(range(10)).options(xformatter=formatter)
+        curve = Curve(range(10)).opts(xformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         xaxis = plot.handles['axis'].xaxis
         xformatter = xaxis.get_major_formatter()
@@ -110,7 +110,7 @@ class TestElementPlot(TestMPLPlot):
     def test_element_yformatter_function(self):
         def formatter(value):
             return str(value) + ' %'
-        curve = Curve(range(10)).options(yformatter=formatter)
+        curve = Curve(range(10)).opts(yformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         yaxis = plot.handles['axis'].yaxis
         yformatter = yaxis.get_major_formatter()
@@ -119,7 +119,7 @@ class TestElementPlot(TestMPLPlot):
     def test_element_zformatter_function(self):
         def formatter(value):
             return str(value) + ' %'
-        curve = Scatter3D([]).options(zformatter=formatter)
+        curve = Scatter3D([]).opts(zformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         zaxis = plot.handles['axis'].zaxis
         zformatter = zaxis.get_major_formatter()
@@ -127,7 +127,7 @@ class TestElementPlot(TestMPLPlot):
 
     def test_element_xformatter_instance(self):
         formatter = PercentFormatter()
-        curve = Curve(range(10)).options(xformatter=formatter)
+        curve = Curve(range(10)).opts(xformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         xaxis = plot.handles['axis'].xaxis
         xformatter = xaxis.get_major_formatter()
@@ -135,7 +135,7 @@ class TestElementPlot(TestMPLPlot):
 
     def test_element_yformatter_instance(self):
         formatter = PercentFormatter()
-        curve = Curve(range(10)).options(yformatter=formatter)
+        curve = Curve(range(10)).opts(yformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         yaxis = plot.handles['axis'].yaxis
         yformatter = yaxis.get_major_formatter()
@@ -143,7 +143,7 @@ class TestElementPlot(TestMPLPlot):
 
     def test_element_zformatter_instance(self):
         formatter = PercentFormatter()
-        curve = Scatter3D([]).options(zformatter=formatter)
+        curve = Scatter3D([]).opts(zformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         zaxis = plot.handles['axis'].zaxis
         zformatter = zaxis.get_major_formatter()
@@ -160,38 +160,38 @@ class TestColorbarPlot(TestMPLPlot):
         self.assertEqual(artist.get_clim(), (1, 4))
 
     def test_colormapper_symmetric(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(symmetric=True)
+        img = Image(np.array([[0, 1], [2, 3]])).opts(symmetric=True)
         plot = mpl_renderer.get_plot(img)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_clim(), (-3, 3))
 
     def test_colormapper_clims(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(clims=(0, 4))
+        img = Image(np.array([[0, 1], [2, 3]])).opts(clims=(0, 4))
         plot = mpl_renderer.get_plot(img)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_clim(), (0, 4))
 
     def test_colormapper_color_levels(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(color_levels=5)
+        img = Image(np.array([[0, 1], [2, 3]])).opts(color_levels=5)
         plot = mpl_renderer.get_plot(img)
         artist = plot.handles['artist']
         self.assertEqual(len(artist.cmap.colors), 5)
 
     def test_colormapper_transparent_nan(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(clipping_colors={'NaN': 'transparent'})
+        img = Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'NaN': 'transparent'})
         plot = mpl_renderer.get_plot(img)
         cmap = plot.handles['artist'].cmap
         self.assertEqual(cmap._rgba_bad, (1.0, 1.0, 1.0, 0))
 
     def test_colormapper_min_max_colors(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(clipping_colors={'min': 'red', 'max': 'blue'})
+        img = Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'min': 'red', 'max': 'blue'})
         plot = mpl_renderer.get_plot(img)
         cmap = plot.handles['artist'].cmap
         self.assertEqual(cmap._rgba_under, (1.0, 0, 0, 1))
         self.assertEqual(cmap._rgba_over, (0, 0, 1.0, 1))
 
     def test_colorbar_label(self):
-        scatter = Scatter(np.random.rand(100, 3), vdims=["y", "color"]).options(color_index=2, colorbar=True)
+        scatter = Scatter(np.random.rand(100, 3), vdims=["y", "color"]).opts(color_index=2, colorbar=True)
         plot = mpl_renderer.get_plot(scatter)
         cbar_ax = plot.handles['cax']
         self.assertEqual(cbar_ax.get_ylabel(), 'color')
@@ -203,7 +203,7 @@ class TestColorbarPlot(TestMPLPlot):
         self.assertEqual(colorbar.get_label(), '')
 
     def test_colorbar_label_style_mapping(self):
-        scatter = Scatter(np.random.rand(100, 3), vdims=["y", "color"]).options(color='color', colorbar=True)
+        scatter = Scatter(np.random.rand(100, 3), vdims=["y", "color"]).opts(color='color', colorbar=True)
         plot = mpl_renderer.get_plot(scatter)
         cbar_ax = plot.handles['cax']
         self.assertEqual(cbar_ax.get_ylabel(), 'color')
@@ -215,7 +215,7 @@ class TestOverlayPlot(TestMPLPlot):
         overlay = (
             Curve(np.random.randn(10).cumsum(), label='A') *
             Curve(np.random.randn(10).cumsum(), label='B')
-        ).options(legend_opts={'framealpha': 0.5, 'facecolor': 'red'})
+        ).opts(legend_opts={'framealpha': 0.5, 'facecolor': 'red'})
         plot = mpl_renderer.get_plot(overlay)
         legend_frame = plot.handles['legend'].get_frame()
         self.assertEqual(legend_frame.get_alpha(), 0.5)

--- a/holoviews/tests/plotting/matplotlib/test_errorbarplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_errorbarplot.py
@@ -15,7 +15,7 @@ class TestErrorBarPlot(TestMPLPlot):
 
     def test_errorbars_color_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, '#000000'), (0, 1, 0.2, 0.4, '#FF0000'), (0, 2, 0.6, 1.2, '#00FF00')],
-                              vdims=['y', 'perr', 'nerr', 'color']).options(color='color')
+                              vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(errorbars)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_edgecolors(),
@@ -27,7 +27,7 @@ class TestErrorBarPlot(TestMPLPlot):
                           (0, 2, 0.6, 1.2, '#00FF00')], vdims=['y', 'perr', 'nerr', 'color']),
             1: ErrorBars([(0, 0, 0.1, 0.2, '#FF0000'), (0, 1, 0.2, 0.4, '#00FF00'),
                           (0, 2, 0.6, 1.2, '#0000FF')], vdims=['y', 'perr', 'nerr', 'color'])
-        }).options(color='color')
+        }).opts(color='color')
         plot = mpl_renderer.get_plot(errorbars)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_edgecolors(),
@@ -38,19 +38,19 @@ class TestErrorBarPlot(TestMPLPlot):
 
     def test_errorbars_linear_color_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 1), (0, 2, 0.6, 1.2, 2)],
-                              vdims=['y', 'perr', 'nerr', 'color']).options(color='color')
+                              vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(errorbars)
 
     def test_errorbars_categorical_color_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, 'A'), (0, 1, 0.2, 0.4, 'B'), (0, 2, 0.6, 1.2, 'C')],
-                              vdims=['y', 'perr', 'nerr', 'color']).options(color='color')
+                              vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(errorbars)
 
     def test_errorbars_line_color_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, '#000000'), (0, 1, 0.2, 0.4, '#FF0000'), (0, 2, 0.6, 1.2, '#00FF00')],
-                              vdims=['y', 'perr', 'nerr', 'color']).options(edgecolor='color')
+                              vdims=['y', 'perr', 'nerr', 'color']).opts(edgecolor='color')
         plot = mpl_renderer.get_plot(errorbars)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_edgecolors(), np.array([
@@ -59,13 +59,13 @@ class TestErrorBarPlot(TestMPLPlot):
 
     def test_errorbars_alpha_op(self):
         errorbars = ErrorBars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                              vdims=['y', 'alpha']).options(alpha='alpha')
+                              vdims=['y', 'alpha']).opts(alpha='alpha')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(errorbars)
 
     def test_errorbars_line_width_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, 1), (0, 1, 0.2, 0.4, 4), (0, 2, 0.6, 1.2, 8)],
-                              vdims=['y', 'perr', 'nerr', 'line_width']).options(linewidth='line_width')
+                              vdims=['y', 'perr', 'nerr', 'line_width']).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(errorbars)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [1, 4, 8])
@@ -76,7 +76,7 @@ class TestErrorBarPlot(TestMPLPlot):
                           (0, 2, 0.6, 1.2, 8)], vdims=['y', 'perr', 'nerr', 'line_width']),
             1: ErrorBars([(0, 0, 0.1, 0.2, 2), (0, 1, 0.2, 0.4, 6),
                           (0, 2, 0.6, 1.2, 4)], vdims=['y', 'perr', 'nerr', 'line_width'])
-        }).options(linewidth='line_width')
+        }).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(errorbars)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [1, 4, 8])

--- a/holoviews/tests/plotting/matplotlib/test_graphplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_graphplot.py
@@ -37,7 +37,7 @@ class TestMplGraphPlot(TestMPLPlot):
                          [p.array() for p in self.graph.edgepaths.split()])
 
     def test_plot_graph_categorical_colored_nodes(self):
-        g = self.graph2.opts(plot=dict(color_index='Label'), style=dict(cmap='Set1'))
+        g = self.graph2.opts(color_index='Label', cmap='Set1')
         plot = mpl_renderer.get_plot(g)
         nodes = plot.handles['nodes']
         facecolors = np.array([[0.89411765, 0.10196078, 0.10980392, 1.],
@@ -51,15 +51,16 @@ class TestMplGraphPlot(TestMPLPlot):
         self.assertEqual(nodes.get_facecolors(), facecolors)
 
     def test_plot_graph_numerically_colored_nodes(self):
-        g = self.graph3.opts(plot=dict(color_index='Weight'), style=dict(cmap='viridis'))
+        g = self.graph3.opts(color_index='Weight', cmap='viridis')
         plot = mpl_renderer.get_plot(g)
         nodes = plot.handles['nodes']
         self.assertEqual(np.asarray(nodes.get_array()), self.weights)
         self.assertEqual(nodes.get_clim(), (self.weights.min(), self.weights.max()))
 
     def test_plot_graph_categorical_colored_edges(self):
-        g = self.graph3.opts(plot=dict(edge_color_index='start'),
-                             style=dict(edge_cmap=['#FFFFFF', '#000000']))
+        g = self.graph3.opts(
+            edge_color_index='start', edge_cmap=['#FFFFFF', '#000000']
+        )
         plot = mpl_renderer.get_plot(g)
         edges = plot.handles['edges']
         colors = np.array([[1., 1., 1., 1.],
@@ -73,8 +74,9 @@ class TestMplGraphPlot(TestMPLPlot):
         self.assertEqual(edges.get_colors(), colors)
 
     def test_plot_graph_numerically_colored_edges(self):
-        g = self.graph4.opts(plot=dict(edge_color_index='Weight'),
-                             style=dict(edge_cmap=['#FFFFFF', '#000000']))
+        g = self.graph4.opts(
+            edge_color_index='Weight', edge_cmap=['#FFFFFF', '#000000']
+        )
         plot = mpl_renderer.get_plot(g)
         edges = plot.handles['edges']
         self.assertEqual(np.asarray(edges.get_array()), self.weights)
@@ -88,7 +90,7 @@ class TestMplGraphPlot(TestMPLPlot):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, '#000000'), (0, 1, 1, '#FF0000'), (1, 1, 2, '#00FF00')],
                       vdims='color')
-        graph = Graph((edges, nodes)).options(node_color='color')
+        graph = Graph((edges, nodes)).opts(node_color='color')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         self.assertEqual(artist.get_facecolors(),
@@ -102,7 +104,7 @@ class TestMplGraphPlot(TestMPLPlot):
             nodes = Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
                       vdims='color')
             return Graph((edges, nodes))
-        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).options(node_color='color')
+        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_color='color')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         self.assertEqual(artist.get_facecolors(),
@@ -115,7 +117,7 @@ class TestMplGraphPlot(TestMPLPlot):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 0.5), (0, 1, 1, 1.5), (1, 1, 2, 2.5)],
                       vdims='color')
-        graph = Graph((edges, nodes)).options(node_color='color')
+        graph = Graph((edges, nodes)).opts(node_color='color')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0.5, 1.5, 2.5]))
@@ -129,7 +131,7 @@ class TestMplGraphPlot(TestMPLPlot):
             nodes = Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
                       vdims='color')
             return Graph((edges, nodes))
-        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).options(node_color='color', framewise=True)
+        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_color='color', framewise=True)
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0.5, 1.5, 2.5]))
@@ -142,7 +144,7 @@ class TestMplGraphPlot(TestMPLPlot):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 'A'), (0, 1, 1, 'B'), (1, 1, 2, 'A')],
                       vdims='color')
-        graph = Graph((edges, nodes)).options(node_color='color')
+        graph = Graph((edges, nodes)).opts(node_color='color')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1, 0]))
@@ -151,7 +153,7 @@ class TestMplGraphPlot(TestMPLPlot):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 6)],
                       vdims='size')
-        graph = Graph((edges, nodes)).options(node_size='size')
+        graph = Graph((edges, nodes)).opts(node_size='size')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         self.assertEqual(artist.get_sizes(), np.array([4, 16, 36]))
@@ -164,7 +166,7 @@ class TestMplGraphPlot(TestMPLPlot):
             nodes = Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
                       vdims='size')
             return Graph((edges, nodes))
-        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).options(node_size='size')
+        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_size='size')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         self.assertEqual(artist.get_sizes(), np.array([4, 16, 36]))
@@ -174,7 +176,7 @@ class TestMplGraphPlot(TestMPLPlot):
     def test_graph_op_node_linewidth(self):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 3.5)], vdims='line_width')
-        graph = Graph((edges, nodes)).options(node_linewidth='line_width')
+        graph = Graph((edges, nodes)).opts(node_linewidth='line_width')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         self.assertEqual(artist.get_linewidths(), [2, 4, 3.5])
@@ -187,7 +189,7 @@ class TestMplGraphPlot(TestMPLPlot):
             nodes = Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
                       vdims='line_width')
             return Graph((edges, nodes))
-        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).options(node_linewidth='line_width')
+        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_linewidth='line_width')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         self.assertEqual(artist.get_linewidths(), [2, 4, 6])
@@ -198,7 +200,7 @@ class TestMplGraphPlot(TestMPLPlot):
         import matplotlib as mpl
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 0.2), (0, 1, 1, 0.6), (1, 1, 2, 1)], vdims='alpha')
-        graph = Graph((edges, nodes)).options(node_alpha='alpha')
+        graph = Graph((edges, nodes)).opts(node_alpha='alpha')
 
         if LooseVersion(mpl.__version__) < LooseVersion("3.4.0"):
             # Python 3.6 only support up to matplotlib 3.3
@@ -211,7 +213,7 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_edge_color(self):
         edges = [(0, 1, 'red'), (0, 2, 'green'), (1, 3, 'blue')]
-        graph = Graph(edges, vdims='color').options(edge_color='color')
+        graph = Graph(edges, vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
         self.assertEqual(edges.get_edgecolors(), np.array([
@@ -224,7 +226,7 @@ class TestMplGraphPlot(TestMPLPlot):
             0: Graph([(0, 1, 'red'), (0, 2, 'green'), (1, 3, 'blue')],
                     vdims='color'),
             1: Graph([(0, 1, 'green'), (0, 2, 'blue'), (1, 3, 'red')],
-                     vdims='color')}).options(edge_color='color')
+                     vdims='color')}).opts(edge_color='color')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
         self.assertEqual(edges.get_edgecolors(), np.array([
@@ -239,7 +241,7 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_edge_color_linear(self):
         edges = [(0, 1, 2), (0, 2, 0.5), (1, 3, 3)]
-        graph = Graph(edges, vdims='color').options(edge_color='color')
+        graph = Graph(edges, vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
         self.assertEqual(np.asarray(edges.get_array()), np.array([2, 0.5, 3]))
@@ -250,7 +252,7 @@ class TestMplGraphPlot(TestMPLPlot):
             0: Graph([(0, 1, 2), (0, 2, 0.5), (1, 3, 3)],
                     vdims='color'),
             1: Graph([(0, 1, 4.3), (0, 2, 1.4), (1, 3, 2.6)],
-                     vdims='color')}).options(edge_color='color', framewise=True)
+                     vdims='color')}).opts(edge_color='color', framewise=True)
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
         self.assertEqual(np.asarray(edges.get_array()), np.array([2, 0.5, 3]))
@@ -261,7 +263,7 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_edge_color_categorical(self):
         edges = [(0, 1, 'C'), (0, 2, 'B'), (1, 3, 'A')]
-        graph = Graph(edges, vdims='color').options(edge_color='color')
+        graph = Graph(edges, vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
         self.assertEqual(np.asarray(edges.get_array()), np.array([0, 1, 2]))
@@ -269,13 +271,13 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_edge_alpha(self):
         edges = [(0, 1, 0.1), (0, 2, 0.5), (1, 3, 0.3)]
-        graph = Graph(edges, vdims='alpha').options(edge_alpha='alpha')
+        graph = Graph(edges, vdims='alpha').opts(edge_alpha='alpha')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(graph)
 
     def test_graph_op_edge_linewidth(self):
         edges = [(0, 1, 2), (0, 2, 10), (1, 3, 6)]
-        graph = Graph(edges, vdims='line_width').options(edge_linewidth='line_width')
+        graph = Graph(edges, vdims='line_width').opts(edge_linewidth='line_width')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
         self.assertEqual(edges.get_linewidths(), [2, 10, 6])
@@ -285,7 +287,7 @@ class TestMplGraphPlot(TestMPLPlot):
             0: Graph([(0, 1, 2), (0, 2, 0.5), (1, 3, 3)],
                     vdims='line_width'),
             1: Graph([(0, 1, 4.3), (0, 2, 1.4), (1, 3, 2.6)],
-                     vdims='line_width')}).options(edge_linewidth='line_width')
+                     vdims='line_width')}).opts(edge_linewidth='line_width')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
         self.assertEqual(edges.get_linewidths(), [2, 0.5, 3])
@@ -324,7 +326,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
                          paths)
 
     def test_plot_trimesh_colored_edges(self):
-        opts = dict(plot=dict(edge_color_index='weight'), style=dict(edge_cmap='Greys'))
+        opts = dict(edge_color_index='weight', edge_cmap='Greys')
         plot = mpl_renderer.get_plot(self.trimesh_weighted.opts(**opts))
         edges = plot.handles['edges']
         colors = np.array([[ 1.,  1.,  1.,  1.],
@@ -332,7 +334,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
         self.assertEqual(edges.get_edgecolors(), colors)
 
     def test_plot_trimesh_categorically_colored_edges(self):
-        opts = dict(plot=dict(edge_color_index='node1'), style=dict(edge_color=Cycle('Set1')))
+        opts = dict(edge_color_index='node1', edge_color=Cycle('Set1'))
         plot = mpl_renderer.get_plot(self.trimesh_weighted.opts(**opts))
         edges = plot.handles['edges']
         colors = np.array([[0.894118, 0.101961, 0.109804, 1.],
@@ -340,8 +342,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
         self.assertEqual(edges.get_edgecolors(), colors)
 
     def test_plot_trimesh_categorically_colored_edges_filled(self):
-        opts = dict(plot=dict(edge_color_index='node1', filled=True),
-                    style=dict(edge_color=Cycle('Set1')))
+        opts = dict(edge_color_index='node1', filled=True, edge_color=Cycle('Set1'))
         plot = mpl_renderer.get_plot(self.trimesh_weighted.opts(**opts))
         edges = plot.handles['edges']
         colors = np.array([[0.894118, 0.101961, 0.109804, 1.],
@@ -355,7 +356,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_node_color(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 'red'), (0, 0, 1, 'green'), (0, 1, 2, 'blue'), (1, 0, 3, 'black')]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).options(node_color='color')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['nodes']
         self.assertEqual(artist.get_facecolors(),
@@ -364,7 +365,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_node_color_linear(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 2), (0, 0, 1, 1), (0, 1, 2, 3), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).options(node_color='color')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['nodes']
         self.assertEqual(np.asarray(artist.get_array()), np.array([2, 1, 3, 4]))
@@ -373,7 +374,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_node_color_categorical(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 'B'), (0, 0, 1, 'C'), (0, 1, 2, 'A'), (1, 0, 3, 'B')]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).options(node_color='color')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['nodes']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1, 2, 0]))
@@ -382,7 +383,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_node_size(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 3), (0, 0, 1, 2), (0, 1, 2, 8), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='size'))).options(node_size='size')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='size'))).opts(node_size='size')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['nodes']
         self.assertEqual(artist.get_sizes(), np.array([9, 4, 64, 16]))
@@ -392,7 +393,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
 
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 0.2), (0, 0, 1, 0.6), (0, 1, 2, 1), (1, 0, 3, 0.3)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='alpha'))).options(node_alpha='alpha')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='alpha'))).opts(node_alpha='alpha')
 
         if LooseVersion(mpl.__version__) < LooseVersion("3.4.0"):
             # Python 3.6 only support up to matplotlib 3.3
@@ -406,7 +407,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_node_line_width(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 0.2), (0, 0, 1, 0.6), (0, 1, 2, 1), (1, 0, 3, 0.3)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='line_width'))).options(node_linewidth='line_width')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='line_width'))).opts(node_linewidth='line_width')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['nodes']
         self.assertEqual(artist.get_linewidths(), [0.2, 0.6, 1, 0.3])
@@ -414,7 +415,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_edge_color_linear_mean_node(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 2), (0, 0, 1, 1), (0, 1, 2, 3), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).options(edge_color='color')
+        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(edge_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['edges']
         self.assertEqual(np.asarray(artist.get_array()), np.array([2, 8/3.]))
@@ -423,7 +424,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_edge_color(self):
         edges = [(0, 1, 2, 'red'), (1, 2, 3, 'blue')]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').options(edge_color='color')
+        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['edges']
         self.assertEqual(artist.get_edgecolors(), np.array([
@@ -432,7 +433,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_edge_color_linear(self):
         edges = [(0, 1, 2, 2.4), (1, 2, 3, 3.6)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').options(edge_color='color')
+        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['edges']
         self.assertEqual(np.asarray(artist.get_array()), np.array([2.4, 3.6]))
@@ -441,7 +442,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_edge_color_categorical(self):
         edges = [(0, 1, 2, 'A'), (1, 2, 3, 'B')]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').options(edge_color='color')
+        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['edges']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1]))
@@ -450,14 +451,14 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_edge_alpha(self):
         edges = [(0, 1, 2, 0.7), (1, 2, 3, 0.3)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='alpha').options(edge_alpha='alpha')
+        trimesh = TriMesh((edges, nodes), vdims='alpha').opts(edge_alpha='alpha')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(trimesh)
 
     def test_trimesh_op_edge_line_width(self):
         edges = [(0, 1, 2, 7), (1, 2, 3, 3)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='line_width').options(edge_linewidth='line_width')
+        trimesh = TriMesh((edges, nodes), vdims='line_width').opts(edge_linewidth='line_width')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['edges']
         self.assertEqual(artist.get_linewidths(), [7, 3])
@@ -490,8 +491,7 @@ class TestMplChordPlot(TestMPLPlot):
         self.assertEqual([l.get_text() for l in labels], ['A', 'B', 'C'])
 
     def test_chord_nodes_categorically_colormapped(self):
-        g = self.chord.opts(plot=dict(color_index='Label'),
-                            style=dict(cmap=['#FFFFFF', '#CCCCCC', '#000000']))
+        g = self.chord.opts(color_index='Label', cmap=['#FFFFFF', '#CCCCCC', '#000000'])
         plot = mpl_renderer.get_plot(g)
         arcs = plot.handles['arcs']
         nodes = plot.handles['nodes']
@@ -502,7 +502,7 @@ class TestMplChordPlot(TestMPLPlot):
         self.assertEqual(nodes.get_facecolors(), colors)
 
     def test_chord_node_color_style_mapping(self):
-        g = self.chord.opts(style=dict(node_color='Label', cmap=['#FFFFFF', '#CCCCCC', '#000000']))
+        g = self.chord.opts(node_color='Label', cmap=['#FFFFFF', '#CCCCCC', '#000000'])
         plot = mpl_renderer.get_plot(g)
         arcs = plot.handles['arcs']
         nodes = plot.handles['nodes']
@@ -522,14 +522,14 @@ class TestMplChordPlot(TestMPLPlot):
         self.assertEqual(edges.get_edgecolors(), colors)
 
     def test_chord_edge_color_style_mapping(self):
-        g = self.chord.opts(style=dict(edge_color=dim('start').astype(str), edge_cmap=['#FFFFFF', '#000000']))
+        g = self.chord.opts(edge_color=dim('start').astype(str), edge_cmap=['#FFFFFF', '#000000'])
         plot = mpl_renderer.get_plot(g)
         edges = plot.handles['edges']
         self.assertEqual(np.asarray(edges.get_array()), np.array([0, 0, 1]))
         self.assertEqual(edges.get_clim(), (0, 2))
 
     def test_chord_edge_color_linear_style_mapping_update(self):
-        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).options(edge_color='weight', framewise=True)
+        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(edge_color='weight', framewise=True)
         plot = mpl_renderer.get_plot(hmap)
         edges = plot.handles['edges']
         self.assertEqual(np.asarray(edges.get_array()), np.array([1, 2, 3]))
@@ -539,7 +539,7 @@ class TestMplChordPlot(TestMPLPlot):
         self.assertEqual(edges.get_clim(), (2, 4))
 
     def test_chord_node_color_linear_style_mapping_update(self):
-        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).options(node_color='Label', framewise=True)
+        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(node_color='Label', framewise=True)
         plot = mpl_renderer.get_plot(hmap)
         arcs = plot.handles['arcs']
         nodes = plot.handles['nodes']
@@ -554,7 +554,7 @@ class TestMplChordPlot(TestMPLPlot):
         self.assertEqual(arcs.get_clim(), (1, 3))
 
     def test_chord_edge_color_style_mapping_update(self):
-        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).options(
+        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(
             edge_color=dim('weight').categorize({1: 'red', 2: 'green', 3: 'blue', 4: 'black'})
         )
         plot = mpl_renderer.get_plot(hmap)
@@ -568,7 +568,7 @@ class TestMplChordPlot(TestMPLPlot):
         ]))
 
     def test_chord_node_color_style_mapping_update(self):
-        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).options(
+        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(
             node_color=dim('Label').categorize({0: 'red', 1: 'green', 2: 'blue', 3: 'black'})
         )
         plot = mpl_renderer.get_plot(hmap)

--- a/holoviews/tests/plotting/matplotlib/test_heatmapplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_heatmapplot.py
@@ -9,7 +9,7 @@ class TestHeatMapPlot(TestMPLPlot):
 
     def test_heatmap_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
-        hm = HeatMap(Image(arr)).opts(plot=dict(invert_axes=True))
+        hm = HeatMap(Image(arr)).opts(invert_axes=True)
         plot = mpl_renderer.get_plot(hm)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_array().data, arr.T[::-1].flatten())
@@ -20,7 +20,7 @@ class TestHeatMapPlot(TestMPLPlot):
         self.assertEqual(plot.get_extents(hmap, {}), (-.5, -22, 2.5, 74))
 
     def test_heatmap_invert_xaxis(self):
-        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).options(invert_xaxis=True)
+        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).opts(invert_xaxis=True)
         plot = mpl_renderer.get_plot(hmap)
         array = plot.handles['artist'].get_array()
         expected = np.array([1, np.inf, np.inf, 2])
@@ -28,7 +28,7 @@ class TestHeatMapPlot(TestMPLPlot):
         self.assertEqual(array, masked)
 
     def test_heatmap_invert_yaxis(self):
-        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).options(invert_yaxis=True)
+        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).opts(invert_yaxis=True)
         plot = mpl_renderer.get_plot(hmap)
         array = plot.handles['artist'].get_array()
         expected = np.array([1, np.inf, np.inf, 2])

--- a/holoviews/tests/plotting/matplotlib/test_histogramplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_histogramplot.py
@@ -24,7 +24,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual([p.get_x() for p in artist.patches], bounds)
 
     def test_histogram_padding_square(self):
-        points = Histogram([(1, 2), (2, -1), (3, 3)]).options(padding=0.1)
+        points = Histogram([(1, 2), (2, -1), (3, 3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.19999999999999996)
@@ -33,7 +33,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.4)
 
     def test_histogram_padding_square_positive(self):
-        points = Histogram([(1, 2), (2, 1), (3, 3)]).options(padding=0.1)
+        points = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.19999999999999996)
@@ -42,7 +42,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_histogram_padding_square_negative(self):
-        points = Histogram([(1, -2), (2, -1), (3, -3)]).options(padding=0.1)
+        points = Histogram([(1, -2), (2, -1), (3, -3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.19999999999999996)
@@ -51,7 +51,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 0)
 
     def test_histogram_padding_nonsquare(self):
-        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).options(padding=0.1, aspect=2)
+        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.35)
@@ -60,7 +60,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_histogram_padding_logx(self):
-        histogram = Histogram([(1, 1), (2, 2), (3,3)]).options(padding=0.1, logx=True)
+        histogram = Histogram([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = mpl_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.41158562699652224)
@@ -69,7 +69,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_histogram_padding_logy(self):
-        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).options(padding=0.1, logy=True)
+        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, logy=True)
         plot = mpl_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.19999999999999996)
@@ -79,7 +79,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.log_handler.assertContains('WARNING', 'Logarithmic axis range encountered value less than')
 
     def test_histogram_padding_datetime_square(self):
-        histogram = Histogram([(np.datetime64('2016-04-0%d' % i, 'ns'), i) for i in range(1, 4)]).options(
+        histogram = Histogram([(np.datetime64('2016-04-0%d' % i, 'ns'), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = mpl_renderer.get_plot(histogram)
@@ -90,7 +90,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_histogram_padding_datetime_nonsquare(self):
-        histogram = Histogram([(np.datetime64('2016-04-0%d' % i, 'ns'), i) for i in range(1, 4)]).options(
+        histogram = Histogram([(np.datetime64('2016-04-0%d' % i, 'ns'), i) for i in range(1, 4)]).opts(
             padding=0.1, aspect=2
         )
         plot = mpl_renderer.get_plot(histogram)
@@ -106,7 +106,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
 
     def test_histogram_color_op(self):
         histogram = Histogram([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(histogram)
         artist = plot.handles['artist']
         children = artist.get_children()
@@ -115,19 +115,19 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
 
     def test_histogram_linear_color_op(self):
         histogram = Histogram([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(histogram)
 
     def test_histogram_categorical_color_op(self):
         histogram = Histogram([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(histogram)
 
     def test_histogram_line_color_op(self):
         histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
-                              vdims=['y', 'color']).options(edgecolor='color')
+                              vdims=['y', 'color']).opts(edgecolor='color')
         plot = mpl_renderer.get_plot(histogram)
         artist = plot.handles['artist']
         children = artist.get_children()
@@ -137,13 +137,13 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
 
     def test_histogram_alpha_op(self):
         histogram = Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                              vdims=['y', 'alpha']).options(alpha='alpha')
+                              vdims=['y', 'alpha']).opts(alpha='alpha')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(histogram)
 
     def test_histogram_line_width_op(self):
         histogram = Histogram([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
-                              vdims=['y', 'line_width']).options(linewidth='line_width')
+                              vdims=['y', 'line_width']).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(histogram)
         artist = plot.handles['artist']
         children = artist.get_children()
@@ -153,7 +153,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
     def test_op_ndoverlay_value(self):
         colors = ['blue', 'red']
         overlay = NdOverlay({color: Histogram(np.arange(i+2))
-                             for i, color in enumerate(colors)}, 'Color').options(
+                             for i, color in enumerate(colors)}, 'Color').opts(
                                      'Histogram', facecolor='Color'
                              )
         plot = mpl_renderer.get_plot(overlay)

--- a/holoviews/tests/plotting/matplotlib/test_labels.py
+++ b/holoviews/tests/plotting/matplotlib/test_labels.py
@@ -40,7 +40,7 @@ class TestLabelsPlot(TestMPLPlot):
             self.assertEqual(text.get_text(), expected['text'][i])
 
     def test_labels_inverted(self):
-        labels = Labels([(0, 1, 'A'), (1, 0, 'B')]).options(invert_axes=True)
+        labels = Labels([(0, 1, 'A'), (1, 0, 'B')]).opts(invert_axes=True)
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         expected = {'x': np.array([0, 1]), 'y': np.array([1, 0]), 'Label': ['A', 'B']}
@@ -50,7 +50,7 @@ class TestLabelsPlot(TestMPLPlot):
             self.assertEqual(text.get_text(), expected['Label'][i])
 
     def test_labels_color_mapped(self):
-        labels = Labels([(0, 1, 0.33333), (1, 0, 0.66666)]).options(color_index=2)
+        labels = Labels([(0, 1, 0.33333), (1, 0, 0.66666)]).opts(color_index=2)
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         expected = {'x': np.array([0, 1]), 'y': np.array([1, 0]),
@@ -69,7 +69,7 @@ class TestLabelsPlot(TestMPLPlot):
 
     def test_label_color_op(self):
         labels = Labels([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
-                        vdims='color').options(color='color')
+                        vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         self.assertEqual([a.get_color() for a in artist],
@@ -80,7 +80,7 @@ class TestLabelsPlot(TestMPLPlot):
             0: Labels([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                       vdims='color'),
             1: Labels([(0, 0, '#FF0000'), (0, 1, '#00FF00'), (0, 2, '#0000FF')],
-                      vdims='color')}).options(color='color')
+                      vdims='color')}).opts(color='color')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         self.assertEqual([a.get_color() for a in artist],
@@ -92,7 +92,7 @@ class TestLabelsPlot(TestMPLPlot):
 
     def test_label_linear_color_op(self):
         labels = Labels([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims='color').options(color='color')
+                        vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         self.assertEqual([rgb2hex(a.get_color()) for a in artist],
@@ -100,7 +100,7 @@ class TestLabelsPlot(TestMPLPlot):
 
     def test_label_categorical_color_op(self):
         labels = Labels([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
-                        vdims='color').options(color='color', cmap='tab10')
+                        vdims='color').opts(color='color', cmap='tab10')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         self.assertEqual([rgb2hex(a.get_color()) for a in artist],
@@ -108,7 +108,7 @@ class TestLabelsPlot(TestMPLPlot):
 
     def test_label_size_op(self):
         labels = Labels([(0, 0, 8), (0, 1, 12), (0, 2, 6)],
-                        vdims='size').options(size='size')
+                        vdims='size').opts(size='size')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         self.assertEqual([a.get_fontsize() for a in artist], [8, 12, 6])
@@ -118,7 +118,7 @@ class TestLabelsPlot(TestMPLPlot):
             0: Labels([(0, 0, 8), (0, 1, 6), (0, 2, 12)],
                       vdims='size'),
             1: Labels([(0, 0, 9), (0, 1, 4), (0, 2, 3)],
-                      vdims='size')}).options(size='size')
+                      vdims='size')}).opts(size='size')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         self.assertEqual([a.get_fontsize() for a in artist], [8, 6, 12])
@@ -128,7 +128,7 @@ class TestLabelsPlot(TestMPLPlot):
 
     def test_label_alpha_op(self):
         labels = Labels([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                        vdims='alpha').options(alpha='alpha')
+                        vdims='alpha').opts(alpha='alpha')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         self.assertEqual([a.get_alpha() for a in artist],
@@ -139,7 +139,7 @@ class TestLabelsPlot(TestMPLPlot):
             0: Labels([(0, 0, 0.3), (0, 1, 1), (0, 2, 0.6)],
                       vdims='alpha'),
             1: Labels([(0, 0, 0.6), (0, 1, 0.1), (0, 2, 1)],
-                      vdims='alpha')}).options(alpha='alpha')
+                      vdims='alpha')}).opts(alpha='alpha')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         self.assertEqual([a.get_alpha() for a in artist],
@@ -151,7 +151,7 @@ class TestLabelsPlot(TestMPLPlot):
 
     def test_label_rotation_op(self):
         labels = Labels([(0, 0, 90), (0, 1, 180), (0, 2, 270)],
-                        vdims='rotation').options(rotation='rotation')
+                        vdims='rotation').opts(rotation='rotation')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         self.assertEqual([a.get_rotation() for a in artist],
@@ -162,7 +162,7 @@ class TestLabelsPlot(TestMPLPlot):
             0: Labels([(0, 0, 45), (0, 1, 180), (0, 2, 90)],
                       vdims='rotation'),
             1: Labels([(0, 0, 30), (0, 1, 120), (0, 2, 60)],
-                      vdims='rotation')}).options(rotation='rotation')
+                      vdims='rotation')}).opts(rotation='rotation')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         self.assertEqual([a.get_rotation() for a in artist],

--- a/holoviews/tests/plotting/matplotlib/test_overlayplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_overlayplot.py
@@ -29,8 +29,8 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestMPLPlot):
 
     def test_overlay_update_plot_opts(self):
         hmap = HoloMap(
-            {0: (Curve([]) * Curve([])).options(title='A'),
-             1: (Curve([]) * Curve([])).options(title='B')}
+            {0: (Curve([]) * Curve([])).opts(title='A'),
+             1: (Curve([]) * Curve([])).opts(title='B')}
         )
         plot = mpl_renderer.get_plot(hmap)
         self.assertEqual(plot.handles['title'].get_text(), 'A')
@@ -39,8 +39,8 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestMPLPlot):
 
     def test_overlay_update_plot_opts_inherited(self):
         hmap = HoloMap(
-            {0: (Curve([]).options(title='A') * Curve([])),
-             1: (Curve([]).options(title='B') * Curve([]))}
+            {0: (Curve([]).opts(title='A') * Curve([])),
+             1: (Curve([]).opts(title='B') * Curve([]))}
         )
         plot = mpl_renderer.get_plot(hmap)
         self.assertEqual(plot.handles['title'].get_text(), 'A')
@@ -48,7 +48,7 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestMPLPlot):
         self.assertEqual(plot.handles['title'].get_text(), 'B')
 
     def test_overlay_apply_ranges_disabled(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).options('Curve', apply_ranges=False)
+        overlay = (Curve(range(10)) * Curve(range(10))).opts('Curve', apply_ranges=False)
         plot = mpl_renderer.get_plot(overlay)
         self.assertTrue(all(np.isnan(e) for e in plot.get_extents(overlay, {})))
 
@@ -81,22 +81,22 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestMPLPlot):
             self.assertEqual(subplot.cyclic_index, i)
 
     def test_overlay_xlabel(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).options(xlabel='custom x-label')
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(xlabel='custom x-label')
         axes = mpl_renderer.get_plot(overlay).handles['axis']
         self.assertEqual(axes.get_xlabel(), 'custom x-label')
 
     def test_overlay_ylabel(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).options(ylabel='custom y-label')
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(ylabel='custom y-label')
         axes = mpl_renderer.get_plot(overlay).handles['axis']
         self.assertEqual(axes.get_ylabel(), 'custom y-label')
 
     def test_overlay_xlabel_override_propagated(self):
-        overlay = (Curve(range(10)).options(xlabel='custom x-label') * Curve(range(10)))
+        overlay = (Curve(range(10)).opts(xlabel='custom x-label') * Curve(range(10)))
         axes = mpl_renderer.get_plot(overlay).handles['axis']
         self.assertEqual(axes.get_xlabel(), 'custom x-label')
 
     def test_overlay_ylabel_override(self):
-        overlay = (Curve(range(10)).options(ylabel='custom y-label') * Curve(range(10)))
+        overlay = (Curve(range(10)).opts(ylabel='custom y-label') * Curve(range(10)))
         axes = mpl_renderer.get_plot(overlay).handles['axis']
         self.assertEqual(axes.get_ylabel(), 'custom y-label')
 

--- a/holoviews/tests/plotting/matplotlib/test_pathplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pathplot.py
@@ -16,7 +16,7 @@ class TestPathPlot(TestMPLPlot):
         data = {'x': xs, 'y': ys, 'color': color}
         levels = [0, 38, 73, 95, 110, 130, 156, 999]
         colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']
-        path = Path([data], vdims='color').options(
+        path = Path([data], vdims='color').opts(
             color='color', color_levels=levels, cmap=colors)
         plot = mpl_renderer.get_plot(path)
         artist = plot.handles['artist']
@@ -28,7 +28,7 @@ class TestPathPlot(TestMPLPlot):
         ys = xs[::-1]
         alpha = [0.1, 0.7, 0.3, 0.2]
         data = {'x': xs, 'y': ys, 'alpha': alpha}
-        path = Path([data], vdims='alpha').options(alpha='alpha')
+        path = Path([data], vdims='alpha').opts(alpha='alpha')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(path)
 
@@ -37,7 +37,7 @@ class TestPathPlot(TestMPLPlot):
         ys = xs[::-1]
         line_width = [1, 7, 3, 2]
         data = {'x': xs, 'y': ys, 'line_width': line_width}
-        path = Path([data], vdims='line_width').options(linewidth='line_width')
+        path = Path([data], vdims='line_width').opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(path)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), line_width)
@@ -48,7 +48,7 @@ class TestPathPlot(TestMPLPlot):
         path = HoloMap({
             0: Path([{'x': xs, 'y': ys, 'line_width': [1, 7, 3, 2]}], vdims='line_width'),
             1: Path([{'x': xs, 'y': ys, 'line_width': [3, 8, 2, 3]}], vdims='line_width')
-        }).options(linewidth='line_width')
+        }).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(path)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [1, 7, 3, 2])
@@ -110,7 +110,7 @@ class TestPolygonPlot(TestMPLPlot):
         polygons = Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(polygons)
         artist = plot.handles['artist']
         colors = np.array([[0. , 0.501961, 0. , 1. ],
@@ -127,7 +127,7 @@ class TestPolygonPlot(TestMPLPlot):
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'blue'},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'green'}
             ], vdims='color'),
-        }).options(color='color')
+        }).opts(color='color')
         plot = mpl_renderer.get_plot(polygons)
         artist = plot.handles['artist']
         colors = np.array([[0, 0.501961, 0, 1],
@@ -142,7 +142,7 @@ class TestPolygonPlot(TestMPLPlot):
         polygons = Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 3}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(polygons)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([7, 3]))
@@ -158,7 +158,7 @@ class TestPolygonPlot(TestMPLPlot):
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 2},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 5}
             ], vdims='color'),
-        }).options(color='color', framewise=True)
+        }).opts(color='color', framewise=True)
         plot = mpl_renderer.get_plot(polygons)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([7, 3]))
@@ -171,7 +171,7 @@ class TestPolygonPlot(TestMPLPlot):
         polygons = Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'b'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'a'}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(polygons)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1]))
@@ -181,7 +181,7 @@ class TestPolygonPlot(TestMPLPlot):
         polygons = Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'alpha': 0.7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'alpha': 0.3}
-        ], vdims='alpha').options(alpha='alpha')
+        ], vdims='alpha').opts(alpha='alpha')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(polygons)
 
@@ -189,7 +189,7 @@ class TestPolygonPlot(TestMPLPlot):
         polygons = Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'line_width': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'line_width': 3}
-        ], vdims='line_width').options(linewidth='line_width')
+        ], vdims='line_width').opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(polygons)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [7, 3])
@@ -201,7 +201,7 @@ class TestContoursPlot(TestMPLPlot):
     def test_contours_categorical_color(self):
         path = Contours([{('x', 'y'): np.random.rand(10, 2), 'z': cat}
                      for cat in ('B', 'A', 'B')],
-                    vdims='z').opts(plot=dict(color_index='z'))
+                    vdims='z').opts(color_index='z')
         plot = mpl_renderer.get_plot(path)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1, 0]))
@@ -211,7 +211,7 @@ class TestContoursPlot(TestMPLPlot):
         contours = Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(contours)
         artist = plot.handles['artist']
         colors = np.array([[0. , 0.501961, 0. , 1. ],
@@ -228,7 +228,7 @@ class TestContoursPlot(TestMPLPlot):
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'blue'},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'green'}
             ], vdims='color'),
-        }).options(color='color')
+        }).opts(color='color')
         plot = mpl_renderer.get_plot(contours)
         artist = plot.handles['artist']
         colors = np.array([[0, 0.501961, 0, 1],
@@ -243,7 +243,7 @@ class TestContoursPlot(TestMPLPlot):
         contours = Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 3}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(contours)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([7, 3]))
@@ -259,7 +259,7 @@ class TestContoursPlot(TestMPLPlot):
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 2},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 5}
             ], vdims='color'),
-        }).options(color='color', framewise=True)
+        }).opts(color='color', framewise=True)
         plot = mpl_renderer.get_plot(contours)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([7, 3]))
@@ -272,7 +272,7 @@ class TestContoursPlot(TestMPLPlot):
         contours = Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'b'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'a'}
-        ], vdims='color').options(color='color')
+        ], vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(contours)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1]))
@@ -282,7 +282,7 @@ class TestContoursPlot(TestMPLPlot):
         contours = Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'alpha': 0.7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'alpha': 0.3}
-        ], vdims='alpha').options(alpha='alpha')
+        ], vdims='alpha').opts(alpha='alpha')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(contours)
 
@@ -290,7 +290,7 @@ class TestContoursPlot(TestMPLPlot):
         contours = Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'line_width': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'line_width': 3}
-        ], vdims='line_width').options(linewidth='line_width')
+        ], vdims='line_width').opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(contours)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [7, 3])
@@ -305,7 +305,7 @@ class TestContoursPlot(TestMPLPlot):
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'line_width': 2},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'line_width': 5}
             ], vdims='line_width'),
-        }).options(linewidth='line_width', framewise=True)
+        }).opts(linewidth='line_width', framewise=True)
         plot = mpl_renderer.get_plot(contours)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [7, 3])

--- a/holoviews/tests/plotting/matplotlib/test_pointplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pointplot.py
@@ -14,12 +14,14 @@ class TestPointPlot(TestMPLPlot):
 
     def test_points_non_numeric_size_warning(self):
         data = (np.arange(10), np.arange(10), list(map(chr, range(94,104))))
-        points = Points(data, vdims=['z']).opts(plot=dict(size_index=2))
+        points = Points(data, vdims=['z']).opts(size_index=2)
         with ParamLogStream() as log:
             mpl_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ('z dimension is not numeric, '
-                   'cannot use to scale Points size.\n')
+        warning = (
+            "The `size_index` parameter is deprecated in favor of size style mapping, e.g. "
+            "`size=dim('size')**2`.\nz dimension is not numeric, cannot use to scale Points size.\n"
+        )
         self.assertEqual(log_msg, warning)
 
     def test_points_cbar_extend_both(self):
@@ -37,8 +39,8 @@ class TestPointPlot(TestMPLPlot):
         plot = mpl_renderer.get_plot(img.opts(colorbar=True, color_index=1))
         self.assertEqual(plot.handles['cbar'].extend, 'max')
 
-    def test_points_cbar_extend_clime(self):
-        img = Points(([0, 1], [0, 3])).opts(style=dict(clim=(None, None)))
+    def test_points_cbar_extend_clim(self):
+        img = Points(([0, 1], [0, 3])).opts(clim=(None, None))
         plot = mpl_renderer.get_plot(img.opts(colorbar=True, color_index=1))
         self.assertEqual(plot.handles['cbar'].extend, 'neither')
 
@@ -50,14 +52,14 @@ class TestPointPlot(TestMPLPlot):
 
     def test_points_rcparams_used(self):
         opts = dict(fig_rcparams={'grid.color': 'red'})
-        points = Points(([0, 1], [0, 3])).opts(plot=opts)
+        points = Points(([0, 1], [0, 3])).opts(**opts)
         plot = mpl_renderer.get_plot(points)
         ax = plot.state.axes[0]
         lines = ax.get_xgridlines()
         self.assertEqual(lines[0].get_color(), 'red')
 
     def test_points_padding_square(self):
-        points = Points([1, 2, 3]).options(padding=0.1)
+        points = Points([1, 2, 3]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], -0.2)
@@ -66,7 +68,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_curve_padding_square_per_axis(self):
-        curve = Points([1, 2, 3]).options(padding=((0, 0.1), (0.1, 0.2)))
+        curve = Points([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0)
@@ -75,7 +77,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.4)
 
     def test_points_padding_hard_xrange(self):
-        points = Points([1, 2, 3]).redim.range(x=(0, 3)).options(padding=0.1)
+        points = Points([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0)
@@ -84,7 +86,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_points_padding_soft_xrange(self):
-        points = Points([1, 2, 3]).redim.soft_range(x=(0, 3)).options(padding=0.1)
+        points = Points([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0)
@@ -93,7 +95,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_points_padding_unequal(self):
-        points = Points([1, 2, 3]).options(padding=(0.05, 0.1))
+        points = Points([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], -0.1)
@@ -102,7 +104,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_points_padding_nonsquare(self):
-        points = Points([1, 2, 3]).options(padding=0.1, aspect=2)
+        points = Points([1, 2, 3]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], -0.1)
@@ -111,7 +113,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_points_padding_logx(self):
-        points = Points([(1, 1), (2, 2), (3,3)]).options(padding=0.1, logx=True)
+        points = Points([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.89595845984076228)
@@ -120,7 +122,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_points_padding_logy(self):
-        points = Points([1, 2, 3]).options(padding=0.1, logy=True)
+        points = Points([1, 2, 3]).opts(padding=0.1, logy=True)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], -0.2)
@@ -129,7 +131,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.3483695221017129)
 
     def test_points_padding_datetime_square(self):
-        points = Points([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).options(
+        points = Points([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = mpl_renderer.get_plot(points)
@@ -140,7 +142,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_points_padding_datetime_nonsquare(self):
-        points = Points([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).options(
+        points = Points([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)]).opts(
             padding=0.1, aspect=2
         )
         plot = mpl_renderer.get_plot(points)
@@ -165,7 +167,7 @@ class TestPointPlot(TestMPLPlot):
 
     def test_point_color_op(self):
         points = Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
-                        vdims='color').options(color='color')
+                        vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_facecolors(),
@@ -175,7 +177,7 @@ class TestPointPlot(TestMPLPlot):
         points = HoloMap({0: Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                                     vdims='color'),
                           1: Points([(0, 0, '#0000FF'), (0, 1, '#00FF00'), (0, 2, '#FF0000')],
-                                    vdims='color')}).options(color='color')
+                                    vdims='color')}).opts(color='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         plot.update((1,))
@@ -184,7 +186,7 @@ class TestPointPlot(TestMPLPlot):
 
     def test_point_line_color_op(self):
         points = Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
-                        vdims='color').options(edgecolors='color')
+                        vdims='color').opts(edgecolors='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_edgecolors(),
@@ -194,7 +196,7 @@ class TestPointPlot(TestMPLPlot):
         points = HoloMap({0: Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                                     vdims='color'),
                           1: Points([(0, 0, '#0000FF'), (0, 1, '#00FF00'), (0, 2, '#FF0000')],
-                                    vdims='color')}).options(edgecolors='color')
+                                    vdims='color')}).opts(edgecolors='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         plot.update((1,))
@@ -203,7 +205,7 @@ class TestPointPlot(TestMPLPlot):
 
     def test_point_fill_color_op(self):
         points = Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
-                        vdims='color').options(facecolors='color')
+                        vdims='color').opts(facecolors='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_facecolors(),
@@ -211,7 +213,7 @@ class TestPointPlot(TestMPLPlot):
 
     def test_point_linear_color_op(self):
         points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims='color').options(color='color')
+                        vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1, 2]))
@@ -221,7 +223,7 @@ class TestPointPlot(TestMPLPlot):
         points = HoloMap({0: Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                                     vdims='color'),
                           1: Points([(0, 0, 2.5), (0, 1, 3), (0, 2, 1.2)],
-                                    vdims='color')}).options(color='color', framewise=True)
+                                    vdims='color')}).opts(color='color', framewise=True)
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_clim(), (0, 2))
@@ -231,7 +233,7 @@ class TestPointPlot(TestMPLPlot):
 
     def test_point_categorical_color_op(self):
         points = Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
-                        vdims='color').options(color='color')
+                        vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1, 0]))
@@ -239,7 +241,7 @@ class TestPointPlot(TestMPLPlot):
 
     def test_point_categorical_color_op_legend(self):
         points = Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
-                        vdims='color').options(color='color', show_legend=True)
+                        vdims='color').opts(color='color', show_legend=True)
         plot = mpl_renderer.get_plot(points)
         leg = plot.handles['axis'].get_legend()
         legend_labels = [l.get_text() for l in leg.texts]
@@ -255,7 +257,7 @@ class TestPointPlot(TestMPLPlot):
         
     def test_point_size_op(self):
         points = Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
-                        vdims='size').options(s='size')
+                        vdims='size').opts(s='size')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_sizes(), np.array([1, 4, 8]))
@@ -264,7 +266,7 @@ class TestPointPlot(TestMPLPlot):
         points = HoloMap({0: Points([(0, 0, 3), (0, 1, 1), (0, 2, 2)],
                                     vdims='size'),
                           1: Points([(0, 0, 2.5), (0, 1, 3), (0, 2, 1.2)],
-                                    vdims='size')}).options(s='size')
+                                    vdims='size')}).opts(s='size')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_sizes(), np.array([3, 1, 2]))
@@ -273,7 +275,7 @@ class TestPointPlot(TestMPLPlot):
 
     def test_point_line_width_op(self):
         points = Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
-                        vdims='line_width').options(linewidth='line_width')
+                        vdims='line_width').opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [1, 4, 8])
@@ -282,7 +284,7 @@ class TestPointPlot(TestMPLPlot):
         points = HoloMap({0: Points([(0, 0, 3), (0, 1, 1), (0, 2, 2)],
                                     vdims='line_width'),
                           1: Points([(0, 0, 2.5), (0, 1, 3), (0, 2, 1.2)],
-                                    vdims='line_width')}).options(linewidth='line_width')
+                                    vdims='line_width')}).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [3, 1, 2])
@@ -291,13 +293,13 @@ class TestPointPlot(TestMPLPlot):
 
     def test_point_marker_op(self):
         points = Points([(0, 0, 'circle'), (0, 1, 'triangle'), (0, 2, 'square')],
-                        vdims='marker').options(marker='marker')
+                        vdims='marker').opts(marker='marker')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(points)
 
     def test_point_alpha_op(self):
         points = Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                        vdims='alpha').options(alpha='alpha')
+                        vdims='alpha').opts(alpha='alpha')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(points)
 
@@ -305,7 +307,7 @@ class TestPointPlot(TestMPLPlot):
         markers = ['d', 's']
         overlay = NdOverlay({marker: Points(np.arange(i))
                              for i, marker in enumerate(markers)},
-                            'Marker').options('Points', marker='Marker')
+                            'Marker').opts('Points', marker='Marker')
         plot = mpl_renderer.get_plot(overlay)
         for subplot, marker in zip(plot.subplots.values(), markers):
             style = dict(subplot.style[subplot.cyclic_index])
@@ -314,20 +316,26 @@ class TestPointPlot(TestMPLPlot):
 
     def test_point_color_index_color_clash(self):
         points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims='color').options(color='color', color_index='color')
+                        vdims='color').opts(color='color', color_index='color')
         with ParamLogStream() as log:
             mpl_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ("Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n")
+        warning = (
+            "The `color_index` parameter is deprecated in favor of color style mapping, e.g. "
+            "`color=dim('color')` or `line_color=dim('color')`\nCannot declare style mapping "
+            "for 'color' option and declare a color_index; ignoring the color_index.\n"
+        )
         self.assertEqual(log_msg, warning)
 
     def test_point_size_index_size_clash(self):
         points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims='size').options(s='size', size_index='size')
+                        vdims='size').opts(s='size', size_index='size')
         with ParamLogStream() as log:
             mpl_renderer.get_plot(points)
         log_msg = log.stream.read()
-        warning = ("Cannot declare style mapping for 's' option "
-                   "and declare a size_index; ignoring the size_index.\n")
+        warning = (
+            "The `size_index` parameter is deprecated in favor of size style mapping, e.g. "
+            "`size=dim('size')**2`.\nCannot declare style mapping for 's' option and declare a "
+            "size_index; ignoring the size_index.\n"
+        )
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
@@ -9,7 +9,7 @@ class TestQuadMeshPlot(TestMPLPlot):
 
     def test_quadmesh_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4,  5]])
-        qmesh = QuadMesh(Image(arr)).opts(plot=dict(invert_axes=True))
+        qmesh = QuadMesh(Image(arr)).opts(invert_axes=True)
         plot = mpl_renderer.get_plot(qmesh)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_array().data, arr.T[:, ::-1].flatten())
@@ -36,7 +36,7 @@ class TestQuadMeshPlot(TestMPLPlot):
         XS, YS, ZS = np.meshgrid(xs, ys, zs)
         values = np.sin(XS) * ZS
         ds = Dataset((xs, ys, zs, values.T), ['x', 'y', 'z'], 'values')
-        hmap = ds.to(QuadMesh).options(colorbar=True, framewise=True)
+        hmap = ds.to(QuadMesh).opts(colorbar=True, framewise=True)
         plot = mpl_renderer.get_plot(hmap)
         cbar = plot.handles['cbar']
         self.assertEqual(

--- a/holoviews/tests/plotting/matplotlib/test_radialheatmap.py
+++ b/holoviews/tests/plotting/matplotlib/test_radialheatmap.py
@@ -55,7 +55,7 @@ class RadialHeatMapPlotTests(TestMPLPlot):
         self.assertEqual(ticks['yticks'], self.yticks)
 
     def test_get_data_xseparators(self):
-        plot = mpl_renderer.get_plot(self.element.opts(plot=dict(xmarks=4)))
+        plot = mpl_renderer.get_plot(self.element.opts(xmarks=4))
         data, style, ticks = plot.get_data(self.element, {'z': {'combined': (0, 3)}}, {})
         xseparators = data['xseparator']
         arrays = [np.array([[0., 0.25],
@@ -65,7 +65,7 @@ class RadialHeatMapPlotTests(TestMPLPlot):
         self.assertEqual(xseparators, arrays)
 
     def test_get_data_yseparators(self):
-        plot = mpl_renderer.get_plot(self.element.opts(plot=dict(ymarks=4)))
+        plot = mpl_renderer.get_plot(self.element.opts(ymarks=4))
         data, style, ticks = plot.get_data(self.element, {'z': {'combined': (0, 3)}}, {})
         yseparators = data['yseparator']
         for circle, r in zip(yseparators, [0.25, 0.375]):
@@ -74,5 +74,5 @@ class RadialHeatMapPlotTests(TestMPLPlot):
     def test_heatmap_holomap(self):
         hm = HoloMap({'A': HeatMap(np.random.randint(0, 10, (100, 3))),
                       'B': HeatMap(np.random.randint(0, 10, (100, 3)))})
-        plot = mpl_renderer.get_plot(hm.options(radial=True))
+        plot = mpl_renderer.get_plot(hm.opts(radial=True))
         self.assertIsInstance(plot, RadialHeatMapPlot)

--- a/holoviews/tests/plotting/matplotlib/test_sankey.py
+++ b/holoviews/tests/plotting/matplotlib/test_sankey.py
@@ -43,7 +43,7 @@ class TestSankeyPlot(TestMPLPlot):
             (0, 2, 5), (0, 3, 7), (0, 4, 6),
             (1, 2, 2), (1, 3, 9), (1, 4, 4)],
             Dataset(enumerate('ABXYZ'), 'index', 'label'))
-        ).options(label_index='label')
+        ).opts(label_index='label')
         plot = mpl_renderer.get_plot(sankey)
         labels = plot.handles['labels']
 

--- a/holoviews/tests/plotting/matplotlib/test_scatter3d.py
+++ b/holoviews/tests/plotting/matplotlib/test_scatter3d.py
@@ -6,12 +6,12 @@ from .test_plot import TestMPLPlot, mpl_renderer
 class TestPointPlot(TestMPLPlot):
 
     def test_scatter3d_colorbar_label(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).options(color='z', colorbar=True)
+        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(color='z', colorbar=True)
         plot = mpl_renderer.get_plot(scatter3d)
         assert plot.handles['cax'].get_ylabel() == 'z'
 
     def test_scatter3d_padding_square(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).options(padding=0.1)
+        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -23,7 +23,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(z_range[1], 4.2)
 
     def test_curve_padding_square_per_axis(self):
-        curve = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).options(padding=((0, 0.1), (0.1, 0.2), (0.2, 0.3)))
+        curve = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=((0, 0.1), (0.1, 0.2), (0.2, 0.3)))
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -35,7 +35,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(z_range[1], 4.6)
 
     def test_scatter3d_padding_hard_zrange(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).redim.range(z=(0, 3)).options(padding=0.1)
+        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).redim.range(z=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -47,7 +47,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(z_range[1], 3)
 
     def test_scatter3d_padding_soft_zrange(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).redim.soft_range(z=(0, 3)).options(padding=0.1)
+        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).redim.soft_range(z=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -59,7 +59,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(z_range[1], 4.2)
 
     def test_scatter3d_padding_unequal(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).options(padding=(0.05, 0.1, 0.2))
+        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=(0.05, 0.1, 0.2))
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -71,7 +71,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(z_range[1], 4.4)
 
     def test_scatter3d_padding_nonsquare(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).options(padding=0.1, aspect=2)
+        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -83,7 +83,7 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(z_range[1], 4.2)
 
     def test_scatter3d_padding_logz(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).options(padding=0.1, logz=True)
+        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=0.1, logz=True)
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()

--- a/holoviews/tests/plotting/matplotlib/test_spikeplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_spikeplot.py
@@ -11,14 +11,14 @@ from .test_plot import TestMPLPlot, mpl_renderer
 class TestSpikesPlot(TestMPLPlot):
 
     def test_spikes_padding_square(self):
-        spikes = Spikes([1, 2, 3]).options(padding=0.1)
+        spikes = Spikes([1, 2, 3]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         self.assertEqual(x_range[0], 0.8)
         self.assertEqual(x_range[1], 3.2)
 
     def test_spikes_padding_square_heights(self):
-        spikes = Spikes([(1, 1), (2, 2), (3, 3)], vdims=['Height']).options(padding=0.1)
+        spikes = Spikes([(1, 1), (2, 2), (3, 3)], vdims=['Height']).opts(padding=0.1)
         plot = mpl_renderer.get_plot(spikes)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.8)
@@ -27,42 +27,42 @@ class TestSpikesPlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_spikes_padding_hard_xrange(self):
-        spikes = Spikes([1, 2, 3]).redim.range(x=(0, 3)).options(padding=0.1)
+        spikes = Spikes([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         self.assertEqual(x_range[0], 0)
         self.assertEqual(x_range[1], 3)
 
     def test_spikes_padding_soft_xrange(self):
-        spikes = Spikes([1, 2, 3]).redim.soft_range(x=(0, 3)).options(padding=0.1)
+        spikes = Spikes([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         self.assertEqual(x_range[0], 0)
         self.assertEqual(x_range[1], 3)
 
     def test_spikes_padding_unequal(self):
-        spikes = Spikes([1, 2, 3]).options(padding=(0.05, 0.1))
+        spikes = Spikes([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         self.assertEqual(x_range[0], 0.9)
         self.assertEqual(x_range[1], 3.1)
 
     def test_spikes_padding_nonsquare(self):
-        spikes = Spikes([1, 2, 3]).options(padding=0.1, aspect=2)
+        spikes = Spikes([1, 2, 3]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         self.assertEqual(x_range[0], 0.9)
         self.assertEqual(x_range[1], 3.1)
 
     def test_spikes_padding_logx(self):
-        spikes = Spikes([(1, 1), (2, 2), (3,3)]).options(padding=0.1, logx=True)
+        spikes = Spikes([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         self.assertEqual(x_range[0], 0.89595845984076228)
         self.assertEqual(x_range[1], 3.3483695221017129)
 
     def test_spikes_padding_datetime_square(self):
-        spikes = Spikes([np.datetime64('2016-04-0%d' % i) for i in range(1, 4)]).options(
+        spikes = Spikes([np.datetime64('2016-04-0%d' % i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = mpl_renderer.get_plot(spikes)
@@ -71,7 +71,7 @@ class TestSpikesPlot(TestMPLPlot):
         self.assertEqual(x_range[1], 16894.2)
 
     def test_spikes_padding_datetime_square_heights(self):
-        spikes = Spikes([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)], vdims=['Height']).options(
+        spikes = Spikes([(np.datetime64('2016-04-0%d' % i), i) for i in range(1, 4)], vdims=['Height']).opts(
             padding=0.1
         )
         plot = mpl_renderer.get_plot(spikes)
@@ -82,7 +82,7 @@ class TestSpikesPlot(TestMPLPlot):
         self.assertEqual(y_range[1], 3.2)
 
     def test_spikes_padding_datetime_nonsquare(self):
-        spikes = Spikes([np.datetime64('2016-04-0%d' % i) for i in range(1, 4)]).options(
+        spikes = Spikes([np.datetime64('2016-04-0%d' % i) for i in range(1, 4)]).opts(
             padding=0.1, aspect=2
         )
         plot = mpl_renderer.get_plot(spikes)
@@ -96,7 +96,7 @@ class TestSpikesPlot(TestMPLPlot):
 
     def test_spikes_color_op(self):
         spikes = Spikes([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
-                              vdims=['y', 'color']).options(color='color')
+                              vdims=['y', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_edgecolors(), np.array([
@@ -108,7 +108,7 @@ class TestSpikesPlot(TestMPLPlot):
             0: Spikes([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                       vdims=['y', 'color']),
             1: Spikes([(0, 0, '#FF0000'), (0, 1, '#00FF00'), (0, 2, '#0000FF')],
-                      vdims=['y', 'color'])}).options(color='color')
+                      vdims=['y', 'color'])}).opts(color='color')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_edgecolors(), np.array([
@@ -121,7 +121,7 @@ class TestSpikesPlot(TestMPLPlot):
 
     def test_spikes_linear_color_op(self):
         spikes = Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims=['y', 'color']).options(color='color')
+                        vdims=['y', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1, 2]))
@@ -132,7 +132,7 @@ class TestSpikesPlot(TestMPLPlot):
             0: Spikes([(0, 0, 0.5), (0, 1, 3.2), (0, 2, 1.8)],
                       vdims=['y', 'color']),
             1: Spikes([(0, 0, 0.1), (0, 1, 0.8), (0, 2, 0.3)],
-                      vdims=['y', 'color'])}).options(color='color', framewise=True)
+                      vdims=['y', 'color'])}).opts(color='color', framewise=True)
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0.5, 3.2, 1.8]))
@@ -143,7 +143,7 @@ class TestSpikesPlot(TestMPLPlot):
 
     def test_spikes_categorical_color_op(self):
         spikes = Spikes([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
-                        vdims=['y', 'color']).options(color='color')
+                        vdims=['y', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1, 0]))
@@ -151,13 +151,13 @@ class TestSpikesPlot(TestMPLPlot):
 
     def test_spikes_alpha_op(self):
         spikes = Spikes([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
-                              vdims=['y', 'alpha']).options(alpha='alpha')
+                              vdims=['y', 'alpha']).opts(alpha='alpha')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(spikes)
 
     def test_spikes_line_width_op(self):
         spikes = Spikes([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
-                              vdims=['y', 'line_width']).options(linewidth='line_width')
+                              vdims=['y', 'line_width']).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [1, 4, 8])
@@ -168,7 +168,7 @@ class TestSpikesPlot(TestMPLPlot):
             0: Spikes([(0, 0, 0.5), (0, 1, 3.2), (0, 2, 1.8)],
                       vdims=['y', 'line_width']),
             1: Spikes([(0, 0, 0.1), (0, 1, 0.8), (0, 2, 0.3)],
-                      vdims=['y', 'line_width'])}).options(linewidth='line_width')
+                      vdims=['y', 'line_width'])}).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [0.5, 3.2, 1.8])
@@ -178,7 +178,7 @@ class TestSpikesPlot(TestMPLPlot):
     def test_op_ndoverlay_value(self):
         colors = ['blue', 'red']
         overlay = NdOverlay({color: Spikes(np.arange(i+2))
-                             for i, color in enumerate(colors)}, 'Color').options(
+                             for i, color in enumerate(colors)}, 'Color').opts(
                                      'Spikes', color='Color'
                              )
         plot = mpl_renderer.get_plot(overlay)
@@ -190,11 +190,14 @@ class TestSpikesPlot(TestMPLPlot):
 
     def test_spikes_color_index_color_clash(self):
         spikes = Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
-                        vdims=['y', 'color']).options(color='color', color_index='color')
+                        vdims=['y', 'color']).opts(color='color', color_index='color')
         with ParamLogStream() as log:
             mpl_renderer.get_plot(spikes)
         log_msg = log.stream.read()
-        warning = ("Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n")
+        warning = (
+            "The `color_index` parameter is deprecated in favor of color style mapping, e.g. "
+            "`color=dim('color')` or `line_color=dim('color')`\nCannot declare style mapping "
+            "for 'color' option and declare a color_index; ignoring the color_index.\n"
+        )
         self.assertEqual(log_msg, warning)
 

--- a/holoviews/tests/plotting/matplotlib/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_vectorfieldplot.py
@@ -15,7 +15,7 @@ class TestVectorFieldPlot(TestMPLPlot):
 
     def test_vectorfield_color_op(self):
         vectorfield = VectorField([(0, 0, 0, 1, '#000000'), (0, 1, 0, 1,'#FF0000'), (0, 2, 0, 1,'#00FF00')],
-                                  vdims=['A', 'M', 'color']).options(color='color')
+                                  vdims=['A', 'M', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_facecolors(), np.array([
@@ -29,7 +29,7 @@ class TestVectorFieldPlot(TestMPLPlot):
             0: VectorField([(0, 0, 0, 1, '#000000'), (0, 1, 0, 1, '#FF0000'), (0, 2, 0, 1, '#00FF00')],
                            vdims=['A', 'M', 'color']),
             1: VectorField([(0, 0, 0, 1, '#0000FF'), (0, 1, 0, 1, '#00FF00'), (0, 2, 0, 1, '#FF0000')],
-                           vdims=['A', 'M', 'color'])}).options(color='color')
+                           vdims=['A', 'M', 'color'])}).opts(color='color')
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_facecolors(), np.array([
@@ -49,7 +49,7 @@ class TestVectorFieldPlot(TestMPLPlot):
             0: VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 1), (0, 2, 0, 1, 2)],
                            vdims=['A', 'M', 'color']),
             1: VectorField([(0, 0, 0, 1, 3.2), (0, 1, 0, 1, 2), (0, 2, 0, 1, 4)],
-                           vdims=['A', 'M', 'color'])}).options(color='color', framewise=True)
+                           vdims=['A', 'M', 'color'])}).opts(color='color', framewise=True)
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1, 2]))
@@ -60,7 +60,7 @@ class TestVectorFieldPlot(TestMPLPlot):
 
     def test_vectorfield_categorical_color_op(self):
         vectorfield = VectorField([(0, 0, 0, 1, 'A'), (0, 1, 0, 1, 'B'), (0, 2, 0, 1, 'C')],
-                                  vdims=['A', 'M', 'color']).options(color='color')
+                                  vdims=['A', 'M', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
         self.assertEqual(np.asarray(artist.get_array()), np.array([0, 1, 2]))
@@ -68,13 +68,13 @@ class TestVectorFieldPlot(TestMPLPlot):
 
     def test_vectorfield_alpha_op(self):
         vectorfield = VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 0.2), (0, 2, 0, 1, 0.7)],
-                                  vdims=['A', 'M', 'alpha']).options(alpha='alpha')
+                                  vdims=['A', 'M', 'alpha']).opts(alpha='alpha')
         with self.assertRaises(Exception):
             mpl_renderer.get_plot(vectorfield)
 
     def test_vectorfield_line_width_op(self):
         vectorfield = VectorField([(0, 0, 0, 1, 1), (0, 1, 0, 1, 4), (0, 2, 0, 1, 8)],
-                                  vdims=['A', 'M', 'line_width']).options(linewidth='line_width')
+                                  vdims=['A', 'M', 'line_width']).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [1, 4, 8])
@@ -84,7 +84,7 @@ class TestVectorFieldPlot(TestMPLPlot):
             0: VectorField([(0, 0, 0, 1, 1), (0, 1, 0, 1, 4), (0, 2, 0, 1, 8)],
                            vdims=['A', 'M', 'line_width']),
             1: VectorField([(0, 0, 0, 1, 3), (0, 1, 0, 1, 2), (0, 2, 0, 1, 5)],
-                           vdims=['A', 'M', 'line_width'])}).options(linewidth='line_width')
+                           vdims=['A', 'M', 'line_width'])}).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_linewidths(), [1, 4, 8])
@@ -93,10 +93,13 @@ class TestVectorFieldPlot(TestMPLPlot):
 
     def test_vectorfield_color_index_color_clash(self):
         vectorfield = VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 1), (0, 2, 0, 1, 2)],
-                                  vdims=['A', 'M', 'color']).options(color='color', color_index='A')
+                                  vdims=['A', 'M', 'color']).opts(color='color', color_index='A')
         with ParamLogStream() as log:
             mpl_renderer.get_plot(vectorfield)
         log_msg = log.stream.read()
-        warning = ("Cannot declare style mapping for 'color' option "
-                   "and declare a color_index; ignoring the color_index.\n")
+        warning = (
+            "The `color_index` parameter is deprecated in favor of color style mapping, e.g. "
+            "`color=dim('color')` or `line_color=dim('color')`\nCannot declare style mapping "
+            "for 'color' option and declare a color_index; ignoring the color_index.\n"
+        )
         self.assertEqual(log_msg, warning)

--- a/holoviews/tests/plotting/plotly/test_areaplot.py
+++ b/holoviews/tests/plotting/plotly/test_areaplot.py
@@ -17,7 +17,7 @@ class TestAreaPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['range'], [0, 3])
 
     def test_area_to_zero_x(self):
-        curve = Area([1, 2, 3]).options(invert_axes=True)
+        curve = Area([1, 2, 3]).opts(invert_axes=True)
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][0]['x'], np.array([1, 2, 3]))
         self.assertEqual(state['data'][0]['y'], np.array([0, 1, 2]))
@@ -40,7 +40,7 @@ class TestAreaPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['range'], [0.5, 3])
 
     def test_area_fill_between_xs(self):
-        area = Area([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2']).options(invert_axes=True)
+        area = Area([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2']).opts(invert_axes=True)
         state = self._get_plot_state(area)
         self.assertEqual(state['data'][0]['x'], np.array([0.5, 1, 2.25]))
         self.assertEqual(state['data'][0]['mode'], 'lines')
@@ -52,6 +52,6 @@ class TestAreaPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['range'], [0, 2])
 
     def test_area_visible(self):
-        curve = Area([1, 2, 3]).options(visible=False)
+        curve = Area([1, 2, 3]).opts(visible=False)
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_barplot.py
+++ b/holoviews/tests/plotting/plotly/test_barplot.py
@@ -19,7 +19,7 @@ class TestBarsPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'y')
 
     def test_bars_plot_inverted(self):
-        bars = Bars([3, 2, 1]).options(invert_axes=True)
+        bars = Bars([3, 2, 1]).opts(invert_axes=True)
         state = self._get_plot_state(bars)
         self.assertEqual(state['data'][0]['y'], ['0', '1', '2'])
         self.assertEqual(state['data'][0]['x'], np.array([3, 2, 1]))
@@ -44,7 +44,7 @@ class TestBarsPlot(TestPlotlyPlot):
 
     def test_bars_grouped_inverted(self):
         bars = Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
-                    kdims=['A', 'B']).options(invert_axes=True)
+                    kdims=['A', 'B']).opts(invert_axes=True)
         state = self._get_plot_state(bars)
         self.assertEqual(state['data'][0]['y'], [['A', 'B', 'C', 'C'], ['1', '2', '2', '1']])
         self.assertEqual(state['data'][0]['x'], np.array([1, 2, 3, 4]))
@@ -57,7 +57,7 @@ class TestBarsPlot(TestPlotlyPlot):
 
     def test_bars_stacked(self):
         bars = Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
-                    kdims=['A', 'B']).options(stacked=True)
+                    kdims=['A', 'B']).opts(stacked=True)
         state = self._get_plot_state(bars)
         self.assertEqual(state['data'][0]['x'], ['A', 'B', 'C'])
         self.assertEqual(state['data'][0]['y'], np.array([0, 2, 3]))
@@ -73,7 +73,7 @@ class TestBarsPlot(TestPlotlyPlot):
 
     def test_bars_stacked_inverted(self):
         bars = Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
-                    kdims=['A', 'B']).options(stacked=True, invert_axes=True)
+                    kdims=['A', 'B']).opts(stacked=True, invert_axes=True)
         state = self._get_plot_state(bars)
         self.assertEqual(state['data'][0]['y'], ['A', 'B', 'C'])
         self.assertEqual(state['data'][0]['x'], np.array([0, 2, 3]))
@@ -88,6 +88,6 @@ class TestBarsPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['xaxis']['title']['text'], 'y')
 
     def test_visible(self):
-        element = Bars([3, 2, 1]).options(visible=False)
+        element = Bars([3, 2, 1]).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_bivariateplot.py
+++ b/holoviews/tests/plotting/plotly/test_bivariateplot.py
@@ -18,13 +18,13 @@ class TestBivariatePlot(TestPlotlyPlot):
         self.assertEqual(state['data'][0]['contours']['coloring'], 'lines')
 
     def test_bivariate_filled(self):
-        bivariate = Bivariate(([3, 2, 1], [0, 1, 2])).options(
+        bivariate = Bivariate(([3, 2, 1], [0, 1, 2])).opts(
             filled=True)
         state = self._get_plot_state(bivariate)
         self.assertEqual(state['data'][0]['contours']['coloring'], 'fill')
 
     def test_bivariate_ncontours(self):
-        bivariate = Bivariate(([3, 2, 1], [0, 1, 2])).options(ncontours=5)
+        bivariate = Bivariate(([3, 2, 1], [0, 1, 2])).opts(ncontours=5)
         state = self._get_plot_state(bivariate)
         self.assertEqual(state['data'][0]['ncontours'], 5)
         self.assertEqual(state['data'][0]['autocontour'], False)
@@ -43,6 +43,6 @@ class TestBivariatePlot(TestPlotlyPlot):
         self.assertFalse(trace['showscale'])
 
     def test_visible(self):
-        element = Bivariate(([3, 2, 1], [0, 1, 2])).options(visible=False)
+        element = Bivariate(([3, 2, 1], [0, 1, 2])).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_boxwhiskerplot.py
+++ b/holoviews/tests/plotting/plotly/test_boxwhiskerplot.py
@@ -19,7 +19,7 @@ class TestBoxWhiskerPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'y')
 
     def test_boxwhisker_single_invert_axes(self):
-        box = BoxWhisker([1, 1, 2, 3, 3, 4, 5, 5]).options(invert_axes=True)
+        box = BoxWhisker([1, 1, 2, 3, 3, 4, 5, 5]).opts(invert_axes=True)
         state = self._get_plot_state(box)
         self.assertEqual(len(state['data']), 1)
         self.assertEqual(state['data'][0]['type'], 'box')
@@ -44,7 +44,7 @@ class TestBoxWhiskerPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'y')
 
     def test_boxwhisker_multi_invert_axes(self):
-        box = BoxWhisker((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y').options(
+        box = BoxWhisker((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y').opts(
             invert_axes=True)
         state = self._get_plot_state(box)
         self.assertEqual(len(state['data']), 2)
@@ -59,6 +59,6 @@ class TestBoxWhiskerPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['xaxis']['title']['text'], 'y')
 
     def test_visible(self):
-        element = BoxWhisker(([3, 2, 1], [0, 1, 2])).options(visible=False)
+        element = BoxWhisker(([3, 2, 1], [0, 1, 2])).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_curveplot.py
+++ b/holoviews/tests/plotting/plotly/test_curveplot.py
@@ -17,7 +17,7 @@ class TestCurvePlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['range'], [1, 3])
 
     def test_curve_inverted(self):
-        curve = Curve([1, 2, 3]).options(invert_axes=True)
+        curve = Curve([1, 2, 3]).opts(invert_axes=True)
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][0]['x'], np.array([1, 2, 3]))
         self.assertEqual(state['data'][0]['y'], np.array([0, 1, 2]))
@@ -28,33 +28,33 @@ class TestCurvePlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'x')
 
     def test_curve_interpolation(self):
-        curve = Curve([1, 2, 3]).options(interpolation='steps-mid')
+        curve = Curve([1, 2, 3]).opts(interpolation='steps-mid')
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][0]['x'], np.array([0., 0.5, 0.5, 1.5, 1.5, 2.]))
         self.assertEqual(state['data'][0]['y'], np.array([1, 1, 2, 2, 3, 3]))
 
     def test_curve_color(self):
-        curve = Curve([1, 2, 3]).options(color='red')
+        curve = Curve([1, 2, 3]).opts(color='red')
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][0]['line']['color'], 'red')
 
     def test_curve_color_mapping_error(self):
-        curve = Curve([1, 2, 3]).options(color='x')
+        curve = Curve([1, 2, 3]).opts(color='x')
         with self.assertRaises(ValueError):
             self._get_plot_state(curve)
 
     def test_curve_dash(self):
-        curve = Curve([1, 2, 3]).options(dash='dash')
+        curve = Curve([1, 2, 3]).opts(dash='dash')
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][0]['line']['dash'], 'dash')
 
     def test_curve_line_width(self):
-        curve = Curve([1, 2, 3]).options(line_width=5)
+        curve = Curve([1, 2, 3]).opts(line_width=5)
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][0]['line']['width'], 5)
 
     def test_visible(self):
-        element = Curve([1, 2, 3]).options(visible=False)
+        element = Curve([1, 2, 3]).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)
 
@@ -92,7 +92,7 @@ class TestMapboxCurvePlot(TestPlotlyPlot):
         )
 
     def test_curve_inverted(self):
-        curve = Tiles("") * Curve([1, 2, 3]).options(invert_axes=True)
+        curve = Tiles("") * Curve([1, 2, 3]).opts(invert_axes=True)
         with self.assertRaises(ValueError) as e:
             self._get_plot_state(curve)
 
@@ -105,33 +105,33 @@ class TestMapboxCurvePlot(TestPlotlyPlot):
         interp_ys = interp_curve.dimension_values("y")
         interp_lons, interp_lats = Tiles.easting_northing_to_lon_lat(interp_xs, interp_ys)
 
-        curve = Tiles("") * Curve(self.ys).options(interpolation='steps-mid')
+        curve = Tiles("") * Curve(self.ys).opts(interpolation='steps-mid')
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][1]['lat'], interp_lats)
         self.assertEqual(state['data'][1]['lon'], interp_lons)
 
     def test_curve_color(self):
-        curve = Tiles("") * Curve([1, 2, 3]).options(color='red')
+        curve = Tiles("") * Curve([1, 2, 3]).opts(color='red')
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][1]['line']['color'], 'red')
 
     def test_curve_color_mapping_error(self):
-        curve = Tiles("") * Curve([1, 2, 3]).options(color='x')
+        curve = Tiles("") * Curve([1, 2, 3]).opts(color='x')
         with self.assertRaises(ValueError):
             self._get_plot_state(curve)
 
     def test_curve_dash(self):
-        curve = Tiles("") * Curve([1, 2, 3]).options(dash='dash')
+        curve = Tiles("") * Curve([1, 2, 3]).opts(dash='dash')
         with self.assertRaises(ValueError) as e:
             self._get_plot_state(curve)
         self.assertIn("dash", str(e.exception))
 
     def test_curve_line_width(self):
-        curve = Tiles("") * Curve([1, 2, 3]).options(line_width=5)
+        curve = Tiles("") * Curve([1, 2, 3]).opts(line_width=5)
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][1]['line']['width'], 5)
 
     def test_visible(self):
-        element = Tiles("") * Curve([1, 2, 3]).options(visible=False)
+        element = Tiles("") * Curve([1, 2, 3]).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][1]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_distributionplot.py
+++ b/holoviews/tests/plotting/plotly/test_distributionplot.py
@@ -13,13 +13,13 @@ class TestDistributionPlot(TestPlotlyPlot):
         self.assertEqual(state['data'][0]['fill'], 'tozeroy')
 
     def test_distribution_not_filled(self):
-        dist = Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2]).options(filled=False)
+        dist = Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2]).opts(filled=False)
         state = self._get_plot_state(dist)
         self.assertEqual(state['data'][0]['type'], 'scatter')
         self.assertEqual(state['data'][0]['mode'], 'lines')
         self.assertEqual(state['data'][0].get('fill'), None)
 
     def test_visible(self):
-        element = Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2]).options(visible=False)
+        element = Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2]).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_elementplot.py
+++ b/holoviews/tests/plotting/plotly/test_elementplot.py
@@ -35,17 +35,17 @@ class TestElementPlot(TestPlotlyPlot):
     ### Axis labelling ###
 
     def test_element_plot_xlabel(self):
-        curve = Curve([(10, 1), (100, 2), (1000, 3)]).options(xlabel='X-Axis')
+        curve = Curve([(10, 1), (100, 2), (1000, 3)]).opts(xlabel='X-Axis')
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['xaxis']['title']['text'], 'X-Axis')
 
     def test_element_plot_ylabel(self):
-        curve = Curve([(10, 1), (100, 2), (1000, 3)]).options(ylabel='Y-Axis')
+        curve = Curve([(10, 1), (100, 2), (1000, 3)]).opts(ylabel='Y-Axis')
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'Y-Axis')
 
     def test_element_plot_zlabel(self):
-        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).options(zlabel='Z-Axis')
+        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(zlabel='Z-Axis')
         state = self._get_plot_state(scatter)
         self.assertEqual(state['layout']['scene']['zaxis']['title']['text'], 'Z-Axis')
 
@@ -57,12 +57,12 @@ class TestElementPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['xaxis']['range'], [10, 1000])
 
     def test_element_plot_xlim(self):
-        curve = Curve([(1, 1), (2, 10), (3, 100)]).options(xlim=(0, 1010))
+        curve = Curve([(1, 1), (2, 10), (3, 100)]).opts(xlim=(0, 1010))
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['xaxis']['range'], [0, 1010])
 
     def test_element_plot_invert_xaxis(self):
-        curve = Curve([(1, 1), (2, 10), (3, 100)]).options(invert_xaxis=True)
+        curve = Curve([(1, 1), (2, 10), (3, 100)]).opts(invert_xaxis=True)
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['xaxis']['range'], [3, 1])
 
@@ -72,12 +72,12 @@ class TestElementPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['range'], [1, 3])
 
     def test_element_plot_ylim(self):
-        curve = Curve([(1, 1), (2, 10), (3, 100)]).options(ylim=(0, 8))
+        curve = Curve([(1, 1), (2, 10), (3, 100)]).opts(ylim=(0, 8))
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['yaxis']['range'], [0, 8])
 
     def test_element_plot_invert_yaxis(self):
-        curve = Curve([(1, 1), (2, 10), (3, 100)]).options(invert_yaxis=True)
+        curve = Curve([(1, 1), (2, 10), (3, 100)]).opts(invert_yaxis=True)
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['yaxis']['range'], [100, 1])
 
@@ -87,40 +87,40 @@ class TestElementPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['scene']['zaxis']['range'], [2, 5])
 
     def test_element_plot_zlim(self):
-        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).options(zlim=(1, 6))
+        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(zlim=(1, 6))
         state = self._get_plot_state(scatter)
         self.assertEqual(state['layout']['scene']['zaxis']['range'], [1, 6])
 
     def test_element_plot_invert_zaxis(self):
-        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).options(invert_zaxis=True)
+        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(invert_zaxis=True)
         state = self._get_plot_state(scatter)
         self.assertEqual(state['layout']['scene']['zaxis']['range'], [5, 2])
 
     def test_element_plot_xpadding(self):
-        curve = Curve([(0, 1), (1, 2), (2, 3)]).options(padding=(0.1, 0))
+        curve = Curve([(0, 1), (1, 2), (2, 3)]).opts(padding=(0.1, 0))
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['xaxis']['range'], [-0.2, 2.2])
         self.assertEqual(state['layout']['yaxis']['range'], [1, 3])
 
     def test_element_plot_ypadding(self):
-        curve = Curve([(0, 1), (1, 2), (2, 3)]).options(padding=(0, 0.1))
+        curve = Curve([(0, 1), (1, 2), (2, 3)]).opts(padding=(0, 0.1))
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['xaxis']['range'], [0, 2])
         self.assertEqual(state['layout']['yaxis']['range'], [0.8, 3.2])
 
     def test_element_plot_zpadding(self):
-        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).options(padding=(0, 0, 0.1))
+        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(padding=(0, 0, 0.1))
         state = self._get_plot_state(scatter)
         self.assertEqual(state['layout']['scene']['zaxis']['range'], [1.7, 5.3])
 
     def test_element_plot_padding(self):
-        curve = Curve([(0, 1), (1, 2), (2, 3)]).options(padding=0.1)
+        curve = Curve([(0, 1), (1, 2), (2, 3)]).opts(padding=0.1)
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['xaxis']['range'], [-0.2, 2.2])
         self.assertEqual(state['layout']['yaxis']['range'], [0.8, 3.2])
 
     def test_element_plot3d_padding(self):
-        scatter = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 5)]).options(padding=0.1)
+        scatter = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 5)]).opts(padding=0.1)
         state = self._get_plot_state(scatter)
         self.assertEqual(state['layout']['scene']['xaxis']['range'], [-0.2, 2.2])
         self.assertEqual(state['layout']['scene']['yaxis']['range'], [0.8, 3.2])
@@ -129,52 +129,52 @@ class TestElementPlot(TestPlotlyPlot):
     ### Axis log ###
 
     def test_element_plot_logx(self):
-        curve = Curve([(10, 1), (100, 2), (1000, 3)]).options(logx=True)
+        curve = Curve([(10, 1), (100, 2), (1000, 3)]).opts(logx=True)
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['xaxis']['type'], 'log')
 
     def test_element_plot_logy(self):
-        curve = Curve([(1, 1), (2, 10), (3, 100)]).options(logy=True)
+        curve = Curve([(1, 1), (2, 10), (3, 100)]).opts(logy=True)
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['yaxis']['type'], 'log')
 
     def test_element_plot_logz(self):
-        scatter = Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).options(logz=True)
+        scatter = Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).opts(logz=True)
         state = self._get_plot_state(scatter)
         self.assertEqual(state['layout']['scene']['zaxis']['type'], 'log')
 
     ### Axis ticks ###
 
     def test_element_plot_xticks_values(self):
-        curve = Curve([(1, 1), (5, 2), (10, 3)]).options(xticks=[1, 5, 10])
+        curve = Curve([(1, 1), (5, 2), (10, 3)]).opts(xticks=[1, 5, 10])
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['xaxis']['tickvals'], [1, 5, 10])
 
     def test_element_plot_yticks_values(self):
-        curve = Curve([(1, 1), (5, 2), (10, 3)]).options(yticks=[1, 1.5, 2.5, 3])
+        curve = Curve([(1, 1), (5, 2), (10, 3)]).opts(yticks=[1, 1.5, 2.5, 3])
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['yaxis']['tickvals'], [1, 1.5, 2.5, 3])
 
     def test_element_plot_zticks_values(self):
-        scatter = Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).options(zticks=[0, 500, 1000])
+        scatter = Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).opts(zticks=[0, 500, 1000])
         state = self._get_plot_state(scatter)
         self.assertEqual(state['layout']['scene']['zaxis']['tickvals'], [0, 500, 1000])
 
     def test_element_plot_xticks_items(self):
-        curve = Curve([(1, 1), (5, 2), (10, 3)]).options(xticks=[(1, 'A'), (5, 'B'), (10, 'C')])
+        curve = Curve([(1, 1), (5, 2), (10, 3)]).opts(xticks=[(1, 'A'), (5, 'B'), (10, 'C')])
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['xaxis']['tickvals'], [1, 5, 10])
         self.assertEqual(state['layout']['xaxis']['ticktext'], ['A', 'B', 'C'])
 
     def test_element_plot_yticks_items(self):
-        curve = Curve([(1, 1), (5, 2), (10, 3)]).options(
+        curve = Curve([(1, 1), (5, 2), (10, 3)]).opts(
             yticks=[(1, 'A'), (1.5, 'B'), (2.5, 'C'), (3, 'D')])
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['yaxis']['tickvals'], [1, 1.5, 2.5, 3])
         self.assertEqual(state['layout']['yaxis']['ticktext'], ['A', 'B', 'C', 'D'])
 
     def test_element_plot_zticks_items(self):
-        scatter = Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).options(
+        scatter = Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).opts(
             zticks=[(0, 'A'), (500, 'B'), (1000, 'C')])
         state = self._get_plot_state(scatter)
         self.assertEqual(state['layout']['scene']['zaxis']['tickvals'], [0, 500, 1000])
@@ -193,33 +193,33 @@ class TestOverlayPlot(TestPlotlyPlot):
     ### Axis log ###
 
     def test_overlay_plot_logx(self):
-        curve = (Curve([(10, 1), (100, 2), (1000, 3)]) * Curve([])).options(logx=True)
+        curve = (Curve([(10, 1), (100, 2), (1000, 3)]) * Curve([])).opts(logx=True)
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['xaxis']['type'], 'log')
 
     def test_overlay_plot_logy(self):
-        curve = (Curve([(1, 1), (2, 10), (3, 100)]) * Curve([])).options(logy=True)
+        curve = (Curve([(1, 1), (2, 10), (3, 100)]) * Curve([])).opts(logy=True)
         state = self._get_plot_state(curve)
         self.assertEqual(state['layout']['yaxis']['type'], 'log')
 
     def test_overlay_plot_logz(self):
-        scatter = (Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]) * Path3D([])).options(logz=True)
+        scatter = (Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]) * Path3D([])).opts(logz=True)
         state = self._get_plot_state(scatter)
         self.assertEqual(state['layout']['scene']['zaxis']['type'], 'log')
 
     ### Axis labelling ###
 
     def test_overlay_plot_xlabel(self):
-        overlay = Curve([]) * Curve([(10, 1), (100, 2), (1000, 3)]).options(xlabel='X-Axis')
+        overlay = Curve([]) * Curve([(10, 1), (100, 2), (1000, 3)]).opts(xlabel='X-Axis')
         state = self._get_plot_state(overlay)
         self.assertEqual(state['layout']['xaxis']['title']['text'], 'X-Axis')
 
     def test_overlay_plot_ylabel(self):
-        overlay = Curve([]) * Curve([(10, 1), (100, 2), (1000, 3)]).options(ylabel='Y-Axis')
+        overlay = Curve([]) * Curve([(10, 1), (100, 2), (1000, 3)]).opts(ylabel='Y-Axis')
         state = self._get_plot_state(overlay)
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'Y-Axis')
 
     def test_overlay_plot_zlabel(self):
-        scatter = Path3D([]) * Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).options(zlabel='Z-Axis')
+        scatter = Path3D([]) * Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(zlabel='Z-Axis')
         state = self._get_plot_state(scatter)
         self.assertEqual(state['layout']['scene']['zaxis']['title']['text'], 'Z-Axis')

--- a/holoviews/tests/plotting/plotly/test_errorbarplot.py
+++ b/holoviews/tests/plotting/plotly/test_errorbarplot.py
@@ -18,7 +18,7 @@ class TestErrorBarsPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['range'], [0.5, 5.25])
 
     def test_errorbars_plot_inverted(self):
-        errorbars = ErrorBars([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2']).options(invert_axes=True)
+        errorbars = ErrorBars([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2']).opts(invert_axes=True)
         state = self._get_plot_state(errorbars)
         self.assertEqual(state['data'][0]['x'], np.array([1, 2, 3]))
         self.assertEqual(state['data'][0]['y'], np.array([0, 1, 2]))
@@ -31,6 +31,6 @@ class TestErrorBarsPlot(TestPlotlyPlot):
         element = ErrorBars(
             [(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)],
             vdims=['y', 'y2']
-        ).options(visible=False)
+        ).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_gridplot.py
+++ b/holoviews/tests/plotting/plotly/test_gridplot.py
@@ -12,13 +12,13 @@ class TestGridPlot(TestPlotlyPlot):
         # Create GridSpace
         grid = GridSpace({(i, j): Curve([i, j]) for i in [0, 1]
                           for j in [0, 1]})
-        grid = grid.options(vspacing=0, hspacing=0)
+        grid = grid.opts(vspacing=0, hspacing=0)
 
         # Create Scatter
         scatter = Scatter([-10, 0])
 
         # Create Horizontal Layout
-        layout = (scatter + grid).options(vspacing=0, hspacing=0)
+        layout = (scatter + grid).opts(vspacing=0, hspacing=0)
 
         state = self._get_plot_state(layout)
 

--- a/holoviews/tests/plotting/plotly/test_histogram.py
+++ b/holoviews/tests/plotting/plotly/test_histogram.py
@@ -53,6 +53,6 @@ class TestHistogramPlot(TestPlotlyPlot):
         self.assert_property_values(marker, props)
 
     def test_visible(self):
-        element = Histogram((self.edges, self.frequencies)).options(visible=False)
+        element = Histogram((self.edges, self.frequencies)).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_imageplot.py
+++ b/holoviews/tests/plotting/plotly/test_imageplot.py
@@ -35,7 +35,7 @@ class TestImagePlot(TestPlotlyPlot):
         self.assertEqual(state['data'][0]['z'], np.array([[np.NaN, 1, 2], [2, 3, 4]]))
 
     def test_image_state_inverted(self):
-        img = Image(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))).options(
+        img = Image(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))).opts(
             invert_axes=True)
         state = self._get_plot_state(img)
         self.assertEqual(state['data'][0]['y0'], 1)
@@ -51,6 +51,6 @@ class TestImagePlot(TestPlotlyPlot):
     def test_visible(self):
         element = Image(
             ([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))
-        ).options(visible=False)
+        ).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_labelplot.py
+++ b/holoviews/tests/plotting/plotly/test_labelplot.py
@@ -20,7 +20,7 @@ class TestLabelsPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'y')
 
     def test_labels_inverted(self):
-        labels = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).options(invert_axes=True)
+        labels = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(invert_axes=True)
         state = self._get_plot_state(labels)
         self.assertEqual(state['data'][0]['x'], np.array([3, 2, 1]))
         self.assertEqual(state['data'][0]['y'], np.array([0, 1, 2]))
@@ -32,22 +32,22 @@ class TestLabelsPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'x')
 
     def test_labels_size(self):
-        labels = Labels([(0, 3, 0), (0, 2, 1), (0, 1, 1)]).options(size='y')
+        labels = Labels([(0, 3, 0), (0, 2, 1), (0, 1, 1)]).opts(size='y')
         state = self._get_plot_state(labels)
         self.assertEqual(state['data'][0]['textfont']['size'], np.array([3, 2, 1]))
 
     def test_labels_xoffset(self):
-        labels = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).options(xoffset=0.5)
+        labels = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(xoffset=0.5)
         state = self._get_plot_state(labels)
         self.assertEqual(state['data'][0]['x'], np.array([0.5, 1.5, 2.5]))
 
     def test_labels_yoffset(self):
-        labels = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).options(yoffset=0.5)
+        labels = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(yoffset=0.5)
         state = self._get_plot_state(labels)
         self.assertEqual(state['data'][0]['y'], np.array([3.5, 2.5, 1.5]))
 
     def test_visible(self):
-        element = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).options(visible=False)
+        element = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)
 
@@ -90,7 +90,7 @@ class TestMapboxLabelsPlot(TestPlotlyPlot):
         )
 
     def test_labels_inverted(self):
-        labels = Tiles("") * Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).options(
+        labels = Tiles("") * Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(
             invert_axes=True
         )
         with self.assertRaises(ValueError) as e:
@@ -99,7 +99,7 @@ class TestMapboxLabelsPlot(TestPlotlyPlot):
         self.assertIn("invert_axes", str(e.exception))
 
     def test_labels_size(self):
-        labels = Tiles("") * Labels([(0, 3, 0), (0, 2, 1), (0, 1, 1)]).options(size=23)
+        labels = Tiles("") * Labels([(0, 3, 0), (0, 2, 1), (0, 1, 1)]).opts(size=23)
         state = self._get_plot_state(labels)
         self.assertEqual(state['data'][1]['textfont']['size'], 23)
 
@@ -109,7 +109,7 @@ class TestMapboxLabelsPlot(TestPlotlyPlot):
             (self.xs[0], self.ys[0], 'A'),
             (self.xs[1], self.ys[1], 'B'),
             (self.xs[2], self.ys[2], 'C')
-        ]).options(xoffset=offset)
+        ]).opts(xoffset=offset)
 
         state = self._get_plot_state(labels)
         lons, lats = Tiles.easting_northing_to_lon_lat(np.array(self.xs) + offset, self.ys)
@@ -122,13 +122,13 @@ class TestMapboxLabelsPlot(TestPlotlyPlot):
             (self.xs[0], self.ys[0], 'A'),
             (self.xs[1], self.ys[1], 'B'),
             (self.xs[2], self.ys[2], 'C')
-        ]).options(yoffset=offset)
+        ]).opts(yoffset=offset)
         state = self._get_plot_state(labels)
         lons, lats = Tiles.easting_northing_to_lon_lat(self.xs, np.array(self.ys) + offset)
         self.assertEqual(state['data'][1]['lon'], lons)
         self.assertEqual(state['data'][1]['lat'], lats)
 
     def test_visible(self):
-        element = Tiles("") * Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).options(visible=False)
+        element = Tiles("") * Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][1]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_layoutplot.py
+++ b/holoviews/tests/plotting/plotly/test_layoutplot.py
@@ -17,7 +17,7 @@ class TestLayoutPlot(TestPlotlyPlot):
     def test_layout_instantiate_subplots_transposed(self):
         layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
                   Curve(range(10)) + Curve(range(10)))
-        plot = plotly_renderer.get_plot(layout.options(transpose=True))
+        plot = plotly_renderer.get_plot(layout.opts(transpose=True))
         positions = [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (3, 0), (3, 1)]
         self.assertEqual(sorted(plot.subplots.keys()), positions)
 

--- a/holoviews/tests/plotting/plotly/test_path3d.py
+++ b/holoviews/tests/plotting/plotly/test_path3d.py
@@ -38,12 +38,12 @@ class TestPath3DPlot(TestPlotlyPlot):
     def test_path3D_multi_colors(self):
         path3D = Path3D([[(0, 1, 0, 'red'), (1, 2, 1, 'red'), (2, 3, 2, 'red')],
                          [(-1, 1, 3, 'blue'), (-2, 2, 4, 'blue'), (-3, 3, 5, 'blue')]],
-                        vdims='color').options(color='color')
+                        vdims='color').opts(color='color')
         state = self._get_plot_state(path3D)
         self.assertEqual(state['data'][0]['line']['color'], 'red')
         self.assertEqual(state['data'][1]['line']['color'], 'blue')
 
     def test_visible(self):
-        element = Path3D([(0, 1, 0), (1, 2, 1), (2, 3, 2)]).options(visible=False)
+        element = Path3D([(0, 1, 0), (1, 2, 1), (2, 3, 2)]).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/plotly/test_quadmeshplot.py
@@ -34,7 +34,7 @@ class TestQuadMeshPlot(TestPlotlyPlot):
         self.assertEqual(state['data'][0]['z'], np.array([[np.NaN, 1, 2], [2, 3, 4]]))
 
     def test_quadmesh_state_inverted(self):
-        img = QuadMesh(([1, 2, 4], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))).options(
+        img = QuadMesh(([1, 2, 4], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))).opts(
             invert_axes=True)
         state = self._get_plot_state(img)
         self.assertEqual(state['data'][0]['x'], np.array([-0.5, .5, 1.5]))
@@ -48,6 +48,6 @@ class TestQuadMeshPlot(TestPlotlyPlot):
     def test_visible(self):
         element = QuadMesh(
             ([1, 2, 4], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))
-        ).options(visible=False)
+        ).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_scatter3dplot.py
+++ b/holoviews/tests/plotting/plotly/test_scatter3dplot.py
@@ -18,18 +18,18 @@ class TestScatter3DPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['scene']['zaxis']['range'], [4, 5])
 
     def test_scatter3d_color_mapped(self):
-        scatter = Scatter3D(([0,1], [2,3], [4,5])).options(color='y')
+        scatter = Scatter3D(([0,1], [2,3], [4,5])).opts(color='y')
         state = self._get_plot_state(scatter)
         self.assertEqual(state['data'][0]['marker']['color'], np.array([2, 3]))
         self.assertEqual(state['data'][0]['marker']['cmin'], 2)
         self.assertEqual(state['data'][0]['marker']['cmax'], 3)
 
     def test_scatter3d_size(self):
-        scatter = Scatter3D(([0,1], [2,3], [4,5])).options(size='y')
+        scatter = Scatter3D(([0,1], [2,3], [4,5])).opts(size='y')
         state = self._get_plot_state(scatter)
         self.assertEqual(state['data'][0]['marker']['size'], np.array([2, 3]))
 
     def test_visible(self):
-        element = Scatter3D(([0, 1], [2, 3], [4, 5])).options(visible=False)
+        element = Scatter3D(([0, 1], [2, 3], [4, 5])).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_scatterplot.py
+++ b/holoviews/tests/plotting/plotly/test_scatterplot.py
@@ -16,7 +16,7 @@ class TestScatterPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['range'], [1, 3])
 
     def test_scatter_inverted(self):
-        scatter = Scatter([1, 2, 3]).options(invert_axes=True)
+        scatter = Scatter([1, 2, 3]).opts(invert_axes=True)
         state = self._get_plot_state(scatter)
         self.assertEqual(state['data'][0]['x'], np.array([1, 2, 3]))
         self.assertEqual(state['data'][0]['y'], np.array([0, 1, 2]))
@@ -27,21 +27,21 @@ class TestScatterPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'x')
 
     def test_scatter_color_mapped(self):
-        scatter = Scatter([3, 2, 1]).options(color='x')
+        scatter = Scatter([3, 2, 1]).opts(color='x')
         state = self._get_plot_state(scatter)
         self.assertEqual(state['data'][0]['marker']['color'], np.array([0, 1, 2]))
         self.assertEqual(state['data'][0]['marker']['cmin'], 0)
         self.assertEqual(state['data'][0]['marker']['cmax'], 2)
 
     def test_scatter_size(self):
-        scatter = Scatter([3, 2, 1]).options(size='y')
+        scatter = Scatter([3, 2, 1]).opts(size='y')
         state = self._get_plot_state(scatter)
         self.assertEqual(state['data'][0]['marker']['size'], np.array([3, 2, 1]))
 
     def test_scatter_colors(self):
         scatter = Scatter([
             (0, 1, 'red'), (1, 2, 'green'), (2, 3, 'blue')
-        ], vdims=['y', 'color']).options(color='color')
+        ], vdims=['y', 'color']).opts(color='color')
         state = self._get_plot_state(scatter)
         self.assertEqual(np.array_equal(state['data'][0]['marker']['color'],
                                         np.array(['red', 'green', 'blue'])), True)
@@ -49,7 +49,7 @@ class TestScatterPlot(TestPlotlyPlot):
     def test_scatter_markers(self):
         scatter = Scatter([
             (0, 1, 'square'), (1, 2, 'circle'), (2, 3, 'triangle-up')
-        ], vdims=['y', 'marker']).options(marker='marker')
+        ], vdims=['y', 'marker']).opts(marker='marker')
         state = self._get_plot_state(scatter)
         self.assertEqual(np.array_equal(state['data'][0]['marker']['symbol'],
                                         np.array(['square', 'circle', 'triangle-up'])), True)
@@ -57,12 +57,12 @@ class TestScatterPlot(TestPlotlyPlot):
     def test_scatter_selectedpoints(self):
         scatter = Scatter([
             (0, 1,), (1, 2), (2, 3)
-        ]).options(selectedpoints=[1, 2])
+        ]).opts(selectedpoints=[1, 2])
         state = self._get_plot_state(scatter)
         self.assertEqual(state['data'][0]['selectedpoints'], [1, 2])
 
     def test_visible(self):
-        element = Scatter([3, 2, 1]).options(visible=False)
+        element = Scatter([3, 2, 1]).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)
 
@@ -95,7 +95,7 @@ class TestMapboxScatterPlot(TestPlotlyPlot):
         self.assertFalse('yaxis' in state['layout'])
 
     def test_scatter_color_mapped(self):
-        scatter = Tiles('') * Scatter([3, 2, 1]).options(color='x')
+        scatter = Tiles('') * Scatter([3, 2, 1]).opts(color='x')
         state = self._get_plot_state(scatter)
         self.assertEqual(state['data'][1]['marker']['color'], np.array([0, 1, 2]))
         self.assertEqual(state['data'][1]['marker']['cmin'], 0)
@@ -103,14 +103,14 @@ class TestMapboxScatterPlot(TestPlotlyPlot):
 
     def test_scatter_size(self):
         # size values should not go through meters-to-lnglat conversion
-        scatter = Tiles('') * Scatter([3, 2, 1]).options(size='y')
+        scatter = Tiles('') * Scatter([3, 2, 1]).opts(size='y')
         state = self._get_plot_state(scatter)
         self.assertEqual(state['data'][1]['marker']['size'], np.array([3, 2, 1]))
 
     def test_scatter_colors(self):
         scatter = Tiles('') * Scatter([
             (0, 1, 'red'), (1, 2, 'green'), (2, 3, 'blue')
-        ], vdims=['y', 'color']).options(color='color')
+        ], vdims=['y', 'color']).opts(color='color')
         state = self._get_plot_state(scatter)
         self.assertEqual(np.array_equal(state['data'][1]['marker']['color'],
                                         np.array(['red', 'green', 'blue'])), True)
@@ -119,7 +119,7 @@ class TestMapboxScatterPlot(TestPlotlyPlot):
     def test_scatter_markers(self):
         scatter = Tiles('') * Scatter([
             (0, 1, 'square'), (1, 2, 'circle'), (2, 3, 'triangle-up')
-        ], vdims=['y', 'marker']).options(marker='marker')
+        ], vdims=['y', 'marker']).opts(marker='marker')
         state = self._get_plot_state(scatter)
         self.assertEqual(
             np.array_equal(
@@ -129,11 +129,11 @@ class TestMapboxScatterPlot(TestPlotlyPlot):
     def test_scatter_selectedpoints(self):
         scatter = Tiles('') * Scatter([
             (0, 1,), (1, 2), (2, 3)
-        ]).options(selectedpoints=[1, 2])
+        ]).opts(selectedpoints=[1, 2])
         state = self._get_plot_state(scatter)
         self.assertEqual(state['data'][1]['selectedpoints'], [1, 2])
 
     def test_visible(self):
-        element = Tiles('') * Scatter([3, 2, 1]).options(visible=False)
+        element = Tiles('') * Scatter([3, 2, 1]).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][1]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_spreadplot.py
+++ b/holoviews/tests/plotting/plotly/test_spreadplot.py
@@ -34,6 +34,6 @@ class TestSpreadPlot(TestPlotlyPlot):
         element = Spread(
             [(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)],
             vdims=['y', 'y2']
-        ).options(visible=False)
+        ).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_surfaceplot.py
+++ b/holoviews/tests/plotting/plotly/test_surfaceplot.py
@@ -35,6 +35,6 @@ class TestSurfacePlot(TestPlotlyPlot):
     def test_visible(self):
         element = Surface(
             ([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))
-        ).options(visible=False)
+        ).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/tests/plotting/plotly/test_violinplot.py
+++ b/holoviews/tests/plotting/plotly/test_violinplot.py
@@ -19,7 +19,7 @@ class TestViolinPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'y')
 
     def test_violin_single_invert_axes(self):
-        violin = Violin([1, 1, 2, 3, 3, 4, 5, 5]).options(invert_axes=True)
+        violin = Violin([1, 1, 2, 3, 3, 4, 5, 5]).opts(invert_axes=True)
         state = self._get_plot_state(violin)
         self.assertEqual(len(state['data']), 1)
         self.assertEqual(state['data'][0]['type'], 'violin')
@@ -44,7 +44,7 @@ class TestViolinPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['yaxis']['title']['text'], 'y')
 
     def test_violin_multi_invert_axes(self):
-        violin = Violin((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y').options(
+        violin = Violin((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y').opts(
             invert_axes=True)
         state = self._get_plot_state(violin)
         self.assertEqual(len(state['data']), 2)
@@ -59,6 +59,6 @@ class TestViolinPlot(TestPlotlyPlot):
         self.assertEqual(state['layout']['xaxis']['title']['text'], 'y')
 
     def test_visible(self):
-        element = Violin([1, 1, 2, 3, 3, 4, 5, 5]).options(visible=False)
+        element = Violin([1, 1, 2, 3, 3, 4, 5, 5]).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][0]['visible'], False)

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -81,7 +81,7 @@ class opts(param.ParameterizedFunction):
     __original_docstring__ = None
 
     # Keywords not to be tab-completed (helps with deprecation)
-    _no_completion = ['title_format', 'color_index', 'size_index', 'finalize_hooks',
+    _no_completion = ['title_format', 'color_index', 'size_index',
                       'scaling_factor', 'scaling_method', 'size_fn', 'normalize_lengths',
                       'group_index', 'category_index', 'stack_index', 'color_by']
 


### PR DESCRIPTION
Removes:

- `DimensionedPlot.title_format`
- `GenericElementPlot.finalize_hooks`

Adds new deprecation warnings:

- `color_index`
- `size_index`
- `scaling_method`
- `scaling_factor`
- `size_fn`