### PR TITLE
Use FullArgSpec for Python 3.11 compatibility

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -21,7 +21,12 @@ from .overlay import Overlay, CompositeOverlay, NdOverlay, Overlayable
 from .options import Store, StoreOptions
 from ..streams import Stream, Params, streams_list_from_dict
 
-
+try:
+    from inspect import FullArgSpec
+except ImportError:
+    # Python ≤3.10
+    from inspect import ArgSpec as FullArgSpec
+    
 
 class HoloMap(Layoutable, UniformNdMapping, Overlayable):
     """
@@ -511,7 +516,7 @@ class Callable(param.Parameterized):
     @property
     def noargs(self):
         "Returns True if the callable takes no arguments"
-        noargs = inspect.ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
+        noargs = FullArgSpec(args=[], varargs=None, keywords=None, defaults=None)
         return self.argspec == noargs
 
 
@@ -611,7 +616,7 @@ class Generator(Callable):
 
     @property
     def argspec(self):
-        return inspect.ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
+        return FullArgSpec(args=[], varargs=None, keywords=None, defaults=None)
 
     def __call__(self):
         try:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1,6 +1,5 @@
 import itertools
 import types
-import inspect
 
 from numbers import Number
 from itertools import groupby

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     # Python ≤3.10
     from inspect import ArgSpec as FullArgSpec
-    
+
 
 class HoloMap(Layoutable, UniformNdMapping, Overlayable):
     """


### PR DESCRIPTION
Currently, using generators in a DynamicMap is broken ([used for live-plots for Adaptive](https://github.com/python-adaptive/adaptive/)):
```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In [8], line 1
----> 1 runner.live_plot(update_interval=0.1)

File ~/Work/adaptive/adaptive/runner.py:677, in AsyncRunner.live_plot(self, plotter, update_interval, name, normalize)
    654 def live_plot(self, *, plotter=None, update_interval=2, name=None, normalize=True):
    655     """Live plotting of the learner's data.
    656 
    657     Parameters
   (...)
    675         The plot that automatically updates every `update_interval`.
    676     """
--> 677     return live_plot(
    678         self, plotter=plotter, update_interval=update_interval, name=name
    679     )

File ~/Work/adaptive/adaptive/notebook_integration.py:138, in live_plot(runner, plotter, update_interval, name, normalize)
    135             yield plotter(runner.learner)
    137 streams = [hv.streams.Stream.define("Next")()]
--> 138 dm = hv.DynamicMap(plot_generator(), streams=streams)
    139 dm.cache_size = 1
    141 if normalize:
    142     # XXX: change when https://github.com/pyviz/holoviews/issues/3637
    143     # is fixed.

File ~/mambaforge/envs/py311/lib/python3.11/site-packages/holoviews/core/spaces.py:795, in DynamicMap.__init__(self, callback, initial_items, streams, **params)
    791     raise TypeError(msg.format(objs = ', '.join('%r' % el for el in invalid)))
    793 super().__init__(initial_items, callback=callback, streams=valid, **params)
--> 795 if self.callback.noargs:
    796     prefix = 'DynamicMaps using generators (or callables without arguments)'
    797     if self.kdims:

File ~/mambaforge/envs/py311/lib/python3.11/site-packages/holoviews/core/spaces.py:514, in Callable.noargs(self)
    511 @property
    512 def noargs(self):
    513     "Returns True if the callable takes no arguments"
--> 514     noargs = inspect.ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
    515     return self.argspec == noargs

AttributeError: module 'inspect' has no attribute 'ArgSpec'
```