### PR TITLE
Maintenance of test CI

### DIFF
--- a/examples/user_guide/16-Streaming_Data.ipynb
+++ b/examples/user_guide/16-Streaming_Data.ipynb
@@ -538,7 +538,7 @@
     "large_source = streamz.dataframe.Random(freq='100us', interval='200ms')\n",
     "sdf = (large_source-0.5).cumsum()\n",
     "dmap = hv.DynamicMap(hv.Curve, streams=[Buffer(sdf.x, length=1000000)])\n",
-    "datashade(dmap, streams=[hv.streams.PlotSize], normalization='linear', cmap=Blues8).opts(width=600)"
+    "datashade(dmap, streams=[hv.streams.PlotSize], cnorm='linear', cmap=list(Blues8)).opts(width=600)"
    ]
   },
   {
@@ -583,7 +583,7 @@
     "    global count\n",
     "    count += 1\n",
     "    buffer.send(np.array([[count, np.random.rand()]]))\n",
-    "   \n",
+    "\n",
     "cb = PeriodicCallback(f, 100)\n",
     "cb.start()\n",
     "\n",
@@ -636,5 +636,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/holoviews/tests/core/test_dynamic.py
+++ b/holoviews/tests/core/test_dynamic.py
@@ -2,6 +2,7 @@ import uuid
 import time
 from collections import deque
 
+import flaky
 import param
 import numpy as np
 from holoviews import Dimension, NdLayout, GridSpace, Layout, NdOverlay
@@ -989,6 +990,7 @@ class TestPeriodicStreamUpdate(ComparisonTestCase):
         dmap.periodic(0.01, 100, param_fn=lambda i: {'x':i})
         self.assertEqual(xval.x, 100)
 
+    @flaky
     def test_periodic_param_fn_non_blocking(self):
         def callback(x): return Curve([1,2,3])
         xval = Stream.define('x',x=0)()

--- a/holoviews/tests/core/test_dynamic.py
+++ b/holoviews/tests/core/test_dynamic.py
@@ -2,7 +2,7 @@ import uuid
 import time
 from collections import deque
 
-import flaky
+import pytest
 import param
 import numpy as np
 from holoviews import Dimension, NdLayout, GridSpace, Layout, NdOverlay
@@ -990,7 +990,7 @@ class TestPeriodicStreamUpdate(ComparisonTestCase):
         dmap.periodic(0.01, 100, param_fn=lambda i: {'x':i})
         self.assertEqual(xval.x, 100)
 
-    @flaky
+    @pytest.mark.flaky
     def test_periodic_param_fn_non_blocking(self):
         def callback(x): return Curve([1,2,3])
         xval = Stream.define('x',x=0)()

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import pyviz_comms as comms
-import flaky
 
 from holoviews.core import DynamicMap
 from holoviews.core.options import Store
@@ -288,7 +287,7 @@ class TestEditToolCallbacks(CallbackTestCase):
         plot = bokeh_server_renderer.get_plot(boxes)
         assert 'data' in plot.handles['cds']._callbacks
 
-    @flaky
+    @pytest.mark.flaky
     def test_poly_edit_callback(self):
         polys = Polygons([[(0, 0), (2, 2), (4, 0)]])
         poly_edit = PolyEdit(source=polys)

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import pyviz_comms as comms
+import flaky
 
 from holoviews.core import DynamicMap
 from holoviews.core.options import Store
@@ -287,6 +288,7 @@ class TestEditToolCallbacks(CallbackTestCase):
         plot = bokeh_server_renderer.get_plot(boxes)
         assert 'data' in plot.handles['cds']._callbacks
 
+    @flaky
     def test_poly_edit_callback(self):
         polys = Polygons([[(0, 0), (2, 2), (4, 0)]])
         poly_edit = PolyEdit(source=polys)

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -10,6 +10,7 @@ import numpy as np
 import param
 import panel as pn
 from matplotlib import style
+from packaging.version import Version
 
 from holoviews import (DynamicMap, HoloMap, Image, ItemTable,
                        GridSpace, Table, Curve)
@@ -17,6 +18,7 @@ from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import Stream
 from holoviews.plotting.mpl import MPLRenderer, CurvePlot
 from holoviews.plotting.renderer import Renderer
+from holoviews.plotting.mpl.util import mpl_version
 from panel.widgets import DiscreteSlider, Player, FloatSlider
 from pyviz_comms import CommManager
 
@@ -57,13 +59,19 @@ class MPLRendererTest(ComparisonTestCase):
         with style.context("default"):
             plot = self.renderer.get_plot(self.image1 + self.image2)
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (576, 257))
+        if mpl_version >= Version("3.7"):
+            self.assertEqual((w, h), (576, 259))
+        else:
+            self.assertEqual((w, h), (576, 257))
 
     def test_get_size_column_plot(self):
         with style.context("default"):
             plot = self.renderer.get_plot((self.image1 + self.image2).cols(1))
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (288, 509))
+        if mpl_version >= Version("3.7"):
+            self.assertEqual((w, h), (288, 511))
+        else:
+            self.assertEqual((w, h), (288, 509))
 
     def test_get_size_grid_plot(self):
         grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ extras_require['tests_core'] = [
     'pytest',
     'pytest-cov',
     'pytest-xdist',
+    'flaky',
     'matplotlib >=3',
     'nbconvert',
     'bokeh',


### PR DESCRIPTION
This PR does 3 things:
- Mark two flaky tests, flaky
- Update test to work with Matplotlib 3.7
- Fix the error seen in the streaming examples because `cmap` is a tuple of hex values.

``` python
import holoviews as hv
from bokeh.palettes import Blues8
from holoviews.operation.datashader import datashade

hv.extension("bokeh")

datashade(hv.Curve([]), cmap=Blues8)
```
![image](https://user-images.githubusercontent.com/19758978/215467751-e4eb0267-a2bc-4370-8593-3b7a020bcacb.png)
