### PR TITLE
Setting expand to false for Image

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1547,6 +1547,9 @@ class rasterize(AggregationOperation):
     ]
 
     def _process(self, element, key=None):
+        if isinstance(element, Image):
+            self.p.expand = False
+
         # Potentially needs traverse to find element types first?
         all_allowed_kws = set()
         all_supplied_kws = set()


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/5358

To be honest, this fix is more of a workaround for the problem than a fix. But the complexity of the the holoviews pipelines makes it hard for me to see when `self.p.expand` is set to `True`, even though `regrid.expand` defaults to False. Suggestions are welcome.

With this change the notebook example outputs this:

https://user-images.githubusercontent.com/19758978/177816756-b6749b29-282f-4097-a1ae-daf4a7eed9a2.mp4


The example in the notebook can be reduced to this MRE:

``` python
import xarray as xr
import numpy as np
import holoviews as hv
from holoviews.operation.datashader import rasterize

da = xr.DataArray(
    np.arange(10_000).reshape(100, 100),
    coords=dict(
        x=np.linspace(166021, 534994, 100),
        y=np.linspace(0.00, 9329005, 100),
    ),
)
rasterize(hv.Image(da))

```

Before this fix:

https://user-images.githubusercontent.com/19758978/177817920-cb102b31-8887-4b1f-9e78-cfe77f92c334.mp4




After this fix:

https://user-images.githubusercontent.com/19758978/177817400-b2837463-019d-4ead-90cd-cd54c840e7a9.mp4


