### PR TITLE
add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ holoviews/.version
 .doit.db
 .vscode/settings.json
 holoviews/.vscode/settings.json
+.venv


### PR DESCRIPTION
I ran into some issues with the conda environment. I often do that. So I switched to a normal virtual environment and pip.

Having .venv in the .gitignore would help me.

Thanks.