### PR TITLE
Fixed declaration of Scatter as Selection1DExpr

### DIFF
--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -5,7 +5,7 @@ from ..core import util
 from ..core import Dimension, Dataset, Element2D, NdOverlay, Overlay
 from ..core.dimension import process_dimensions
 from .geom import Rectangles, Points, VectorField # noqa: backward compatible import
-from .selection import Selection1DExpr, Selection2DExpr
+from .selection import Selection1DExpr
 
 
 class Chart(Dataset, Element2D):
@@ -54,7 +54,7 @@ class Chart(Dataset, Element2D):
         return super(Chart, self).__getitem__(index)
 
 
-class Scatter(Selection2DExpr, Chart):
+class Scatter(Selection1DExpr, Chart):
     """
     Scatter is a Chart element representing a set of points in a 1D
     coordinate system where the key dimension maps to the points

--- a/holoviews/tests/element/test_selection.py
+++ b/holoviews/tests/element/test_selection.py
@@ -282,33 +282,33 @@ class TestSelection2DExpr(ComparisonTestCase):
     def test_scatter_selection_numeric(self):
         scatter = Scatter([3, 2, 1, 3, 4])
         expr, bbox, region = scatter._get_selection_expr_for_stream_value(bounds=(1, 0, 3, 2))
-        self.assertEqual(bbox, {'x': (1, 3), 'y': (0, 2)})
-        self.assertEqual(expr.apply(scatter), np.array([False, True, True, False, False]))
-        self.assertEqual(region, Rectangles([(1, 0, 3, 2)]) * Path([]))
+        self.assertEqual(bbox, {'x': (1, 3)})
+        self.assertEqual(expr.apply(scatter), np.array([False, True, True, True, False]))
+        self.assertEqual(region, NdOverlay({0: VSpan(1, 3)}))
 
     def test_scatter_selection_numeric_inverted(self):
         scatter = Scatter([3, 2, 1, 3, 4]).opts(invert_axes=True)
         expr, bbox, region = scatter._get_selection_expr_for_stream_value(bounds=(0, 1, 2, 3))
-        self.assertEqual(bbox, {'x': (1, 3), 'y': (0, 2)})
-        self.assertEqual(expr.apply(scatter), np.array([False, True, True, False, False]))
-        self.assertEqual(region, Rectangles([(0, 1, 2, 3)]) * Path([]))
+        self.assertEqual(bbox, {'x': (1, 3)})
+        self.assertEqual(expr.apply(scatter), np.array([False, True, True, True, False]))
+        self.assertEqual(region, NdOverlay({0: HSpan(1, 3)}))
 
     def test_scatter_selection_categorical(self):
         scatter = Scatter((['B', 'A', 'C', 'D', 'E'], [3, 2, 1, 3, 4]))
         expr, bbox, region = scatter._get_selection_expr_for_stream_value(
             bounds=(0, 1, 2, 3), x_selection=['B', 'A', 'C'], y_selection=None
         )
-        self.assertEqual(bbox, {'x': ['B', 'A', 'C'], 'y': (1, 3)})
+        self.assertEqual(bbox, {'x': ['B', 'A', 'C']})
         self.assertEqual(expr.apply(scatter), np.array([True, True, True, False, False]))
-        self.assertEqual(region, Rectangles([(0, 1, 2, 3)]) * Path([]))
+        self.assertEqual(region, NdOverlay({0: VSpan(0, 2)}))
 
     def test_scatter_selection_numeric_index_cols(self):
         scatter = Scatter([3, 2, 1, 3, 2])
         expr, bbox, region = scatter._get_selection_expr_for_stream_value(
             bounds=(1, 0, 3, 2), index_cols=['y']
         )
-        self.assertEqual(bbox, {'x': (1, 3), 'y': (0, 2)})
-        self.assertEqual(expr.apply(scatter), np.array([False, False, True, False, False]))
+        self.assertEqual(bbox, {'x': (1, 3)})
+        self.assertEqual(expr.apply(scatter), np.array([False, True, True, False, True]))
         self.assertEqual(region, None)
 
     def test_image_selection_numeric(self):

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -1123,8 +1123,9 @@ class TestExprSelectionStream(ComparisonTestCase):
     def setUp(self):
         extension("bokeh")
 
-    def test_selection_expr_stream_scatter_points(self):
-        for element_type in [Scatter, Points]:
+    def test_selection_expr_stream_2D_elements(self):
+        element_type_2D = [Points]
+        for element_type in element_type_2D:
             # Create SelectionExpr on element
             element = element_type(([1, 2, 3], [1, 5, 10]))
             expr_stream = SelectionExpr(element)
@@ -1150,8 +1151,36 @@ class TestExprSelectionStream(ComparisonTestCase):
                 {'x': (1, 3), 'y': (1, 4)}
             )
 
-    def test_selection_expr_stream_invert_axes(self):
-        for element_type in [Scatter, Points]:
+    def test_selection_expr_stream_1D_elements(self):
+        element_type_1D = [Scatter]
+        for element_type in element_type_1D:
+            # Create SelectionExpr on element
+            element = element_type(([1, 2, 3], [1, 5, 10]))
+            expr_stream = SelectionExpr(element)
+
+            # Check stream properties
+            self.assertEqual(len(expr_stream.input_streams), 1)
+            self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
+            self.assertIsNone(expr_stream.bbox)
+            self.assertIsNone(expr_stream.selection_expr)
+
+            # Simulate interactive update by triggering source stream
+            expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
+
+            # Check SelectionExpr values
+            self.assertEqual(
+                repr(expr_stream.selection_expr),
+                repr(((dim('x')>=1)&(dim('x')<=3)))
+            )
+            self.assertEqual(
+                expr_stream.bbox,
+                {'x': (1, 3)}
+            )
+
+
+    def test_selection_expr_stream_invert_axes_2D_elements(self):
+        element_type_2D = [Points]
+        for element_type in element_type_2D:
             # Create SelectionExpr on element
             element = element_type(([1, 2, 3], [1, 5, 10])).opts(invert_axes=True)
             expr_stream = SelectionExpr(element)
@@ -1177,8 +1206,35 @@ class TestExprSelectionStream(ComparisonTestCase):
                 {'y': (1, 3), 'x': (1, 4)}
             )
 
-    def test_selection_expr_stream_invert_xaxis_yaxis(self):
-        for element_type in [Scatter, Points]:
+    def test_selection_expr_stream_invert_axes_1D_elements(self):
+        element_type_1D = [Scatter]
+        for element_type in element_type_1D:
+            # Create SelectionExpr on element
+            element = element_type(([1, 2, 3], [1, 5, 10])).opts(invert_axes=True)
+            expr_stream = SelectionExpr(element)
+
+            # Check stream properties
+            self.assertEqual(len(expr_stream.input_streams), 1)
+            self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
+            self.assertIsNone(expr_stream.bbox)
+            self.assertIsNone(expr_stream.selection_expr)
+
+            # Simulate interactive update by triggering source stream
+            expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
+
+            # Check SelectionExpr values
+            self.assertEqual(
+                repr(expr_stream.selection_expr),
+                repr(((dim('x')>=1)&(dim('x')<=4)))
+            )
+            self.assertEqual(
+                expr_stream.bbox,
+                {'x': (1, 4)}
+            )
+
+    def test_selection_expr_stream_invert_xaxis_yaxis_2D_elements(self):
+        element_type_2D = [Points]
+        for element_type in element_type_2D:
 
             # Create SelectionExpr on element
             element = element_type(([1, 2, 3], [1, 5, 10])).opts(
@@ -1206,6 +1262,36 @@ class TestExprSelectionStream(ComparisonTestCase):
             self.assertEqual(
                 expr_stream.bbox,
                 {'x': (1, 3), 'y': (1, 4)}
+            )
+
+    def test_selection_expr_stream_invert_xaxis_yaxis_1D_elements(self):
+        element_type_1D = [Scatter]
+        for element_type in element_type_1D:
+
+            # Create SelectionExpr on element
+            element = element_type(([1, 2, 3], [1, 5, 10])).opts(
+                invert_xaxis=True,
+                invert_yaxis=True,
+            )
+            expr_stream = SelectionExpr(element)
+
+            # Check stream properties
+            self.assertEqual(len(expr_stream.input_streams), 1)
+            self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
+            self.assertIsNone(expr_stream.bbox)
+            self.assertIsNone(expr_stream.selection_expr)
+
+            # Simulate interactive update by triggering source stream
+            expr_stream.input_streams[0].event(bounds=(3, 4, 1, 1))
+
+            # Check SelectionExpr values
+            self.assertEqual(
+                repr(expr_stream.selection_expr),
+                repr(((dim('x')>=1)&(dim('x')<=3)))
+            )
+            self.assertEqual(
+                expr_stream.bbox,
+                {'x': (1, 3)}
             )
 
     def test_selection_expr_stream_hist(self):
@@ -1361,8 +1447,9 @@ class TestExprSelectionStream(ComparisonTestCase):
         self.assertEqual(expr_stream.bbox, None)
         self.assertEqual(len(events), 3)
 
-    def test_selection_expr_stream_dynamic_map(self):
-        for element_type in [Scatter, Points]:
+    def test_selection_expr_stream_dynamic_map_2D_elements(self):
+        element_type_2D = [Points]
+        for element_type in element_type_2D: # Scatter,
             # Create SelectionExpr on element
             dmap = Dynamic(element_type(([1, 2, 3], [1, 5, 10])))
             expr_stream = SelectionExpr(dmap)
@@ -1384,4 +1471,30 @@ class TestExprSelectionStream(ComparisonTestCase):
             self.assertEqual(
                 expr_stream.bbox,
                 {'x': (1, 3), 'y': (1, 4)}
+            )
+
+    def test_selection_expr_stream_dynamic_map_1D_elements(self):
+        element_type_1D = [Scatter]
+        for element_type in element_type_1D:
+            # Create SelectionExpr on element
+            dmap = Dynamic(element_type(([1, 2, 3], [1, 5, 10])))
+            expr_stream = SelectionExpr(dmap)
+
+            # Check stream properties
+            self.assertEqual(len(expr_stream.input_streams), 1)
+            self.assertIsInstance(expr_stream.input_streams[0], SelectionXY)
+            self.assertIsNone(expr_stream.bbox)
+            self.assertIsNone(expr_stream.selection_expr)
+
+            # Simulate interactive update by triggering source stream
+            expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
+
+            # Check SelectionExpr values
+            self.assertEqual(
+                repr(expr_stream.selection_expr),
+                repr(((dim('x')>=1)&(dim('x')<=3)))
+            )
+            self.assertEqual(
+                expr_stream.bbox,
+                {'x': (1, 3)}
             )


### PR DESCRIPTION
The semantics of chart elements means they should all be `Selection1DExpr`: `Points` is the appropriate, corresponding 2D element.