### PR TITLE
Better error message for hv.Cycle if wrong backend

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -331,8 +331,16 @@ class Cycle(param.Parameterized):
 
     def _get_values(self):
         if self.values: return self.values
-        elif self.key:
+        elif self.key and self.key in self.default_cycles:
             return list(self.default_cycles[self.key])
+        elif self.key:
+            current = Store.current_backend
+            others = " or ".join({"matplotlib", "bokeh", "plotly"} - {current})
+            raise ValueError(
+                "The key you have supplied is not available "
+                f"for the {current} backend. Try to switch to {others} "
+                "with 'hv.extension(backend)'."
+            )
         else:
             raise ValueError("Supply either a key or explicit values.")
 


### PR DESCRIPTION
Fixes #5238
https://discourse.holoviz.org/t/no-colormaps-in-hv-cycle/4048