### PR TITLE
Add docstrings needed to help a user create a simple Scatter example

### DIFF
--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -520,23 +520,43 @@ class Opts(object):
 
 
     def __call__(self, *args, **kwargs):
-        """Applies nested options definition.
+        # This docstring should be similar to the .opts docstring
+        """Applies options like `cmap` on a HoloViews object or nested group
+        of objects.
 
-        Applies options on an object or nested group of objects in a
-        flat format. Unlike the .options method, .opts modifies the
-        options in place by default. If the options are to be set
-        directly on the object a simple format may be used, e.g.:
+        Please note 
+        
+        - The object is modified in place by default
+        - options are only applied to the currently selected backend
+        - the available options differ between backends.
 
-            obj.opts(cmap='viridis', show_title=False)
+        Reference: https://holoviews.org/user_guide/Applying_Customizations.html
 
-        If the object is nested the options must be qualified using
-        a type[.group][.label] specification, e.g.:
+        Examples:
+        
+        If the options are to be set directly on the object a simple format
+        may be used, e.g.:
 
-            obj.opts('Image', cmap='viridis', show_title=False)
+        >>> obj.opts(cmap='viridis', show_title=False)
+
+        If the object is nested the options must be qualified using a
+        type[.group][.label] specification, e.g.:
+
+        >>> obj.opts('Image', cmap='viridis', show_title=False)
 
         or using:
 
-            obj.opts({'Image': dict(cmap='viridis', show_title=False)})
+        >>> obj.opts({'Image': dict(cmap='viridis', show_title=False)})
+
+        You can see the options applied using
+
+        >>> obj.opts.info()
+        :Image   [x]   (y)
+        | Options(cmap='viridis', show_title=False)
+
+        You can explore the available options using
+
+        >>> hv.help(obj)
 
         Args:
             *args: Sets of options to apply to object

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -856,6 +856,57 @@ class Dimensioned(LabelledData):
 
     @property
     def opts(self):
+        # This docstring should be similar to the Opts.__call__ docstring
+        """Call `.opts(...)` to set options like for example `cmap` and
+        `show_title` on the HoloViews object.
+
+        Please note 
+        
+        - The object is modified in place by default
+        - options are only applied to the currently selected backend
+        - the available options differ between backends.
+
+        Reference: https://holoviews.org/user_guide/Applying_Customizations.html
+
+        Examples:
+
+        If the options are to be set directly on the object a simple format
+        may be used, e.g.:
+
+        >>> obj.opts(cmap='viridis', show_title=False)
+
+        If the object is nested the options must be qualified using a
+        type[.group][.label] specification, e.g.:
+
+        >>> obj.opts('Image', cmap='viridis', show_title=False)
+
+        or using:
+
+        >>> obj.opts({'Image': dict(cmap='viridis', show_title=False)})
+
+        You can see the options applied using
+
+        >>> obj.opts.info()
+        :Image   [x]   (y)
+        | Options(cmap='viridis', show_title=False)
+
+        You can explore the available options using
+
+        >>> hv.help(obj)
+
+        Args:
+            *args: Sets of options to apply to object
+                Supports a number of formats including lists of Options
+                objects, a type[.group][.label] followed by a set of
+                keyword options to apply and a dictionary indexed by
+                type[.group][.label] specs.
+            backend (optional): Backend to apply options to
+                Defaults to current selected backend
+            clone (bool, optional): Whether to clone object
+                Options can be applied in place with clone=False
+            **kwargs: Keywords of options
+                Set of options to apply to the object
+        """
         return Opts(self)
 
     @property

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -56,10 +56,27 @@ class Chart(Dataset, Element2D):
 
 class Scatter(Selection2DExpr, Chart):
     """
-    Scatter is a Chart element representing a set of points in a 1D
-    coordinate system where the key dimension maps to the points
-    location along the x-axis while the first value dimension
-    represents the location of the point along the y-axis.
+    The `Scatter` element visualizes as markers placed in a space of one
+    independent variable, traditionally denoted as `x`, against a dependent
+    variable, traditionally denoted as `y`.
+
+    Scatter elements most naturally overlay with other elements that express
+    dependent relationships between the x and y axes in two-dimensional space,
+    such as Chart types like `Curve`.
+    
+    Reference: [Bokeh](http://holoviews.org/reference/elements/bokeh/Scatter.html), [Matplotlib](http://holoviews.org/reference/elements/matplotlib/Scatter.html), [Plotly](http://holoviews.org/reference/elements/plotly/Scatter.html)
+
+    Example:
+
+    >>> scatter = hv.Scatter(data, kdims="x", vdims="y")
+    >>> scatter.opts(color='black', marker='s', size=10, tools=["hover"])
+    >>> scatter
+
+    ![Scatter Reference](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQmxagf9BtB3Rc1Y98w4lvreN-keSk0_YHytg&usqp=CAU)
+
+    For full documentation and the available style and plot options, use
+
+    >>> hv.help(scatter)
     """
 
     group = param.String(default='Scatter', constant=True)


### PR DESCRIPTION
This addresses a small part of https://github.com/holoviz/holoviews/issues/5361 by adding docstrings to `Scatter` and `.opts` as well as updating the docstring of `Opts`.

For me this makes it so much easier to understand the objects and navigate the documentation.

https://user-images.githubusercontent.com/42288570/180598895-cb30e328-27e7-409a-86ce-117244028fd3.mp4


