### PR TITLE
Add deserialization of non-deserialized base64 data in `CDSCallback._process_msg`

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import time
 
 from collections import defaultdict, OrderedDict
@@ -924,6 +925,15 @@ class CDSCallback(Callback):
                 values = new_values
             elif any(isinstance(v, (int, float)) for v in values):
                 values = [np.nan if v is None else v for v in values]
+            elif isinstance(values, list) and len(values) == 4 and isinstance(values[3], list):
+                # Account for issue seen in https://github.com/holoviz/geoviews/issues/584
+                # This could be fixed in Bokeh 3.0, but has not been tested.
+                # Example:
+                # ['pm9vF9dSY8EAAADgPFNjwQAAAMAmU2PBAAAAAMtSY8E=','float64', 'little', [4]]
+                buffer = base64.decodebytes(values[0].encode())
+                byteorders = {"little": "<", "big": ">"}
+                dtype = np.dtype(values[1]).newbyteorder(byteorders[values[2]])
+                values = np.frombuffer(buffer, dtype)
             msg['data'][col] = values
         return self._transform(msg)
 

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -21,7 +21,7 @@ from bokeh.events import Tap
 from bokeh.io.doc import set_curdoc
 from bokeh.models import Range1d, Plot, ColumnDataSource, Selection, PolyEditTool
 from holoviews.plotting.bokeh.callbacks import (
-    Callback, PointDrawCallback, PolyDrawCallback, PolyEditCallback,
+    Callback, CDSCallback, PointDrawCallback, PolyDrawCallback, PolyEditCallback,
     BoxEditCallback, PointerXCallback, TapCallback
 )
 from holoviews.plotting.bokeh.renderer import BokehRenderer
@@ -435,3 +435,15 @@ class TestServerCallbacks(CallbackTestCase):
         ))
         stream.event(x_range=(0, 3))
         self.assertEqual(stream.x_range, (0, 3))
+
+
+def test_msg_with_base64_array():
+    # Account for issue seen in https://github.com/holoviz/geoviews/issues/584
+    data = np.array([10.0, 20.0, 30.0, 40.0])
+
+    data_before = ["AAAAAAAAJEAAAAAAAAA0QAAAAAAAAD5AAAAAAAAAREA=", "float64", "little", [4]]
+    msg_before = {"data": {"x": data_before}}
+    msg_after = CDSCallback(None, None, None)._process_msg(msg_before)
+    data_after = msg_after["data"]["x"]
+
+    assert np.equal(data, data_after).all()


### PR DESCRIPTION
Fixes https://github.com/holoviz/geoviews/issues/584

The data in the `msg` `CDSCallback._process_msg` received had not been deserialized in some cases. This PR adds a deserialization step.

Values for byte-ordering were found [here](https://github.com/bokeh/bokeh/blob/7f0ebed4702e719485c6eafe857307f195bffa87/src/bokeh/core/serialization.py#L145).

