### PR TITLE
Fix stacklevel start

### DIFF
--- a/holoviews/util/_exception.py
+++ b/holoviews/util/_exception.py
@@ -18,7 +18,7 @@ def deprecation_warning(msg, warning=FutureWarning):
     param_dir = os.path.dirname(param.__file__)
 
     frame = inspect.currentframe()
-    stacklevel = 1
+    stacklevel = 0
     while frame:
         fname = inspect.getfile(frame)
         if (fname.startswith(pkg_dir) or fname.startswith(param_dir)) and not fname.startswith(test_dir):


### PR DESCRIPTION
 `stacklevel` should have started with 0 and not 1.

Like the [function](https://github.com/pandas-dev/pandas/blob/cac2e8785f119369c89497647eb0e077ef12854b/pandas/util/_exceptions.py#L43) it is inspired by.