### PR TITLE
Support numpy 1.24

### DIFF
--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -804,7 +804,7 @@ def to_geom_dict(eltype, data, kdims, vdims, interface=None):
 
     xname, yname = (kd.name for kd in kdims[:2])
     if isinstance(data, dict):
-        data = {k: v if isscalar(v) else np.asarray(v) for k, v in data.items()}
+        data = {k: _asarray(v) for k, v in data.items()}
         return data
     new_el = Dataset(data, kdims, vdims)
     if new_el.interface is interface:
@@ -886,6 +886,29 @@ def from_shapely(data):
         new_data['geometry'] = GeoSeries(new_data['geometry'])
         data = GeoDataFrame(new_data)
     return data
+
+
+def _asarray(v):
+    """Convert input to scaler or array
+
+    If the value is scalar it returns it immediately.
+
+    Then it tries with a normal `np.asarray(v)` if this does not work
+    it tries with `np.asarray(v, dtype=object)`.
+
+    The ValueError raised is because of an inhomogeneous shape of the input,
+    which raises an error in numpy v1.24 and above.
+
+    Reason why it is not located in holoviews.core.util is that there is a already a
+    function called `asarray`.
+
+    """
+    if isscalar(v):
+        return v
+    try:
+        return np.asarray(v)
+    except ValueError:
+        return np.asarray(v, dtype=object)
 
 
 Interface.register(SpatialPandasInterface)

--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -804,7 +804,7 @@ def to_geom_dict(eltype, data, kdims, vdims, interface=None):
 
     xname, yname = (kd.name for kd in kdims[:2])
     if isinstance(data, dict):
-        data = {k: _asarray(v) for k, v in data.items()}
+        data = {k: v if isscalar(v) else _asarray(v) for k, v in data.items()}
         return data
     new_el = Dataset(data, kdims, vdims)
     if new_el.interface is interface:
@@ -889,11 +889,9 @@ def from_shapely(data):
 
 
 def _asarray(v):
-    """Convert input to scaler or array
+    """Convert input to array
 
-    If the value is scalar it returns it immediately.
-
-    Then it tries with a normal `np.asarray(v)` if this does not work
+    First it tries with a normal `np.asarray(v)` if this does not work
     it tries with `np.asarray(v, dtype=object)`.
 
     The ValueError raised is because of an inhomogeneous shape of the input,
@@ -901,10 +899,7 @@ def _asarray(v):
 
     Reason why it is not located in holoviews.core.util is that there is a already a
     function called `asarray`.
-
     """
-    if isscalar(v):
-        return v
     try:
         return np.asarray(v)
     except ValueError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ filterwarnings = [
     "ignore:make_current is deprecated; start the event loop first:DeprecationWarning:panel.io.server",
     # 2023-01-02: Numpy 1.24 warnings
     "ignore:`.+?` is a deprecated alias for `.+?`.:DeprecationWarning:bokeh",  # https://github.com/bokeh/bokeh/pull/12690
-    "ignore:`.+?` is a deprecated alias for `.+?`.:DeprecationWarning:cupy",  # https://github.com/cupy/cupy/issues/7211
+    "ignore:`.+?` is a deprecated alias for `.+?`.:DeprecationWarning:cupy",  # https://github.com/cupy/cupy/pull/7245
     "ignore:`.+?` is a deprecated alias for `.+?`.:DeprecationWarning:plotly.express.imshow_utils",  # https://github.com/plotly/plotly.py/pull/3997
     "ignore:`.+?` is a deprecated alias for `.+?`.:DeprecationWarning:skimage.util.dtype",  # https://github.com/scikit-image/scikit-image/pull/6637
 ]


### PR DESCRIPTION
With the release of numpy 1.24, the warning for inhomogeneous shape is now a ValueError.

This fix will make Geoviews tests pass (tested locally) in combination with the changes made in https://github.com/holoviz/geoviews/pull/608.


![np_123](https://user-images.githubusercontent.com/19758978/210242810-032eeed7-16ec-45ee-aa6b-cd65621c37b7.png)

![np_124](https://user-images.githubusercontent.com/19758978/210242816-b89a25f7-61c3-4851-b258-228060926cea.png)
