### PR TITLE
During lasso select, mask values using Dask-compatible method

### DIFF
--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -122,7 +122,7 @@ def spatial_select_columnar(xvals, yvals, geometry):
         mask[np.where(mask)[0]] = geom_mask
     except TypeError:
         # Dask not compatible with above assignment statement.
-        # To circumvent, create a Series, fill in geom_mask values, 
+        # To circumvent, create a Series, fill in geom_mask values,
         # and use mask() method to fill in values.
         geom_mask_expanded = pd.Series(False, index=mask.index)
         geom_mask_expanded[np.where(mask)[0]] = geom_mask

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -138,7 +138,12 @@ def spatial_select(xvals, yvals, geometry):
     if xvals.ndim > 1:
         return spatial_select_gridded(xvals, yvals, geometry)
     else:
-        return spatial_select_columnar(xvals, yvals, geometry)
+        df = xvals.to_frame(name="xvals")
+        df["yvals"] = yvals
+        def spatial_select_df(df, geometry):
+            return spatial_select_columnar(df.xvals, df.yvals, geometry)
+        return df.map_partitions(spatial_select_df, geometry)
+        # return spatial_select_columnar(xvals, yvals, geometry)
 
 def spatial_geom_select(x0vals, y0vals, x1vals, y1vals, geometry):
     try:

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -138,12 +138,7 @@ def spatial_select(xvals, yvals, geometry):
     if xvals.ndim > 1:
         return spatial_select_gridded(xvals, yvals, geometry)
     else:
-        df = xvals.to_frame(name="xvals")
-        df["yvals"] = yvals
-        def spatial_select_df(df, geometry):
-            return spatial_select_columnar(df.xvals, df.yvals, geometry)
-        return df.map_partitions(spatial_select_df, geometry)
-        # return spatial_select_columnar(xvals, yvals, geometry)
+        return spatial_select_columnar(xvals, yvals, geometry)
 
 def spatial_geom_select(x0vals, y0vals, x1vals, y1vals, geometry):
     try:

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -124,9 +124,13 @@ def spatial_select_columnar(xvals, yvals, geometry):
         # Dask not compatible with above assignment statement.
         # To circumvent, create a Series, fill in geom_mask values,
         # and use mask() method to fill in values.
+        # mask() does not preserve the dtype of the original Series,
+        # and needs to be reset after the operation.
         geom_mask_expanded = pd.Series(False, index=mask.index)
         geom_mask_expanded[np.where(mask)[0]] = geom_mask
+        meta_orig = mask._meta
         mask = mask.mask(mask, geom_mask_expanded)
+        mask._meta = meta_orig
     return mask
 
 

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -107,7 +107,9 @@ def spatial_select_columnar(xvals, yvals, geometry):
                 yvals.name = "yvals"
                 df = xvals.to_frame().join(yvals)
                 return df.map_partitions(
-                    lambda df, geometry: spatial_select_columnar(df.xvals, df.yvals, geometry), geometry
+                    lambda df, geometry: spatial_select_columnar(df.xvals, df.yvals, geometry),
+                    geometry,
+                    meta=pd.Series(dtype=bool)
                 )
             except Exception:
                 xvals = np.asarray(xvals)
@@ -130,7 +132,7 @@ def spatial_select_columnar(xvals, yvals, geometry):
             geom_mask = np.array([poly.contains(p) for p in points])
         except ImportError:
             raise ImportError("Lasso selection on tabular data requires "
-                            "either spatialpandas or shapely to be available.")
+                              "either spatialpandas or shapely to be available.")
     if isinstance(xvals, pd.Series):
         sel_mask[sel_mask.index[np.where(sel_mask)[0]]] = geom_mask
     else:

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -124,13 +124,9 @@ def spatial_select_columnar(xvals, yvals, geometry):
         # Dask not compatible with above assignment statement.
         # To circumvent, create a Series, fill in geom_mask values,
         # and use mask() method to fill in values.
-        # mask() does not preserve the dtype of the original Series,
-        # and needs to be reset after the operation.
         geom_mask_expanded = pd.Series(False, index=mask.index)
         geom_mask_expanded[np.where(mask)[0]] = geom_mask
-        meta_orig = mask._meta
         mask = mask.mask(mask, geom_mask_expanded)
-        mask._meta = meta_orig
     return mask
 
 

--- a/holoviews/tests/element/test_selection.py
+++ b/holoviews/tests/element/test_selection.py
@@ -652,4 +652,3 @@ class TestSpatialSelectColumnar:
     def test_spatial_select_columnar_meta_bool(self, geometry, dask_df, enclosed_pt_mask):
         mask = spatial_select_columnar(dask_df.x, dask_df.y, geometry)
         assert mask._meta.dtype.name == 'bool'
-


### PR DESCRIPTION
Fixes #5567.

Dask is not compatible with direct assignment when using an array of indices. This change catches the `TypeError` raised when direct assignment is attempted on a Dask Series, and reverts to using the mask() method of `dask.Series`.