### PR TITLE
Always return a str when using hv.Dimension.pprint_value

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -416,7 +416,7 @@ class Dimension(param.Parameterized):
                 else:
                     formatted_value = formatter % value
         else:
-            formatted_value = bytes_to_unicode(value)
+            formatted_value = str(bytes_to_unicode(value))
 
         if print_unit and self.unit is not None:
             formatted_value = formatted_value + ' ' + bytes_to_unicode(self.unit)

--- a/holoviews/tests/core/test_dimensions.py
+++ b/holoviews/tests/core/test_dimensions.py
@@ -77,6 +77,12 @@ class DimensionReprTest(ComparisonTestCase):
         dim = Dimension('test', label='Test Dimension', unit='m')
         self.assertEqual(eval(repr(dim)) == dim, True)
 
+    def test_pprint_value_boolean(self):
+        # https://github.com/holoviz/holoviews/issues/5378
+        dim = Dimension('test')
+        self.assertEqual(dim.pprint_value(True), 'True')
+        self.assertEqual(dim.pprint_value(False), 'False')
+
 
 class DimensionEqualityTest(ComparisonTestCase):
 


### PR DESCRIPTION
Fixes #5378