### PR TITLE
update call to panel add_periodic_callback

### DIFF
--- a/examples/gallery/apps/bokeh/game_of_life.py
+++ b/examples/gallery/apps/bokeh/game_of_life.py
@@ -91,6 +91,6 @@ panel = pn.pane.HoloViews(plot, center=True, widget_location='right')
 
 def advance():
     counter.event(counter=counter.counter+1)
-panel.add_periodic_callback(advance, 50)
+pn.state.add_periodic_callback(advance, period=50, start=False)
 
 panel.servable('Game of Life')


### PR DESCRIPTION
fixes #5433 

`panel.add_periodic_callback(advance, 50)` is now `pn.state.add_periodic_callback(advance, period=50, start=False)`

The `start=False` does not seem necessary for this example but I think it adds clarity and is safer for people adapting the example.