### PR TITLE
Upgrade warning and set stacklevel to first file outside holoviews

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -1,11 +1,7 @@
-import os
-import inspect
-from functools import lru_cache
-from warnings import warn
-
 import numpy as np
 import pandas as pd
 
+from ...util._exception import deprecation_warning
 from .interface import Interface, DataError
 from ..dimension import dimension_name
 from ..element import Element
@@ -13,32 +9,6 @@ from ..dimension import OrderedDict as cyODict
 from ..ndmapping import NdMapping, item_check, sorted_context
 from .. import util
 from .util import finite_range
-
-
-@lru_cache(maxsize=None)
-def deprecation_warning(msg):
-    "To only run the warning once"
-
-    # Finding the first stacklevel outside holoviews and param
-    # Inspired by: pandas.util._exceptions.find_stack_level
-    import holoviews as hv
-    import param
-
-    pkg_dir = os.path.dirname(hv.__file__)
-    test_dir = os.path.join(pkg_dir, "tests")
-    param_dir = os.path.dirname(param.__file__)
-
-    frame = inspect.currentframe()
-    stacklevel = 1
-    while frame:
-        fname = inspect.getfile(frame)
-        if (fname.startswith(pkg_dir) or fname.startswith(param_dir)) and not fname.startswith(test_dir):
-            frame = frame.f_back
-            stacklevel += 1
-        else:
-            break
-
-    warn(msg, FutureWarning, stacklevel=stacklevel)
 
 
 class PandasInterface(Interface):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -1,3 +1,5 @@
+import os
+import inspect
 from functools import lru_cache
 from warnings import warn
 
@@ -16,7 +18,25 @@ from .util import finite_range
 @lru_cache(maxsize=None)
 def deprecation_warning(msg):
     "To only run the warning once"
-    warn(msg, DeprecationWarning, stacklevel=2)
+
+    # Finding the first stacklevel outside holoviews
+    # Inspired by: pandas.util._exceptions.find_stack_level
+    import holoviews as hv
+
+    pkg_dir = os.path.dirname(hv.__file__)
+    test_dir = os.path.join(pkg_dir, "tests")
+
+    frame = inspect.currentframe()
+    stacklevel = 1
+    while frame:
+        fname = inspect.getfile(frame)
+        if fname.startswith(pkg_dir) and not fname.startswith(test_dir):
+            frame = frame.f_back
+            stacklevel += 1
+        else:
+            break
+
+    warn(msg, FutureWarning, stacklevel=stacklevel)
 
 
 class PandasInterface(Interface):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -19,18 +19,20 @@ from .util import finite_range
 def deprecation_warning(msg):
     "To only run the warning once"
 
-    # Finding the first stacklevel outside holoviews
+    # Finding the first stacklevel outside holoviews and param
     # Inspired by: pandas.util._exceptions.find_stack_level
     import holoviews as hv
+    import param
 
     pkg_dir = os.path.dirname(hv.__file__)
     test_dir = os.path.join(pkg_dir, "tests")
+    param_dir = os.path.dirname(param.__file__)
 
     frame = inspect.currentframe()
     stacklevel = 1
     while frame:
         fname = inspect.getfile(frame)
-        if fname.startswith(pkg_dir) and not fname.startswith(test_dir):
+        if (fname.startswith(pkg_dir) or fname.startswith(param_dir)) and not fname.startswith(test_dir):
             frame = frame.f_back
             stacklevel += 1
         else:

--- a/holoviews/util/_exception.py
+++ b/holoviews/util/_exception.py
@@ -5,7 +5,7 @@ from warnings import warn
 
 
 @lru_cache(maxsize=None)
-def deprecation_warning(msg):
+def deprecation_warning(msg, warning=FutureWarning):
     "To only run the warning once"
 
     # Finding the first stacklevel outside holoviews and param
@@ -27,4 +27,4 @@ def deprecation_warning(msg):
         else:
             break
 
-    warn(msg, FutureWarning, stacklevel=stacklevel)
+    warn(msg, warning, stacklevel=stacklevel)

--- a/holoviews/util/_exception.py
+++ b/holoviews/util/_exception.py
@@ -1,0 +1,30 @@
+import os
+import inspect
+from functools import lru_cache
+from warnings import warn
+
+
+@lru_cache(maxsize=None)
+def deprecation_warning(msg):
+    "To only run the warning once"
+
+    # Finding the first stacklevel outside holoviews and param
+    # Inspired by: pandas.util._exceptions.find_stack_level
+    import holoviews as hv
+    import param
+
+    pkg_dir = os.path.dirname(hv.__file__)
+    test_dir = os.path.join(pkg_dir, "tests")
+    param_dir = os.path.dirname(param.__file__)
+
+    frame = inspect.currentframe()
+    stacklevel = 1
+    while frame:
+        fname = inspect.getfile(frame)
+        if (fname.startswith(pkg_dir) or fname.startswith(param_dir)) and not fname.startswith(test_dir):
+            frame = frame.f_back
+            stacklevel += 1
+        else:
+            break
+
+    warn(msg, FutureWarning, stacklevel=stacklevel)


### PR DESCRIPTION
The warning will now emit a FutureWarning in a notebook. 

I found a way to determine the first stack level outside holoviews, hopefully making it easier to understand.

![image](https://user-images.githubusercontent.com/19758978/194288146-e1a1a913-4137-4a58-acfe-d5d30d39038e.png)
