### PR TITLE
CI: increase the test suite timeout to 90 min

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10']
-    timeout-minutes: 60
+    timeout-minutes: 90
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Some jobs are failing from time to time as need slightly more than 60 minutes to complete. A better solution would be to make the `develop_install` step faster, or even reuse the action Philipp make available to cache/install 🙃 But for now that will do!