### PR TITLE
Fix hv.Empty not working in AdjointLayout plot

### DIFF
--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -62,8 +62,8 @@ class Empty(Dimensioned, Composable):
 
     group = param.String(default='Empty')
 
-    def __init__(self):
-        super().__init__(None)
+    def __init__(self, **params) -> None:
+        super().__init__(None, **params)
 
 
 

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -62,7 +62,7 @@ class Empty(Dimensioned, Composable):
 
     group = param.String(default='Empty')
 
-    def __init__(self, **params) -> None:
+    def __init__(self, **params):
         super().__init__(None, **params)
 
 

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -178,7 +178,7 @@ def element_display(element, max_frames):
     info = process_object(element)
     if info:
         display(HTML(info))
-        return
+        return None
 
     backend = Store.current_backend
     if type(element) not in Store.registry[backend]:

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -15,7 +15,7 @@ from ..core.options import (Store, StoreOptions, SkipRendering,
                             AbbreviatedException)
 from ..core import (
     ViewableElement, HoloMap, AdjointLayout, NdLayout, GridSpace,
-    Layout, CompositeOverlay, DynamicMap, Dimensioned
+    Layout, CompositeOverlay, DynamicMap, Dimensioned, Empty
 )
 from ..core.traversal import unique_dimkeys
 from ..core.io import FileArchive
@@ -253,6 +253,8 @@ def display(obj, raw_output=False, **kwargs):
             output = map_display(obj)
     elif isinstance(obj, Plot):
         output = render(obj)
+    elif isinstance(obj, Empty):
+        output = ({}, {})
     else:
         output = obj
         raw = kwargs.pop('raw', False)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -138,7 +138,7 @@ class Plot(param.Parameterized):
             for plot in self.subplots.values():
                 if plot is not None:
                     plot.pane = pane
-                if not plot.root:
+                if plot is None or not plot.root:
                     continue
                 for cb in getattr(plot, 'callbacks', []):
                     if hasattr(pane, '_on_error') and getattr(cb, 'comm', None):

--- a/holoviews/tests/plotting/bokeh/test_layoutplot.py
+++ b/holoviews/tests/plotting/bokeh/test_layoutplot.py
@@ -228,6 +228,14 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(s1.height, 0)
         self.assertEqual(f1.plot_height, f2.plot_height)
 
+    def test_empty_adjoint_plot_with_renderer(self):
+        # https://github.com/holoviz/holoviews/pull/5584
+        scatter = Scatter(range(10))
+        adjoin_layout_plot = scatter << Empty() << scatter.hist(adjoin=False)
+
+        # To render the plot
+        bokeh_renderer(adjoin_layout_plot)
+
     def test_layout_plot_with_adjoints(self):
         layout = (Curve([]) + Curve([]).hist()).cols(1)
         plot = bokeh_renderer.get_plot(layout)


### PR DESCRIPTION
Fixes #5559

Small regression, which made the following code error. 

``` python
import holoviews as hv
import numpy as np

hv.extension("bokeh")

scatter = hv.Scatter(np.random.rand(100, 2))
scatter << hv.Empty() << scatter.hist(adjoin=False)

```
![image](https://user-images.githubusercontent.com/19758978/211054492-5794a5cd-7d1d-47fd-a0df-806d661bd656.png)
