### PR TITLE
Small improvements to vscode-notebook support

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -419,7 +419,7 @@ class Renderer(Exporter):
         # Handle rendering object as ipywidget
         widget = ipywidget(plot, combine_events=True)
         if hasattr(widget, '_repr_mimebundle_'):
-            return widget._repr_mimebundle()
+            return widget._repr_mimebundle_(), {}
         plaintext = repr(widget)
         if len(plaintext) > 110:
             plaintext = plaintext[:110] + '…'


### PR DESCRIPTION
VScode notebook did not interactive work with a DynamicMap. 

It still does not fully work as `pn.config.comms` needs to be set to `vscode`. I think It would be nice if the comms was set by holoviews and not dependent on Panel, but I think this is out of scope for this PR.  

With `pn.config.comms = vscode`:

https://user-images.githubusercontent.com/19758978/185586615-4372d741-aabc-43a5-9a93-b442d59b2c68.mp4



With `pn.config.comms = default`:

https://user-images.githubusercontent.com/19758978/185586673-97a323bb-8c77-4712-a0c5-b6dfe9378da7.mp4




``` python
import holoviews as hv
import pandas as pd

hv.extension('bokeh')

import panel as pn
pn.config.comms = "vscode"  # <- this is needed for it to work

# creating a dataframe with both an int and an obj dtype
df = pd.DataFrame({
    'count':    [ 0,    1,    2 ], 
    'distance': [ 3,    4,    7 ],
    'length':   [ 5,  -20,   35 ]
})

# set up a DynamicMap where the user can select the y_axis column
y_dim = hv.Dimension('y_column', values=df.columns.tolist(), default='distance')

def return_scatter(col_name):
    return hv.Scatter(df, kdims='count', vdims=[col_name])

hv.DynamicMap(return_scatter, kdims=y_dim).opts(framewise=True, axiswise=True)
```