### PR TITLE
Supporting widgets in slices for loc and iloc

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1509,7 +1509,7 @@ def resolve_dependent_value(value):
 
     Resolves parameter values, Parameterized instance methods,
     parameterized functions with dependencies on the supplied value,
-    including such parameters embedded in a list, tuple, or dictionary.
+    including such parameters embedded in a list, tuple, dictionary, or slice.
 
     Args:
        value: A value which will be resolved
@@ -1527,6 +1527,12 @@ def resolve_dependent_value(value):
         value = {
             resolve_dependent_value(k): resolve_dependent_value(v) for k, v in value.items()
         }
+    elif isinstance(value, slice):
+        value = slice(
+            resolve_dependent_value(value.start),
+            resolve_dependent_value(value.stop),
+            resolve_dependent_value(value.step),
+        )
 
     if 'panel' in sys.modules:
         from panel.widgets import RangeSlider, Widget

--- a/holoviews/tests/core/test_apply.py
+++ b/holoviews/tests/core/test_apply.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import param
 
-from panel.widgets import RadioButtonGroup, TextInput
+from panel.widgets import IntSlider, RadioButtonGroup, TextInput
 
 from holoviews import Dataset, util
 from holoviews.core.spaces import DynamicMap, HoloMap
@@ -292,3 +292,18 @@ def test_nested_widgets():
     df1 = transform.apply(ds, keep_index=True, compute=False)
     df2 = df.groupby(["D", "A"]).mean()
     pd.testing.assert_frame_equal(df1, df2)
+
+
+def test_slice_iloc():
+    df = pd._testing.makeDataFrame()
+    column = IntSlider(start=10, end=40)
+    ds = Dataset(df)
+    transform = util.transform.df_dim("*").iloc[:column].mean(axis=0)
+
+    params = list(transform.params.values())
+    assert len(params) == 1
+    assert params[0] == column.param.value
+
+    df1 = transform.apply(ds, keep_index=True, compute=False)
+    df2 = df.iloc[:10].mean(axis=0)
+    pd.testing.assert_series_equal(df1, df2)

--- a/holoviews/tests/core/test_apply.py
+++ b/holoviews/tests/core/test_apply.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import param
+import pytest
 
 from panel.widgets import IntSlider, RadioButtonGroup, TextInput
 
@@ -307,3 +308,23 @@ def test_slice_iloc():
     df1 = transform.apply(ds, keep_index=True, compute=False)
     df2 = df.iloc[:10].mean(axis=0)
     pd.testing.assert_series_equal(df1, df2)
+
+
+def test_slice_loc():
+    df = pd._testing.makeDataFrame()
+    df.index = np.arange(5, len(df) + 5)  # Start index at 5
+    column = IntSlider(start=10, end=40)
+    ds = Dataset(df)
+    transform = util.transform.df_dim("*").loc[:column].mean(axis=0)
+
+    params = list(transform.params.values())
+    assert len(params) == 1
+    assert params[0] == column.param.value
+
+    df1 = transform.apply(ds, keep_index=True, compute=False)
+    df2 = df.loc[5:10].mean(axis=0)
+    pd.testing.assert_series_equal(df1, df2)
+
+    df3 = df.iloc[5:10].mean(axis=0)
+    with pytest.raises(AssertionError):
+        pd.testing.assert_series_equal(df1, df3)

--- a/holoviews/tests/core/test_apply.py
+++ b/holoviews/tests/core/test_apply.py
@@ -312,7 +312,7 @@ def test_slice_iloc():
 
 def test_slice_loc():
     df = pd._testing.makeDataFrame()
-    df.index = np.arange(5, len(df) + 5)  # Start index at 5
+    df.index = np.arange(5, len(df) + 5)
     column = IntSlider(start=10, end=40)
     ds = Dataset(df)
     transform = util.transform.df_dim("*").loc[:column].mean(axis=0)
@@ -328,3 +328,34 @@ def test_slice_loc():
     df3 = df.iloc[5:10].mean(axis=0)
     with pytest.raises(AssertionError):
         pd.testing.assert_series_equal(df1, df3)
