### PR TITLE
Revert "Raising DataError when passing DataFrame with int columns to Dataset"

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -64,7 +64,7 @@ class PandasInterface(Interface):
             elif kdims == [] and vdims is None:
                 vdims = list(data.columns[:nvdim if nvdim else None])
 
-            if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
+            if any(not isinstance(d, str) for d in kdims+vdims):
                 deprecation_warning(
                     "Having a non-string as a column name in a DataFrame is deprecated "
                     "and will not be supported in Holoviews version 1.16."

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -13,10 +13,10 @@ from .. import util
 from .util import finite_range
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=None)
 def deprecation_warning(msg):
     "To only run the warning once"
-    warn(msg)
+    warn(msg, DeprecationWarning, stacklevel=2)
 
 
 class PandasInterface(Interface):
@@ -66,7 +66,7 @@ class PandasInterface(Interface):
 
             if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
                 deprecation_warning(
-                    "Having integer as a column name in a DataFrame is deprecated "
+                    "Having a non-string as a column name in a DataFrame is deprecated "
                     "and will not be supported in Holoviews version 1.16."
                 )
 

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 import numpy as np
 import pandas as pd
 
@@ -54,6 +56,12 @@ class PandasInterface(Interface):
                              if d not in kdims]
             elif kdims == [] and vdims is None:
                 vdims = list(data.columns[:nvdim if nvdim else None])
+
+            if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
+                warn(
+                    "Having integer as a column name in a DataFrame is deprecated "
+                    "and will not be supported in Holoviews version 1.16."
+                )
 
             # Handle reset of index if kdims reference index by name
             for kd in kdims:

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -13,7 +13,7 @@ from .. import util
 from .util import finite_range
 
 
-@lru_cache
+@lru_cache(maxsize=1)
 def deprecation_warning(msg):
     "To only run the warning once"
     warn(msg)

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from warnings import warn
 
 import numpy as np
@@ -10,6 +11,12 @@ from ..dimension import OrderedDict as cyODict
 from ..ndmapping import NdMapping, item_check, sorted_context
 from .. import util
 from .util import finite_range
+
+
+@lru_cache
+def deprecation_warning(msg):
+    "To only run the warning once"
+    warn(msg)
 
 
 class PandasInterface(Interface):
@@ -58,7 +65,7 @@ class PandasInterface(Interface):
                 vdims = list(data.columns[:nvdim if nvdim else None])
 
             if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
-                warn(
+                deprecation_warning(
                     "Having integer as a column name in a DataFrame is deprecated "
                     "and will not be supported in Holoviews version 1.16."
                 )

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -55,9 +55,6 @@ class PandasInterface(Interface):
             elif kdims == [] and vdims is None:
                 vdims = list(data.columns[:nvdim if nvdim else None])
 
-            if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
-                raise DataError("pandas DataFrame column names used as dimensions "
-                                "must be strings not integers.", cls)
             # Handle reset of index if kdims reference index by name
             for kd in kdims:
                 kd = dimension_name(kd)
@@ -67,6 +64,9 @@ class PandasInterface(Interface):
                        for name in index_names):
                     data = data.reset_index()
                     break
+            if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
+                raise DataError("pandas DataFrame column names used as dimensions "
+                                "must be strings not integers.", cls)
 
             if kdims:
                 kdim = dimension_name(kdims[0])


### PR DESCRIPTION
Reverts holoviz/holoviews#5354

As it is a breaking change. It will be reverted and added in `1.16` or `2.0` (whatever comes first). 

For now, a warning will be given when using a DataFrame with integers as column names. 