### PR TITLE
Installation instructions update

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -10,7 +10,7 @@ the
 `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ scientific
 Python distributions::
 
-  conda install -c pyviz holoviews bokeh
+  conda install -c pyviz holoviews
 
 This recommended installation includes the default `Matplotlib
 <http://matplotlib.org>`_ plotting library backend, the


### PR DESCRIPTION
Supersedes #5550  (see the discussion there for more context).

Removed bokeh from the conda installation command. Another task is to move some of this content to the instructions on the holoviz site.