+
+
+def test_int_iloc():
+    df = pd._testing.makeDataFrame()
+    column = IntSlider(start=10, end=40)
+    ds = Dataset(df)
+    transform = util.transform.df_dim("*").iloc[column]
+
+    params = list(transform.params.values())
+    assert len(params) == 1
+    assert params[0] == column.param.value
+
+    df1 = transform.apply(ds, keep_index=True, compute=False)
+    df2 = df.iloc[10]
+    pd.testing.assert_series_equal(df1, df2)
+
+
+def test_int_loc():
+    df = pd._testing.makeDataFrame()
+    df.index = np.arange(5, len(df) + 5)
+    column = IntSlider(start=10, end=40)
+    ds = Dataset(df)
+    transform = util.transform.df_dim("*").loc[column]
+
+    params = list(transform.params.values())
+    assert len(params) == 1
+    assert params[0] == column.param.value
+
+    df1 = transform.apply(ds, keep_index=True, compute=False)
+    df2 = df.loc[10]
+    pd.testing.assert_series_equal(df1, df2)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -583,12 +583,6 @@ class dim(object):
                     dataset, flat, expanded, ranges, all_values,
                     keep_index, compute, strict
                 )
-            elif isinstance(arg, slice):
-                arg = slice(
-                    resolve_dependent_value(arg.start),
-                    resolve_dependent_value(arg.stop),
-                    resolve_dependent_value(arg.step)
-                )
             arg = resolve_dependent_value(arg)
             fn_args.append(arg)
         fn_kwargs = {}
@@ -597,12 +591,6 @@ class dim(object):
                 v = v.apply(
                     dataset, flat, expanded, ranges, all_values,
                     keep_index, compute, strict
-                )
-            elif isinstance(v, slice):
-                v = slice(
-                    resolve_dependent_value(v.start),
-                    resolve_dependent_value(v.stop),
-                    resolve_dependent_value(v.step)
                 )
             fn_kwargs[k] = resolve_dependent_value(v)
         args = tuple(fn_args[::-1] if op['reverse'] else fn_args)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -84,7 +84,7 @@ class iloc(object):
         return dim(self.expr, self)
 
     def __call__(self, values):
-        return values[self.index]
+        return values[resolve_dependent_value(self.index)]
 
 
 @_maybe_map
@@ -335,6 +335,9 @@ class dim(object):
         params = {}
         for op in self.ops:
             op_args = list(op['args'])+list(op['kwargs'].values())
+            if hasattr(op['fn'], 'index'):
+                # Special case for iloc to check if slice has parameters
+                op_args += [op['fn'].index]
             op_args = flatten(op_args)
             for op_arg in op_args:
                 if Widget and isinstance(op_arg, Widget):

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -84,7 +84,10 @@ class iloc(object):
         return dim(self.expr, self)
 
     def __call__(self, values):
-        return values[resolve_dependent_value(self.index)]
+        if isinstance(values, (pd.Series, pd.DataFrame)):
+            return values.iloc[resolve_dependent_value(self.index)]
+        else:
+            return values[resolve_dependent_value(self.index)]
 
 
 class loc(object):
@@ -355,7 +358,7 @@ class dim(object):
         for op in self.ops:
             op_args = list(op['args'])+list(op['kwargs'].values())
             if hasattr(op['fn'], 'index'):
-                # Special case for iloc to check if slice has parameters
+                # Special case for loc and iloc to check for parameters
                 op_args += [op['fn'].index]
             op_args = flatten(op_args)
             for op_arg in op_args:

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -87,6 +87,24 @@ class iloc(object):
         return values[resolve_dependent_value(self.index)]
 
 
