### PR TITLE
Add support to Python 3.11

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,7 +133,7 @@ jobs:
             pip install pyctdev
         - name: doit develop_install
           run: |
-            doit ecosystem=pip develop_install -o flakes -o tests -o examples_tests
+            doit ecosystem=pip develop_install -o flakes -o tests_core
         - name: doit env_capture
           run: |
             doit ecosystem=pip env_capture
@@ -143,6 +143,3 @@ jobs:
         - name: doit test_unit
           run: |
             doit ecosystem=pip test_unit
-        - name: test examples
-          run: |
-            doit ecosystem=pip test_examples

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        # python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.11']
     timeout-minutes: 90
     defaults:
       run:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -106,3 +106,42 @@ jobs:
         run: |
           conda activate test-environment
           codecov
+
+  test_pip:
+      name: Pip tests on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+      runs-on: ${{ matrix.os }}
+      strategy:
+        fail-fast: false
+        matrix:
+          os: ['ubuntu-latest']
+          python-version: ["3.11"]
+      steps:
+        - name: Checkout source
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
+        - name: Install Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v4
+          with:
+            python-version: ${{ matrix.python-version }}
+        - name: Update setuptools
+          run: |
+            pip install --upgrade setuptools
+        - name: Install pyctdev
+          run: |
+            pip install pyctdev
+        - name: doit develop_install
+          run: |
+            doit ecosystem=pip develop_install -o flakes -o tests -o examples_tests
+        - name: doit env_capture
+          run: |
+            doit ecosystem=pip env_capture
+        - name: doit test_flakes
+          run: |
+            doit ecosystem=pip test_flakes
+        - name: doit test_unit
+          run: |
+            doit ecosystem=pip test_unit
+        - name: test examples
+          run: |
+            doit ecosystem=pip test_examples

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,8 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        # python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        python-version: ['3.11']
+        python-version: ['3.7', '3.9', '3.11']
     timeout-minutes: 90
     defaults:
       run:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,89 +26,90 @@ jobs:
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: pre-commit
         uses: pre-commit/action@v2.0.3
-  test_suite:
-    name: Pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
-    needs: [pre_commit]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        # python-version: ['3.7', '3.8', '3.9', '3.10']
-        python-version: ['3.11']
-    timeout-minutes: 90
-    defaults:
-      run:
-        shell: bash -l {0}
-    env:
-      HV_REQUIREMENTS: "-o flakes -o tests -o examples_tests"
-      MPLBACKEND: "Agg"
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: "100"
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: "latest"
-      - name: Fetch unshallow
-        run: git fetch --prune --tags --unshallow
-      - name: conda setup
-        run: |
-          conda update -n base -c defaults conda
-          conda config --prepend channels conda-forge
-          conda config --prepend channels bokeh/label/dev
-          conda config --prepend channels pyviz/label/dev
-          conda config --remove channels defaults
-          conda config --set channel_priority strict
-          conda create -n test-environment python=${{ matrix.python-version }} pyctdev
-      - name: doit env_capture
-        run: |
-          conda activate test-environment
-          doit env_capture
-      - name: doit develop_install
-        if: matrix.os != 'macos-latest'
-        run: |
-          conda activate test-environment
-          conda list
-          doit develop_install ${{ env.HV_REQUIREMENTS }}
-          python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
-          echo "-----"
-          git describe
-      # Temporary hacked step as on MacOS doit develop_install updated CPython leading to a pyctdev failure
-      - name: doit develop_install
-        if: matrix.os == 'macos-latest'
-        run: |
-          conda activate test-environment
-          conda list
-          doit develop_install ${{ env.HV_REQUIREMENTS }} || echo "Keep going"
-          pip install --no-deps --no-build-isolation -e .
-          python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
-          echo "-----"
-          git describe
-      - name: doit env_capture
-        run: |
-          conda activate test-environment
-          doit env_capture
-      - name: doit test_flakes
-        run: |
-          conda activate test-environment
-          doit test_flakes
-      - name: doit test_unit
-        run: |
-          conda activate test-environment
-          doit test_unit
-      - name: test examples
-        run: |
-          conda activate test-environment
-          doit test_examples
-      - name: codecov
-        run: |
-          conda activate test-environment
-          codecov
+  # test_suite:
+  #   name: Pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
+  #   needs: [pre_commit]
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+  #       # python-version: ['3.7', '3.8', '3.9', '3.10']
+  #       python-version: ['3.11']
+  #   timeout-minutes: 90
+  #   defaults:
+  #     run:
+  #       shell: bash -l {0}
+  #   env:
+  #     HV_REQUIREMENTS: "-o flakes -o tests -o examples_tests"
+  #     MPLBACKEND: "Agg"
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: "100"
+  #     - uses: conda-incubator/setup-miniconda@v2
+  #       with:
+  #         miniconda-version: "latest"
+  #     - name: Fetch unshallow
+  #       run: git fetch --prune --tags --unshallow
+  #     - name: conda setup
+  #       run: |
+  #         conda update -n base -c defaults conda
+  #         conda config --prepend channels conda-forge
+  #         conda config --prepend channels bokeh/label/dev
+  #         conda config --prepend channels pyviz/label/dev
+  #         conda config --remove channels defaults
+  #         conda config --set channel_priority strict
+  #         conda create -n test-environment python=${{ matrix.python-version }} pyctdev
+  #     - name: doit env_capture
+  #       run: |
+  #         conda activate test-environment
+  #         doit env_capture
+  #     - name: doit develop_install
+  #       if: matrix.os != 'macos-latest'
+  #       run: |
+  #         conda activate test-environment
+  #         conda list
+  #         doit develop_install ${{ env.HV_REQUIREMENTS }}
+  #         python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
+  #         echo "-----"
+  #         git describe
+  #     # Temporary hacked step as on MacOS doit develop_install updated CPython leading to a pyctdev failure
+  #     - name: doit develop_install
+  #       if: matrix.os == 'macos-latest'
+  #       run: |
+  #         conda activate test-environment
+  #         conda list
+  #         doit develop_install ${{ env.HV_REQUIREMENTS }} || echo "Keep going"
+  #         pip install --no-deps --no-build-isolation -e .
+  #         python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
+  #         echo "-----"
+  #         git describe
+  #     - name: doit env_capture
+  #       run: |
+  #         conda activate test-environment
+  #         doit env_capture
+  #     - name: doit test_flakes
+  #       run: |
+  #         conda activate test-environment
+  #         doit test_flakes
+  #     - name: doit test_unit
+  #       run: |
+  #         conda activate test-environment
+  #         doit test_unit
+  #     - name: test examples
+  #       run: |
+  #         conda activate test-environment
+  #         doit test_examples
+  #     - name: codecov
+  #       run: |
+  #         conda activate test-environment
+  #         codecov
 
   test_pip:
       name: Pip tests on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+      needs: [pre_commit]
       runs-on: ${{ matrix.os }}
       strategy:
         fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,120 +26,83 @@ jobs:
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: pre-commit
         uses: pre-commit/action@v2.0.3
