### PR TITLE
Implement support for autoranging along one axis

### DIFF
--- a/examples/user_guide/Customizing_Plots.ipynb
+++ b/examples/user_guide/Customizing_Plots.ipynb
@@ -519,9 +519,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "#### Padding\n",
     "\n",

--- a/examples/user_guide/Customizing_Plots.ipynb
+++ b/examples/user_guide/Customizing_Plots.ipynb
@@ -519,7 +519,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "#### Padding\n",
     "\n",
@@ -557,6 +559,47 @@
    "outputs": [],
    "source": [
     "curve.relabel('Explicit xlim/ylim').opts(xlim=(-10, 110), ylim=(-14, 6))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Autoranging\n",
+    "\n",
+    "With the `autorange` keyword, you can ensure the data in the viewport is automatically ranged to maximise the use of the x- or y-axis. To illustrate, here is the same `curve` autoranging on the `y-axis`: note the difference in behavior when zooming into the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "curve.relabel('Autoranging on y').opts(autorange='y')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To pin the ends of the ranges you can use the `xlim` and `ylim` options, using a value of `None` to allow autoranging to operate. Here the bottom range of the y-axis is pinned to the value of `-14`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "curve.relabel('Autoranging on y with set lower limit').opts(autorange='y', ylim=(-14,None))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Autoranging works analogously for the x-axis and also respects the padding setting."
    ]
   },
   {

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -986,9 +986,15 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             p0, p1 = self.padding, self.padding
 
 
-        lower, upper = self.ylim
-        lower = None if (lower is None) or np.isnan(lower) else lower
-        upper = None if (upper is None) or np.isnan(upper) else upper
+        if dim == 'x':
+            lower, upper = self.xlim
+            lower = None if (lower is None) or np.isnan(lower) else lower
+            upper = None if (upper is None) or np.isnan(upper) else upper
+
+        else:
+            lower, upper = self.ylim
+            lower = None if (lower is None) or np.isnan(lower) else lower
+            upper = None if (upper is None) or np.isnan(upper) else upper
 
         # Clean this up in bokeh 3.0 using View.find_one API
         self.state.js_on_event('rangesupdate', CustomJS(code=f"""

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -10,7 +10,7 @@ import bokeh.plotting
 from bokeh.core.properties import value
 from bokeh.document.events import ModelChangedEvent
 from bokeh.models import (
-    BinnedTicker, ColorBar, ColorMapper, EqHistColorMapper,
+    BinnedTicker, ColorBar, ColorMapper, CustomJS, EqHistColorMapper,
     Legend, Renderer, Title, tools,
 )
 from bokeh.models.axes import CategoricalAxis, DatetimeAxis
@@ -76,6 +76,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
     align = param.ObjectSelector(default='start', objects=['start', 'center', 'end'], doc="""
         Alignment (vertical or horizontal) of the plot in a layout.""")
+
+    autorange = param.ObjectSelector(default=None, objects=['x', 'y'], doc="""
+        Whether to auto-range along either the x- or y-axis, i.e.
+        when panning or zooming along the orthogonal axis it will
+        ensure all the data along the selected axis remains visible.""")
 
     border = param.Number(default=10, doc="""
         Minimum border around plot.""")
@@ -953,6 +958,66 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if invert: factors = factors[::-1]
             axis_range.factors = factors
 
+    def _setup_autorange(self):
+        """
+        Sets up a callback which will iterate over available data
+        renderers and auto-range along one axis.
+        """
+        if self.autorange is None:
+            return
+        dim = self.autorange
+        if dim == 'x':
+            didx = 0
+            odim = 'y'
+        else:
+            didx = 1
+            odim = 'x'
+        if not self.padding:
+            p0, p1 = 0, 0
+        elif isinstance(self.padding, tuple):
+            pad = self.padding[didx]
+            if isinstance(pad, tuple):
+                p0, p1 = pad
+            else:
+                p0, p1 = pad, pad
+        else:
+            p0, p1 = self.padding, self.padding
+        # Clean this up in bokeh 3.0 using View.find_one API
+        self.state.js_on_event('rangesupdate', CustomJS(code=f"""
+          const ref = cb_obj.origin.id
+          const find = (view) => {{
+            for (const sv of view.child_views) {{
+              if (sv.model.id == ref)
+                return sv
+              const obj = find(sv)
+              if (obj !== null)
+                return obj
+            }}
+            return null
+          }}
+          let plot_view = null;
+          for (const root of cb_obj.origin.document.roots()) {{
+            const root_view = window.Bokeh.index[root.id]
+            plot_view = find(root_view)
+            if (plot_view != null)
+              break
+          }}
+          if (plot_view == null)
+            return
+          let [vmin, vmax] = [Infinity, -Infinity] 
+          for (const dr of cb_obj.origin.data_renderers) {{
+            const rv = plot_view.renderer_view(dr)
+            const index = rv.glyph_view.index
+            const bbox = {{{odim}0: cb_obj.{odim}0, {odim}1: cb_obj.{odim}1, {dim}0: index.bbox.{dim}0, {dim}1: index.bbox.{dim}1}}
+            const {{{dim}0, {dim}1}} = index.bounds(bbox)
+            if ({dim}0 < vmin) {{ vmin = {dim}0 }}
+            if ({dim}1 > vmax) {{ vmax = {dim}1 }}
+          }}
+          const span = vmax-vmin
+          const lpad = span*{p0}
+          const upad = span*{p1}
+          cb_obj.origin.{dim}_range.setv({{start: vmin-lpad, end: vmax+upad}})
+        """))
 
     def _categorize_data(self, data, cols, dims):
         """
@@ -1397,6 +1462,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self.handles['y_range'] = plot.y_range
         self.handles['plot'] = plot
 
+        if self.autorange:
+            self._setup_autorange()
         self._init_glyphs(plot, element, ranges, source)
         if not self.overlaid:
             self._update_plot(key, plot, style_element)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -985,9 +985,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             p0, p1 = self.padding, self.padding
 
-        lower, upper = None, None
-        if self.ylim is not (np.nan, np.nan):
-            lower, upper = self.ylim
+
+        lower, upper = self.ylim
+        lower = None if (lower is None) or np.isnan(lower) else lower
+        upper = None if (upper is None) or np.isnan(upper) else upper
 
         # Clean this up in bokeh 3.0 using View.find_one API
         self.state.js_on_event('rangesupdate', CustomJS(code=f"""

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1030,10 +1030,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             }}
           }}
 
-          const use_auto_lower =  {"true" if lower is None else "false"}
-          const use_auto_upper =  {"true" if upper is None else "false"}
-          vmin = use_auto_lower ? vmin : {lower}
-          vmax = use_auto_upper ? vmax : {upper}
+          vmin = {"vmin" if lower is None else lower}
+          vmax = {"vmax" if upper is None else upper}
 
           const invert = {str(invert).lower()}
           const span = vmax-vmin

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1006,7 +1006,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
           }}
           if (plot_view == null)
             return
-          let [vmin, vmax] = [Infinity, -Infinity] 
+          let [vmin, vmax] = [Infinity, -Infinity]
           for (const dr of cb_obj.origin.data_renderers) {{
             const index = plot_view.renderer_view(dr).glyph_view.index.index
             for (let pos = 0; pos < index._boxes.length - 4; pos += 4) {{

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1008,10 +1008,15 @@ class ElementPlot(BokehPlot, GenericElementPlot):
           for (const dr of cb_obj.origin.data_renderers) {{
             const rv = plot_view.renderer_view(dr)
             const index = rv.glyph_view.index
-            const bbox = {{{odim}0: cb_obj.{odim}0, {odim}1: cb_obj.{odim}1, {dim}0: index.bbox.{dim}0, {dim}1: index.bbox.{dim}1}}
+            const bbox = {{
+              {odim}0: cb_obj.{odim}0,
+              {odim}1: cb_obj.{odim}1,
+              {dim}0: index.bbox.{dim}0,
+              {dim}1: index.bbox.{dim}1
+            }}
             const {{{dim}0, {dim}1}} = index.bounds(bbox)
-            if ({dim}0 < vmin) {{ vmin = {dim}0 }}
-            if ({dim}1 > vmax) {{ vmax = {dim}1 }}
+            vmin = Math.min(vmin, {dim}0)
+            vmax = Math.max(vmax, {dim}1)
           }}
           const span = vmax-vmin
           const lpad = span*{p0}


### PR DESCRIPTION
Took me a little while because the spatial indexing would just not behave for me but this works really nicely now.

```python
hv.Curve(np.random.randn(100000).cumsum()).opts(width=800, autorange='y')
```

![autorange1d](https://user-images.githubusercontent.com/1550771/206708748-96a5c41a-882f-4f86-9c88-ddab31214eaa.gif)

This does not work when batching is enabled for multiple curves because the index no longer stores the individual vertices in that case (i.e. each line is treated as a unit in the spatial index).