+class loc(object):
+    """Implements loc for dim expressions.
+    """
+
+    __name__ = 'loc'
+
+    def __init__(self, dim_expr):
+        self.expr = dim_expr
+        self.index = slice(None)
+
+    def __getitem__(self, index):
+        self.index = index
+        return dim(self.expr, self)
+
+    def __call__(self, values):
+        return values.loc[resolve_dependent_value(self.index)]
+
+
 @_maybe_map
 def bin(values, bins, labels=None):
     """Bins data into declared bins
@@ -163,7 +181,7 @@ python_isin = _maybe_map(_python_isin)
 
 function_types = (
     BuiltinFunctionType, BuiltinMethodType, FunctionType,
-    MethodType, np.ufunc, iloc
+    MethodType, np.ufunc, iloc, loc
 )
 
 
@@ -196,6 +214,7 @@ class dim(object):
         astype: 'astype',
         round_: 'round',
         iloc: 'iloc',
+        loc: 'loc',
     }
 
     _numpy_funcs = {
@@ -793,6 +812,8 @@ class dim(object):
                     format_string = prev+').{fn}('
                 elif isinstance(fn, iloc):
                     format_string = prev+').iloc[{0}]'.format(repr(fn.index))
+                elif isinstance(fn, loc):
+                    format_string = prev+').loc[{0}]'.format(repr(fn.index))
                 elif fn in self._custom_funcs:
                     fn_name = self._custom_funcs[fn]
                     format_string = prev+').{fn}('
@@ -874,6 +895,9 @@ class df_dim(dim):
                      if dataset.interface.multi == intfc.multi]
         return dataset.clone(datatype=datatypes)
 
+    @property
+    def loc(self):
+        return loc(self)
 
 
 class xr_dim(dim):

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -327,24 +327,36 @@ class dim(object):
 
     @property
     def params(self):
+        if 'panel' in sys.modules:
+            from panel.widgets.base import Widget
+        else:
+            Widget = None
+
         params = {}
         for op in self.ops:
             op_args = list(op['args'])+list(op['kwargs'].values())
             op_args = flatten(op_args)
             for op_arg in op_args:
-                if 'panel' in sys.modules:
-                    from panel.widgets.base import Widget
-                    if isinstance(op_arg, Widget):
-                        op_arg = op_arg.param.value
+                if Widget and isinstance(op_arg, Widget):
+                    op_arg = op_arg.param.value
                 if isinstance(op_arg, dim):
                     params.update(op_arg.params)
                 elif isinstance(op_arg, slice):
-                    if isinstance(op_arg.start, param.Parameter):
-                        params[op_arg.start.name+str(id(op_arg.start))] = op_arg.start
-                    if isinstance(op_arg.stop, param.Parameter):
-                        params[op_arg.stop.name+str(id(op_arg.stop))] = op_arg.stop
-                    if isinstance(op_arg.step, param.Parameter):
-                        params[op_arg.step.name+str(id(op_arg.step))] = op_arg.step
+                    (start, stop, step) = (op_arg.start, op_arg.stop, op_arg.step)
+
+                    if Widget and isinstance(start, Widget):
+                        start = start.param.value
+                    if Widget and isinstance(stop, Widget):
+                        stop = stop.param.value
+                    if Widget and isinstance(step, Widget):
+                        step = step.param.value
+
+                    if isinstance(start, param.Parameter):
+                        params[start.name+str(id(start))] = start
+                    if isinstance(stop, param.Parameter):
+                        params[stop.name+str(id(stop))] = stop
+                    if isinstance(step, param.Parameter):
+                        params[step.name+str(id(step))] = step
                 if (isinstance(op_arg, param.Parameter) and
                     isinstance(op_arg.owner, param.Parameterized)):
                     params[op_arg.name+str(id(op_arg))] = op_arg


### PR DESCRIPTION
Part of the solution for https://github.com/holoviz/hvplot/issues/771

Checklist: 
- [x] Add support for slice in `resolve_dependent_value`.
- [x] Support for `pn.widgets` in slice for `transform.params()`.
- [x] Add `loc` to `df_dim`.
   - [ ] I'm not sure if it should be moved up into `dim`.
- [x] Solve widget values in `loc` and `iloc`.
- [x] Support integer lookup for pandas in `iloc`.