### PR TITLE
Fix for empty opts warning and incorrect clearing semantics

### DIFF
--- a/examples/user_guide/03-Applying_Customizations.ipynb
+++ b/examples/user_guide/03-Applying_Customizations.ipynb
@@ -740,7 +740,7 @@
     "    'Curve.Sinusoid': {'style':dict(color='grey')}, \n",
     "    'Curve.Sinusoid.Squared': {'style':dict(color='black'),\n",
     "                                'plot':dict(interpolation='steps-mid')}}\n",
-    "curves.opts(full_literal_spec)"
+    "hv.opts.apply_groups(curves, full_literal_spec)"
    ]
   },
   {

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -559,6 +559,8 @@ class Opts(object):
         Returns:
             Returns the object or a clone with the options applied
         """
+        if not(args) and not(kwargs):
+            return self._obj
         if self._mode is None:
             apply_groups, _, _ = util.deprecated_opts_signature(args, kwargs)
             if apply_groups:


### PR DESCRIPTION
Simple fix for #5407.

Discussing this with @maximlt @Hoxbro, we will follow up with a PR to finally remove the public version of this format which we will merge before the next minor release.