### PR TITLE
Enhance Tiles example notebook

### DIFF
--- a/examples/reference/elements/bokeh/Tiles.ipynb
+++ b/examples/reference/elements/bokeh/Tiles.ipynb
@@ -54,6 +54,13 @@
    "source": [
     "One thing to note about tile sources is that they are always defined in the [pseudo-Mercator projection](https://epsg.io/3857), which means that if you want to overlay any data on top of a tile source the values have to be expressed as eastings and northings. If you have data in another projection, e.g. latitudes and longitudes, it may make sense to use [GeoViews](http://geoviews.org/) for it to handle the projections for you.\n",
     "\n",
+    ">\n",
+    "> **Note**: \n",
+    "> \n",
+    ">   Holoviews provides functions to project longitude, latitude into Web Mercator coordinates. \n",
+    ">   See [`hv.util.transform.lon_lat_to_easting_northing(longitude, latitude)`](https://holoviews.org/reference_manual/holoviews.element.html?highlight=lon_lat_to_easting_northing#holoviews.element.Tiles.lon_lat_to_easting_northing)\n",
+    ">\n",
+    "\n",
     "Both HoloViews and GeoViews provides a number of tile sources by default, provided by CartoDB, Stamen, OpenStreetMap, Esri and Wikipedia. These can be imported from the ``holoviews.element.tiles`` module and are provided as callable functions which return a ``Tiles`` element:"
    ]
   },
@@ -70,7 +77,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The full set of predefined tile sources can be accessed on the ``holoviews.element.tiles.tile_sources`` dictionary:"
+    "The full set of predefined tile sources can be accessed on the ``holoviews.element.tiles.tile_sources`` dictionary. Some tile sources from CartoDB are no longer publicly available and marked with a deprecation warning. These are filtered below:"
    ]
   },
   {
@@ -79,7 +86,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.Layout([ts().relabel(name) for name, ts in hv.element.tiles.tile_sources.items()]).opts(\n",
+    "valid_src = {k: v for k, v in hv.element.tiles.tile_sources.items() if v.__name__ != 'deprecated_tilesource_warning'}\n",
+    "hv.Layout([ts().relabel(name) for name, ts in valid_src.items()]).opts(\n",
     "    opts.Tiles(xaxis=None, yaxis=None, width=225, height=225)).cols(4)"
    ]
   },
@@ -92,11 +100,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
- added a note to the `lon_lat_to_easting_northing()` function used for coordinate transformation from (long, lat) to web mercator
- remove deprecated tile sources when plotting so we don't have empty plots and JS errors