### PR TITLE
Shapely 2 support

### DIFF
--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -402,7 +402,6 @@ class MultiInterface(Interface):
             dvals = ds.interface.values(
                 ds, dimension, True, flat, compute, keep_index
             )
-            empty = len(dvals) == 0
             scalar = len(util.unique_array(dvals)) == 1 and not is_geom
             gt = ds.interface.geom_type(ds) if hasattr(ds.interface, 'geom_type') else None
 
@@ -410,7 +409,7 @@ class MultiInterface(Interface):
                 gt = geom_type
 
             if (gt in ('Polygon', 'Ring') and (not scalar or expanded) and
-                not geom_type == 'Points' and not empty):
+                not geom_type == 'Points' and len(dvals)):
                 gvals = ds.array([0, 1])
                 dvals = ensure_ring(gvals, dvals)
             if scalar and not expanded:
@@ -421,7 +420,7 @@ class MultiInterface(Interface):
             if not len(dvals):
                 continue
             values.append(dvals)
-            if (not is_points and expanded) or empty:
+            if not is_points and expanded:
                 values.append([np.NaN])
 
         if not values:

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -402,6 +402,7 @@ class MultiInterface(Interface):
             dvals = ds.interface.values(
                 ds, dimension, True, flat, compute, keep_index
             )
+            empty = len(dvals) == 0
             scalar = len(util.unique_array(dvals)) == 1 and not is_geom
             gt = ds.interface.geom_type(ds) if hasattr(ds.interface, 'geom_type') else None
 
@@ -409,7 +410,7 @@ class MultiInterface(Interface):
                 gt = geom_type
 
             if (gt in ('Polygon', 'Ring') and (not scalar or expanded) and
-                not geom_type == 'Points'):
+                not geom_type == 'Points' and not empty):
                 gvals = ds.array([0, 1])
                 dvals = ensure_ring(gvals, dvals)
             if scalar and not expanded:
@@ -420,7 +421,7 @@ class MultiInterface(Interface):
             if not len(dvals):
                 continue
             values.append(dvals)
-            if not is_points and expanded:
+            if (not is_points and expanded) or empty:
                 values.append([np.NaN])
 
         if not values:


### PR DESCRIPTION
With the new release of Shapely 2.0, a check to see if an empty geometry is needed, else this will error out:

``` python
import geoviews as gv
import geoviews.feature as gf

gv.extension("bokeh")
gf.borders
```

