### PR TITLE
Support jupyterlite

### DIFF
--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -121,6 +121,8 @@ except ImportError:
 
 if '_pyodide' in sys.modules:
     from .pyodide import pyodide_extension, in_jupyterlite
+    # The notebook_extension is needed inside jupyterlite,
+    # so the override is only done if we are not inside jupyterlite.
     if not in_jupyterlite():
         extension = pyodide_extension
     del pyodide_extension, in_jupyterlite

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -120,7 +120,10 @@ except ImportError:
             raise Exception("IPython notebook not available: use hv.extension instead.")
 
 if '_pyodide' in sys.modules:
-    from .pyodide import pyodide_extension as extension # noqa (API import)
+    from .pyodide import pyodide_extension, in_jupyterlite
+    if not in_jupyterlite():
+        extension = pyodide_extension
+    del pyodide_extension, in_jupyterlite
 
 # A single holoviews.rc file may be executed if found.
 for rcfile in [os.environ.get("HOLOVIEWSRC", ''),

--- a/holoviews/pyodide.py
+++ b/holoviews/pyodide.py
@@ -74,6 +74,10 @@ def render_png(element):
 def render_svg(element):
     return render_image(element, 'svg')
 
+def in_jupyterlite():
+    import js
+    return hasattr(js, "_JUPYTERLAB")
+
 #-----------------------------------------------------------------------------
 # Public API
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #5475

The solution to the problem is to use the existing `notebook_extension` and not the `pyodide_extension` inside the jupyterlite: 

![image](https://user-images.githubusercontent.com/19758978/199037135-77acabe3-e0be-491e-bc2d-f486e4c2d779.png)

Therefore a small check is added to see if holoviews is inside jupyterlite, and depending on that, either use `notebook_extension` or `pyodide_extension`.