### PR TITLE
Add support for stepwise Area plots

### DIFF
--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -209,7 +209,7 @@ class AreaPlot(AreaMixin, ChartPlot):
 
     style_opts = ['color', 'facecolor', 'alpha', 'edgecolor', 'linewidth',
                   'hatch', 'linestyle', 'joinstyle',
-                  'fill', 'capstyle', 'interpolate']
+                  'fill', 'capstyle', 'interpolate', 'step']
 
     _nonvectorized_styles = style_opts
 


### PR DESCRIPTION
Add support for the `step` option of the matplotlib `fill_between` method.
https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.fill_between.html