### PR TITLE
Avoid KeyError when overlaying dynamic groupbys

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -876,6 +876,8 @@ class DimensionedPlot(Plot):
             Looks up options for object, including plot defaults.
             keyfn determines returned key otherwise None key is used.
             """
+            if isinstance(x, DynamicMap):
+                return (None, {})
             options = cls.lookup_options(x, opt_type)
             selected = {o: options.options[o]
                         for o in opts if o in options.options}


### PR DESCRIPTION
WIP

Here is the test example:

```python
import holoviews as hv
import pandas as pd
import numpy as np
hv.extension('bokeh')

df1 = pd.DataFrame({'sym':['CAT1']*5 + ['CAT2']*5, 'x':list(range(10)), 'y':np.random.rand(10)})
df2 = pd.DataFrame({'sym':['CAT1']*10, 'x':list(range(10)), 'y':np.random.rand(10)})

ds1 = hv.Dataset(df1)
ds2 = hv.Dataset(df2)
ds1.to(hv.Spikes, 'x', 'y', groupby=['sym'], dynamic=True) * ds2.to(hv.Spikes, 'x', 'y', groupby=['sym'], dynamic=True).opts(color='blue')
```

With this PR you can select `CAT2`:

<img width="1345" alt="image" src="https://user-images.githubusercontent.com/890576/214905441-cb0086a8-b3f9-43d8-9b11-7d3039a322ff.png">

On `main` you get a keyerror:

<details>
Traceback (most recent call last):
  File "/Users/jstevens/Desktop/development/holoviews/holoviews/plotting/renderer.py", line 538, in plotting_class
    plotclass = Store.registry[cls.backend][element_type]
KeyError: None

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/pyviz_comms/__init__.py", line 338, in _handle_msg
    self._on_msg(msg)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/panel/viewable.py", line 294, in _on_msg
    doc.unhold()
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/bokeh/document/document.py", line 799, in unhold
    self.callbacks.unhold()
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/bokeh/document/callbacks.py", line 396, in unhold
    self.trigger_on_change(event)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/bokeh/document/callbacks.py", line 373, in trigger_on_change
    invoke_with_curdoc(doc, event.callback_invoker)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/bokeh/document/callbacks.py", line 408, in invoke_with_curdoc
    return f()
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/bokeh/util/callback_manager.py", line 191, in invoke
    callback(attr, old, new)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/panel/reactive.py", line 405, in _comm_change
    state._handle_exception(e)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/panel/io/state.py", line 391, in _handle_exception
    raise exception
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/panel/reactive.py", line 403, in _comm_change
    self._schedule_change(doc, comm)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/panel/reactive.py", line 385, in _schedule_change
    self._change_event(doc)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/panel/reactive.py", line 381, in _change_event
    self._process_events(events)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/panel/reactive.py", line 319, in _process_events
    self.param.update(**self_events)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/param/parameterized.py", line 1898, in update
    self_._batch_call_watchers()
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/param/parameterized.py", line 2059, in _batch_call_watchers
    self_._execute_watcher(watcher, events)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/param/parameterized.py", line 2021, in _execute_watcher
    watcher.fn(*args, **kwargs)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/panel/pane/holoviews.py", line 240, in _widget_callback
    self._update_plot(plot, pane)
  File "/Users/jstevens/miniconda3/envs/analytics/lib/python3.7/site-packages/panel/pane/holoviews.py", line 222, in _update_plot
    plot.update(key)
  File "/Users/jstevens/Desktop/development/holoviews/holoviews/plotting/plot.py", line 937, in update
    item = self.__getitem__(key)
  File "/Users/jstevens/Desktop/development/holoviews/holoviews/plotting/plot.py", line 423, in __getitem__
    self.update_frame(frame)
  File "/Users/jstevens/Desktop/development/holoviews/holoviews/plotting/bokeh/element.py", line 2432, in update_frame
    defaults=False)
  File "/Users/jstevens/Desktop/development/holoviews/holoviews/plotting/plot.py", line 890, in _traverse_options
    traversed = obj.traverse(lookup, specs)
  File "/Users/jstevens/Desktop/development/holoviews/holoviews/core/dimension.py", line 662, in traverse
    accumulator += el.traverse(fn, specs, full_breadth)
  File "/Users/jstevens/Desktop/development/holoviews/holoviews/core/dimension.py", line 655, in traverse
    accumulator.append(fn(self))
  File "/Users/jstevens/Desktop/development/holoviews/holoviews/plotting/plot.py", line 879, in lookup
    options = cls.lookup_options(x, opt_type)
  File "/Users/jstevens/Desktop/development/holoviews/holoviews/plotting/plot.py", line 275, in lookup_options
    return lookup_options(obj, group, cls.backend)
  File "/Users/jstevens/Desktop/development/holoviews/holoviews/core/options.py", line 94, in lookup_options
    plot_class = Store.renderers[backend].plotting_class(obj)
  File "/Users/jstevens/Desktop/development/holoviews/holoviews/plotting/renderer.py", line 540, in plotting_class
    raise SkipRendering(f"No plotting class for {element_type.__name__} found")
AttributeError: 'NoneType' object has no attribute '__name__'
</details>

I thought I could return an empty element from the dynamicmap created by `groupby` in the `.to` call but I always hit key errors in the plotting code until this change.