-  # test_suite:
-  #   name: Pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
-  #   needs: [pre_commit]
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-  #       # python-version: ['3.7', '3.8', '3.9', '3.10']
-  #       python-version: ['3.11']
-  #   timeout-minutes: 90
-  #   defaults:
-  #     run:
-  #       shell: bash -l {0}
-  #   env:
-  #     HV_REQUIREMENTS: "-o flakes -o tests -o examples_tests"
-  #     MPLBACKEND: "Agg"
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: "100"
-  #     - uses: conda-incubator/setup-miniconda@v2
-  #       with:
-  #         miniconda-version: "latest"
-  #     - name: Fetch unshallow
-  #       run: git fetch --prune --tags --unshallow
-  #     - name: conda setup
-  #       run: |
-  #         conda update -n base -c defaults conda
-  #         conda config --prepend channels conda-forge
-  #         conda config --prepend channels bokeh/label/dev
-  #         conda config --prepend channels pyviz/label/dev
-  #         conda config --remove channels defaults
-  #         conda config --set channel_priority strict
-  #         conda create -n test-environment python=${{ matrix.python-version }} pyctdev
-  #     - name: doit env_capture
-  #       run: |
-  #         conda activate test-environment
-  #         doit env_capture
-  #     - name: doit develop_install
-  #       if: matrix.os != 'macos-latest'
-  #       run: |
-  #         conda activate test-environment
-  #         conda list
-  #         doit develop_install ${{ env.HV_REQUIREMENTS }}
-  #         python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
-  #         echo "-----"
-  #         git describe
-  #     # Temporary hacked step as on MacOS doit develop_install updated CPython leading to a pyctdev failure
-  #     - name: doit develop_install
-  #       if: matrix.os == 'macos-latest'
-  #       run: |
-  #         conda activate test-environment
-  #         conda list
-  #         doit develop_install ${{ env.HV_REQUIREMENTS }} || echo "Keep going"
-  #         pip install --no-deps --no-build-isolation -e .
-  #         python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
-  #         echo "-----"
-  #         git describe
-  #     - name: doit env_capture
-  #       run: |
-  #         conda activate test-environment
-  #         doit env_capture
-  #     - name: doit test_flakes
-  #       run: |
-  #         conda activate test-environment
-  #         doit test_flakes
-  #     - name: doit test_unit
-  #       run: |
-  #         conda activate test-environment
-  #         doit test_unit
-  #     - name: test examples
-  #       run: |
-  #         conda activate test-environment
-  #         doit test_examples
-  #     - name: codecov
-  #       run: |
-  #         conda activate test-environment
-  #         codecov
-
-  test_pip:
-      name: Pip tests on ${{ matrix.os }} with Python ${{ matrix.python-version }}
-      needs: [pre_commit]
-      runs-on: ${{ matrix.os }}
-      strategy:
-        fail-fast: false
-        matrix:
-          os: ['ubuntu-latest']
-          python-version: ["3.11"]
-      steps:
-        - name: Checkout source
-          uses: actions/checkout@v3
-          with:
-            fetch-depth: 0
-        - name: Install Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v4
-          with:
-            python-version: ${{ matrix.python-version }}
-        - name: Update setuptools
-          run: |
-            pip install --upgrade setuptools
-        - name: Install pyctdev
-          run: |
-            pip install pyctdev
-        - name: doit develop_install
-          run: |
-            doit ecosystem=pip develop_install -o flakes -o tests_core
-        - name: doit env_capture
-          run: |
-            doit ecosystem=pip env_capture
-        - name: doit test_flakes
-          run: |
-            doit ecosystem=pip test_flakes
-        - name: doit test_unit
-          run: |
-            doit ecosystem=pip test_unit
+  test_suite:
+    name: Pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
+    needs: [pre_commit]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        # python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.11']
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      HV_REQUIREMENTS: "-o flakes -o tests -o examples_tests"
+      MPLBACKEND: "Agg"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "100"
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+      - name: Fetch unshallow
+        run: git fetch --prune --tags --unshallow
+      - name: conda setup
+        run: |
+          conda update -n base -c defaults conda
+          conda config --prepend channels conda-forge
+          conda config --prepend channels bokeh/label/dev
+          conda config --prepend channels pyviz/label/dev
+          conda config --remove channels defaults
+          conda config --set channel_priority strict
+          conda create -n test-environment python=${{ matrix.python-version }} pyctdev
+      - name: doit env_capture
+        run: |
+          conda activate test-environment
+          doit env_capture
+      - name: doit develop_install
+        if: matrix.os != 'macos-latest'
+        run: |
+          conda activate test-environment
+          conda list
+          doit develop_install ${{ env.HV_REQUIREMENTS }}
+          python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
+          echo "-----"
+          git describe
+      # Temporary hacked step as on MacOS doit develop_install updated CPython leading to a pyctdev failure
+      - name: doit develop_install
+        if: matrix.os == 'macos-latest'
+        run: |
+          conda activate test-environment
+          conda list
+          doit develop_install ${{ env.HV_REQUIREMENTS }} || echo "Keep going"
+          pip install --no-deps --no-build-isolation -e .
+          python -c "from param import version; print(version.Version.setup_version('.', 'holoviews', archive_commit='$Format:%h$'))"
+          echo "-----"
+          git describe
+      - name: doit env_capture
+        run: |
+          conda activate test-environment
+          doit env_capture
+      - name: doit test_flakes
+        run: |
+          conda activate test-environment
+          doit test_flakes
+      - name: doit test_unit
+        run: |
+          conda activate test-environment
+          doit test_unit
+      - name: test examples
+        run: |
+          conda activate test-environment
+          doit test_examples
+      - name: codecov
+        run: |
+          conda activate test-environment
+          codecov

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1,6 +1,5 @@
 import itertools
 import types
