### PR TITLE
CI: pin pydata-sphinx-theme to 0.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ extras_require['doc'] = extras_require['examples'] + [
     'pscript',
     'graphviz',
     'bokeh >2.2',
-    'pydata-sphinx-theme >=0.9.0',
+    'pydata-sphinx-theme ==0.9.0',
     'sphinx-copybutton',
     'pooch',
 ]


### PR DESCRIPTION
pydata-sphinx-theme 0.10.1 doesn't support usage of `self` in a toc. Pinning it for now.