### PR TITLE
Add changelog for v1.15.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,16 @@ Enhancements:
 - Make lasso select mask values using a Dask-compatible method ([#5568](https://github.com/holoviz/holoviews/pull/5568))
 - Make plotly legend group unique ([#5570](https://github.com/holoviz/holoviews/pull/5570))
 - Set pan and wheel_zoom as the default Bokeh active tools ([#5480](https://github.com/holoviz/holoviews/pull/5480))
-- Enable rendering colorbars on bokeh GraphPlots ([#5585](https://github.com/holoviz/holoviews/pull/5585))
-- Add Plotly Scatter3d documentation and fix colorbar title ([#5418](https://github.com/holoviz/holoviews/pull/5418))
+- Enable rendering colorbars on bokeh `GraphPlot`s ([#5585](https://github.com/holoviz/holoviews/pull/5585))
+- Add Plotly `Scatter3d` documentation and fix colorbar title ([#5418](https://github.com/holoviz/holoviews/pull/5418))
 
 Bug fixes:
 - Only trigger range-update once in callbacks ([#5558](https://github.com/holoviz/holoviews/pull/5558))
 - Ensure dynamically created subplots can be updated ([#5555](https://github.com/holoviz/holoviews/pull/5555))
 - Fix start of stack-level in deprecations ([#5569](https://github.com/holoviz/holoviews/pull/5569))
 - When sorting colormap records, replace None with an empty string ([#5539](https://github.com/holoviz/holoviews/pull/5539))
-- Add deserialization of non-deserialized base64 data ([#5587](https://github.com/holoviz/holoviews/pull/5587))
-- Fix hv.Empty not working in AdjointLayout plot ([#5584](https://github.com/holoviz/holoviews/pull/5584))
+- Fix annotator in Geoviews by adding deserialization of non-deserialized base64 data ([#5587](https://github.com/holoviz/holoviews/pull/5587))
+- Fix `hv.Empty` not working in `AdjointLayout` plot ([#5584](https://github.com/holoviz/holoviews/pull/5584))
 - Check for categorical data to histogram ([#5540](https://github.com/holoviz/holoviews/pull/5540))
 - Fix `clim_percentile` ([#5495](https://github.com/holoviz/holoviews/pull/5495))
 
@@ -30,14 +30,14 @@ Compatibility:
 
 Documentation:
 - Installation instructions update ([#5562](https://github.com/holoviz/holoviews/pull/5562))
-- use OSM for reference tile source ([#5536](https://github.com/holoviz/holoviews/pull/5536))
+- Use OSM for reference tile source in notebook documentation ([#5536](https://github.com/holoviz/holoviews/pull/5536))
 - Enhance Tiles example notebook ([#5563](https://github.com/holoviz/holoviews/pull/5563))
 
 Maintenance:
 - Various fixes and general maintenance of the CI ([#5384](https://github.com/holoviz/holoviews/pull/5384), [#5573](https://github.com/holoviz/holoviews/pull/5573), [#5576](https://github.com/holoviz/holoviews/pull/5576), [#5582](https://github.com/holoviz/holoviews/pull/5582))
-- Maintenance of the codebase ([#5509](https://github.com/holoviz/holoviews/pull/5509), [#5577](https://github.com/holoviz/holoviews/pull/5577))
-- master to main ([#5579](https://github.com/holoviz/holoviews/pull/5579))
-- Update binder ([#5583](https://github.com/holoviz/holoviews/pull/5583))
+- Updated codebase to modern Python conventions ([#5509](https://github.com/holoviz/holoviews/pull/5509), [#5577](https://github.com/holoviz/holoviews/pull/5577))
+- Renamed `master` branch to `main` ([#5579](https://github.com/holoviz/holoviews/pull/5579))
+- Update binder link and dependency pinning ([#5583](https://github.com/holoviz/holoviews/pull/5583))
 - Update copyright to only contain start year ([#5580](https://github.com/holoviz/holoviews/pull/5580))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,45 @@
+Version 1.15.4
+==============
+**January 12, 2023**
+
+This release contains a small number of enhancements and important bug fixes.
+Many thanks to our new contributors @mmorys, @jj-github-jj, and @sandhujasmine, but also our returning contributions @droumis, @jlstevens, @MarcSkovMadsen, @maximlt, @philippjfr, @stanwest, and @Hoxbro.
+
+
+Enhancements:
+- Make lasso select mask values using a Dask-compatible method ([#5568](https://github.com/holoviz/holoviews/pull/5568))
+- Make plotly legend group unique ([#5570](https://github.com/holoviz/holoviews/pull/5570))
+- Set pan and wheel_zoom as the default Bokeh active tools ([#5480](https://github.com/holoviz/holoviews/pull/5480))
+- Enable rendering colorbars on bokeh GraphPlots ([#5585](https://github.com/holoviz/holoviews/pull/5585))
+
+Bug fixes:
+- Only trigger range-update once in callbacks ([#5558](https://github.com/holoviz/holoviews/pull/5558))
+- Ensure dynamically created subplots can be updated ([#5555](https://github.com/holoviz/holoviews/pull/5555))
+- Fix start of stack-level in deprecations ([#5569](https://github.com/holoviz/holoviews/pull/5569))
+- When sorting colormap records, replace None with an empty string ([#5539](https://github.com/holoviz/holoviews/pull/5539))
+- Add deserialization of non-deserialized base64 data ([#5587](https://github.com/holoviz/holoviews/pull/5587))
+- Fix hv.Empty not working in AdjointLayout plot ([#5584](https://github.com/holoviz/holoviews/pull/5584))
+- Check for categorical data to histogram ([#5540](https://github.com/holoviz/holoviews/pull/5540))
+- Fix `clim_percentile` ([#5495](https://github.com/holoviz/holoviews/pull/5495))
+
+Compatibility:
+- Compatibility with Shapely 2.0 ([#5561](https://github.com/holoviz/holoviews/pull/5561))
+- Compatibility with Numpy 1.24 ([#5581](https://github.com/holoviz/holoviews/pull/5581))
+- Compatibility with Ibis 4.0 ([#5588](https://github.com/holoviz/holoviews/pull/5588))
+
+Documentation:
+- Installation instructions update ([#5562](https://github.com/holoviz/holoviews/pull/5562))
+- use OSM for reference tile source ([#5536](https://github.com/holoviz/holoviews/pull/5536))
+- Enhance Tiles example notebook ([#5563](https://github.com/holoviz/holoviews/pull/5563))
+
+Maintenance:
+- Various fixes and general maintenance of the CI ([#5384](https://github.com/holoviz/holoviews/pull/5384), [#5573](https://github.com/holoviz/holoviews/pull/5573), [#5576](https://github.com/holoviz/holoviews/pull/5576), [#5582](https://github.com/holoviz/holoviews/pull/5582))
+- Maintenance of the codebase ([#5509](https://github.com/holoviz/holoviews/pull/5509), [#5577](https://github.com/holoviz/holoviews/pull/5577))
+- master to main ([#5579](https://github.com/holoviz/holoviews/pull/5579))
+- Update binder ([#5583](https://github.com/holoviz/holoviews/pull/5583))
+- Update copyright to only contain start year ([#5580](https://github.com/holoviz/holoviews/pull/5580))
+
+
 Version 1.15.3
 ==============
 **December 6, 2022**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version 1.15.4
 **January 12, 2023**
 
 This release contains a small number of enhancements and important bug fixes.
-Many thanks to our new contributors @mmorys, @jj-github-jj, and @sandhujasmine, but also our returning contributions @droumis, @jlstevens, @MarcSkovMadsen, @maximlt, @philippjfr, @stanwest, and @Hoxbro.
+Many thanks to our new contributors @mmorys, @jj-github-jj, and @sandhujasmine, but also our returning contributors @droumis, @jlstevens, @MarcSkovMadsen, @maximlt, @philippjfr, @stanwest, and @Hoxbro.
 
 
 Enhancements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Many thanks to our new contributors @mmorys, @jj-github-jj, and @sandhujasmine, 
 
 
 Enhancements:
+
 - Make lasso select mask values using a Dask-compatible method ([#5568](https://github.com/holoviz/holoviews/pull/5568))
 - Make plotly legend group unique ([#5570](https://github.com/holoviz/holoviews/pull/5570))
 - Set pan and wheel_zoom as the default Bokeh active tools ([#5480](https://github.com/holoviz/holoviews/pull/5480))
@@ -14,6 +15,7 @@ Enhancements:
 - Add Plotly `Scatter3d` documentation and fix colorbar title ([#5418](https://github.com/holoviz/holoviews/pull/5418))
 
 Bug fixes:
+
 - Only trigger range-update once in callbacks ([#5558](https://github.com/holoviz/holoviews/pull/5558))
 - Ensure dynamically created subplots can be updated ([#5555](https://github.com/holoviz/holoviews/pull/5555))
 - Fix start of stack-level in deprecations ([#5569](https://github.com/holoviz/holoviews/pull/5569))
@@ -24,16 +26,19 @@ Bug fixes:
 - Fix `clim_percentile` ([#5495](https://github.com/holoviz/holoviews/pull/5495))
 
 Compatibility:
+
 - Compatibility with Shapely 2.0 ([#5561](https://github.com/holoviz/holoviews/pull/5561))
 - Compatibility with Numpy 1.24 ([#5581](https://github.com/holoviz/holoviews/pull/5581))
 - Compatibility with Ibis 4.0 ([#5588](https://github.com/holoviz/holoviews/pull/5588))
 
 Documentation:
+
 - Installation instructions update ([#5562](https://github.com/holoviz/holoviews/pull/5562))
 - Use OSM for reference tile source in notebook documentation ([#5536](https://github.com/holoviz/holoviews/pull/5536))
 - Enhance Tiles example notebook ([#5563](https://github.com/holoviz/holoviews/pull/5563))
 
 Maintenance:
+
 - Various fixes and general maintenance of the CI ([#5384](https://github.com/holoviz/holoviews/pull/5384), [#5573](https://github.com/holoviz/holoviews/pull/5573), [#5576](https://github.com/holoviz/holoviews/pull/5576), [#5582](https://github.com/holoviz/holoviews/pull/5582))
 - Updated codebase to modern Python conventions ([#5509](https://github.com/holoviz/holoviews/pull/5509), [#5577](https://github.com/holoviz/holoviews/pull/5577))
 - Renamed `master` branch to `main` ([#5579](https://github.com/holoviz/holoviews/pull/5579))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Version 1.15.4
 ==============
-**January 12, 2023**
+**January 16, 2023**
 
 This release contains a small number of enhancements and important bug fixes.
 Many thanks to our new contributors @mmorys, @jj-github-jj, and @sandhujasmine, but also our returning contributors @droumis, @jlstevens, @MarcSkovMadsen, @maximlt, @philippjfr, @stanwest, and @Hoxbro.
@@ -11,6 +11,7 @@ Enhancements:
 - Make plotly legend group unique ([#5570](https://github.com/holoviz/holoviews/pull/5570))
 - Set pan and wheel_zoom as the default Bokeh active tools ([#5480](https://github.com/holoviz/holoviews/pull/5480))
 - Enable rendering colorbars on bokeh GraphPlots ([#5585](https://github.com/holoviz/holoviews/pull/5585))
+- Add Plotly Scatter3d documentation and fix colorbar title ([#5418](https://github.com/holoviz/holoviews/pull/5418))
 
 Bug fixes:
 - Only trigger range-update once in callbacks ([#5558](https://github.com/holoviz/holoviews/pull/5558))

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -4,6 +4,85 @@ Releases
 Version 1.15
 ~~~~~~~~~~~~
 
+Version 1.15.4
+**************
+
+**January 16, 2023**
+
+This release contains a small number of enhancements and important bug
+fixes. Many thanks to our new contributors @mmorys, @jj-github-jj, and
+@sandhujasmine, but also our returning contributors @droumis,
+@jlstevens, @MarcSkovMadsen, @maximlt, @philippjfr, @stanwest, and
+@Hoxbro.
+
+Enhancements:
+
+-  Make lasso select mask values using a Dask-compatible method
+   (`#5568 <https://github.com/holoviz/holoviews/pull/5568>`__)
+-  Make plotly legend group unique
+   (`#5570 <https://github.com/holoviz/holoviews/pull/5570>`__)
+-  Set pan and wheel_zoom as the default Bokeh active tools
+   (`#5480 <https://github.com/holoviz/holoviews/pull/5480>`__)
+-  Enable rendering colorbars on bokeh ``GraphPlot``\ s
+   (`#5585 <https://github.com/holoviz/holoviews/pull/5585>`__)
+-  Add Plotly ``Scatter3d`` documentation and fix colorbar title
+   (`#5418 <https://github.com/holoviz/holoviews/pull/5418>`__)
+
+Bug fixes:
+
+-  Only trigger range-update once in callbacks
+   (`#5558 <https://github.com/holoviz/holoviews/pull/5558>`__)
+-  Ensure dynamically created subplots can be updated
+   (`#5555 <https://github.com/holoviz/holoviews/pull/5555>`__)
+-  Fix start of stack-level in deprecations
+   (`#5569 <https://github.com/holoviz/holoviews/pull/5569>`__)
+-  When sorting colormap records, replace None with an empty string
+   (`#5539 <https://github.com/holoviz/holoviews/pull/5539>`__)
+-  Fix annotator in Geoviews by adding deserialization of
+   non-deserialized base64 data
+   (`#5587 <https://github.com/holoviz/holoviews/pull/5587>`__)
+-  Fix ``hv.Empty`` not working in ``AdjointLayout`` plot
+   (`#5584 <https://github.com/holoviz/holoviews/pull/5584>`__)
+-  Check for categorical data to histogram
+   (`#5540 <https://github.com/holoviz/holoviews/pull/5540>`__)
+-  Fix ``clim_percentile``
+   (`#5495 <https://github.com/holoviz/holoviews/pull/5495>`__)
+
+Compatibility:
+
+-  Compatibility with Shapely 2.0
+   (`#5561 <https://github.com/holoviz/holoviews/pull/5561>`__)
+-  Compatibility with Numpy 1.24
+   (`#5581 <https://github.com/holoviz/holoviews/pull/5581>`__)
+-  Compatibility with Ibis 4.0
+   (`#5588 <https://github.com/holoviz/holoviews/pull/5588>`__)
+
+Documentation:
+
+-  Installation instructions update
+   (`#5562 <https://github.com/holoviz/holoviews/pull/5562>`__)
+-  Use OSM for reference tile source in notebook documentation
+   (`#5536 <https://github.com/holoviz/holoviews/pull/5536>`__)
+-  Enhance Tiles example notebook
+   (`#5563 <https://github.com/holoviz/holoviews/pull/5563>`__)
+
+Maintenance:
+
+-  Various fixes and general maintenance of the CI
+   (`#5384 <https://github.com/holoviz/holoviews/pull/5384>`__,
+   `#5573 <https://github.com/holoviz/holoviews/pull/5573>`__,
+   `#5576 <https://github.com/holoviz/holoviews/pull/5576>`__,
+   `#5582 <https://github.com/holoviz/holoviews/pull/5582>`__)
+-  Updated codebase to modern Python conventions
+   (`#5509 <https://github.com/holoviz/holoviews/pull/5509>`__,
+   `#5577 <https://github.com/holoviz/holoviews/pull/5577>`__)
+-  Renamed ``master`` branch to ``main``
+   (`#5579 <https://github.com/holoviz/holoviews/pull/5579>`__)
+-  Update binder link and dependency pinning
+   (`#5583 <https://github.com/holoviz/holoviews/pull/5583>`__)
+-  Update copyright to only contain start year
+   (`#5580 <https://github.com/holoviz/holoviews/pull/5580>`__)
+
 Version 1.15.3
 **************
 
@@ -15,22 +94,22 @@ adds support for Python 3.11. Many thanks to our maintainers
 
 Bug Fixes:
 
-  - Fix for empty opts warning and incorrect clearing semantics
-    (`#5496 <https://github.com/holoviz/holoviews/pull/5496>`__)
-  - Fix potential race condition in the Options system
-    (`#5535 <https://github.com/holoviz/holoviews/pull/5535>`__)
+- Fix for empty opts warning and incorrect clearing semantics
+  (`#5496 <https://github.com/holoviz/holoviews/pull/5496>`__)
+- Fix potential race condition in the Options system
+  (`#5535 <https://github.com/holoviz/holoviews/pull/5535>`__)
 
 Enhancements:
 
-  - Add support to Python 3.11
-    (`#5513 <https://github.com/holoviz/holoviews/pull/5513>`__)
-  - Cleanup the top `__init__` module
-    (`#5516 <https://github.com/holoviz/holoviews/pull/5516>`__)
+- Add support to Python 3.11
+  (`#5513 <https://github.com/holoviz/holoviews/pull/5513>`__)
+- Cleanup the top `__init__` module
+  (`#5516 <https://github.com/holoviz/holoviews/pull/5516>`__)
 
 Documentation:
 
-  - Fixes to release notes and CHANGELOG
-    (`#5506 <https://github.com/holoviz/holoviews/pull/5506>`__)
+- Fixes to release notes and CHANGELOG
+  (`#5506 <https://github.com/holoviz/holoviews/pull/5506>`__)
 
 
 Version 1.15.2


### PR DESCRIPTION
It needs https://github.com/holoviz/holoviews/pull/5588 to be merged.

And need to be exported to `docs/release.rst`.