### PR TITLE
Return `decimate` samples in order

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -909,7 +909,8 @@ class decimate(Operation):
 
         if len(sliced) > self.p.max_samples:
             prng = np.random.RandomState(self.p.random_seed)
-            return sliced.iloc[prng.choice(len(sliced), self.p.max_samples, False)]
+            choice = prng.choice(len(sliced), self.p.max_samples, False)
+            return sliced.iloc[np.sort(choice)]
         return sliced
 
     def _process(self, element, key=None):


### PR DESCRIPTION
Closes #5451
The Area chart type does not function properly with out-of-order data. When sampling for `decimate` results, return data in the original order.