### PR TITLE
Ensure pytest configuration does not fiddle with panel.state._curdoc

### DIFF
--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -14,5 +14,4 @@ def server_cleanup():
         state.kill_all_servers()
         state._indicators.clear()
         state._locations.clear()
-        state._curdoc = None
         state.cache.clear()


### PR DESCRIPTION
`panel.state._curdoc` is now a ContextVar and does not have to be unset