### PR TITLE
Remove bokeh from install instructions (Fix #5547)

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -10,7 +10,7 @@ the
 `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ scientific
 Python distributions::
 
-  conda install -c pyviz holoviews 
+  conda install -c pyviz holoviews
 
 This recommended installation includes the default `Matplotlib
 <http://matplotlib.org>`_ plotting library backend, the

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -10,7 +10,7 @@ the
 `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ scientific
 Python distributions::
 
-  conda install -c pyviz holoviews bokeh
+  conda install -c pyviz holoviews 
 
 This recommended installation includes the default `Matplotlib
 <http://matplotlib.org>`_ plotting library backend, the

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -10,7 +10,7 @@ the
 `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ scientific
 Python distributions::
 
-  conda install -c pyviz holoviews
+  conda install -c pyviz holoviews "bokeh <3"
 
 This recommended installation includes the default `Matplotlib
 <http://matplotlib.org>`_ plotting library backend, the


### PR DESCRIPTION
Very small change to fix https://github.com/holoviz/holoviews/issues/5547
Let `bokeh` get installed as a dependency of the `panel` library
