### PR TITLE
Add convenience function to Opts

### DIFF
--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -649,3 +649,20 @@ class Opts(metaclass=AccessorPipelineMeta):
 
         kwargs['clone'] = False if clone is None else clone
         return self._obj.options(*new_args, **kwargs)
+
+    def __getitem__(self, item):
+        options = self.get().kwargs
+        if item in options:
+            return options[item]
+        else:
+            raise KeyError(
+                f"{item!r} is not in opts. Valid items is {', '.join(options)}."
+            )
+
+    def __setitem__(self, item, value):
+        self(**{item: value})
+
+    def __repr__(self):
+        options = self.get().kwargs
+        kws = ', '.join(f"{k}={options[k]!r}" for k in sorted(options.keys()))
+        return f"Opts({kws})"

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -659,9 +659,6 @@ class Opts(metaclass=AccessorPipelineMeta):
                 f"{item!r} is not in opts. Valid items is {', '.join(options)}."
             )
 
-    def __setitem__(self, item, value):
-        self(**{item: value})
-
     def __repr__(self):
         options = self.get().kwargs
         kws = ', '.join(f"{k}={options[k]!r}" for k in sorted(options.keys()))


### PR DESCRIPTION
Inspired by [this](https://discourse.holoviz.org/t/can-i-read-what-opts-have-been-applied-to-my-plot/4872) discussion on discourse and my own experience when trying to find the values set in `Opts`. 

![image](https://user-images.githubusercontent.com/19758978/215436914-9c3cb43b-70ea-480c-8ed0-bb241f9d0035.png)

I'm not sure if `__setitem__` should be added, as it could add more confusion.