### PR TITLE
WIP: Ensure rectilinear rasters support geometry selections

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -422,6 +422,10 @@ class XArrayInterface(GridInterface):
             return data.T.flatten() if flat and not keep_index else data
         elif expanded:
             data = cls.coords(dataset, dim.name, expanded=True)
+            if keep_index:
+                da = dataset.data[dataset.vdims[0].name].copy().rename(dim.name)
+                da.data[:] = data
+                return da
             return data.T.flatten() if flat else data
         else:
             if keep_index:

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -403,7 +403,7 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
         agg = super().aggregate(dimensions, function, spreadfn, **kwargs)
         return Curve(agg) if isinstance(agg, Dataset) and len(self.vdims) == 1 else agg
 
-    def select(self, selection_specs=None, **selection):
+    def select(self, selection_expr=None, selection_specs=None, **selection):
         """
         Allows selecting data by the slices, sets and scalar values
         along a particular dimension. The indices should be supplied as
@@ -413,6 +413,8 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
         supplied, which will ensure the selection is only applied if the
         specs match the selected object.
         """
+        if selection_expr is not None:
+            return super().select(selection_expr, selection_specs, **selection)
         if selection_specs and not any(self.matches(sp) for sp in selection_specs):
             return self
 

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -73,7 +73,7 @@ def spatial_select_gridded(xvals, yvals, geometry):
         target = Image((xs, ys, np.empty(ys.shape+xs.shape)))
         poly = Polygons([geometry])
         mask = rasterize(poly, target=target, dynamic=False, aggregator='any')
-        return mask.dimension_values(2, flat=False)
+        return mask.interface.values(mask, mask.vdims[0], keep_index=True)
     else:
         mask = spatial_select_columnar(xvals.flatten(), yvals.flatten(), geometry)
         return mask.reshape(xvals.shape)


### PR DESCRIPTION
Somewhat hacky fix to ensure that:

- `Image` correctly implements dim expression selections
- Geometry selections work on rectilinear coordinates