### PR TITLE
Allow holoviews to import with numpy 1.12

### DIFF
--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -151,8 +151,19 @@ def categorize(values, categories, default=None):
     return result
 
 
+if hasattr(np, 'isin'):
+    isin = _maybe_map(np.isin)
+else:
+    # for 1.4 <= numpy < 1.13; in1d() available since 1.4
+    def _isin(element, test_elements, assume_unique=False, invert=False):
+        # from 1.13's numpy.lib.arraysetops
+        element = np.asarray(element)
+        return np.in1d(element, test_elements, assume_unique=assume_unique,
+                invert=invert).reshape(element.shape)
+    isin = _maybe_map(_isin)
+    del _isin
+
 digitize = _maybe_map(np.digitize)
-isin = _maybe_map(np.isin)
 astype = _maybe_map(np.asarray)
 round_ = _maybe_map(np.round)
 


### PR DESCRIPTION
setup.py says:

```
install_requires = [
    [...]
    "numpy >=1.0",
    [...]
```

But if you try to import holoviews in an environment with numpy 1.12 you get:

```
>>> import holoviews
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/sefkw/code/holoviz/holoviews2017/holoviews/__init__.py", line 9, in <module>
    from . import util                                       # noqa (API import)
  File "/home/sefkw/code/holoviz/holoviews2017/holoviews/util/__init__.py", line 22, in <module>
    from ..operation.element import function
  File "/home/sefkw/code/holoviz/holoviews2017/holoviews/operation/__init__.py", line 4, in <module>
    from .element import *      # noqa (API import)
  File "/home/sefkw/code/holoviz/holoviews2017/holoviews/operation/element.py", line 20, in <module>
    from ..element.chart import Histogram, Scatter
  File "/home/sefkw/code/holoviz/holoviews2017/holoviews/element/__init__.py", line 4, in <module>
    from .chart import * # noqa (API import)
  File "/home/sefkw/code/holoviz/holoviews2017/holoviews/element/chart.py", line 7, in <module>
    from .geom import Rectangles, Points, VectorField # noqa: backward compatible import
  File "/home/sefkw/code/holoviz/holoviews2017/holoviews/element/geom.py", line 6, in <module>
    from .selection import Selection2DExpr, SelectionGeomExpr
  File "/home/sefkw/code/holoviz/holoviews2017/holoviews/element/selection.py", line 12, in <module>
    from ..util.transform import dim
  File "/home/sefkw/code/holoviz/holoviews2017/holoviews/util/transform.py", line 155, in <module>
    isin = _maybe_map(np.isin)
AttributeError: module 'numpy' has no attribute 'isin'
```

`numpy.isin()` didn't appear until numpy 1.13 (yes, welcome to 5 years ago...🤣)


The requirement for `np.isin()` to exist to be able to import holoviews probably happened in https://github.com/holoviz/holoviews/pull/4044 (holoviews v1.13?).


Would you take some kind of change like this to try to support such an old numpy? Or would it be preferable to just update the declaration of lowest supported version? Or make the requirement for np.isin to be more optional? Or...?


The proposed change might take the lowest numpy down to 1.4 (but I only tried with 1.12).
