### PR TITLE
use matplotlib's public api to list the colormaps

### DIFF
--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -699,8 +699,12 @@ def _list_cmaps(provider=None, records=False):
 
     if 'matplotlib' in provider:
         try:
+            import matplotlib as mpl
             from matplotlib import cm
-            if hasattr(cm, '_cmap_registry'):
+
+            if hasattr(mpl, "colormaps"):
+                mpl_cmaps = list(mpl.colormaps)
+            elif hasattr(cm, '_cmap_registry'):
                 mpl_cmaps = list(cm._cmap_registry)
             else:
                 mpl_cmaps = list(cm.cmaps_listed)+list(cm.datad)

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -702,6 +702,8 @@ def _list_cmaps(provider=None, records=False):
             import matplotlib as mpl
             from matplotlib import cm
 
+            # matplotlib.colormaps has been introduced in matplotlib 3.5
+            # matplotlib.cm._cmap_registry was removed in matplotlib 3.6
             if hasattr(mpl, "colormaps"):
                 mpl_cmaps = list(mpl.colormaps)
             elif hasattr(cm, '_cmap_registry'):


### PR DESCRIPTION
- [x] closes #5476

This uses `matplotlib.colormaps` to get the colormaps (if it is available) instead of `matplotlib.cm._cmap_registry`, which was removed in `matplotlib=3.6` without warning because it was internal API.