### PR TITLE
CI: fix the tests worfklow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,7 @@ jobs:
           conda config --prepend channels bokeh/label/dev
           conda config --prepend channels pyviz/label/dev
           conda config --remove channels defaults
-          conda config --set channels-priority strict
+          conda config --set channel_priority strict
           conda create -n test-environment python=${{ matrix.python-version }} pyctdev
       - name: doit env_capture
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,9 +33,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        os: ['macos-latest']
-        python-version: ['3.7']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     timeout-minutes: 90
     defaults:
       run:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,6 @@ jobs:
     env:
       HV_REQUIREMENTS: "-o flakes -o tests -o examples_tests"
       MPLBACKEND: "Agg"
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge -c nodefaults"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,10 +67,22 @@ jobs:
           conda activate test-environment
           doit env_capture
       - name: doit develop_install
+        if: matrix.os != 'macos-latest'
         run: |
           conda activate test-environment
           conda list
           doit develop_install ${{ env.HV_REQUIREMENTS }}
+          python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
+          echo "-----"
+          git describe
+      # Temporary hacked step as on MacOS doit develop_install updated CPython leading to a pyctdev failure
+      - name: doit develop_install
+        if: matrix.os == 'macos-latest'
+        run: |
+          conda activate test-environment
+          conda list
+          doit develop_install ${{ env.HV_REQUIREMENTS }} || echo "Keep going"
+          pip install --no-deps --no-build-isolation -e .
           python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
           echo "-----"
           git describe

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,11 +57,11 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda update -n base -c defaults conda
-          conda config --prepend channels nodefaults
           conda config --prepend channels conda-forge
           conda config --prepend channels bokeh/label/dev
           conda config --prepend channels pyviz/label/dev
           conda config --remove channels defaults
+          conda config --set channels-priority strict
           conda create -n test-environment python=${{ matrix.python-version }} pyctdev
       - name: doit env_capture
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,6 @@ jobs:
         run: git fetch --prune --tags --unshallow
       - name: conda setup
         run: |
-          eval "$(conda shell.bash hook)"
           conda update -n base -c defaults conda
           conda config --prepend channels conda-forge
           conda config --prepend channels bokeh/label/dev
@@ -66,12 +65,10 @@ jobs:
           conda create -n test-environment python=${{ matrix.python-version }} pyctdev
       - name: doit env_capture
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit env_capture
       - name: doit develop_install
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda list
           doit develop_install ${{ env.HV_REQUIREMENTS }}
@@ -80,26 +77,21 @@ jobs:
           git describe
       - name: doit env_capture
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit env_capture
       - name: doit test_flakes
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit test_flakes
       - name: doit test_unit
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit test_unit
       - name: test examples
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit test_examples
       - name: codecov
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           codecov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,8 +33,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        # os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['macos-latest']
+        python-version: ['3.7']
     timeout-minutes: 90
     defaults:
       run:


### PR DESCRIPTION
It's really annoying but Python itself gets updated in `doit develop_install`, despite the channels being correctly constrained, leading to this bug we already encountered a few times now:

```
2022-10-28T17:04:57.6857340Z The following packages will be DOWNGRADED:
2022-10-28T17:04:57.6857490Z 
2022-10-28T17:04:57.6857770Z   cryptography                        38.0.2-py37hbf3704f_1 --> 38.0.2-py37h1818b49_1 None
2022-10-28T17:04:57.6858210Z   libarchive                               3.5.2-hbf7dfe4_3 --> 3.5.2-hde4784d_3 None
2022-10-28T17:04:57.6858630Z   openssl                                  3.0.5-hfd90126_2 --> 1.1.1q-hfd90126_1 None
2022-10-28T17:04:57.6859050Z   python                        3.7.12-hf3644f1_100_cpython --> 3.7.12-haf480d7_100_cpython None
2022-10-28T17:04:57.6859470Z   sigtool                                  0.1.3-h88f4db0_0 --> 0.1.3-h57ddcff_0 None
```