### PR TITLE
Extend startup timeout for example tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,13 +76,15 @@ jobs:
         if: matrix.python-version != '3.11'
         run: |
           conda activate test-environment
+          echo "c.ExecutePreprocessor.startup_timeout=120" >> ~/.jupyter/jupyter_nbconvert_config.py
           doit test_examples
       - name: test examples - python 3.11
         # Should be removed when numba support python 3.11
         if: matrix.python-version == '3.11'
         run: |
           conda activate test-environment
-          pytest -n auto --dist loadscope --nbval-lax examples/reference/elements --force-flaky
+          echo "c.ExecutePreprocessor.startup_timeout=120" >> ~/.jupyter/jupyter_nbconvert_config.py
+          pytest -n auto --dist loadscope --nbval-lax examples/reference/elements
       - name: codecov
         run: |
           conda activate test-environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,6 +76,7 @@ jobs:
         if: matrix.python-version != '3.11'
         run: |
           conda activate test-environment
+          mkdir -p ~/.jupyter/
           echo "c.ExecutePreprocessor.startup_timeout=120" >> ~/.jupyter/jupyter_nbconvert_config.py
           doit test_examples
       - name: test examples - python 3.11
@@ -83,6 +84,7 @@ jobs:
         if: matrix.python-version == '3.11'
         run: |
           conda activate test-environment
+          mkdir -p ~/.jupyter/
           echo "c.ExecutePreprocessor.startup_timeout=120" >> ~/.jupyter/jupyter_nbconvert_config.py
           pytest -n auto --dist loadscope --nbval-lax examples/reference/elements
       - name: codecov

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ extras_require['tests_core'] = [
     'pytest',
     'pytest-cov',
     'pytest-xdist',
-    'flaky',
     'matplotlib >=3',
     'nbconvert',
     'bokeh',

--- a/tox.ini
+++ b/tox.ini
@@ -28,11 +28,10 @@ commands = pytest holoviews --cov=./holoviews -vv
 [_examples]
 description = Test that default examples run
 deps = .[examples_tests]
-commands = pytest -n auto --dist loadscope --nbval-lax examples -k "not Plotting_with_Bokeh and not 17-Dashboards and not Plots_and_Renderers" --force-flaky
+commands = pytest -n auto --dist loadscope --nbval-lax examples -k "not Plotting_with_Bokeh and not 17-Dashboards and not Plots_and_Renderers"
 # 'Plotting_with_Bokeh' needs selenium, phantomjs, firefox and geckodriver to save a png picture.
 # '17-Dashboards' can give a timeout error.
 # 'Plots_and_Renderers' can give file not found here.
-# --force-flaky is because of "RuntimeError: Kernel died before replying to kernel_info"
 
 [_all_recommended]
 description = Run all recommended tests


### PR DESCRIPTION
It seems even with flaky the example test can still be flaky. 

https://github.com/holoviz/holoviews/actions/runs/3822961042/jobs/6503633987

Trying another approach. 