### PR TITLE
Update copyright to only contain start year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2005-2019, holoviz (https://holoviz.org)
+Copyright (c) 2005, holoviz (https://holoviz.org)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,9 +8,9 @@ param.parameterized.docstring_describe_params = False
 from nbsite.shared_conf import *
 
 # Declare information specific to this project.
-project = u'HoloViews'
-authors = u'HoloViz developers'
-copyright = u'2022 ' + authors
+project = 'HoloViews'
+authors = 'HoloViz developers'
+copyright = '2005 ' + authors
 description = 'Stop plotting your data - annotate your data and let it visualize itself.'
 
 import holoviews


### PR DESCRIPTION
It will be easier if we only include the start year in the license file. An explanation of why can be seen [here](https://hynek.me/til/copyright-years/)