``` python-traceback
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
File ~/miniconda3/envs/shapely2/lib/python3.10/site-packages/IPython/core/formatters.py:972, in MimeBundleFormatter.__call__(self, obj, include, exclude)
    969     method = get_real_method(obj, self.print_method)
    971     if method is not None:
--> 972         return method(include=include, exclude=exclude)
    973     return None
    974 else:

File ~/Development/holoviz/repos/holoviews/holoviews/core/dimension.py:1293, in Dimensioned._repr_mimebundle_(self, include, exclude)
   1286 def _repr_mimebundle_(self, include=None, exclude=None):
   1287     """
   1288     Resolves the class hierarchy for the class rendering the
   1289     object using any display hooks registered on Store.display
   1290     hooks.  The output of all registered display_hooks is then
   1291     combined and returned.
   1292     """
-> 1293     return Store.render(self)

File ~/Development/holoviz/repos/holoviews/holoviews/core/options.py:1426, in Store.render(cls, obj)
   1424 data, metadata = {}, {}
   1425 for hook in hooks:
-> 1426     ret = hook(obj)
   1427     if ret is None:
   1428         continue

File ~/Development/holoviz/repos/holoviews/holoviews/ipython/display_hooks.py:277, in pprint_display(obj)
    275 if not ip.display_formatter.formatters['text/plain'].pprint:
    276     return None
--> 277 return display(obj, raw_output=True)

File ~/Development/holoviz/repos/holoviews/holoviews/ipython/display_hooks.py:247, in display(obj, raw_output, **kwargs)
    245 elif isinstance(obj, (CompositeOverlay, ViewableElement)):
    246     with option_state(obj):
--> 247         output = element_display(obj)
    248 elif isinstance(obj, (Layout, NdLayout, AdjointLayout)):
    249     with option_state(obj):

File ~/Development/holoviz/repos/holoviews/holoviews/ipython/display_hooks.py:141, in display_hook.<locals>.wrapped(element)
    139 try:
    140     max_frames = OutputSettings.options['max_frames']
--> 141     mimebundle = fn(element, max_frames=max_frames)
    142     if mimebundle is None:
    143         return {}, {}

File ~/Development/holoviz/repos/holoviews/holoviews/ipython/display_hooks.py:187, in element_display(element, max_frames)
    184 if type(element) not in Store.registry[backend]:
    185     return None
--> 187 return render(element)

File ~/Development/holoviz/repos/holoviews/holoviews/ipython/display_hooks.py:68, in render(obj, **kwargs)
     65 if renderer.fig == 'pdf':
     66     renderer = renderer.instance(fig='png')
---> 68 return renderer.components(obj, **kwargs)

File ~/Development/holoviz/repos/holoviews/holoviews/plotting/renderer.py:398, in Renderer.components(self, obj, fmt, comm, **kwargs)
    395 embed = (not (dynamic or streams or self.widget_mode == 'live') or config.embed)
    397 if embed or config.comms == 'default':
--> 398     return self._render_panel(plot, embed, comm)
    399 return self._render_ipywidget(plot)

File ~/Development/holoviz/repos/holoviews/holoviews/plotting/renderer.py:405, in Renderer._render_panel(self, plot, embed, comm)
    403 doc = Document()
    404 with config.set(embed=embed):
--> 405     model = plot.layout._render_model(doc, comm)
    406 if embed:
    407     return render_model(model, comm)

File ~/Development/holoviz/repos/panel/panel/viewable.py:507, in Renderable._render_model(self, doc, comm)
    505 if comm is None:
    506     comm = state._comm_manager.get_server_comm()
--> 507 model = self.get_root(doc, comm)
    509 if config.embed:
    510     embed_state(self, model, doc,
    511                 json=config.embed_json,
    512                 json_prefix=config.embed_json_prefix,
    513                 save_path=config.embed_save_path,
    514                 load_path=config.embed_load_path,
    515                 progress=False)

File ~/Development/holoviz/repos/panel/panel/viewable.py:558, in Renderable.get_root(self, doc, comm, preprocess)
    541 """
    542 Returns the root model and applies pre-processing hooks
    543 
   (...)
    555 Returns the bokeh model corresponding to this panel object
    556 """
    557 doc = init_doc(doc)
--> 558 root = self._get_model(doc, comm=comm)
    559 if preprocess:
    560     self._preprocess(root)

File ~/Development/holoviz/repos/panel/panel/layout/base.py:146, in Panel._get_model(self, doc, root, parent, comm)
    144 if root is None:
    145     root = model
--> 146 objects = self._get_objects(model, [], doc, root, comm)
    147 props = dict(self._init_params(), objects=objects)
    148 model.update(**self._process_param_change(props))

File ~/Development/holoviz/repos/panel/panel/layout/base.py:131, in Panel._get_objects(self, model, old_objects, doc, root, comm)
    129 else:
    130     try:
--> 131         child = pane._get_model(doc, root, model, comm)
    132     except RerenderError:
    133         return self._get_objects(model, current_objects[:i], doc, root, comm)

File ~/Development/holoviz/repos/panel/panel/pane/holoviews.py:265, in HoloViews._get_model(self, doc, root, parent, comm)
    263     plot = self.object
    264 else:
--> 265     plot = self._render(doc, comm, root)
    267 plot.pane = self
    268 backend = plot.renderer.backend

File ~/Development/holoviz/repos/panel/panel/pane/holoviews.py:342, in HoloViews._render(self, doc, comm, root)
    339     if comm:
    340         kwargs['comm'] = comm
--> 342 return renderer.get_plot(self.object, **kwargs)

File ~/Development/holoviz/repos/holoviews/holoviews/plotting/bokeh/renderer.py:70, in BokehRenderer.get_plot(self_or_cls, obj, doc, renderer, **kwargs)
     63 @bothmethod
     64 def get_plot(self_or_cls, obj, doc=None, renderer=None, **kwargs):
     65     """
     66     Given a HoloViews Viewable return a corresponding plot instance.
     67     Allows supplying a document attach the plot to, useful when
     68     combining the bokeh model with another plot.
     69     """
---> 70     plot = super().get_plot(obj, doc, renderer, **kwargs)
     71     if plot.document is None:
     72         plot.document = Document() if self_or_cls.notebook_context else curdoc()

File ~/Development/holoviz/repos/holoviews/holoviews/plotting/renderer.py:240, in Renderer.get_plot(self_or_cls, obj, doc, renderer, comm, **kwargs)
    237     defaults = [kd.default for kd in plot.dimensions]
    238     init_key = tuple(v if d is None else d for v, d in
    239                      zip(plot.keys[0], defaults))
--> 240     plot.update(init_key)
    241 else:
    242     plot = obj

File ~/Development/holoviz/repos/holoviews/holoviews/plotting/plot.py:948, in DimensionedPlot.update(self, key)
    946 def update(self, key):
    947     if len(self) == 1 and ((key == 0) or (key == self.keys[0])) and not self.drawn:
--> 948         return self.initialize_plot()
    949     item = self.__getitem__(key)
    950     self.traverse(lambda x: setattr(x, '_updated', True))

File ~/Development/holoviz/repos/geoviews/geoviews/plotting/bokeh/plot.py:111, in GeoPlot.initialize_plot(self, ranges, plot, plots, source)
    109 def initialize_plot(self, ranges=None, plot=None, plots=None, source=None):
    110     opts = {} if isinstance(self, HvOverlayPlot) else {'source': source}
--> 111     fig = super(GeoPlot, self).initialize_plot(ranges, plot, plots, **opts)
    112     if self.geographic and self.show_bounds and not self.overlaid:
    113         from . import GeoShapePlot

File ~/Development/holoviz/repos/holoviews/holoviews/plotting/bokeh/element.py:1397, in ElementPlot.initialize_plot(self, ranges, plot, plots, source)
   1394     self.handles['y_range'] = plot.y_range
   1395 self.handles['plot'] = plot
-> 1397 self._init_glyphs(plot, element, ranges, source)
   1398 if not self.overlaid:
   1399     self._update_plot(key, plot, style_element)

File ~/Development/holoviz/repos/holoviews/holoviews/plotting/bokeh/element.py:1341, in ElementPlot._init_glyphs(self, plot, element, ranges, source)
   1339 else:
   1340     style = self.style[self.cyclic_index]
-> 1341     data, mapping, style = self.get_data(element, ranges, style)
   1342     current_id = element._plot_id
   1344 with abbreviated_exception():

File ~/Development/holoviz/repos/geoviews/geoviews/plotting/bokeh/__init__.py:237, in FeaturePlot.get_data(self, element, ranges, style)
    235     el_type = Polygons
    236 polys = el_type(geoms, crs=element.crs, **util.get_param_values(element))
--> 237 return super(FeaturePlot, self).get_data(polys, ranges, style)

File ~/Development/holoviz/repos/geoviews/geoviews/plotting/bokeh/plot.py:171, in GeoPlot.get_data(self, element, ranges, style)
    169 if self._project_operation and self.geographic:
    170     element = self._project_operation(element, projection=self.projection)
--> 171 return super(GeoPlot, self).get_data(element, ranges, style)

File ~/Development/holoviz/repos/holoviews/holoviews/plotting/bokeh/path.py:243, in ContourPlot.get_data(self, element, ranges, style)
    241     xs, ys = multi_polygons_data(element)
    242 else:
--> 243     xs, ys = (list(element.dimension_values(kd, expanded=False))
    244               for kd in element.kdims)
    245 if self.invert_axes:
    246     xs, ys = ys, xs

File ~/Development/holoviz/repos/holoviews/holoviews/plotting/bokeh/path.py:243, in <genexpr>(.0)
    241     xs, ys = multi_polygons_data(element)
    242 else:
--> 243     xs, ys = (list(element.dimension_values(kd, expanded=False))
    244               for kd in element.kdims)
    245 if self.invert_axes:
    246     xs, ys = ys, xs

File ~/Development/holoviz/repos/holoviews/holoviews/core/data/__init__.py:204, in PipelineMeta.pipelined.<locals>.pipelined_fn(*args, **kwargs)
    201     inst._in_method = True
    203 try:
--> 204     result = method_fn(*args, **kwargs)
    205     if PipelineMeta.disable:
    206         return result

File ~/Development/holoviz/repos/holoviews/holoviews/core/data/__init__.py:1102, in Dataset.dimension_values(self, dimension, expanded, flat)
   1086 """Return the values along the requested dimension.
   1087 
   1088 Args:
   (...)
   1099     NumPy array of values along the requested dimension
   1100 """
   1101 dim = self.get_dimension(dimension, strict=True)
-> 1102 values = self.interface.values(self, dim, expanded, flat)
   1103 if dim.nodata is not None:
   1104     # Ensure nodata applies to boolean data in py2
   1105     values = np.where(values==dim.nodata, np.NaN, values)

File ~/Development/holoviz/repos/holoviews/holoviews/core/data/multipath.py:414, in MultiInterface.values(cls, dataset, dimension, expanded, flat, compute, keep_index)
    411 if (gt in ('Polygon', 'Ring') and (not scalar or expanded) and
    412     not geom_type == 'Points'):
    413     gvals = ds.array([0, 1])
--> 414     dvals = ensure_ring(gvals, dvals)
    415 if scalar and not expanded:
    416     dvals = dvals[:1]

File ~/Development/holoviz/repos/holoviews/holoviews/core/data/multipath.py:568, in ensure_ring(geom, values)
    566 starts = [0] + list(breaks+1)
    567 ends = list(breaks-1) + [len(geom)-1]
--> 568 zipped = zip(geom[starts], geom[ends], ends, values[starts])
    569 unpacked = tuple(zip(*[(v, i+1) for s, e, i, v in zipped
    570                  if (s!=e).any()]))
    571 if not unpacked:

IndexError: index 0 is out of bounds for axis 0 with size 0
```