### PR TITLE
Added final CHANGELOG entry for 1.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Compatibility:
   see `rescale_discrete_levels` below. To revert to the old colorbar
   behavior, set `ColorbarPlot.rescale_discrete_levels = False` in the
   `bokeh` or `mpl` plotting modules as appropriate.
+- Updated Sankey algorithm means that some users may need to update the
+  `node_padding` parameter for plots generated with earlier releases.
 
 Major features:
 

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -32,6 +32,8 @@ Compatibility:
    see ``rescale_discrete_levels`` below. To revert to the old colorbar
    behavior, set ``ColorbarPlot.rescale_discrete_levels = False`` in the
    ``bokeh`` or ``mpl`` plotting modules as appropriate.
+-  Updated Sankey algorithm means that some users may need to update the
+   ``node_padding`` parameter for plots generated with earlier releases.
 
 Major features:
 


### PR DESCRIPTION

Addresses final comment in https://github.com/holoviz/holoviews/pull/5349 regarding the need for an entry in the compatibility section to inform users of changes to the Sankey algorithm.