### PR TITLE
Fix potential race condition in the Options system

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1787,7 +1787,7 @@ class StoreOptions(object):
         """
         max_ids = []
         for backend in Store.renderers.keys():
-            store_ids = Store.custom_options(backend=backend).keys()
+            store_ids = list(Store.custom_options(backend=backend))
             max_id = max(store_ids)+1 if len(store_ids) > 0 else 0
             max_ids.append(max_id)
         # If no backends defined (e.g. plotting not imported) return zero

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1787,7 +1787,9 @@ class StoreOptions(object):
         """
         max_ids = []
         for backend in Store.renderers.keys():
-            store_ids = list(Store.custom_options(backend=backend))
+            # Ensure store_ids is immediately cast to list to avoid a
+            # race condition (#5533)
+            store_ids = list(Store.custom_options(backend=backend).keys())
             max_id = max(store_ids)+1 if len(store_ids) > 0 else 0
             max_ids.append(max_id)
         # If no backends defined (e.g. plotting not imported) return zero


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/5430
Fixes https://github.com/holoviz/holoviews/issues/5533

We think that this small change avoids a race condition in the Options system where the garbage collector cleans up a `weakref` in this line:

```python
max_id = max(store_ids)+1 if len(store_ids) > 0 else 0
```

It should not cause any other issues, because this would have been used when Python 2 was supported, at the time `.keys()` was returning a list. We may encounter this sort of issue in other places, if we don't handle weakrefs properly?