### PR TITLE
Cleanup the top __init__ module

### DIFF
--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -170,4 +170,4 @@ def help(obj, visualization=True, ansi=True, backend=None,
         pydoc.help(obj)
 
 
-del io, os, rcfile, warnings
+del os, rcfile, warnings

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -73,7 +73,7 @@ In a notebook or ipython environment the usual
 To ask the community go to https://discourse.holoviz.org/.
 To report issues go to https://github.com/holoviz/holoviews.
 """
-import io, os, sys
+import os, sys
 
 import param
 
@@ -134,7 +134,7 @@ for rcfile in [os.environ.get("HOLOVIEWSRC", ''),
                "~/.config/holoviews/holoviews.rc"]:
     filename = os.path.expanduser(rcfile)
     if os.path.isfile(filename):
-        with io.open(filename, encoding='utf8') as f:
+        with open(filename, encoding='utf8') as f:
             code = compile(f.read(), filename, 'exec')
             try:
                 exec(code)

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -75,7 +75,6 @@ To report issues go to https://github.com/holoviz/holoviews.
 """
 import io, os, sys
 
-import numpy as np # noqa (API import)
 import param
 
 __version__ = str(param.version.Version(fpath=__file__, archive_commit="$Format:%h$",
@@ -171,4 +170,4 @@ def help(obj, visualization=True, ansi=True, backend=None,
         pydoc.help(obj)
 
 
-del io, np, os, rcfile, warnings
+del io, os, rcfile, warnings


### PR DESCRIPTION
- Remove unused numpy import
- No longer import `io` to use `io.open` and instead use the builtin `open` as these two are the same in Python 3.