### PR TITLE
Only trigger range updates once

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -595,17 +595,14 @@ class RangeXYCallback(Callback):
     }
 
     _js_on_event = """
+    if (this._updating)
+        return
     const plot = this.origin
     const plots = plot.x_range.plots.concat(plot.y_range.plots)
-    const updated = [plot]
     for (const p of plots) {
-      if (updated.indexOf(p) >= 0 || p.tags.indexOf('ranges-updating') >= 0)
-        continue
-      p.tags.push('ranges-updating')
       const event = new this.constructor(p.x_range.start, p.x_range.end, p.y_range.start, p.y_range.end)
+      event._updating = true
       p.trigger_event(event)
-      p.tags = p.tags.filter(x => x !== 'ranges-updating')
-      updated.push(p)
     }
     """
 


### PR DESCRIPTION
Fixes #5546 
Fixes #5556

The previous implementation would update the same plot multiple times during an event. Which wasn't noticeable for a few plots but _very_ noticeable when working with many plots. 

@zieherf and @CrashLandonB, if possible, can you test the fix on your code? This can be done by pasting this at the start of your script:
``` python
hv.extension("bokeh")
hv.plotting.bokeh.callbacks.RangeXYCallback._js_on_event = """
if (this._updating)
    return
const plot = this.origin
const plots = plot.x_range.plots.concat(plot.y_range.plots)
for (const p of plots) {
    const event = new this.constructor(p.x_range.start, p.x_range.end, p.y_range.start, p.y_range.end)
    event._updating = true
    p.trigger_event(event)
}
"""