### PR TITLE
Faster hashing for arrays and pandas objects

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1,9 +1,11 @@
 import sys, warnings, operator
 import builtins as builtins   # noqa (compatibility)
+import hashlib
 import json
 import time
 import types
 import numbers
+import pickle
 import inspect
 import itertools
 import string
@@ -39,6 +41,11 @@ arraylike_types = (np.ndarray,)
 masked_types = ()
 
 anonymous_dimension_label = '_'
+
+_NP_SIZE_LARGE = 1_000_000
+_NP_SAMPLE_SIZE = 1_000_000
+_PANDAS_ROWS_LARGE = 1_000_000
+_PANDAS_SAMPLE_SIZE = 1_000_000
 
 pandas_version = LooseVersion(pd.__version__)
 try:
@@ -135,6 +142,12 @@ class Config(param.ParameterizedFunction):
 
 config = Config()
 
+
+def _int_to_bytes(i):
+    num_bytes = (i.bit_length() + 8) // 8
+    return i.to_bytes(num_bytes, "little", signed=True)
+
+
 class HashableJSON(json.JSONEncoder):
     """
     Extends JSONEncoder to generate a hashable string for as many types
@@ -164,9 +177,26 @@ class HashableJSON(json.JSONEncoder):
         if isinstance(obj, set):
             return hash(frozenset(obj))
         elif isinstance(obj, np.ndarray):
-            return obj.tolist()
+            h = hashlib.new("md5")
+            for s in obj.shape:
+                h.update(_int_to_bytes(s))
+            if obj.size >= _NP_SIZE_LARGE:
+                state = np.random.RandomState(0)
+                obj = state.choice(obj.flat, size=_NP_SAMPLE_SIZE)
+            h.update(obj.tobytes())
+            return h.hexdigest()
         if pd and isinstance(obj, (pd.Series, pd.DataFrame)):
-            return obj.to_csv(header=True).encode('utf-8')
+            if len(obj) > _PANDAS_ROWS_LARGE:
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
+            try:
+                b = b"%s" % pd.util.hash_pandas_object(obj).sum()
+            except TypeError:
+                # Use pickle if pandas cannot hash the object for example if
+                # it contains unhashable objects.
+                b = pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
+            h = hashlib.new("md5")
+            h.update(b)
+            return h.hexdigest()
         elif isinstance(obj, self.string_hashable):
             return str(obj)
         elif isinstance(obj, self.repr_hashable):
@@ -329,7 +359,7 @@ def deephash(obj):
     """
     try:
         return hash(json.dumps(obj, cls=HashableJSON, sort_keys=True))
-    except:
+    except Exception:
         return None
 
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -194,11 +194,13 @@ class HashableJSON(json.JSONEncoder):
                 # Use pickle if pandas cannot hash the object for example if
                 # it contains unhashable objects.
                 pd_values = [pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)]
-            if isinstance(obj.columns, pd.MultiIndex):
+            if isinstance(obj, pd.Series):
+                columns = [obj.name]
+            elif isinstance(obj.columns, pd.MultiIndex):
                 columns = [name for cols in obj.columns for name in cols]
             else:
                 columns = list(obj.columns)
-            all_vals = pd_values + columns + list(obj.index.names) + list(obj.columns.names)
+            all_vals = pd_values + columns + list(obj.index.names)
             h = hashlib.md5()
             for val in all_vals:
                 if not isinstance(val, bytes):

--- a/holoviews/tests/core/test_utils.py
+++ b/holoviews/tests/core/test_utils.py
@@ -73,6 +73,15 @@ class TestDeepHash(ComparisonTestCase):
         self.assertEqual(deephash(pd.DataFrame({'a':[1,2,3],'b':[4,5,6]})),
                          deephash(pd.DataFrame({'a':[1,2,3],'b':[4,5,6]})))
 
+    def test_deephash_dataframe_column_inequality(self):
+        self.assertNotEqual(deephash(pd.DataFrame({'a':[1,2,3],'b':[4,5,6]})),
+                            deephash(pd.DataFrame({'a':[1,2,3],'c':[4,5,6]})))
+
+    def test_deephash_dataframe_index_inequality(self):
+        self.assertNotEqual(deephash(pd.DataFrame({'a':[1,2,3],'b':[4,5,6]})),
+                            deephash(pd.DataFrame({'a':[1,2,3],'b':[4,5,6]},
+                                                  index=pd.Series([0, 1, 2], name='Index'))))
+
     def test_deephash_dataframe_inequality(self):
         self.assertNotEqual(deephash(pd.DataFrame({'a':[1,2,3],'b':[4,5,6]})),
                             deephash(pd.DataFrame({'a':[1,2,3],'b':[4,5,8]})))
@@ -80,6 +89,19 @@ class TestDeepHash(ComparisonTestCase):
     def test_deephash_series_equality(self):
         self.assertEqual(deephash(pd.Series([1,2,3])),
                          deephash(pd.Series([1,2,3])))
+
+    def test_deephash_series_name_inequality(self):
+        self.assertNotEqual(deephash(pd.Series([1,2,3], name='Foo')),
+                            deephash(pd.Series([1,2,3], name='Bar')))
+
+    def test_deephash_series_index_inequality(self):
+        self.assertNotEqual(deephash(pd.Series([1,2,3], index=pd.Series([0, 1, 2], name='Index'))),
+                            deephash(pd.Series([1,2,3], index=pd.Series([2, 1, 0], name='Index'))))
+
+
+    def test_deephash_series_index_name_inequality(self):
+        self.assertNotEqual(deephash(pd.Series([1,2,3], index=pd.Series([0, 1, 2], name='Foo'))),
+                            deephash(pd.Series([1,2,3], index=pd.Series([0, 1, 2], name='Bar'))))
 
     def test_deephash_series_inequality(self):
         self.assertNotEqual(deephash(pd.Series([1,2,3])),


### PR DESCRIPTION
Our hashing implementations for arrays and pandas objects were both horrifically slow. Here we use the approach also used by Panel and Streamlit which is to sample 1m values and then hashing that. The chance of collisions is still vanishingly small and for a 2500 x 2500 array this approach is about 35x faster (7 seconds -> 200 milliseconds).

Fixes https://github.com/holoviz/panel/issues/3874