-import inspect
 
 from numbers import Number
 from itertools import groupby
@@ -511,7 +510,7 @@ class Callable(param.Parameterized):
     @property
     def noargs(self):
         "Returns True if the callable takes no arguments"
-        noargs = inspect.ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
+        noargs = util.ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
         return self.argspec == noargs
 
 
@@ -611,7 +610,7 @@ class Generator(Callable):
 
     @property
     def argspec(self):
-        return inspect.ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
+        return util.ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
 
     def __call__(self):
         try:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -13,7 +13,7 @@ import unicodedata
 import datetime as dt
 
 from collections.abc import Iterable # noqa
-from collections import defaultdict, OrderedDict # noqa (compatibility)
+from collections import defaultdict, OrderedDict, namedtuple # noqa (compatibility)
 from contextlib import contextmanager
 from packaging.version import Version as LooseVersion
 from functools import partial
@@ -41,6 +41,9 @@ arraylike_types = (np.ndarray,)
 masked_types = ()
 
 anonymous_dimension_label = '_'
+
+# Argspec was removed in Python 3.11
+ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
 
 _NP_SIZE_LARGE = 1_000_000
 _NP_SAMPLE_SIZE = 1_000_000
@@ -419,10 +422,8 @@ def argspec(callable_obj):
     else:
         raise ValueError("Cannot determine argspec for non-callable type.")
 
