### PR TITLE
Enable rendering colorbars on bokeh GraphPlots

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1602,7 +1602,7 @@ class CompositeElementPlot(ElementPlot):
             for k, v in list(self.handles.items()):
                 if not k.endswith('color_mapper'):
                     continue
-                self._draw_colorbar(plot, v, k[:-12])
+                self._draw_colorbar(plot, v, k.replace('color_mapper', ''))
 
 
     def _process_properties(self, key, properties, mapping):
@@ -2011,7 +2011,7 @@ class ColorbarPlot(ElementPlot):
             for k, v in list(self.handles.items()):
                 if not k.endswith('color_mapper'):
                     continue
-                self._draw_colorbar(plot, v, k[:-12])
+                self._draw_colorbar(plot, v, k.replace('color_mapper', ''))
         return ret
 
 

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -371,6 +371,11 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
             if self.handles['hover'].renderers == 'auto':
                 self.handles['hover'].renderers = []
             self.handles['hover'].renderers.append(renderer)
+        if self.colorbar:
+            for k, v in list(self.handles.items()):
+                if not k.endswith('color_mapper'):
+                    continue
+                self._draw_colorbar(plot, v, k.replace('color_mapper', ''))
 
 
 

--- a/holoviews/tests/plotting/bokeh/test_graphplot.py
+++ b/holoviews/tests/plotting/bokeh/test_graphplot.py
@@ -187,6 +187,15 @@ class TestBokehGraphPlot(TestBokehPlot):
         self.assertEqual(glyph.line_color, 'black')
         self.assertEqual(cds.data['node_color'], np.array([0.5, 1.5, 2.5]))
 
+    def test_graph_op_node_color_colorbar(self):
+        edges = [(0, 1), (0, 2)]
+        nodes = Nodes([(0, 0, 0, 0.5), (0, 1, 1, 1.5), (1, 1, 2, 2.5)],
+                      vdims='color')
+        graph = Graph((edges, nodes)).opts(node_color='color', colorbar=True)
+        plot = bokeh_renderer.get_plot(graph)
+        assert 'node_color_colorbar' in plot.handles
+        assert plot.handles['node_color_colorbar'].color_mapper is plot.handles['node_color_color_mapper']
+
     def test_graph_op_node_color_categorical(self):
         edges = [(0, 1), (0, 2)]
         nodes = Nodes([(0, 0, 0, 'A'), (0, 1, 1, 'B'), (1, 1, 2, 'C')],
@@ -250,6 +259,13 @@ class TestBokehGraphPlot(TestBokehPlot):
         cmapper = plot.handles['edge_color_color_mapper']
         self.assertEqual(glyph.line_color, {'field': 'edge_color', 'transform': cmapper})
         self.assertEqual(cds.data['edge_color'], np.array([2, 0.5, 3]))
+
+    def test_graph_op_edge_color_colorbar(self):
+        edges = [(0, 1, 2), (0, 2, 0.5), (1, 3, 3)]
+        graph = Graph(edges, vdims='color').opts(edge_color='color', colorbar=True)
+        plot = bokeh_renderer.get_plot(graph)
+        assert 'edge_color_colorbar' in plot.handles
+        assert plot.handles['edge_color_colorbar'].color_mapper is plot.handles['edge_color_color_mapper']
 
     def test_graph_op_edge_color_categorical(self):
         edges = [(0, 1, 'C'), (0, 2, 'B'), (1, 3, 'A')]


### PR DESCRIPTION
Seeming oversight that Graph plots were not able to render colorbars. Fixes user issue: https://discourse.holoviz.org/t/show-color-map-or-edge-labels-in-hvnx-draw/4808

```python
G = nx.Graph()

G.add_edge('a', 'b', weight=0.6)
G.add_edge('a', 'c', weight=0.2)
G.add_edge('c', 'd', weight=0.1)
G.add_edge('c', 'e', weight=0.7)
G.add_edge('c', 'f', weight=0.9)
G.add_edge('a', 'd', weight=0.3)

G.add_node('a', size=20)
G.add_node('b', size=10)
G.add_node('c', size=12)
G.add_node('d', size=5)
G.add_node('e', size=8)
G.add_node('f', size=3)

pos = nx.spring_layout(G)  # positions for all nodes

hvnx.draw(G, pos, edge_color='weight', edge_cmap='viridis',
          edge_width=hv.dim('weight')*10, node_size=hv.dim('size')*20, colorbar=True)
```

<img width="405" alt="Screen Shot 2023-01-08 at 12 51 45" src="https://user-images.githubusercontent.com/1550771/211194582-d4ec3e02-f1c2-4be9-95a8-0aff866943c5.png">
