### PR TITLE
Apply autorange on data change events

### DIFF
--- a/examples/user_guide/Customizing_Plots.ipynb
+++ b/examples/user_guide/Customizing_Plots.ipynb
@@ -597,7 +597,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Autoranging works analogously for the x-axis and also respects the padding setting."
+    "Autoranging works analogously for the x-axis and also respects the padding setting. In addition, autoranging is triggered when the plotted data is updated dynamically, as is common when building interactive visualizations with operations or `DynamicMap`s."
    ]
   },
   {

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1015,6 +1015,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
           let plot_view = null;
           for (const root of plot.document.roots()) {{
             const root_view = window.Bokeh.index[root.id]
+            if (root_view === undefined)
+              return
             plot_view = find(root_view)
             if (plot_view != null)
               break

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1028,13 +1028,17 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             return
           let [vmin, vmax] = [Infinity, -Infinity]
           for (const dr of plot.data_renderers) {{
-            const glyph_view = plot_view.renderer_view(dr).glyph_view
-            const index = glyph_view.index.index
-            for (let pos = 0; pos < index._boxes.length - 4; pos += 4) {{
-              const [x0, y0, x1, y1] = index._boxes.slice(pos, pos+4)
-              if ({odim}0 > plot.{odim}_range.start && {odim}1 < plot.{odim}_range.end) {{
-                vmin = Math.min(vmin, {dim}0)
-                vmax = Math.max(vmax, {dim}1)
+            const renderer = plot_view.renderer_view(dr)
+            const glyph_view = renderer.glyph_view
+
+            if (!renderer.glyph.model.tags.includes('no_apply_ranges')) {{
+              const index = glyph_view.index.index
+              for (let pos = 0; pos < index._boxes.length - 4; pos += 4) {{
+                const [x0, y0, x1, y1] = index._boxes.slice(pos, pos+4)
+                if ({odim}0 > plot.{odim}_range.start && {odim}1 < plot.{odim}_range.end) {{
+                  vmin = Math.min(vmin, {dim}0)
+                  vmax = Math.max(vmax, {dim}1)
+                }}
               }}
             }}
           }}
@@ -1145,6 +1149,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         Returns a Bokeh glyph object.
         """
+        mapping['tags'] = ['apply_ranges' if self.apply_ranges else 'no_apply_ranges']
         properties = mpl_to_bokeh(properties)
         plot_method = self._plot_methods.get('batched' if self.batched else 'single')
         if isinstance(plot_method, tuple):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1000,8 +1000,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         callback = CustomJS(code=f"""
         const cb = function() {{
           const ref = plot.id
+
           const find = (view) => {{
-            for (const sv of view.child_views) {{
+            let iterable = view.child_views === undefined ? []  : view.child_views
+            for (const sv of iterable) {{
               if (sv.model.id == ref)
                 return sv
               const obj = find(sv)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -964,6 +964,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         Sets up a callback which will iterate over available data
         renderers and auto-range along one axis.
         """
+        if not isinstance(self, OverlayPlot) and not self.apply_ranges:
+            return
+
         if self.autorange is None:
             return
         dim = self.autorange


### PR DESCRIPTION
- Had to schedule the `CustomJS` callback using `setTimeout` because the `ColumnDataSource.data` callback fires before the glyphs (and more importantly their indexes) are updated.
- We remove all usage of `cb_obj` in the callback which allows us to reuse the callback between both data and range updaates.
- We add the autorange callback to a new `_js_on_data_callbacks` instance variable which then gets applied to all sources attached to a `GlyphRenderer`

## ToDo

- [x] Check inverted axes work with this
- [x] Guard against failed lookups in `Bokeh.index`
- [x] Guard the `view.child_views` lookup to avoid errors in layouts
- [x] Somehow filter out GlyphRenderers which were generated by plots with apply_ranges=False (suggest using `.tags` property to mark them)