-    return inspect.ArgSpec(args=args,
-                           varargs=spec.varargs,
-                           keywords=get_keywords(spec),
-                           defaults=spec.defaults)
+    keywords = get_keywords(spec)
+    return ArgSpec(args=args, varargs=spec.varargs, keywords=keywords, defaults=spec.defaults)
 
 
 def validate_dynamic_argspec(callback, kdims, streams):

--- a/holoviews/tests/plotting/plotly/test_distributionplot.py
+++ b/holoviews/tests/plotting/plotly/test_distributionplot.py
@@ -1,9 +1,18 @@
+from unittest import SkipTest
+
 from holoviews.element import Distribution
 
 from .test_plot import TestPlotlyPlot
 
 
 class TestDistributionPlot(TestPlotlyPlot):
+
+    def setUp(self):
+        super().setUp()
+        try:
+            import scipy  # noqa
+        except ImportError:
+            raise SkipTest("Test requires scipy")
 
     def test_distribution_filled(self):
         dist = Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2])

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ extras_require['tests_core'] = [
     'plotly >=4.0',
     'dash >=1.16',
     'codecov',
+    'ipython >=5.4.0',
 ]
 
 # Optional tests dependencies, i.e. one should be able
@@ -55,7 +56,6 @@ extras_require['tests'] = extras_require['tests_core'] + [
     'cftime',
     'scipy',
     'selenium',
-    'ipython >=5.4.0',
 ]
 
 extras_require['tests_gpu'] = extras_require['tests'] + [

--- a/setup.py
+++ b/setup.py
@@ -49,16 +49,21 @@ extras_require['tests_core'] = [
 extras_require['tests'] = extras_require['tests_core'] + [
     'dask',
     'ibis-framework',  # Mapped to ibis-sqlite in setup.cfg for conda
-    'spatialpandas',
     'xarray >=0.10.4',
     'networkx',
-    'datashader >=0.11.1',
     'shapely',
     'ffmpeg',
     'cftime',
     'scipy',
     'selenium',
 ]
+
+# Packages not working on python 3.11 becauase of numba
+if sys.version_info < (3, 11):
+    extras_require['tests'] += [
+        'spatialpandas',
+        'datashader >=0.11.1',
+    ]
 
 extras_require['tests_gpu'] = extras_require['tests'] + [
     'cudf',
@@ -85,7 +90,6 @@ extras_require["examples"] = extras_require["recommended"] + [
     "plotly >=4.0",
     'dash >=1.16',
     "streamz >=0.5.0",
-    "datashader >=0.11.1",
     "ffmpeg",
     "cftime",
     "netcdf4",
@@ -95,6 +99,12 @@ extras_require["examples"] = extras_require["recommended"] + [
     "scikit-image",
     "pyarrow",
 ]
+
+if sys.version_info < (3, 11):
+    extras_require["examples"] += [
+        "datashader >=0.11.1",
+    ]
+
 
 extras_require["examples_tests"] = extras_require["examples"] + extras_require['tests_nb']
 

--- a/setup.py
+++ b/setup.py
@@ -187,6 +187,7 @@ setup_args.update(
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Operating System :: OS Independent",
             "Intended Audience :: Science/Research",
             "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ extras_require['tests_core'] = [
     'dash >=1.16',
     'codecov',
     'ipython >=5.4.0',
+    # Issues with comm (see https://github.com/ipython/ipykernel/issues/1026)
+    'ipykernel <6.18.0',
 ]
 
 # Optional tests dependencies, i.e. one should be able

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version             test group                  extra envs  extra commands
-envlist = {py37,py38,py39,py310}-{flakes,unit,examples,all_recommended}-{default}-{dev,pkg}
+envlist = {py37,py38,py39,py310,py311}-{flakes,unit,examples,all_recommended}-{default}-{dev,pkg}
 
 [_flakes]
 description = Flake check python


### PR DESCRIPTION
Python 3.11 removed `inspect.getargspec` that was deprecated since Python 3.0. HoloViews no longer used it, in favor of `inspect.getfullargspec`. However, HoloViews still used directly the named tuple `ArgSpec` returned by that function, that was also removed in Python 3.11 and caused the breakage. There was no warning for that removal, probably as `ArgSpect` (and the newer `FullArgSpec`) aren't part of the Python public API.