### PR TITLE
Add sorting of imports

### DIFF
--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -120,7 +120,7 @@ except ImportError:
             raise Exception("IPython notebook not available: use hv.extension instead.")
 
 if '_pyodide' in sys.modules:
-    from .pyodide import pyodide_extension, in_jupyterlite
+    from .pyodide import in_jupyterlite, pyodide_extension
     # The notebook_extension is needed inside jupyterlite,
     # so the override is only done if we are not inside jupyterlite.
     if not in_jupyterlite():

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -1,19 +1,22 @@
 import sys
-
 from collections import OrderedDict
 from inspect import getmro
 
 import param
-
-from panel.pane import PaneBase
 from panel.layout import Row, Tabs
+from panel.pane import PaneBase
 from panel.util import param_name
 
-from .core import DynamicMap, HoloMap, ViewableElement, Element, Layout, Overlay, Store
+from .core import DynamicMap, Element, HoloMap, Layout, Overlay, Store, ViewableElement
 from .core.util import isscalar
-from .element import Rectangles, Path, Polygons, Points, Table, Curve
-from .plotting.links import VertexTableLink, DataLink, RectanglesTableLink, SelectionLink
-from .streams import BoxEdit, PolyDraw, PolyEdit, Selection1D, PointDraw, CurveEdit
+from .element import Curve, Path, Points, Polygons, Rectangles, Table
+from .plotting.links import (
+    DataLink,
+    RectanglesTableLink,
+    SelectionLink,
+    VertexTableLink,
+)
+from .streams import BoxEdit, CurveEdit, PointDraw, PolyDraw, PolyEdit, Selection1D
 
 
 def preprocess(function, current=[]):

--- a/holoviews/core/__init__.py
+++ b/holoviews/core/__init__.py
@@ -3,17 +3,17 @@ from datetime import date, datetime
 import pandas as pd
 
 from .boundingregion import *  # noqa (API import)
-from .data import *            # noqa (API import)
-from .dimension import *       # noqa (API import)
-from .element import *         # noqa (API import)
-from .layout import *          # noqa (API import)
-from .operation import *       # noqa (API import)
-from .overlay import *         # noqa (API import)
-from .sheetcoords import *     # noqa (API import)
-from .spaces import *          # noqa (API import)
-from .tree import *            # noqa (API import)
-from .util import config       # noqa (API import)
+from .data import *  # noqa (API import)
+from .dimension import *  # noqa (API import)
+from .element import *  # noqa (API import)
 from .io import FileArchive
+from .layout import *  # noqa (API import)
+from .operation import *  # noqa (API import)
+from .overlay import *  # noqa (API import)
+from .sheetcoords import *  # noqa (API import)
+from .spaces import *  # noqa (API import)
+from .tree import *  # noqa (API import)
+from .util import config  # noqa (API import)
 
 archive = FileArchive()
 

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -3,7 +3,6 @@ Module for accessor objects for viewable HoloViews objects.
 """
 import copy
 import sys
-
 from collections import OrderedDict
 from functools import wraps
 from types import FunctionType
@@ -26,7 +25,10 @@ class AccessorPipelineMeta(type):
     def pipelined(mcs, __call__):
         @wraps(__call__)
         def pipelined_call(*args, **kwargs):
-            from ..operation.element import method as method_op, factory
+            from ..operation.element import (
+                factory,
+                method as method_op,
+            )
             from .data import Dataset, MultiDimensionalMapping
             inst = args[0]
 
@@ -132,11 +134,11 @@ class Apply(metaclass=AccessorPipelineMeta):
             A new object where the function was applied to all
             contained (Nd)Overlay or Element objects.
         """
+        from ..util import Dynamic
         from .data import Dataset
         from .dimension import ViewableElement
         from .element import Element
-        from .spaces import HoloMap, DynamicMap
-        from ..util import Dynamic
+        from .spaces import DynamicMap, HoloMap
 
         if isinstance(self._obj, DynamicMap) and dynamic == False:
             samples = tuple(d.values for d in self._obj.kdims)
@@ -227,8 +229,8 @@ class Apply(metaclass=AccessorPipelineMeta):
         See :py:meth:`Dimensioned.opts` and :py:meth:`Apply.__call__`
         for more information.
         """
-        from ..util.transform import dim
         from ..streams import Params
+        from ..util.transform import dim
         params = {}
         for arg in kwargs.values():
             if isinstance(arg, dim):
@@ -272,8 +274,8 @@ class Apply(metaclass=AccessorPipelineMeta):
         See :py:meth:`Dataset.transform` and :py:meth:`Apply.__call__`
         for more information.
         """
-        from ..util.transform import dim
         from ..streams import Params
+        from ..util.transform import dim
         params = {}
         for _, arg in list(args)+list(kwargs.items()):
             if isinstance(arg, dim):
@@ -358,8 +360,8 @@ class Redim(metaclass=AccessorPipelineMeta):
         return dimension
 
     def _create_expression_transform(self, kdims, vdims, exclude=[]):
-        from .dimension import dimension_name
         from ..util.transform import dim
+        from .dimension import dimension_name
 
         def _transform_expression(expression):
             if dimension_name(expression.dimension) in exclude:
@@ -503,7 +505,7 @@ class Opts(metaclass=AccessorPipelineMeta):
             Options object associated with the object containing the
             applied option keywords.
         """
-        from .options import Store, Options
+        from .options import Options, Store
         keywords = {}
         groups = Options._option_groups if group is None else [group]
         backend = backend if backend else Store.current_backend

--- a/holoviews/core/boundingregion.py
+++ b/holoviews/core/boundingregion.py
@@ -9,6 +9,7 @@ File originally part of the Topographica project.
 ###
 import param
 from param.parameterized import get_occupied_slots
+
 from .util import datetime_types
 
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -1,37 +1,38 @@
-import types
 import copy
-
+import types
 from contextlib import contextmanager
 from functools import wraps
 
 import numpy as np
+import pandas as pd  # noqa
 import param
-import pandas as pd # noqa
-
 from param.parameterized import ParameterizedMetaclass
 
+from .. import util as core_util
 from ..accessors import Redim
 from ..dimension import (
-    Dimension, Dimensioned, LabelledData, dimension_name, process_dimensions
+    Dimension,
+    Dimensioned,
+    LabelledData,
+    dimension_name,
+    process_dimensions,
 )
 from ..element import Element
-from ..ndmapping import OrderedDict, MultiDimensionalMapping
-from ..spaces import HoloMap, DynamicMap
-from .. import util as core_util
-
+from ..ndmapping import MultiDimensionalMapping, OrderedDict
+from ..spaces import DynamicMap, HoloMap
 from .array import ArrayInterface
-from .cudf import cuDFInterface               # noqa (API import)
-from .dask import DaskInterface               # noqa (API import)
-from .dictionary import DictInterface         # noqa (API import)
-from .grid import GridInterface               # noqa (API import)
-from .ibis import IbisInterface               # noqa (API import)
+from .cudf import cuDFInterface  # noqa (API import)
+from .dask import DaskInterface  # noqa (API import)
+from .dictionary import DictInterface  # noqa (API import)
+from .grid import GridInterface  # noqa (API import)
+from .ibis import IbisInterface  # noqa (API import)
+from .image import ImageInterface  # noqa (API import)
 from .interface import Interface, iloc, ndloc
-from .multipath import MultiInterface         # noqa (API import)
-from .image import ImageInterface             # noqa (API import)
+from .multipath import MultiInterface  # noqa (API import)
 from .pandas import PandasInterface
-from .spatialpandas import SpatialPandasInterface     # noqa (API import)
-from .spatialpandas_dask import DaskSpatialPandasInterface # noqa (API import)
-from .xarray import XArrayInterface           # noqa (API import)
+from .spatialpandas import SpatialPandasInterface  # noqa (API import)
+from .spatialpandas_dask import DaskSpatialPandasInterface  # noqa (API import)
+from .xarray import XArrayInterface  # noqa (API import)
 
 default_datatype = 'dataframe'
 
@@ -291,7 +292,8 @@ class Dataset(Element, metaclass=PipelineMeta):
 
     def __init__(self, data, kdims=None, vdims=None, **kwargs):
         from ...operation.element import (
-            chain as chain_op, factory
+            chain as chain_op,
+            factory,
         )
         self._in_method = False
         input_data = data
@@ -787,7 +789,7 @@ argument to specify a selection specification""")
         # Note: Special handling sampling of gridded 2D data as Curve
         # may be replaced with more general handling
         # see https://github.com/holoviz/holoviews/issues/1173
-        from ...element import Table, Curve
+        from ...element import Curve, Table
         datatype = ['dataframe', 'dictionary', 'dask', 'ibis', 'cuDF']
         if len(samples) == 1:
             sel = {kd.name: s for kd, s in zip(self.kdims, samples[0])}

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -1,10 +1,10 @@
 import numpy as np
 
-from .interface import Interface, DataError
+from .. import util
 from ..dimension import dimension_name
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
-from .. import util
+from .interface import DataError, Interface
 
 
 class ArrayInterface(Interface):

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -1,6 +1,5 @@
 import sys
 import warnings
-
 from itertools import product
 
 import numpy as np

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -6,7 +6,7 @@ import pandas as pd
 from .. import util
 from ..dimension import Dimension
 from ..element import Element
-from ..ndmapping import NdMapping, item_check, OrderedDict, sorted_context
+from ..ndmapping import NdMapping, OrderedDict, item_check, sorted_context
 from .interface import Interface
 from .pandas import PandasInterface
 

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -2,13 +2,12 @@ from collections import OrderedDict, defaultdict
 
 import numpy as np
 
-from .interface import Interface, DataError
+from .. import util
 from ..dimension import dimension_name
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
 from ..util import isscalar
-from .. import util
-
+from .interface import DataError, Interface
 
 
 class DictInterface(Interface):

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -2,14 +2,13 @@ from collections import OrderedDict, defaultdict
 
 import numpy as np
 
-from .dictionary import DictInterface
-from .interface import Interface, DataError
+from .. import util
 from ..dimension import dimension_name
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
-from .. import util
-from .util import finite_range, is_dask, dask_array_module, get_array_types
-
+from .dictionary import DictInterface
+from .interface import DataError, Interface
+from .util import dask_array_module, finite_range, get_array_types, is_dask
 
 
 class GridInterface(DictInterface):

--- a/holoviews/core/data/ibis.py
+++ b/holoviews/core/data/ibis.py
@@ -1,15 +1,15 @@
 import sys
-import numpy as np
 from collections.abc import Iterable
+
+import numpy as np
 from packaging.version import Version
 
 from .. import util
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
-from .interface import Interface
 from . import pandas
+from .interface import Interface
 from .util import cached
-
 
 try:
     import ibis

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -1,13 +1,13 @@
 import numpy as np
 
+from .. import util
 from ..boundingregion import BoundingBox
 from ..dimension import dimension_name
 from ..element import Element
-from ..ndmapping import  NdMapping, item_check
-from ..sheetcoords import Slice, SheetCoordinateSystem
-from .. import util
+from ..ndmapping import NdMapping, item_check
+from ..sheetcoords import SheetCoordinateSystem, Slice
 from .grid import GridInterface
-from .interface import Interface, DataError
+from .interface import DataError, Interface
 from .util import finite_range
 
 

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -1,8 +1,8 @@
 import sys
 import warnings
 
-import param
 import numpy as np
+import param
 
 from .. import util
 from ..element import Element
@@ -24,8 +24,8 @@ class Accessor:
         self.dataset = dataset
 
     def __getitem__(self, index):
-        from ..data import Dataset
         from ...operation.element import method
+        from ..data import Dataset
         in_method = self.dataset._in_method
         if not in_method:
             self.dataset._in_method = True

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -4,7 +4,7 @@ from .. import util
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
 from .dictionary import DictInterface
-from .interface import Interface, DataError
+from .interface import DataError, Interface
 
 
 class MultiInterface(Interface):
@@ -31,7 +31,7 @@ class MultiInterface(Interface):
 
     @classmethod
     def init(cls, eltype, data, kdims, vdims):
-        from ...element import Polygons, Path
+        from ...element import Path, Polygons
 
         new_data = []
         dims = {'kdims': eltype.kdims, 'vdims': eltype.vdims}
@@ -101,7 +101,7 @@ class MultiInterface(Interface):
 
     @classmethod
     def geom_type(cls, dataset):
-        from holoviews.element import Polygons, Path, Points
+        from holoviews.element import Path, Points, Polygons
         if isinstance(dataset, type):
             eltype = dataset
         else:

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -1,16 +1,16 @@
 from collections import OrderedDict
-from packaging.version import Version
 
 import numpy as np
 import pandas as pd
+from packaging.version import Version
 from pandas.api.types import is_numeric_dtype
 
 from ...util._exception import deprecation_warning
-from .interface import Interface, DataError
-from ..dimension import dimension_name, Dimension
+from .. import util
+from ..dimension import Dimension, dimension_name
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
-from .. import util
+from .interface import DataError, Interface
 from .util import finite_range
 
 

--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -1,12 +1,11 @@
 import sys
-
 from collections import defaultdict
 
 import numpy as np
 import pandas as pd
 
 from ..dimension import dimension_name
-from ..util import isscalar, unique_iterator, unique_array
+from ..util import isscalar, unique_array, unique_iterator
 from .interface import DataError, Interface
 from .multipath import MultiInterface, ensure_ring
 from .pandas import PandasInterface
@@ -142,7 +141,10 @@ class SpatialPandasInterface(MultiInterface):
     @classmethod
     def has_holes(cls, dataset):
         from spatialpandas.geometry import (
-            MultiPolygonDtype, PolygonDtype, Polygon, MultiPolygon
+            MultiPolygon,
+            MultiPolygonDtype,
+            Polygon,
+            PolygonDtype,
         )
         col = cls.geo_column(dataset.data)
         series = dataset.data[col]
@@ -387,6 +389,7 @@ class SpatialPandasInterface(MultiInterface):
     @classmethod
     def split(cls, dataset, start, end, datatype, **kwargs):
         from spatialpandas import GeoDataFrame, GeoSeries
+
         from ...element import Polygons
 
         objs = []
@@ -459,8 +462,13 @@ def get_geom_type(gdf, col):
         A string representing the type of geometry
     """
     from spatialpandas.geometry import (
-        PointDtype, MultiPointDtype, LineDtype, MultiLineDtype,
-        PolygonDtype, MultiPolygonDtype, RingDtype
+        LineDtype,
+        MultiLineDtype,
+        MultiPointDtype,
+        MultiPolygonDtype,
+        PointDtype,
+        PolygonDtype,
+        RingDtype,
     )
 
     column = gdf[col]
@@ -486,7 +494,12 @@ def geom_to_array(geom, index=None, multi=False, geom_type=None):
         Array or list of arrays.
     """
     from spatialpandas.geometry import (
-        Point, Polygon, Line, Ring, MultiPolygon, MultiPoint
+        Line,
+        MultiPoint,
+        MultiPolygon,
+        Point,
+        Polygon,
+        Ring,
     )
     if isinstance(geom, Point):
         if index is None:
@@ -533,7 +546,7 @@ def geom_array_to_array(geom_array, index, expand=False, geom_type=None):
     Returns:
         Flattened array
     """
-    from spatialpandas.geometry import PointArray, MultiPointArray
+    from spatialpandas.geometry import MultiPointArray, PointArray
     if isinstance(geom_array, PointArray):
         return geom_array.y if index else geom_array.x
     arrays = []
@@ -557,7 +570,7 @@ def geom_array_to_array(geom_array, index, expand=False, geom_type=None):
 
 
 def geom_length(geom):
-    from spatialpandas.geometry import Polygon, Ring, MultiPolygon, MultiLine
+    from spatialpandas.geometry import MultiLine, MultiPolygon, Polygon, Ring
     if isinstance(geom, Polygon):
         offset = 0
         exterior = geom.data[0]
@@ -644,7 +657,7 @@ def geom_to_holes(geom):
     Returns:
         List of arrays representing holes
     """
-    from spatialpandas.geometry import Polygon, MultiPolygon
+    from spatialpandas.geometry import MultiPolygon, Polygon
     if isinstance(geom, Polygon):
         holes = []
         for i, hole in enumerate(geom.data):
@@ -683,11 +696,21 @@ def to_spatialpandas(data, xdim, ydim, columns=[], geom='point'):
     Returns:
         A spatialpandas.GeoDataFrame version of the data
     """
-    from spatialpandas import GeoSeries, GeoDataFrame
+    from spatialpandas import GeoDataFrame, GeoSeries
     from spatialpandas.geometry import (
-        Point, Line, Polygon, Ring, LineArray, PolygonArray, PointArray,
-        MultiLineArray, MultiPolygonArray, MultiPointArray, RingArray
+        Line,
+        LineArray,
+        MultiLineArray,
+        MultiPointArray,
+        MultiPolygonArray,
+        Point,
+        PointArray,
+        Polygon,
+        PolygonArray,
+        Ring,
+        RingArray,
     )
+
     from ...element import Polygons
     poly = any(Polygons._hole_key in d for d in data) or geom == 'Polygon'
     if poly:
@@ -870,8 +893,8 @@ def from_shapely(data):
         A GeoDataFrame containing the shapely geometry data.
     """
 
-    from spatialpandas import GeoDataFrame, GeoSeries
     from shapely.geometry.base import BaseGeometry
+    from spatialpandas import GeoDataFrame, GeoSeries
 
     if not data:
         pass

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -1,6 +1,5 @@
 import sys
 import types
-
 from collections import OrderedDict
 
 import numpy as np
@@ -8,10 +7,10 @@ import pandas as pd
 
 from .. import util
 from ..dimension import Dimension, asdim, dimension_name
-from ..ndmapping import NdMapping, item_check, sorted_context
 from ..element import Element
+from ..ndmapping import NdMapping, item_check, sorted_context
 from .grid import GridInterface
-from .interface import Interface, DataError
+from .interface import DataError, Interface
 from .util import dask_array_module, finite_range
 
 

--- a/holoviews/core/decollate.py
+++ b/holoviews/core/decollate.py
@@ -1,13 +1,21 @@
-import param
-from .operation import OperationCallable
-from .. import (
-    Layout, DynamicMap, Element, Callable, Overlay, GridSpace, NdOverlay, HoloMap
-)
-from . import ViewableTree, AdjointLayout
 from collections import namedtuple
-from ..streams import Stream, Derived
 
+import param
+
+from .. import (
+    Callable,
+    DynamicMap,
+    Element,
+    GridSpace,
+    HoloMap,
+    Layout,
+    NdOverlay,
+    Overlay,
+)
 from ..plotting.util import initialize_dynamic
+from ..streams import Derived, Stream
+from . import AdjointLayout, ViewableTree
+from .operation import OperationCallable
 
 Expr = namedtuple("HoloviewsExpr", ["fn", "args", "kwargs"])
 StreamIndex = namedtuple("StreamIndex", ["index"])

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -4,22 +4,21 @@ axis or map dimension. Also supplies the Dimensioned abstract
 baseclass for classes that accept Dimension values.
 """
 import builtins
-import re
 import datetime as dt
+import re
 import weakref
-
-from operator import itemgetter
-from collections import defaultdict, Counter
-from itertools import chain
-from functools import partial
+from collections import Counter, defaultdict
 from collections.abc import Iterable
+from functools import partial
+from itertools import chain
+from operator import itemgetter
 
-import param
 import numpy as np
+import param
 
 from . import util
-from .accessors import Opts, Apply, Redim
-from .options import Store, Options, cleanup_custom_options
+from .accessors import Apply, Opts, Redim
+from .options import Options, Store, cleanup_custom_options
 from .pprint import PrettyPrinter
 from .tree import AttrTree
 from .util import OrderedDict, bytes_to_unicode

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -1,14 +1,14 @@
 from itertools import groupby
-import numpy as np
 
-import param
+import numpy as np
 import pandas as pd
+import param
 
 from .dimension import Dimensioned, ViewableElement, asdim
 from .layout import Composable, Layout, NdLayout
-from .ndmapping import OrderedDict, NdMapping
-from .overlay import Overlayable, NdOverlay, CompositeOverlay
-from .spaces import HoloMap, GridSpace
+from .ndmapping import NdMapping, OrderedDict
+from .overlay import CompositeOverlay, NdOverlay, Overlayable
+from .spaces import GridSpace, HoloMap
 from .tree import AttrTree
 from .util import get_param_values
 

--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -12,29 +12,28 @@ Archives: A collection of HoloViews objects that are first collected
           objects for a report then generating a PDF or collecting
           HoloViews objects to dump to HDF5.
 """
-import re
-import os
-import time
-import string
-import zipfile
-import tarfile
-import shutil
 import itertools
+import os
 import pickle
+import re
+import shutil
+import string
+import tarfile
+import time
+import zipfile
 from collections import defaultdict
-
-from io import BytesIO
 from hashlib import sha256
+from io import BytesIO
 
 import param
 from param.parameterized import bothmethod
 
 from .dimension import LabelledData
 from .element import Collator, Element
-from .overlay import Overlay, Layout
-from .ndmapping import OrderedDict, NdMapping, UniformNdMapping
+from .ndmapping import NdMapping, OrderedDict, UniformNdMapping
 from .options import Store
-from .util import unique_iterator, group_sanitizer, label_sanitizer
+from .overlay import Layout, Overlay
+from .util import group_sanitizer, label_sanitizer, unique_iterator
 
 
 def sanitizer(name, replacements=[(':','_'), ('/','_'), ('\\','_')]):

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -5,12 +5,12 @@ AdjointLayout allows one or two Views to be adjoined to a primary View
 to act as supplementary elements.
 """
 
-import param
 import numpy as np
+import param
 
-from .dimension import Dimension, Dimensioned, ViewableElement, ViewableTree
-from .ndmapping import OrderedDict, NdMapping, UniformNdMapping
 from . import traversal
+from .dimension import Dimension, Dimensioned, ViewableElement, ViewableTree
+from .ndmapping import NdMapping, OrderedDict, UniformNdMapping
 
 
 class Layoutable:

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -6,17 +6,22 @@ also enables slicing over multiple dimension ranges.
 
 from itertools import cycle
 from operator import itemgetter
+
 import numpy as np
 import pandas as pd
-
 import param
 
 from . import util
-from .dimension import OrderedDict, Dimension, Dimensioned, ViewableElement, asdim
+from .dimension import Dimension, Dimensioned, OrderedDict, ViewableElement, asdim
 from .util import (
-    unique_iterator, sanitize_identifier, dimension_sort, wrap_tuple,
-    process_ellipses, get_ndmapping_label
+    dimension_sort,
+    get_ndmapping_label,
+    process_ellipses,
+    sanitize_identifier,
+    unique_iterator,
+    wrap_tuple,
 )
+
 
 class item_check:
     """

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -4,6 +4,7 @@ map types. The former class only allows indexing whereas the latter
 also enables slicing over multiple dimension ranges.
 """
 
+from collections import OrderedDict
 from itertools import cycle
 from operator import itemgetter
 
@@ -12,7 +13,7 @@ import pandas as pd
 import param
 
 from . import util
-from .dimension import Dimension, Dimensioned, OrderedDict, ViewableElement, asdim
+from .dimension import Dimension, Dimensioned, ViewableElement, asdim
 from .util import (
     dimension_sort,
     get_ndmapping_label,

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -4,13 +4,13 @@ the purposes of analysis or visualization.
 """
 import param
 
+from . import Dataset, util
 from .dimension import ViewableElement
 from .element import Element
 from .layout import Layout
 from .options import Store
 from .overlay import NdOverlay, Overlay
 from .spaces import Callable, HoloMap
-from . import util, Dataset
 
 
 class Operation(param.ParameterizedFunction):

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -36,19 +36,16 @@ import difflib
 import inspect
 import pickle
 import traceback
-
-from contextlib import contextmanager
 from collections import defaultdict
+from contextlib import contextmanager
 
 import numpy as np
 import param
 
-from .accessors import Opts # noqa (clean up in 2.0)
-from .tree import AttrTree
-from .util import (
-    OrderedDict, group_sanitizer, label_sanitizer, sanitize_identifier
-)
+from .accessors import Opts  # noqa (clean up in 2.0)
 from .pprint import InfoPrinter
+from .tree import AttrTree
+from .util import OrderedDict, group_sanitizer, label_sanitizer, sanitize_identifier
 
 
 def cleanup_custom_options(id, weakref=None):
@@ -928,7 +925,7 @@ class Compositor(param.Parameterized):
         Finds any applicable compositor and applies it.
         """
         from .element import Element
-        from .overlay import Overlay, CompositeOverlay
+        from .overlay import CompositeOverlay, Overlay
         unpack = False
         if not isinstance(overlay, CompositeOverlay):
             overlay = Overlay([overlay])

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -9,13 +9,14 @@ for indexing, slicing and animating collections of Views.
 
 from collections import OrderedDict
 from functools import reduce
-import numpy as np
 
+import numpy as np
 import param
+
 from .dimension import Dimension, Dimensioned, ViewableElement, ViewableTree
+from .layout import AdjointLayout, Composable, Layout, Layoutable
 from .ndmapping import UniformNdMapping
-from .layout import Composable, Layout, AdjointLayout, Layoutable
-from .util import sanitize_identifier, unique_array, dimensioned_streams
+from .util import dimensioned_streams, sanitize_identifier, unique_array
 
 
 class Overlayable:

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -15,12 +15,10 @@ import re
 import textwrap
 
 import param
-
 from param.ipython import ParamPager
 from param.parameterized import bothmethod
 
 from .util import group_sanitizer, label_sanitizer
-
 
 
 class ParamFilter(param.ParameterizedFunction):
@@ -360,7 +358,7 @@ class PrettyPrinter(param.Parameterized):
     def option_info(cls_or_slf, node):
         if not cls_or_slf.show_options:
             return None
-        from .options import Store, Options
+        from .options import Options, Store
         options = {}
         for g in Options._option_groups:
             gopts = Store.lookup_options(Store.current_backend, node, g,

--- a/holoviews/core/sheetcoords.py
+++ b/holoviews/core/sheetcoords.py
@@ -76,9 +76,9 @@ outside of the actual matrix.
 """
 
 import numpy as np
+
 from .boundingregion import BoundingBox
 from .util import datetime_types
-
 
 # Note about the 'bounds-master' approach we have adopted
 # =======================================================

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1,25 +1,23 @@
 import itertools
 import types
-
-from numbers import Number
-from itertools import groupby
-from functools import partial
 from collections import defaultdict
 from contextlib import contextmanager
+from functools import partial
+from itertools import groupby
+from numbers import Number
 from types import FunctionType
 
 import numpy as np
 import param
 
+from ..streams import Params, Stream, streams_list_from_dict
 from . import traversal, util
 from .accessors import Opts, Redim
-from .dimension import OrderedDict, Dimension, ViewableElement
-from .layout import Layout, AdjointLayout, NdLayout, Empty, Layoutable
-from .ndmapping import UniformNdMapping, NdMapping, item_check
-from .overlay import Overlay, CompositeOverlay, NdOverlay, Overlayable
+from .dimension import Dimension, OrderedDict, ViewableElement
+from .layout import AdjointLayout, Empty, Layout, Layoutable, NdLayout
+from .ndmapping import NdMapping, UniformNdMapping, item_check
 from .options import Store, StoreOptions
-from ..streams import Stream, Params, streams_list_from_dict
-
+from .overlay import CompositeOverlay, NdOverlay, Overlay, Overlayable
 
 
 class HoloMap(Layoutable, UniformNdMapping, Overlayable):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1,29 +1,28 @@
-import sys
-import warnings
-import operator
+import datetime as dt
 import hashlib
-import json
-import time
-import types
-import numbers
-import pickle
 import inspect
 import itertools
+import json
+import numbers
+import operator
+import pickle
 import string
+import sys
+import time
+import types
 import unicodedata
-import datetime as dt
-
-from collections.abc import Iterable # noqa
-from collections import defaultdict, OrderedDict, namedtuple
+import warnings
+from collections import OrderedDict, defaultdict, namedtuple
+from collections.abc import Iterable  # noqa
 from contextlib import contextmanager
-from packaging.version import Version
 from functools import partial
-from threading import Thread, Event
+from threading import Event, Thread
 from types import FunctionType
 
 import numpy as np
 import pandas as pd
 import param
+from packaging.version import Version
 
 # Python 2 builtins
 basestring = str
@@ -55,16 +54,19 @@ pandas_version = Version(pd.__version__)
 try:
     if pandas_version >= Version('1.3.0'):
         from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtypeType
-        from pandas.core.dtypes.generic import ABCSeries, ABCIndex as ABCIndexClass
+        from pandas.core.dtypes.generic import (
+            ABCIndex as ABCIndexClass,
+            ABCSeries,
+        )
     elif pandas_version >= Version('0.24.0'):
         from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtypeType
-        from pandas.core.dtypes.generic import ABCSeries, ABCIndexClass
+        from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
     elif pandas_version > Version('0.20.0'):
         from pandas.core.dtypes.dtypes import DatetimeTZDtypeType
-        from pandas.core.dtypes.generic import ABCSeries, ABCIndexClass
+        from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
     else:
         from pandas.types.dtypes import DatetimeTZDtypeType
-        from pandas.types.dtypes.generic import ABCSeries, ABCIndexClass
+        from pandas.types.dtypes.generic import ABCIndexClass, ABCSeries
     pandas_datetime_types = (pd.Timestamp, DatetimeTZDtypeType, pd.Period)
     pandas_timedelta_types = (pd.Timedelta,)
     datetime_types = datetime_types + pandas_datetime_types

--- a/holoviews/element/__init__.py
+++ b/holoviews/element/__init__.py
@@ -1,16 +1,16 @@
 from ..core import HoloMap
-from ..core.data import Dataset, DataConversion
-from .annotation import * # noqa (API import)
-from .chart import * # noqa (API import)
-from .geom import * # noqa (API import)
-from .chart3d import * # noqa (API import)
-from .graphs import * # noqa (API import)
-from .path import * # noqa (API import)
-from .raster import * # noqa (API import)
-from .sankey import * # noqa (API import)
-from .stats import * # noqa (API import)
-from .tabular import * # noqa (API import)
-from .tiles import * # noqa (API import)
+from ..core.data import DataConversion, Dataset
+from .annotation import *  # noqa (API import)
+from .chart import *  # noqa (API import)
+from .chart3d import *  # noqa (API import)
+from .geom import *  # noqa (API import)
+from .graphs import *  # noqa (API import)
+from .path import *  # noqa (API import)
+from .raster import *  # noqa (API import)
+from .sankey import *  # noqa (API import)
+from .stats import *  # noqa (API import)
+from .tabular import *  # noqa (API import)
+from .tiles import *  # noqa (API import)
 
 
 class ElementConversion(DataConversion):

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -1,10 +1,11 @@
 from numbers import Number
+
 import numpy as np
 import param
 
-from ..core.util import datetime_types
-from ..core import Dimension, Element2D, Element
+from ..core import Dimension, Element, Element2D
 from ..core.data import Dataset
+from ..core.util import datetime_types
 
 
 class Annotation(Element2D):

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -1,10 +1,9 @@
 import numpy as np
 import param
 
-from ..core import util
-from ..core import Dimension, Dataset, Element2D, NdOverlay, Overlay
+from ..core import Dataset, Dimension, Element2D, NdOverlay, Overlay, util
 from ..core.dimension import process_dimensions
-from .geom import Rectangles, Points, VectorField # noqa: backward compatible import
+from .geom import Points, Rectangles, VectorField  # noqa: backward compatible import
 from .selection import Selection1DExpr
 
 

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -18,19 +18,32 @@ thus would not supply any information regarding *why* two elements are
 considered different.
 """
 from functools import partial
+from unittest import TestCase
+from unittest.util import safe_repr
+
 import numpy as np
 import pandas as pd
-from unittest.util import safe_repr
-from unittest import TestCase
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
-from . import *    # noqa (All Elements need to support comparison)
-from ..core import (Element, Empty, AdjointLayout, Overlay, Dimension,
-                    HoloMap, Dimensioned, Layout, NdLayout, NdOverlay,
-                    GridSpace, DynamicMap, GridMatrix, OrderedDict)
-from ..core.options import Options, Cycle
-from ..core.util import (cast_array_to_int64, datetime_types, dt_to_int,
-                         is_float)
+from ..core import (
+    AdjointLayout,
+    Dimension,
+    Dimensioned,
+    DynamicMap,
+    Element,
+    Empty,
+    GridMatrix,
+    GridSpace,
+    HoloMap,
+    Layout,
+    NdLayout,
+    NdOverlay,
+    OrderedDict,
+    Overlay,
+)
+from ..core.options import Cycle, Options
+from ..core.util import cast_array_to_int64, datetime_types, dt_to_int, is_float
+from . import *  # noqa (All Elements need to support comparison)
 
 
 class ComparisonInterface:

--- a/holoviews/element/geom.py
+++ b/holoviews/element/geom.py
@@ -1,8 +1,7 @@
 import numpy as np
-
 import param
 
-from ..core import Dimension, Dataset, Element2D
+from ..core import Dataset, Dimension, Element2D
 from .selection import Selection2DExpr, SelectionGeomExpr
 
 

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -1,18 +1,23 @@
-from types import FunctionType
 from collections import defaultdict
+from types import FunctionType
 
-import param
 import numpy as np
 import pandas as pd
+import param
 
-from ..core import Dimension, Dataset, Element2D
+from ..core import Dataset, Dimension, Element2D
 from ..core.accessors import Redim
-from ..core.util import is_dataframe, max_range, search_indices
 from ..core.operation import Operation
+from ..core.util import is_dataframe, max_range, search_indices
 from .chart import Points
 from .path import Path
-from .util import (split_path, circular_layout,
-                   connect_edges_pd, quadratic_bezier, connect_tri_edges_pd)
+from .util import (
+    circular_layout,
+    connect_edges_pd,
+    connect_tri_edges_pd,
+    quadratic_bezier,
+    split_path,
+)
 
 
 class RedimGraph(Redim):

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -6,8 +6,8 @@ quickly draw common shapes.
 """
 
 import numpy as np
-
 import param
+
 from ..core import Dataset
 from ..core.data import MultiInterface
 from ..core.dimension import Dimension

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -1,20 +1,20 @@
+import colorsys
 from operator import itemgetter
 
 import numpy as np
-import colorsys
 import param
 
-from ..core import util, config, Dimension, Element2D, Overlay, Dataset
+from ..core import Dataset, Dimension, Element2D, Overlay, config, util
+from ..core.boundingregion import BoundingBox, BoundingRegion
 from ..core.data import ImageInterface
 from ..core.data.interface import DataError
 from ..core.dimension import dimension_name
-from ..core.boundingregion import BoundingRegion, BoundingBox
 from ..core.sheetcoords import SheetCoordinateSystem, Slice
 from .chart import Curve
 from .geom import Selection2DExpr
 from .graphs import TriMesh
 from .tabular import Table
-from .util import compute_slice_bounds, categorical_aggregate2d
+from .util import categorical_aggregate2d, compute_slice_bounds
 
 
 class Raster(Element2D):

--- a/holoviews/element/sankey.py
+++ b/holoviews/element/sankey.py
@@ -2,16 +2,15 @@ import math
 from functools import cmp_to_key
 from itertools import cycle
 
-import param
 import numpy as np
+import param
 
-from ..core.dimension import Dimension
 from ..core.data import Dataset
+from ..core.dimension import Dimension
 from ..core.operation import Operation
 from ..core.util import get_param_values, unique_array
-from .graphs import Graph, Nodes, EdgePaths
+from .graphs import EdgePaths, Graph, Nodes
 from .util import quadratic_bezier
-
 
 _Y_N_DECIMAL_DIGITS = 6
 _Y_EPS = 10 ** -_Y_N_DECIMAL_DIGITS

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from ..core import Dataset, NdOverlay, util
-from ..streams import SelectionXY, Selection1D, Lasso
+from ..streams import Lasso, Selection1D, SelectionXY
 from ..util.transform import dim
 from .annotation import HSpan, VSpan
 
@@ -63,8 +63,8 @@ class SelectionIndexExpr:
 def spatial_select_gridded(xvals, yvals, geometry):
     rectilinear = (np.diff(xvals, axis=0) == 0).all()
     if rectilinear:
-        from .raster import Image
         from .path import Polygons
+        from .raster import Image
         try:
             from ..operation.datashader import rasterize
         except ImportError:
@@ -120,7 +120,7 @@ def spatial_select_columnar(xvals, yvals, geometry):
     masked_xvals = xvals[sel_mask]
     masked_yvals = yvals[sel_mask]
     try:
-        from spatialpandas.geometry import Polygon, PointArray
+        from spatialpandas.geometry import PointArray, Polygon
         points = PointArray((masked_xvals.astype('float'), masked_yvals.astype('float')))
         poly = Polygon([np.concatenate([geometry, geometry[:1]]).flatten()])
         geom_mask = points.intersects(poly)
@@ -148,7 +148,7 @@ def spatial_select(xvals, yvals, geometry):
 
 def spatial_geom_select(x0vals, y0vals, x1vals, y1vals, geometry):
     try:
-        from shapely.geometry import box, Polygon
+        from shapely.geometry import Polygon, box
         boxes = (box(x0, y0, x1, y1) for x0, y0, x1, y1 in
                  zip(x0vals, y0vals, x1vals, y1vals))
         poly = Polygon(geometry)

--- a/holoviews/element/stats.py
+++ b/holoviews/element/stats.py
@@ -1,10 +1,10 @@
-import param
 import numpy as np
+import param
 
-from ..core.dimension import Dimension, process_dimensions
 from ..core.data import Dataset
+from ..core.dimension import Dimension, process_dimensions
 from ..core.element import Element, Element2D
-from ..core.util import get_param_values, unique_iterator, OrderedDict
+from ..core.util import OrderedDict, get_param_values, unique_iterator
 from .selection import Selection1DExpr, Selection2DExpr
 
 

--- a/holoviews/element/tabular.py
+++ b/holoviews/element/tabular.py
@@ -1,10 +1,9 @@
 from collections import OrderedDict
 
 import numpy as np
-
 import param
 
-from ..core import Element, Dataset, Tabular
+from ..core import Dataset, Element, Tabular
 from ..core.dimension import Dimension, dimension_name
 from .selection import SelectionIndexExpr
 

--- a/holoviews/element/tiles.py
+++ b/holoviews/element/tiles.py
@@ -1,12 +1,12 @@
 from types import FunctionType
 
-import param
 import numpy as np
+import param
 
 from ..core import util
 from ..core.dimension import Dimension
 from ..core.element import Element2D
-from ..util.transform import lon_lat_to_easting_northing, easting_northing_to_lon_lat
+from ..util.transform import easting_northing_to_lon_lat, lon_lat_to_easting_northing
 
 
 class Tiles(Element2D):

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -1,19 +1,22 @@
 import itertools
 
-import param
 import numpy as np
 import pandas as pd
+import param
 
 from ..core import Dataset, OrderedDict
 from ..core.boundingregion import BoundingBox
-from ..core.data import default_datatype, PandasInterface
+from ..core.data import PandasInterface, default_datatype
 from ..core.operation import Operation
 from ..core.sheetcoords import Slice
 from ..core.util import (
-    cartesian_product, datetime_types, is_cyclic, is_nan,
-    one_to_one, sort_topologically
+    cartesian_product,
+    datetime_types,
+    is_cyclic,
+    is_nan,
+    one_to_one,
+    sort_topologically,
 )
-
 
 
 def split_path(path):

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -2,22 +2,20 @@ import os
 from unittest import SkipTest
 
 import param
-import holoviews
-
 from IPython.core.completer import IPCompleter
 from IPython.display import HTML, publish_display_data
 from param import ipython as param_ext
 
-from ..core.dimension import LabelledData
-from ..core.tree import AttrTree
-from ..core.options import Store
-from ..element.comparison import ComparisonTestCase
-from ..util import extension
-from ..plotting.renderer import Renderer
-from .magics import load_magics
-from .display_hooks import display
-from .display_hooks import pprint_display, png_display, svg_display
+import holoviews
 
+from ..core.dimension import LabelledData
+from ..core.options import Store
+from ..core.tree import AttrTree
+from ..element.comparison import ComparisonTestCase
+from ..plotting.renderer import Renderer
+from ..util import extension
+from .display_hooks import display, png_display, pprint_display, svg_display
+from .magics import load_magics
 
 AttrTree._disabled_prefixes = ['_repr_','_ipython_canary_method_should_not_exist']
 

--- a/holoviews/ipython/archive.py
+++ b/holoviews/ipython/archive.py
@@ -3,23 +3,20 @@ Implements NotebookArchive used to automatically capture notebook data
 and export it to disk via the display hooks.
 """
 
-import time
-import sys
 import os
+import sys
+import time
 import traceback
 
-from IPython.display import Javascript, display
-from .preprocessors import Substitute
-
-from nbformat import reader
-from nbconvert import HTMLExporter
-
-from nbconvert.preprocessors.clearoutput import ClearOutputPreprocessor
-from nbconvert import NotebookExporter
-
 import param
+from IPython.display import Javascript, display
+from nbconvert import HTMLExporter, NotebookExporter
+from nbconvert.preprocessors.clearoutput import ClearOutputPreprocessor
+from nbformat import reader
+
 from ..core.io import FileArchive, Pickler
 from ..plotting.renderer import HTML_TAGS, MIME_TYPES
+from .preprocessors import Substitute
 
 
 class NotebookArchive(FileArchive):

--- a/holoviews/ipython/archive.py
+++ b/holoviews/ipython/archive.py
@@ -8,43 +8,14 @@ import sys
 import os
 import traceback
 
-from IPython import version_info
 from IPython.display import Javascript, display
 from .preprocessors import Substitute
 
-# Import appropriate nbconvert machinery
-if version_info[0] >= 4:
-    # Jupyter/IPython >=4.0
-    from nbformat import reader
-    from nbconvert import HTMLExporter
+from nbformat import reader
+from nbconvert import HTMLExporter
 
-    from nbconvert.preprocessors.clearoutput import ClearOutputPreprocessor
-    from nbconvert import NotebookExporter
-else:
-    # IPython <= 3.0
-    from IPython.nbformat import reader
-    from IPython.nbconvert import HTMLExporter
-
-    if version_info[0] == 3:
-        # IPython 3
-        from IPython.nbconvert.preprocessors.clearoutput import ClearOutputPreprocessor
-        from IPython.nbconvert import NotebookExporter
-    else:
-        # IPython 2
-        from IPython.nbformat import current
-        NotebookExporter, ClearOutputPreprocessor = None, None
-
-        def v3_strip_output(nb):
-            """strip the outputs from a notebook object"""
-            nb["nbformat"] = 3
-            nb["nbformat_minor"] = 0
-            nb.metadata.pop('signature', None)
-            for cell in nb.worksheets[0].cells:
-                if 'outputs' in cell:
-                    cell['outputs'] = []
-                if 'prompt_number' in cell:
-                    cell['prompt_number'] = None
-            return nb
+from nbconvert.preprocessors.clearoutput import ClearOutputPreprocessor
+from nbconvert import NotebookExporter
 
 import param
 from ..core.io import FileArchive, Pickler
@@ -217,13 +188,9 @@ class NotebookArchive(FileArchive):
 
 
     def _clear_notebook(self, node):                # pragma: no cover
-        if NotebookExporter is not None:
-            exporter = NotebookExporter()
-            exporter.register_preprocessor(ClearOutputPreprocessor(enabled=True))
-            cleared,_ = exporter.from_notebook_node(node)
-        else:
-            stripped_node = v3_strip_output(node)
-            cleared = current.writes(stripped_node, 'ipynb')
+        exporter = NotebookExporter()
+        exporter.register_preprocessor(ClearOutputPreprocessor(enabled=True))
+        cleared, _ = exporter.from_notebook_node(node)
         return cleared
 
 

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -1,25 +1,32 @@
 """
 Definition and registration of display hooks for the IPython Notebook.
 """
-from functools import wraps
-from contextlib import contextmanager
-
 import sys
 import traceback
+from contextlib import contextmanager
+from functools import wraps
 
 import IPython
 from IPython import get_ipython
 from IPython.display import HTML
 
 import holoviews
-from ..core.options import (Store, StoreOptions, SkipRendering,
-                            AbbreviatedException)
+
 from ..core import (
-    ViewableElement, HoloMap, AdjointLayout, NdLayout, GridSpace,
-    Layout, CompositeOverlay, DynamicMap, Dimensioned, Empty
+    AdjointLayout,
+    CompositeOverlay,
+    Dimensioned,
+    DynamicMap,
+    Empty,
+    GridSpace,
+    HoloMap,
+    Layout,
+    NdLayout,
+    ViewableElement,
 )
-from ..core.traversal import unique_dimkeys
 from ..core.io import FileArchive
+from ..core.options import AbbreviatedException, SkipRendering, Store, StoreOptions
+from ..core.traversal import unique_dimkeys
 from ..core.util import mimebundle_to_html
 from ..plotting import Plot
 from ..plotting.renderer import MIME_TYPES

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -1,13 +1,11 @@
-import time
 import sys
+import time
 
-from IPython.core.magic import Magics, magics_class, line_magic, line_cell_magic
-
+from IPython.core.magic import Magics, line_cell_magic, line_magic, magics_class
+from IPython.display import HTML, display
 
 from ..core.options import Options, Store, StoreOptions, options_policy
 from ..core.pprint import InfoPrinter
-
-from IPython.display import display, HTML
 from ..operation import Compositor
 
 #========#
@@ -20,14 +18,14 @@ try:
 except ImportError:
     pyparsing = None
 else:
-    from holoviews.util.parser import CompositorSpec
-    from holoviews.util.parser import OptsSpec
+    from holoviews.util.parser import CompositorSpec, OptsSpec
 
 
 # Set to True to automatically run notebooks.
 STORE_HISTORY = False
 
 from IPython.core import page
+
 InfoPrinter.store = Store
 
 

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -1,11 +1,7 @@
 import time
 import sys
 
-try:
-    from IPython.core.magic import Magics, magics_class, line_magic, line_cell_magic
-except ImportError:
-    from unittest import SkipTest
-    raise SkipTest("IPython extension requires IPython >= 0.13")
+from IPython.core.magic import Magics, magics_class, line_magic, line_cell_magic
 
 
 from ..core.options import Options, Store, StoreOptions, options_policy

--- a/holoviews/ipython/preprocessors.py
+++ b/holoviews/ipython/preprocessors.py
@@ -4,6 +4,7 @@ Prototype demo:
 python holoviews/ipython/convert.py Conversion_Example.ipynb | python
 """
 import ast
+
 from nbconvert.preprocessors import Preprocessor
 
 

--- a/holoviews/ipython/widgets.py
+++ b/holoviews/ipython/widgets.py
@@ -1,17 +1,7 @@
 import sys
 import math
 import time
-from unittest import SkipTest
-
-try:
-    import IPython
-    from IPython.core.display import clear_output
-except ImportError:
-    clear_output = None
-    raise SkipTest("IPython extension requires IPython >= 0.12")
-
-# IPython 0.13 does not have version_info
-ipython2 = hasattr(IPython, 'version_info') and (IPython.version_info[0] == 2)
+from IPython.core.display import clear_output
 
 import param
 from ..core.util import ProgressIndicator
@@ -71,8 +61,8 @@ class ProgressBar(ProgressIndicator):
         elif self.display == 'stdout':
             if percentage==100 and self.elapsed_time:
                 elapsed = time.time() -  self.start_time
-                if clear_output and not ipython2: clear_output()
-                if clear_output and ipython2: clear_output(wait=True)
+                if clear_output:
+                    clear_output(wait=True)
                 self.out = '\r' + ('100%% %s %02d:%02d:%02d'
                                    % (self.label.lower(), elapsed//3600,
                                       elapsed//60, elapsed%60))
@@ -92,8 +82,8 @@ class ProgressBar(ProgressIndicator):
 
 
     def _stdout_display(self, percentage, display=True):
-        if clear_output and not ipython2: clear_output()
-        if clear_output and ipython2: clear_output(wait=True)
+        if clear_output:
+            clear_output(wait=True)
         percent_per_char = 100.0 / self.width
         char_count = int(math.floor(percentage/percent_per_char)
                          if percentage<100.0 else self.width)

--- a/holoviews/ipython/widgets.py
+++ b/holoviews/ipython/widgets.py
@@ -1,9 +1,10 @@
-import sys
 import math
+import sys
 import time
-from IPython.core.display import clear_output
 
 import param
+from IPython.core.display import clear_output
+
 from ..core.util import ProgressIndicator
 
 

--- a/holoviews/operation/__init__.py
+++ b/holoviews/operation/__init__.py
@@ -1,8 +1,8 @@
+from ..core import Overlay  # noqa (API import)
 from ..core.operation import Operation
 from ..core.options import Compositor
+from .element import *  # noqa (API import)
 
-from .element import *      # noqa (API import)
-from ..core import Overlay  # noqa (API import)
 
 def public(obj):
     if not isinstance(obj, type): return False

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1,39 +1,70 @@
 import warnings
-
 from collections.abc import Callable
 from functools import partial
 
-import param
-import numpy as np
-import pandas as pd
-import xarray as xr
+import dask.dataframe as dd
 import datashader as ds
 import datashader.reductions as rd
 import datashader.transfer_functions as tf
-import dask.dataframe as dd
-
+import numpy as np
+import pandas as pd
+import param
+import xarray as xr
 from datashader.colors import color_lookup
-from param.parameterized import bothmethod
 from packaging.version import Version
+from param.parameterized import bothmethod
 
 try:
-    from datashader.bundling import (directly_connect_edges as connect_edges,
-                                     hammer_bundle)
+    from datashader.bundling import (
+        directly_connect_edges as connect_edges,
+        hammer_bundle,
+    )
 except ImportError:
     hammer_bundle, connect_edges = object, object
 
-from ..core import (Operation, Element, Dimension, NdOverlay,
-                    CompositeOverlay, Dataset, Overlay, OrderedDict, Store)
-from ..core.data import PandasInterface, XArrayInterface, DaskInterface, cuDFInterface
-from ..core.util import (
-    Iterable, cast_array_to_int64, cftime_types, cftime_to_timestamp,
-    datetime_types, dt_to_int, isfinite, get_param_values, max_range
+from ..core import (
+    CompositeOverlay,
+    Dataset,
+    Dimension,
+    Element,
+    NdOverlay,
+    Operation,
+    OrderedDict,
+    Overlay,
+    Store,
 )
-from ..element import (Image, Path, Curve, RGB, Graph, TriMesh,
-                       QuadMesh, Contours, Spikes, Area, Rectangles,
-                       Spread, Segments, Scatter, Points, Polygons)
+from ..core.data import DaskInterface, PandasInterface, XArrayInterface, cuDFInterface
+from ..core.util import (
+    Iterable,
+    cast_array_to_int64,
+    cftime_to_timestamp,
+    cftime_types,
+    datetime_types,
+    dt_to_int,
+    get_param_values,
+    isfinite,
+    max_range,
+)
+from ..element import (
+    RGB,
+    Area,
+    Contours,
+    Curve,
+    Graph,
+    Image,
+    Path,
+    Points,
+    Polygons,
+    QuadMesh,
+    Rectangles,
+    Scatter,
+    Segments,
+    Spikes,
+    Spread,
+    TriMesh,
+)
 from ..element.util import connect_tri_edges_pd
-from ..streams import RangeXY, PlotSize, PointerXY
+from ..streams import PlotSize, PointerXY, RangeXY
 
 ds_version = Version(ds.__version__)
 

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -6,22 +6,37 @@ import warnings
 
 import numpy as np
 import param
-
 from packaging.version import Version
 from param import _is_number
 
-from ..core import (Operation, NdOverlay, Overlay, GridMatrix,
-                    HoloMap, Dataset, Element, Collator, Dimension)
+from ..core import (
+    Collator,
+    Dataset,
+    Dimension,
+    Element,
+    GridMatrix,
+    HoloMap,
+    NdOverlay,
+    Operation,
+    Overlay,
+)
 from ..core.data import ArrayInterface, DictInterface, PandasInterface, default_datatype
 from ..core.data.util import dask_array_module
 from ..core.util import (
-    group_sanitizer, label_sanitizer, datetime_types, isfinite,
-    dt_to_int, isdatetime, is_dask_array, is_cupy_array, is_ibis_expr
+    datetime_types,
+    dt_to_int,
+    group_sanitizer,
+    is_cupy_array,
+    is_dask_array,
+    is_ibis_expr,
+    isdatetime,
+    isfinite,
+    label_sanitizer,
 )
 from ..element.chart import Histogram, Scatter
-from ..element.raster import Image, RGB
 from ..element.path import Contours, Polygons
-from ..element.util import categorical_aggregate2d # noqa (API import)
+from ..element.raster import RGB, Image
+from ..element.util import categorical_aggregate2d  # noqa (API import)
 from ..streams import RangeXY
 
 column_interfaces = [ArrayInterface, DictInterface, PandasInterface]
@@ -545,10 +560,10 @@ class contours(Operation):
 
     def _process(self, element, key=None):
         try:
-            from matplotlib.contour import QuadContourSet
             from matplotlib.axes import Axes
+            from matplotlib.contour import QuadContourSet
+            from matplotlib.dates import date2num, num2date
             from matplotlib.figure import Figure
-            from matplotlib.dates import num2date, date2num
         except ImportError:
             raise ImportError("contours operation requires matplotlib.")
         extent = element.range(0) + element.range(1)[::-1]

--- a/holoviews/operation/normalization.py
+++ b/holoviews/operation/normalization.py
@@ -14,10 +14,11 @@ each element.
 """
 
 import param
-from ..core.operation import Operation
-from ..element import Raster
+
 from ..core import Overlay
+from ..core.operation import Operation
 from ..core.util import match_spec
+from ..element import Raster
 
 
 class Normalization(Operation):

--- a/holoviews/operation/stats.py
+++ b/holoviews/operation/stats.py
@@ -1,12 +1,10 @@
-import param
 import numpy as np
+import param
 
-from ..core import Dimension, Dataset, NdOverlay
+from ..core import Dataset, Dimension, NdOverlay
 from ..core.operation import Operation
 from ..core.util import cartesian_product, isfinite
-from ..element import (Curve, Area, Image, Distribution, Bivariate,
-                       Contours, Polygons)
-
+from ..element import Area, Bivariate, Contours, Curve, Distribution, Image, Polygons
 from .element import contours
 
 

--- a/holoviews/operation/timeseries.py
+++ b/holoviews/operation/timeseries.py
@@ -1,9 +1,9 @@
-import param
 import numpy as np
 import pandas as pd
+import param
 from packaging.version import Version
 
-from ..core import Operation, Element
+from ..core import Element, Operation
 from ..core.data import PandasInterface
 from ..core.util import pandas_version
 from ..element import Scatter

--- a/holoviews/plotting/__init__.py
+++ b/holoviews/plotting/__init__.py
@@ -5,13 +5,13 @@ any third-party plotting/rendering package.
 This file defines the HTML tags used to wrap rendered output for
 display in the IPython Notebook (optional).
 """
-from ..core.options import Cycle, Compositor
-from ..element import Area, Image, QuadMesh, Polygons, Raster
-from ..element.sankey import _layout_sankey, Sankey
+from ..core.options import Compositor, Cycle
+from ..element import Area, Image, Polygons, QuadMesh, Raster
+from ..element.sankey import Sankey, _layout_sankey
+from ..operation.stats import bivariate_kde, univariate_kde
 from .plot import Plot
-from .renderer import Renderer, HTML_TAGS # noqa (API import)
-from .util import apply_nodata, list_cmaps # noqa (API import)
-from ..operation.stats import univariate_kde, bivariate_kde
+from .renderer import HTML_TAGS, Renderer  # noqa (API import)
+from .util import apply_nodata, list_cmaps  # noqa (API import)
 
 Compositor.register(Compositor("Image", apply_nodata, None,
                                'data', transfer_options=True,

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -1,48 +1,112 @@
 import sys
 
 import numpy as np
-
 from bokeh.palettes import all_palettes
 from param import concrete_descendents
 
-from ...core import (Store, Overlay, NdOverlay, Layout, AdjointLayout,
-                     GridSpace, GridMatrix, NdLayout, config)
-from ...element import (Curve, Points, Scatter, Image, Raster, Path,
-                        RGB, Histogram, Spread, HeatMap, Contours, Bars,
-                        Box, Bounds, Ellipse, Polygons, BoxWhisker, Arrow,
-                        ErrorBars, Text, HLine, VLine, HSpan, VSpan, Spline, Spikes,
-                        Table, ItemTable, Area, HSV, QuadMesh, VectorField,
-                        Graph, Nodes, EdgePaths, Distribution, Bivariate,
-                        TriMesh, Violin, Chord, Div, HexTiles, Labels, Sankey,
-                        Tiles, Segments, Slope, Rectangles)
-from ...core.options import Options, Cycle, Palette
-
-from .annotation import (
-    TextPlot, LineAnnotationPlot, BoxAnnotationPlot, SplinePlot, ArrowPlot,
-    DivPlot, LabelsPlot, SlopePlot
+from ...core import (
+    AdjointLayout,
+    GridMatrix,
+    GridSpace,
+    Layout,
+    NdLayout,
+    NdOverlay,
+    Overlay,
+    Store,
+    config,
+)
+from ...core.options import Cycle, Options, Palette
+from ...element import (
+    HSV,
+    RGB,
+    Area,
+    Arrow,
+    Bars,
+    Bivariate,
+    Bounds,
+    Box,
+    BoxWhisker,
+    Chord,
+    Contours,
+    Curve,
+    Distribution,
+    Div,
+    EdgePaths,
+    Ellipse,
+    ErrorBars,
+    Graph,
+    HeatMap,
+    HexTiles,
+    Histogram,
+    HLine,
+    HSpan,
+    Image,
+    ItemTable,
+    Labels,
+    Nodes,
+    Path,
+    Points,
+    Polygons,
+    QuadMesh,
+    Raster,
+    Rectangles,
+    Sankey,
+    Scatter,
+    Segments,
+    Slope,
+    Spikes,
+    Spline,
+    Spread,
+    Table,
+    Text,
+    Tiles,
+    TriMesh,
+    VectorField,
+    Violin,
+    VLine,
+    VSpan,
 )
 from ..plot import PlotSelector
 from ..util import fire
-from .callbacks import Callback # noqa (API import)
-from .element import OverlayPlot, ElementPlot
-from .chart import (PointPlot, CurvePlot, SpreadPlot, ErrorPlot, HistogramPlot,
-                    SideHistogramPlot, BarPlot, SpikesPlot, SideSpikesPlot,
-                    AreaPlot, VectorFieldPlot)
-from .geometry import SegmentPlot, RectanglesPlot
-from .graphs import GraphPlot, NodePlot, TriMeshPlot, ChordPlot
+from .annotation import (
+    ArrowPlot,
+    BoxAnnotationPlot,
+    DivPlot,
+    LabelsPlot,
+    LineAnnotationPlot,
+    SlopePlot,
+    SplinePlot,
+    TextPlot,
+)
+from .callbacks import Callback  # noqa (API import)
+from .chart import (
+    AreaPlot,
+    BarPlot,
+    CurvePlot,
+    ErrorPlot,
+    HistogramPlot,
+    PointPlot,
+    SideHistogramPlot,
+    SideSpikesPlot,
+    SpikesPlot,
+    SpreadPlot,
+    VectorFieldPlot,
+)
+from .element import ElementPlot, OverlayPlot
+from .geometry import RectanglesPlot, SegmentPlot
+from .graphs import ChordPlot, GraphPlot, NodePlot, TriMeshPlot
 from .heatmap import HeatMapPlot, RadialHeatMapPlot
 from .hex_tiles import HexTilesPlot
-from .links import LinkCallback # noqa (API import)
-from .path import PathPlot, PolygonPlot, ContourPlot
-from .plot import GridPlot, LayoutPlot, AdjointLayoutPlot
-from .raster import RasterPlot, RGBPlot, HSVPlot, QuadMeshPlot
+from .links import LinkCallback  # noqa (API import)
+from .path import ContourPlot, PathPlot, PolygonPlot
+from .plot import AdjointLayoutPlot, GridPlot, LayoutPlot
+from .raster import HSVPlot, QuadMeshPlot, RasterPlot, RGBPlot
 from .renderer import BokehRenderer
 from .sankey import SankeyPlot
-from .stats import DistributionPlot, BivariatePlot, BoxWhiskerPlot, ViolinPlot
+from .stats import BivariatePlot, BoxWhiskerPlot, DistributionPlot, ViolinPlot
 from .tabular import TablePlot
 from .tiles import TilePlot
-from .util import bokeh_version # noqa (API import)
-
+from .util import bokeh_version  # noqa (API import)
 
 Store.renderers['bokeh'] = BokehRenderer.instance()
 

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -1,22 +1,19 @@
 from collections import defaultdict
 from html import escape
 
-import param
 import numpy as np
-
-from bokeh.models import BoxAnnotation, Span, Arrow, Slope
-from panel.models import HTML
-
-from bokeh.models import TeeHead, NormalHead
+import param
+from bokeh.models import Arrow, BoxAnnotation, NormalHead, Slope, Span, TeeHead
 from bokeh.transform import dodge
+from panel.models import HTML
 
 from ...core.util import datetime_types, dimension_sanitizer
 from ...element import HLine, VLine, VSpan
 from ..plot import GenericElementPlot
-from .element import AnnotationPlot, ElementPlot, CompositeElementPlot, ColorbarPlot
+from .element import AnnotationPlot, ColorbarPlot, CompositeElementPlot, ElementPlot
+from .plot import BokehPlot
 from .selection import BokehOverlaySelectionDisplay
 from .styles import base_properties, fill_properties, line_properties, text_properties
-from .plot import BokehPlot
 from .util import date_to_integer
 
 arrow_start = {'<->': NormalHead, '<|-|>': NormalHead}

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1,29 +1,58 @@
 import asyncio
 import base64
 import time
-
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
 
 import numpy as np
-
 from bokeh.models import (
-    CustomJS, FactorRange, DatetimeAxis, Range1d, DataRange1d,
-    PolyDrawTool, BoxEditTool, PolyEditTool, FreehandDrawTool,
-    PointDrawTool
+    BoxEditTool,
+    CustomJS,
+    DataRange1d,
+    DatetimeAxis,
+    FactorRange,
+    FreehandDrawTool,
+    PointDrawTool,
+    PolyDrawTool,
+    PolyEditTool,
+    Range1d,
 )
 from panel.io.state import state
 
 from ...core.options import CallbackError
-from ...core.util import (
-    datetime_types, dimension_sanitizer, dt64_to_dt
-)
+from ...core.util import datetime_types, dimension_sanitizer, dt64_to_dt
 from ...element import Table
 from ...streams import (
-    Stream, PointerXY, RangeXY, Selection1D, RangeX, RangeY, PointerX,
-    PointerY, BoundsX, BoundsY, Tap, SingleTap, DoubleTap, MouseEnter,
-    MouseLeave, PressUp, PanEnd, PlotSize, Draw, BoundsXY, PlotReset,
-    BoxEdit, PointDraw, PolyDraw, PolyEdit, CDSStream, FreehandDraw,
-    CurveEdit, SelectionXY, Lasso, SelectMode
+    BoundsX,
+    BoundsXY,
+    BoundsY,
+    BoxEdit,
+    CDSStream,
+    CurveEdit,
+    DoubleTap,
+    Draw,
+    FreehandDraw,
+    Lasso,
+    MouseEnter,
+    MouseLeave,
+    PanEnd,
+    PlotReset,
+    PlotSize,
+    PointDraw,
+    PointerX,
+    PointerXY,
+    PointerY,
+    PolyDraw,
+    PolyEdit,
+    PressUp,
+    RangeX,
+    RangeXY,
+    RangeY,
+    Selection1D,
+    SelectionXY,
+    SelectMode,
+    SingleTap,
+    Stream,
+    Tap,
 )
 from .util import convert_timestamp
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -2,27 +2,26 @@ from collections import defaultdict
 
 import numpy as np
 import param
-
-from bokeh.models import (
-    CategoricalColorMapper, CustomJS, FactorRange, Range1d, Whisker
-)
+from bokeh.models import CategoricalColorMapper, CustomJS, FactorRange, Range1d, Whisker
 from bokeh.models.tools import BoxSelectTool
 from bokeh.transform import jitter
 
 from ...core.data import Dataset
 from ...core.dimension import dimension_name
-from ...core.util import (
-    OrderedDict, dimension_sanitizer, isfinite
-)
+from ...core.util import OrderedDict, dimension_sanitizer, isfinite
 from ...operation import interpolate_curve
 from ...util.transform import dim
 from ..mixins import AreaMixin, BarsMixin, SpikesMixin
 from ..util import compute_sizes, get_min_distance
-from .element import ElementPlot, ColorbarPlot, LegendPlot, OverlayPlot
+from .element import ColorbarPlot, ElementPlot, LegendPlot, OverlayPlot
 from .selection import BokehOverlaySelectionDisplay
 from .styles import (
-    expand_batched_style, base_properties, line_properties, fill_properties,
-    mpl_to_bokeh, rgb2hex
+    base_properties,
+    expand_batched_style,
+    fill_properties,
+    line_properties,
+    mpl_to_bokeh,
+    rgb2hex,
 )
 from .util import categorize_array
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1,56 +1,82 @@
 import warnings
-
 from itertools import chain
 from types import FunctionType
 
-import param
-import numpy as np
 import bokeh
 import bokeh.plotting
+import numpy as np
+import param
 from bokeh.core.properties import value
 from bokeh.document.events import ModelChangedEvent
 from bokeh.models import (
-    BinnedTicker, ColorBar, ColorMapper, CustomJS, EqHistColorMapper,
-    Legend, Renderer, Title, tools,
+    BinnedTicker,
+    ColorBar,
+    ColorMapper,
+    CustomJS,
+    EqHistColorMapper,
+    Legend,
+    Renderer,
+    Title,
+    tools,
 )
 from bokeh.models.axes import CategoricalAxis, DatetimeAxis
-from bokeh.models.formatters import (
-    TickFormatter, MercatorTickFormatter
-)
+from bokeh.models.formatters import MercatorTickFormatter, TickFormatter
 from bokeh.models.layouts import Tabs
 from bokeh.models.mappers import (
-    LinearColorMapper, LogColorMapper, CategoricalColorMapper
+    CategoricalColorMapper,
+    LinearColorMapper,
+    LogColorMapper,
 )
-from bokeh.models.ranges import Range1d, DataRange1d, FactorRange
+from bokeh.models.ranges import DataRange1d, FactorRange, Range1d
 from bokeh.models.tickers import (
-    Ticker, BasicTicker, FixedTicker, LogTicker, MercatorTicker
+    BasicTicker,
+    FixedTicker,
+    LogTicker,
+    MercatorTicker,
+    Ticker,
 )
 from bokeh.models.tools import Tool
-
 from packaging.version import Version
 
-from ...core import DynamicMap, CompositeOverlay, Element, Dimension, Dataset
-from ...core.options import abbreviated_exception, SkipRendering
-from ...core import util
-from ...element import (
-    Annotation, Contours, Graph, Path, Tiles, VectorField
-)
-from ...streams import Buffer, RangeXY, PlotSize
+from ...core import CompositeOverlay, Dataset, Dimension, DynamicMap, Element, util
+from ...core.options import SkipRendering, abbreviated_exception
+from ...element import Annotation, Contours, Graph, Path, Tiles, VectorField
+from ...streams import Buffer, PlotSize, RangeXY
 from ...util.transform import dim
 from ..plot import GenericElementPlot, GenericOverlayPlot
-from ..util import process_cmap, color_intervals, dim_range_key
+from ..util import color_intervals, dim_range_key, process_cmap
 from .plot import BokehPlot
 from .styles import (
-    base_properties, legend_dimensions, line_properties, mpl_to_bokeh,
-    property_prefixes, rgba_tuple, text_properties, validate
+    base_properties,
+    legend_dimensions,
+    line_properties,
+    mpl_to_bokeh,
+    property_prefixes,
+    rgba_tuple,
+    text_properties,
+    validate,
 )
 from .tabular import TablePlot
 from .util import (
-    TOOL_TYPES, bokeh_version, bokeh3, date_to_integer, decode_bytes, get_tab_title,
-    glyph_order, py2js_tickformatter, recursive_model_update,
-    theme_attr_json, cds_column_replace, hold_policy, match_dim_specs,
-    compute_layout_properties, wrap_formatter, match_ax_type,
-    prop_is_none, remove_legend, property_to_dict
+    TOOL_TYPES,
+    bokeh3,
+    bokeh_version,
+    cds_column_replace,
+    compute_layout_properties,
+    date_to_integer,
+    decode_bytes,
+    get_tab_title,
+    glyph_order,
+    hold_policy,
+    match_ax_type,
+    match_dim_specs,
+    prop_is_none,
+    property_to_dict,
+    py2js_tickformatter,
+    recursive_model_update,
+    remove_legend,
+    theme_attr_json,
+    wrap_formatter,
 )
 
 if bokeh3:

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -1,10 +1,15 @@
 from collections import defaultdict
 
-import param
 import numpy as np
+import param
 from bokeh.models import (
-    StaticLayoutProvider, NodesAndLinkedEdges, EdgesAndLinkedNodes,
-    Patches, Bezier, ColumnDataSource, NodesOnly
+    Bezier,
+    ColumnDataSource,
+    EdgesAndLinkedNodes,
+    NodesAndLinkedEdges,
+    NodesOnly,
+    Patches,
+    StaticLayoutProvider,
 )
 
 from ...core.data import Dataset
@@ -13,12 +18,15 @@ from ...core.util import dimension_sanitizer, unique_array
 from ...element import Graph
 from ...util.transform import dim
 from ..mixins import ChordMixin
-from ..util import process_cmap, get_directed_graph_paths
+from ..util import get_directed_graph_paths, process_cmap
 from .chart import ColorbarPlot, PointPlot
 from .element import CompositeElementPlot, LegendPlot
 from .styles import (
-    base_properties, line_properties, fill_properties, text_properties,
-    rgba_tuple
+    base_properties,
+    fill_properties,
+    line_properties,
+    rgba_tuple,
+    text_properties,
 )
 from .util import bokeh3
 

--- a/holoviews/plotting/bokeh/heatmap.py
+++ b/holoviews/plotting/bokeh/heatmap.py
@@ -1,16 +1,13 @@
-import param
 import numpy as np
-
+import param
 from bokeh.models.glyphs import AnnularWedge
 
 from ...core.data import GridInterface
-from ...core.util import is_nan, dimension_sanitizer
 from ...core.spaces import HoloMap
+from ...core.util import dimension_sanitizer, is_nan
 from .element import ColorbarPlot, CompositeElementPlot
 from .selection import BokehOverlaySelectionDisplay
-from .styles import (
-    base_properties, line_properties, fill_properties, text_properties
-)
+from .styles import base_properties, fill_properties, line_properties, text_properties
 
 
 class HeatMapPlot(ColorbarPlot):

--- a/holoviews/plotting/bokeh/hex_tiles.py
+++ b/holoviews/plotting/bokeh/hex_tiles.py
@@ -1,8 +1,7 @@
 import types
 
-import param
 import numpy as np
-
+import param
 from bokeh.util.hex import cartesian_to_axial
 
 from ...core import Dimension, Operation
@@ -12,7 +11,7 @@ from ...element import HexTiles
 from ...util.transform import dim as dim_transform
 from .element import ColorbarPlot
 from .selection import BokehOverlaySelectionDisplay
-from .styles import base_properties, line_properties, fill_properties
+from .styles import base_properties, fill_properties, line_properties
 
 
 class hex_binning(Operation):

--- a/holoviews/plotting/bokeh/links.py
+++ b/holoviews/plotting/bokeh/links.py
@@ -1,15 +1,18 @@
 import numpy as np
-
 from bokeh.models import CustomJS
 from bokeh.models.tools import RangeTool
 
-from .util import bokeh3
 from ...core.util import isscalar
 from ..links import (
-    Link, RectanglesTableLink, DataLink, RangeToolLink,
-    SelectionLink, VertexTableLink
+    DataLink,
+    Link,
+    RangeToolLink,
+    RectanglesTableLink,
+    SelectionLink,
+    VertexTableLink,
 )
 from ..plot import GenericElementPlot, GenericOverlayPlot
+from .util import bokeh3
 
 if bokeh3:
     from bokeh.models import Toolbar

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
-import param
 import numpy as np
+import param
 
 from ...core import util
 from ...element import Contours, Polygons
@@ -10,8 +10,12 @@ from .callbacks import PolyDrawCallback, PolyEditCallback
 from .element import ColorbarPlot, LegendPlot, OverlayPlot
 from .selection import BokehOverlaySelectionDisplay
 from .styles import (
-    expand_batched_style, base_properties, line_properties, fill_properties,
-    mpl_to_bokeh, validate
+    base_properties,
+    expand_batched_style,
+    fill_properties,
+    line_properties,
+    mpl_to_bokeh,
+    validate,
 )
 from .util import multi_polygons_data
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -1,37 +1,66 @@
-from itertools import groupby
 from collections import defaultdict
+from itertools import groupby
 
 import numpy as np
 import param
-
 from bokeh.layouts import gridplot
 from bokeh.models import (
-    ColumnDataSource, Column, Row, Div, Title, Legend, Axis, ColorBar
+    Axis,
+    ColorBar,
+    Column,
+    ColumnDataSource,
+    Div,
+    Legend,
+    Row,
+    Title,
 )
 from bokeh.models.layouts import Tabs
 
-from ...selection import NoOpSelectionDisplay
 from ...core import (
-    OrderedDict, Store, AdjointLayout, NdLayout, Layout, Empty,
-    GridSpace, HoloMap, Element
+    AdjointLayout,
+    Element,
+    Empty,
+    GridSpace,
+    HoloMap,
+    Layout,
+    NdLayout,
+    OrderedDict,
+    Store,
 )
 from ...core.options import SkipRendering
 from ...core.util import (
-    cftime_to_timestamp, cftime_types, get_method_owner,
-    is_param_method, unique_iterator, wrap_tuple, wrap_tuple_streams,
-    _STANDARD_CALENDARS
+    _STANDARD_CALENDARS,
+    cftime_to_timestamp,
+    cftime_types,
+    get_method_owner,
+    is_param_method,
+    unique_iterator,
+    wrap_tuple,
+    wrap_tuple_streams,
 )
+from ...selection import NoOpSelectionDisplay
 from ..links import Link
 from ..plot import (
-    DimensionedPlot, GenericCompositePlot, GenericLayoutPlot,
-    GenericElementPlot, GenericOverlayPlot, GenericAdjointLayoutPlot,
-    CallbackPlot
+    CallbackPlot,
+    DimensionedPlot,
+    GenericAdjointLayoutPlot,
+    GenericCompositePlot,
+    GenericElementPlot,
+    GenericLayoutPlot,
+    GenericOverlayPlot,
 )
-from ..util import attach_streams, displayable, collate
+from ..util import attach_streams, collate, displayable
 from .links import LinkCallback
 from .util import (
-    bokeh3, filter_toolboxes, make_axis, update_shared_sources, empty_plot,
-    decode_bytes, theme_attr_json, cds_column_replace, get_default
+    bokeh3,
+    cds_column_replace,
+    decode_bytes,
+    empty_plot,
+    filter_toolboxes,
+    get_default,
+    make_axis,
+    theme_attr_json,
+    update_shared_sources,
 )
 
 if bokeh3:

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -2,8 +2,7 @@ import sys
 
 import numpy as np
 import param
-
-from bokeh.models import DatetimeAxis, CustomJSHover
+from bokeh.models import CustomJSHover, DatetimeAxis
 
 from ...core.util import cartesian_product, dimension_sanitizer, isfinite
 from ...element import Raster

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -2,9 +2,8 @@ import base64
 import logging
 from io import BytesIO
 
-import param
 import bokeh
-
+import param
 from bokeh.document import Document
 from bokeh.io import curdoc
 from bokeh.models import Model
@@ -13,11 +12,10 @@ from panel.io.notebook import render_mimebundle
 from panel.io.state import state
 from param.parameterized import bothmethod
 
-from ...core import Store, HoloMap
+from ...core import HoloMap, Store
 from ..plot import Plot
-from ..renderer import Renderer, MIME_TYPES, HTML_TAGS
+from ..renderer import HTML_TAGS, MIME_TYPES, Renderer
 from .util import compute_plot_size
-
 
 default_theme = Theme(json={
     'attrs': {

--- a/holoviews/plotting/bokeh/sankey.py
+++ b/holoviews/plotting/bokeh/sankey.py
@@ -1,13 +1,11 @@
-import param
 import numpy as np
-
+import param
 from bokeh.models import Patches
 
 from ...core.data import Dataset
-from ...core.util import max_range, dimension_sanitizer
+from ...core.util import dimension_sanitizer, max_range
 from ...util.transform import dim
 from .graphs import GraphPlot
-
 
 
 class SankeyPlot(GraphPlot):

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -1,24 +1,27 @@
 from collections import defaultdict
 from functools import partial
 
-import param
 import numpy as np
+import param
+from bokeh.models import Circle, FactorRange, HBar, VBar
 
-from bokeh.models import FactorRange, Circle, VBar, HBar
-
-from .selection import BokehOverlaySelectionDisplay
 from ...core import NdOverlay
 from ...core.dimension import Dimension, Dimensioned
 from ...core.ndmapping import sorted_context
 from ...core.util import (
-    dimension_sanitizer, wrap_tuple, unique_iterator, isfinite,
-    is_dask_array, is_cupy_array
+    dimension_sanitizer,
+    is_cupy_array,
+    is_dask_array,
+    isfinite,
+    unique_iterator,
+    wrap_tuple,
 )
 from ...operation.stats import univariate_kde
 from ...util.transform import dim
 from .chart import AreaPlot
-from .element import CompositeElementPlot, ColorbarPlot, LegendPlot
+from .element import ColorbarPlot, CompositeElementPlot, LegendPlot
 from .path import PolygonPlot
+from .selection import BokehOverlaySelectionDisplay
 from .styles import base_properties, fill_properties, line_properties
 from .util import decode_bytes
 

--- a/holoviews/plotting/bokeh/styles.py
+++ b/holoviews/plotting/bokeh/styles.py
@@ -3,13 +3,18 @@ Defines valid style options, validation and utilities
 """
 
 import numpy as np
-
 from bokeh.core.properties import (
-    Angle, Color, DashPattern, FontSize, MarkerType, Percent, Size
+    Angle,
+    Color,
+    DashPattern,
+    FontSize,
+    MarkerType,
+    Percent,
+    Size,
 )
 
 try:
-    from matplotlib import colors, cm
+    from matplotlib import cm, colors
 except ImportError:
     cm, colors = None, None
 

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -1,15 +1,21 @@
 import param
-
 from bokeh.models import Column
 from bokeh.models.widgets import (
-    DataTable, TableColumn, NumberEditor, NumberFormatter, DateFormatter,
-    DateEditor, StringFormatter, StringEditor, IntEditor
+    DataTable,
+    DateEditor,
+    DateFormatter,
+    IntEditor,
+    NumberEditor,
+    NumberFormatter,
+    StringEditor,
+    StringFormatter,
+    TableColumn,
 )
 
 from ...core import Dataset, Dimension
+from ...core.util import dimension_sanitizer, isdatetime
 from ...element import ItemTable
 from ...streams import Buffer
-from ...core.util import dimension_sanitizer, isdatetime
 from ..plot import GenericElementPlot
 from .plot import BokehPlot
 from .selection import TabularSelectionDisplay

--- a/holoviews/plotting/bokeh/tiles.py
+++ b/holoviews/plotting/bokeh/tiles.py
@@ -1,6 +1,5 @@
 import numpy as np
-
-from bokeh.models import WMTSTileSource, BBoxTileSource, QUADKEYTileSource
+from bokeh.models import BBoxTileSource, QUADKEYTileSource, WMTSTileSource
 
 from ...core.options import SkipRendering
 from ...element.tiles import _ATTRIBUTIONS

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -9,6 +9,7 @@ from types import FunctionType
 
 import bokeh
 import numpy as np
+import pandas as pd
 import param
 from bokeh.core.json_encoder import serialize_json  # noqa (API import)
 from bokeh.core.validation import silence
@@ -40,7 +41,6 @@ from ...core.util import (
     cftime_to_timestamp,
     cftime_types,
     isnumeric,
-    pd,
     unique_array,
 )
 from ..util import dim_axis_label

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -3,54 +3,62 @@ import datetime as dt
 import inspect
 import re
 import time
-
 from collections import defaultdict
 from contextlib import contextmanager
 from types import FunctionType
 
-import param
 import bokeh
 import numpy as np
-
-from bokeh.core.json_encoder import serialize_json # noqa (API import)
+import param
+from bokeh.core.json_encoder import serialize_json  # noqa (API import)
 from bokeh.core.validation import silence
-from bokeh.layouts import Row, Column
-from bokeh.models import tools
+from bokeh.layouts import Column, Row
 from bokeh.models import (
-    Model, FactorRange, Range1d, Plot, Spacer, CustomJS,
-    GridBox, DatetimeAxis, CategoricalAxis
+    CategoricalAxis,
+    CustomJS,
+    DatetimeAxis,
+    FactorRange,
+    GridBox,
+    Model,
+    Plot,
+    Range1d,
+    Spacer,
+    tools,
 )
-from bokeh.models.formatters import (
-    TickFormatter, PrintfTickFormatter
-)
+from bokeh.models.formatters import PrintfTickFormatter, TickFormatter
 from bokeh.models.widgets import DataTable, Div
-from bokeh.themes.theme import Theme
 from bokeh.themes import built_in_themes
+from bokeh.themes.theme import Theme
 from packaging.version import Version
 
 from ...core.ndmapping import NdMapping
 from ...core.overlay import Overlay
+from ...core.spaces import DynamicMap, get_nested_dmaps
 from ...core.util import (
-    arraylike_types, callable_name, cftime_types,
-    cftime_to_timestamp, isnumeric, pd, unique_array
+    arraylike_types,
+    callable_name,
+    cftime_to_timestamp,
+    cftime_types,
+    isnumeric,
+    pd,
+    unique_array,
 )
-from ...core.spaces import get_nested_dmaps, DynamicMap
 from ..util import dim_axis_label
 
 bokeh_version = Version(bokeh.__version__)
 bokeh3 = bokeh_version >= Version("3.0")
 
 if bokeh3:
+    from bokeh.models import GridPlot, Tabs, Toolbar
     from bokeh.models.formatters import CustomJSTickFormatter
-    from bokeh.models import Toolbar, Tabs, GridPlot
     from bokeh.plotting import figure
     class WidgetBox: pass  # Does not exist in Bokeh 3
 
 else:
     from bokeh.layouts import WidgetBox
+    from bokeh.models import ToolbarBox as Toolbar  # Not completely correct
     from bokeh.models.formatters import FuncTickFormatter as CustomJSTickFormatter
     from bokeh.models.widgets import Tabs
-    from bokeh.models import ToolbarBox as Toolbar  # Not completely correct
     from bokeh.plotting import Figure as figure
     class GridPlot: pass  # Does not exist in Bokeh 2
 

--- a/holoviews/plotting/links.py
+++ b/holoviews/plotting/links.py
@@ -1,5 +1,4 @@
 import weakref
-
 from collections import defaultdict
 
 import param

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..core import util, Dataset, Dimension
+from ..core import Dataset, Dimension, util
 from ..element import Bars
 from ..element.util import categorical_aggregate2d
 from .util import get_axis_padding

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -1,34 +1,32 @@
 import os
 
-from matplotlib import rc_params_from_file
-from matplotlib.colors import ListedColormap, LinearSegmentedColormap
-from param import concrete_descendents
 from colorcet import kbc, register_cmap
+from matplotlib import rc_params_from_file
+from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 from packaging.version import Version
+from param import concrete_descendents
 
-from ...core import Layout, Collator, GridMatrix, config
-from ...core.options import Cycle, Palette, Options
+from ...core import Collator, GridMatrix, Layout, config
+from ...core.options import Cycle, Options, Palette
 from ...core.overlay import NdOverlay, Overlay
-from ...element import * # noqa (API import)
+from ...element import *  # noqa (API import)
 from ..plot import PlotSelector
 from ..util import fire_colors
-from .annotation import * # noqa (API import)
-from .chart import * # noqa (API import)
-from .chart3d import * # noqa (API import)
+from .annotation import *  # noqa (API import)
+from .chart import *  # noqa (API import)
+from .chart3d import *  # noqa (API import)
 from .element import ElementPlot
-from .geometry import * # noqa (API import)
-from .graphs import * # noqa (API import)
-from .heatmap import * # noqa (API import)
-from .hex_tiles import * # noqa (API import)
-from .path import * # noqa (API import)
-from .plot import * # noqa (API import)
-from .raster import * # noqa (API import)
-from .sankey import * # noqa (API import)
-from .stats import * # noqa (API import)
-from .tabular import * # noqa (API import)
-
+from .geometry import *  # noqa (API import)
+from .graphs import *  # noqa (API import)
+from .heatmap import *  # noqa (API import)
+from .hex_tiles import *  # noqa (API import)
+from .path import *  # noqa (API import)
+from .plot import *  # noqa (API import)
+from .raster import *  # noqa (API import)
 from .renderer import MPLRenderer
-
+from .sankey import *  # noqa (API import)
+from .stats import *  # noqa (API import)
+from .tabular import *  # noqa (API import)
 
 mpl_ge_150 = Version(mpl.__version__) >= Version('1.5.0')
 

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -1,13 +1,12 @@
-import param
-import numpy as np
 import matplotlib
-
+import numpy as np
+import param
 from matplotlib import patches
 from matplotlib.lines import Line2D
 
-from ...core.util import match_spec
 from ...core.options import abbreviated_exception
-from .element import ElementPlot, ColorbarPlot
+from ...core.util import match_spec
+from .element import ColorbarPlot, ElementPlot
 from .plot import mpl_rc_context
 
 

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -1,29 +1,33 @@
-import param
-import numpy as np
 import matplotlib as mpl
-from packaging.version import Version
-
+import numpy as np
+import param
 from matplotlib import cm
 from matplotlib.collections import LineCollection
 from matplotlib.dates import DateFormatter, date2num
+from packaging.version import Version
 
 from ...core.dimension import Dimension, dimension_name
 from ...core.options import Store, abbreviated_exception
 from ...core.util import (
-    match_spec, isfinite, dt_to_int, dt64_to_dt, search_indices,
-    unique_array, isscalar, isdatetime
+    dt64_to_dt,
+    dt_to_int,
+    isdatetime,
+    isfinite,
+    isscalar,
+    match_spec,
+    search_indices,
+    unique_array,
 )
-from ...element import Raster, HeatMap
+from ...element import HeatMap, Raster
 from ...operation import interpolate_curve
 from ...util.transform import dim
-from ..plot import PlotSelector
 from ..mixins import AreaMixin, BarsMixin, SpikesMixin
-from ..util import compute_sizes, get_sideplot_ranges, get_min_distance
-from .element import ElementPlot, ColorbarPlot, LegendPlot
-from .path  import PathPlot
+from ..plot import PlotSelector
+from ..util import compute_sizes, get_min_distance, get_sideplot_ranges
+from .element import ColorbarPlot, ElementPlot, LegendPlot
+from .path import PathPlot
 from .plot import AdjoinedPlot, mpl_rc_context
 from .util import mpl_version
-
 
 
 class ChartPlot(ElementPlot):

--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -8,8 +8,8 @@ from ...core import Dimension
 from ...core.options import abbreviated_exception
 from ...util.transform import dim as dim_expr
 from ..util import map_colors
-from .element import ColorbarPlot
 from .chart import PointPlot
+from .element import ColorbarPlot
 from .path import PathPlot
 from .util import mpl_version
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -3,24 +3,30 @@ import math
 import warnings
 from types import FunctionType
 
-import param
-import numpy as np
 import matplotlib.colors as mpl_colors
-
+import numpy as np
+import param
 from matplotlib import ticker
 from matplotlib.dates import date2num
 from matplotlib.image import AxesImage
 from packaging.version import Version
 
-from ...core import util
-from ...core import (OrderedDict, NdOverlay, DynamicMap, Dataset,
-                     CompositeOverlay, Element3D, Element)
+from ...core import (
+    CompositeOverlay,
+    Dataset,
+    DynamicMap,
+    Element,
+    Element3D,
+    NdOverlay,
+    OrderedDict,
+    util,
+)
 from ...core.options import abbreviated_exception
 from ...element import Graph, Path
 from ...streams import Stream
 from ...util.transform import dim
 from ..plot import GenericElementPlot, GenericOverlayPlot
-from ..util import process_cmap, color_intervals, dim_range_key
+from ..util import color_intervals, dim_range_key, process_cmap
 from .plot import MPLPlot, mpl_rc_context
 from .util import EqHistNormalize, mpl_version, validate, wrap_formatter
 

--- a/holoviews/plotting/mpl/geometry.py
+++ b/holoviews/plotting/mpl/geometry.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from matplotlib.collections import LineCollection, PatchCollection
 from matplotlib.patches import Rectangle
 

--- a/holoviews/plotting/mpl/graphs.py
+++ b/holoviews/plotting/mpl/graphs.py
@@ -1,16 +1,15 @@
 import warnings
 
-import param
 import numpy as np
-
+import param
 from matplotlib.collections import LineCollection, PolyCollection
 
 from ...core.data import Dataset
 from ...core.options import Cycle, abbreviated_exception
-from ...core.util import unique_array, search_indices, is_number, isscalar
+from ...core.util import is_number, isscalar, search_indices, unique_array
 from ...util.transform import dim
 from ..mixins import ChordMixin
-from ..util import process_cmap, get_directed_graph_paths
+from ..util import get_directed_graph_paths, process_cmap
 from .element import ColorbarPlot
 from .util import filter_styles
 

--- a/holoviews/plotting/mpl/heatmap.py
+++ b/holoviews/plotting/mpl/heatmap.py
@@ -2,13 +2,12 @@ from itertools import product
 
 import numpy as np
 import param
-
-from matplotlib.patches import Wedge, Circle
 from matplotlib.collections import LineCollection, PatchCollection
+from matplotlib.patches import Circle, Wedge
 
 from ...core.data import GridInterface
-from ...core.util import dimension_sanitizer, is_nan
 from ...core.spaces import HoloMap
+from ...core.util import dimension_sanitizer, is_nan
 from ..mixins import HeatMapMixin
 from .element import ColorbarPlot
 from .raster import QuadMeshPlot

--- a/holoviews/plotting/mpl/hex_tiles.py
+++ b/holoviews/plotting/mpl/hex_tiles.py
@@ -1,5 +1,5 @@
-import param
 import numpy as np
+import param
 
 from .element import ColorbarPlot
 

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -1,8 +1,7 @@
-import param
 import numpy as np
-
-from matplotlib.collections import PatchCollection, LineCollection
-from matplotlib.dates import date2num, DateFormatter
+import param
+from matplotlib.collections import LineCollection, PatchCollection
+from matplotlib.dates import DateFormatter, date2num
 
 from ...core import util
 from ...core.dimension import Dimension

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -1,22 +1,40 @@
-from itertools import chain
 from contextlib import contextmanager
+from itertools import chain
 
-import param
-import numpy as np
 import matplotlib as mpl
-
-from mpl_toolkits.mplot3d import Axes3D  # noqa (For 3D plots)
-from matplotlib import pyplot as plt
-from matplotlib import gridspec, animation, rcParams
+import numpy as np
+import param
+from matplotlib import (
+    animation,
+    gridspec,
+    pyplot as plt,
+    rcParams,
+)
 from matplotlib.font_manager import font_scalings
+from mpl_toolkits.mplot3d import Axes3D  # noqa (For 3D plots)
 
-from ...core import (OrderedDict, HoloMap, AdjointLayout, NdLayout,
-                     GridSpace, Element, CompositeOverlay, Empty,
-                     Collator, GridMatrix, Layout)
-from ...core.options import Store, SkipRendering
-from ...core.util import int_to_roman, int_to_alpha, wrap_tuple_streams
-from ..plot import (DimensionedPlot, GenericLayoutPlot, GenericCompositePlot,
-                    GenericElementPlot, GenericAdjointLayoutPlot)
+from ...core import (
+    AdjointLayout,
+    Collator,
+    CompositeOverlay,
+    Element,
+    Empty,
+    GridMatrix,
+    GridSpace,
+    HoloMap,
+    Layout,
+    NdLayout,
+    OrderedDict,
+)
+from ...core.options import SkipRendering, Store
+from ...core.util import int_to_alpha, int_to_roman, wrap_tuple_streams
+from ..plot import (
+    DimensionedPlot,
+    GenericAdjointLayoutPlot,
+    GenericCompositePlot,
+    GenericElementPlot,
+    GenericLayoutPlot,
+)
 from ..util import attach_streams, collate, displayable
 from .util import compute_ratios, fix_aspect, get_old_rcparams
 

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -1,17 +1,16 @@
 import sys
 
-import param
 import numpy as np
+import param
 from packaging.version import Version
 
-from ...core import CompositeOverlay, Element
-from ...core import traversal
+from ...core import CompositeOverlay, Element, traversal
 from ...core.util import isfinite, match_spec, max_range, unique_iterator
-from ...element.raster import Image, Raster, RGB
+from ...element.raster import RGB, Image, Raster
 from ..util import categorical_legend
 from .chart import PointPlot
-from .element import ElementPlot, ColorbarPlot, LegendPlot, OverlayPlot
-from .plot import MPLPlot, GridPlot, mpl_rc_context
+from .element import ColorbarPlot, ElementPlot, LegendPlot, OverlayPlot
+from .plot import GridPlot, MPLPlot, mpl_rc_context
 from .util import get_raster_array, mpl_version
 
 

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -1,22 +1,20 @@
-import os
 import base64
-
-from io import BytesIO
-from tempfile import NamedTemporaryFile
+import os
 from contextlib import contextmanager
+from io import BytesIO
 from itertools import chain
-
-import param
+from tempfile import NamedTemporaryFile
 
 import matplotlib as mpl
-
+import param
 from matplotlib import pyplot as plt
 from param.parameterized import bothmethod
 
 from ...core import HoloMap
 from ...core.options import Store
-from ..renderer import Renderer, MIME_TYPES, HTML_TAGS
-from .util import get_tight_bbox, get_old_rcparams
+from ..renderer import HTML_TAGS, MIME_TYPES, Renderer
+from .util import get_old_rcparams, get_tight_bbox
+
 
 class OutputWarning(param.Parameterized):pass
 outputwarning = OutputWarning(name='Warning')

--- a/holoviews/plotting/mpl/sankey.py
+++ b/holoviews/plotting/mpl/sankey.py
@@ -1,7 +1,6 @@
 import param
-
-from matplotlib.patches import Rectangle
 from matplotlib.collections import PatchCollection
+from matplotlib.patches import Rectangle
 
 from ...core.util import max_range
 from ...util.transform import dim

--- a/holoviews/plotting/mpl/stats.py
+++ b/holoviews/plotting/mpl/stats.py
@@ -1,5 +1,5 @@
-import param
 import numpy as np
+import param
 
 from ...core.ndmapping import sorted_context
 from .chart import AreaPlot, ChartPlot

--- a/holoviews/plotting/mpl/tabular.py
+++ b/holoviews/plotting/mpl/tabular.py
@@ -1,13 +1,11 @@
 from collections import defaultdict
 
 import param
-
 from matplotlib.font_manager import FontProperties
 from matplotlib.table import Table as mpl_Table
 
 from .element import ElementPlot
 from .plot import mpl_rc_context
-
 
 
 class TablePlot(ElementPlot):

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -2,39 +2,38 @@ import inspect
 import re
 import warnings
 
-import numpy as np
 import matplotlib
-
-from matplotlib import units as munits
-from matplotlib import ticker
+import numpy as np
+from matplotlib import (
+    ticker,
+    units as munits,
+)
 from matplotlib.colors import Normalize, cnames
 from matplotlib.lines import Line2D
 from matplotlib.markers import MarkerStyle
 from matplotlib.patches import Path, PathPatch
-from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
-from matplotlib.rcsetup import (
-    validate_fontsize, validate_fonttype, validate_hatch)
+from matplotlib.rcsetup import validate_fontsize, validate_fonttype, validate_hatch
+from matplotlib.transforms import Affine2D, Bbox, TransformedBbox
 from packaging.version import Version
 
 try:  # starting Matplotlib 3.4.0
-    from matplotlib._enums import CapStyle as validate_capstyle
-    from matplotlib._enums import JoinStyle as validate_joinstyle
+    from matplotlib._enums import (
+        CapStyle as validate_capstyle,
+        JoinStyle as validate_joinstyle,
+    )
 except ImportError:  # before Matplotlib 3.4.0
-    from matplotlib.rcsetup import (
-    validate_capstyle, validate_joinstyle)
+    from matplotlib.rcsetup import validate_capstyle, validate_joinstyle
 
 try:
-    from nc_time_axis import NetCDFTimeConverter, CalendarDateTime
+    from nc_time_axis import CalendarDateTime, NetCDFTimeConverter
     nc_axis_available = True
 except ImportError:
     from matplotlib.dates import DateConverter
     NetCDFTimeConverter = DateConverter
     nc_axis_available = False
 
-from ...core.util import (
-    arraylike_types, cftime_types, is_number
-)
-from ...element import Raster, RGB, Polygons
+from ...core.util import arraylike_types, cftime_types, is_number
+from ...element import RGB, Polygons, Raster
 from ..util import COLOR_ALIASES, RGB_HEX_REGEX
 
 mpl_version = Version(matplotlib.__version__)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -5,39 +5,48 @@ of this Plot baseclass.
 """
 import uuid
 import warnings
-
-from collections import Counter, defaultdict, OrderedDict
+from collections import Counter, OrderedDict, defaultdict
 from functools import partial
 from itertools import groupby, product
 
 import numpy as np
 import param
-
 from panel.config import config
 from panel.io.document import unlocked
 from panel.io.notebook import push
 from panel.io.state import state
 from pyviz_comms import JupyterComm
-from ..selection import NoOpSelectionDisplay
-from ..core import util, traversal
+
+from ..core import traversal, util
 from ..core.data import Dataset, disable_pipeline
 from ..core.element import Element, Element3D
-from ..core.overlay import Overlay, CompositeOverlay
-from ..core.layout import Empty, NdLayout, Layout
-from ..core.options import Store, Compositor, SkipRendering, lookup_options
-from ..core.overlay import NdOverlay
-from ..core.spaces import HoloMap, DynamicMap
-from ..core.util import stream_parameters, isfinite
-from ..element import Table, Graph
-from ..streams import Stream, RangeXY, RangeX, RangeY
+from ..core.layout import Empty, Layout, NdLayout
+from ..core.options import Compositor, SkipRendering, Store, lookup_options
+from ..core.overlay import CompositeOverlay, NdOverlay, Overlay
+from ..core.spaces import DynamicMap, HoloMap
+from ..core.util import isfinite, stream_parameters
+from ..element import Graph, Table
+from ..selection import NoOpSelectionDisplay
+from ..streams import RangeX, RangeXY, RangeY, Stream
 from ..util.transform import dim
 from .util import (
-    get_dynamic_mode, initialize_unbounded, dim_axis_label,
-    attach_streams, traverse_setter, get_nested_streams,
-    compute_overlayable_zorders, get_nested_plot_frame,
-    split_dmap_overlay, get_axis_padding, get_range, get_minimum_span,
-    get_plot_frame, scale_fontsize, dynamic_update
+    attach_streams,
+    compute_overlayable_zorders,
+    dim_axis_label,
+    dynamic_update,
+    get_axis_padding,
+    get_dynamic_mode,
+    get_minimum_span,
+    get_nested_plot_frame,
+    get_nested_streams,
+    get_plot_frame,
+    get_range,
+    initialize_unbounded,
+    scale_fontsize,
+    split_dmap_overlay,
+    traverse_setter,
 )
+
 
 class Plot(param.Parameterized):
     """

--- a/holoviews/plotting/plotly/__init__.py
+++ b/holoviews/plotting/plotly/__init__.py
@@ -1,30 +1,25 @@
 import plotly
-
-from param import concrete_descendents
 from packaging.version import Version
+from param import concrete_descendents
 
-from ...core import (
-    Overlay, NdOverlay, Layout, NdLayout, GridSpace, GridMatrix, config
-)
-from ...core.options import Store, Cycle, Options
+from ...core import GridMatrix, GridSpace, Layout, NdLayout, NdOverlay, Overlay, config
+from ...core.options import Cycle, Options, Store
 from ...core.util import VersionError
-from ...element import *              # noqa (Element import for registration)
-
+from ...element import *  # noqa (Element import for registration)
+from .annotation import *  # noqa (API import)
+from .callbacks import *  # noqa (API import)
+from .chart import *  # noqa (API import)
+from .chart3d import *  # noqa (API import)
 from .element import ElementPlot
+from .element import *  # noqa (API import)
+from .images import *  # noqa (API import)
+from .plot import *  # noqa (API import)
+from .raster import *  # noqa (API import)
 from .renderer import PlotlyRenderer
-
-from .annotation import *            # noqa (API import)
-from .tiles import *                 # noqa (API import)
-from .element import *               # noqa (API import)
-from .chart import *                 # noqa (API import)
-from .chart3d import *               # noqa (API import)
-from .raster import *                # noqa (API import)
-from .plot import *                  # noqa (API import)
-from .stats import *                 # noqa (API import)
-from .tabular import *               # noqa (API import)
-from .callbacks import *             # noqa (API import)
-from .shapes import *                # noqa (API import)
-from .images import *                # noqa (API import)
+from .shapes import *  # noqa (API import)
+from .stats import *  # noqa (API import)
+from .tabular import *  # noqa (API import)
+from .tiles import *  # noqa (API import)
 
 if Version(plotly.__version__) < Version('4.0.0'):
     raise VersionError(

--- a/holoviews/plotting/plotly/annotation.py
+++ b/holoviews/plotting/plotly/annotation.py
@@ -1,7 +1,7 @@
 import param
 
-from .chart import ScatterPlot
 from ...element import Tiles
+from .chart import ScatterPlot
 
 
 class LabelPlot(ScatterPlot):

--- a/holoviews/plotting/plotly/callbacks.py
+++ b/holoviews/plotting/plotly/callbacks.py
@@ -1,13 +1,18 @@
 from weakref import WeakValueDictionary
 
-from ...streams import (
-    Stream, Selection1D, RangeXY, RangeX, RangeY, BoundsXY, BoundsX, BoundsY,
-    SelectionXY
-)
-
-from .util import _trace_to_subplot
-
 from ...element import Tiles
+from ...streams import (
+    BoundsX,
+    BoundsXY,
+    BoundsY,
+    RangeX,
+    RangeXY,
+    RangeY,
+    Selection1D,
+    SelectionXY,
+    Stream,
+)
+from .util import _trace_to_subplot
 
 
 class PlotlyCallbackMetaClass(type):

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -1,10 +1,10 @@
-import param
 import numpy as np
+import param
 
-from ...operation import interpolate_curve
 from ...element import Tiles
+from ...operation import interpolate_curve
 from ..mixins import AreaMixin, BarsMixin
-from .element import ElementPlot, ColorbarPlot
+from .element import ColorbarPlot, ElementPlot
 from .selection import PlotlyOverlaySelectionDisplay
 
 

--- a/holoviews/plotting/plotly/chart3d.py
+++ b/holoviews/plotting/plotly/chart3d.py
@@ -1,13 +1,12 @@
-import param
 import numpy as np
-
+import param
 from plotly import colors
 from plotly.figure_factory._trisurf import trisurf as trisurface
 
-from .selection import PlotlyOverlaySelectionDisplay
 from ...core.options import SkipRendering
-from .element import ElementPlot, ColorbarPlot
-from .chart import ScatterPlot, CurvePlot
+from .chart import CurvePlot, ScatterPlot
+from .element import ColorbarPlot, ElementPlot
+from .selection import PlotlyOverlaySelectionDisplay
 
 
 class Chart3DPlot(ElementPlot):

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -1,23 +1,31 @@
 # standard library imports
-import uuid
-import copy
-from collections import OrderedDict, namedtuple
-import pickle
 import base64
+import copy
+import pickle
+import uuid
+from collections import OrderedDict, namedtuple
+
+from dash.exceptions import PreventUpdate
 
 # Holoviews imports
 import holoviews as hv
-from dash.exceptions import PreventUpdate
-from holoviews.plotting.plotly import PlotlyRenderer, DynamicMap
-from holoviews.plotting.plotly.util import clean_internal_figure_properties
 from holoviews.core.decollate import (
-    initialize_dynamic, to_expr_extract_streams, expr_to_fn_of_stream_contents
+    expr_to_fn_of_stream_contents,
+    initialize_dynamic,
+    to_expr_extract_streams,
 )
-from holoviews.streams import Derived, History
+from holoviews.plotting.plotly import DynamicMap, PlotlyRenderer
 from holoviews.plotting.plotly.callbacks import (
-    Selection1DCallback, RangeXYCallback, RangeXCallback, RangeYCallback,
-    BoundsXYCallback, BoundsXCallback, BoundsYCallback
+    BoundsXCallback,
+    BoundsXYCallback,
+    BoundsYCallback,
+    RangeXCallback,
+    RangeXYCallback,
+    RangeYCallback,
+    Selection1DCallback,
 )
+from holoviews.plotting.plotly.util import clean_internal_figure_properties
+from holoviews.streams import Derived, History
 
 # Dash imports
 try:
@@ -25,11 +33,10 @@ try:
     import dash_html_components as html
 except ImportError:
     from dash import dcc, html
-from dash import callback_context
-from dash.dependencies import Output, Input, State
-
 # plotly.py imports
 import plotly.graph_objects as go
+from dash import callback_context
+from dash.dependencies import Input, Output, State
 
 # Activate plotly as current HoloViews extension
 hv.extension("plotly")

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -1,7 +1,8 @@
+import re
 import uuid
+
 import numpy as np
 import param
-import re
 
 from ... import Tiles
 from ...core import util
@@ -13,7 +14,12 @@ from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dim_range_key
 from .plot import PlotlyPlot
 from .util import (
-    STYLE_ALIASES, get_colorscale, merge_figure, legend_trace_types, merge_layout)
+    STYLE_ALIASES,
+    get_colorscale,
+    legend_trace_types,
+    merge_figure,
+    merge_layout,
+)
 
 
 class ElementPlot(PlotlyPlot, GenericElementPlot):

--- a/holoviews/plotting/plotly/images.py
+++ b/holoviews/plotting/plotly/images.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from plotly.graph_objs.layout import Image as _Image
 
 from ...core.util import VersionError

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -1,16 +1,28 @@
 import param
 
 from holoviews.plotting.util import attach_streams
-from ...core import (OrderedDict, NdLayout, AdjointLayout, Empty,
-                     HoloMap, GridSpace, GridMatrix)
-from ...element import Histogram
+
+from ...core import (
+    AdjointLayout,
+    Empty,
+    GridMatrix,
+    GridSpace,
+    HoloMap,
+    NdLayout,
+    OrderedDict,
+)
 from ...core.options import Store
 from ...core.util import wrap_tuple
+from ...element import Histogram
 from ..plot import (
-    DimensionedPlot, GenericLayoutPlot, GenericCompositePlot,
-    GenericElementPlot, GenericAdjointLayoutPlot, CallbackPlot
+    CallbackPlot,
+    DimensionedPlot,
+    GenericAdjointLayoutPlot,
+    GenericCompositePlot,
+    GenericElementPlot,
+    GenericLayoutPlot,
 )
-from .util import figure_grid, configure_matching_axes_from_dims
+from .util import configure_matching_axes_from_dims, figure_grid
 
 
 class PlotlyPlot(DimensionedPlot, CallbackPlot):

--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -1,18 +1,15 @@
 import base64
-
 from io import BytesIO
 
-import param
 import panel as pn
-
+import param
 from param.parameterized import bothmethod
 
-from ..renderer import Renderer, MIME_TYPES, HTML_TAGS
-from ...core.options import Store
 from ...core import HoloMap
+from ...core.options import Store
+from ..renderer import HTML_TAGS, MIME_TYPES, Renderer
 from .callbacks import callbacks
 from .util import clean_internal_figure_properties
-
 
 with param.logging_level('CRITICAL'):
     import plotly.graph_objs as go
@@ -93,7 +90,6 @@ class PlotlyRenderer(Renderer):
     def _figure_data(self, plot, fmt, as_script=False, **kwargs):
         if fmt == 'gif':
             import plotly.io as pio
-
             from PIL import Image
             from plotly.io.orca import ensure_server, shutdown_server, status
 

--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -5,9 +5,6 @@ from io import BytesIO
 import param
 import panel as pn
 
-with param.logging_level('CRITICAL'):
-    import plotly.graph_objs as go
-
 from param.parameterized import bothmethod
 
 from ..renderer import Renderer, MIME_TYPES, HTML_TAGS
@@ -16,6 +13,9 @@ from ...core import HoloMap
 from .callbacks import callbacks
 from .util import clean_internal_figure_properties
 
+
+with param.logging_level('CRITICAL'):
+    import plotly.graph_objs as go
 
 
 def _PlotlyHoloviewsPane(fig_dict, **kwargs):

--- a/holoviews/plotting/plotly/selection.py
+++ b/holoviews/plotting/plotly/selection.py
@@ -1,7 +1,6 @@
-from ...core.overlay import NdOverlay, Overlay
-
-from ...selection import OverlaySelectionDisplay
 from ...core.options import Store
+from ...core.overlay import NdOverlay, Overlay
+from ...selection import OverlaySelectionDisplay
 
 
 class PlotlyOverlaySelectionDisplay(OverlaySelectionDisplay):

--- a/holoviews/plotting/plotly/shapes.py
+++ b/holoviews/plotting/plotly/shapes.py
@@ -1,7 +1,7 @@
-import param
 import numpy as np
+import param
 
-from ...element import HLine, VLine, HSpan, VSpan, Tiles
+from ...element import HLine, HSpan, Tiles, VLine, VSpan
 from ..mixins import GeomMixin
 from .element import ElementPlot
 

--- a/holoviews/plotting/plotly/stats.py
+++ b/holoviews/plotting/plotly/stats.py
@@ -1,8 +1,8 @@
 import param
 
-from .selection import PlotlyOverlaySelectionDisplay
 from .chart import ChartPlot
-from .element import ElementPlot, ColorbarPlot
+from .element import ColorbarPlot, ElementPlot
+from .selection import PlotlyOverlaySelectionDisplay
 
 
 class BivariatePlot(ChartPlot, ColorbarPlot):

--- a/holoviews/plotting/plotly/tiles.py
+++ b/holoviews/plotting/plotly/tiles.py
@@ -1,7 +1,8 @@
+import numpy as np
+
+from holoviews.element.tiles import _ATTRIBUTIONS
 from holoviews.plotting.plotly import ElementPlot
 from holoviews.plotting.plotly.util import STYLE_ALIASES
-import numpy as np
-from holoviews.element.tiles import _ATTRIBUTIONS
 
 
 class TilePlot(ElementPlot):

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -4,38 +4,35 @@ regardless of plotting package or backend.
 """
 import base64
 import os
-
-from io import BytesIO, StringIO
 from contextlib import contextmanager
 from functools import partial
+from io import BytesIO, StringIO
 
-import param
 import panel
-
+import param
 from bokeh.document import Document
-from bokeh.io import curdoc
 from bokeh.embed import file_html
+from bokeh.io import curdoc
 from bokeh.resources import CDN, INLINE
 from packaging.version import Version
 from panel import config
-from panel.io.notebook import ipywidget, load_notebook, render_model, render_mimebundle
+from panel.io.notebook import ipywidget, load_notebook, render_mimebundle, render_model
 from panel.io.state import state
 from panel.models.comm_manager import CommManager as PnCommManager
 from panel.pane import HoloViews as HoloViewsPane
-from panel.widgets.player import PlayerBase
 from panel.viewable import Viewable
+from panel.widgets.player import PlayerBase
+from param.parameterized import bothmethod
 from pyviz_comms import CommManager, JupyterCommManager
 
-from ..core import Layout, HoloMap, AdjointLayout, DynamicMap
+from ..core import AdjointLayout, DynamicMap, HoloMap, Layout
 from ..core.data import disable_pipeline
 from ..core.io import Exporter
-from ..core.options import Store, StoreOptions, SkipRendering, Compositor
+from ..core.options import Compositor, SkipRendering, Store, StoreOptions
 from ..core.util import unbound_dimensions
 from ..streams import Stream
 from . import Plot
-from .util import displayable, collate, initialize_dynamic
-
-from param.parameterized import bothmethod
+from .util import collate, displayable, initialize_dynamic
 
 panel_version = Version(panel.__version__)
 

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -1,26 +1,38 @@
+import bisect
 import re
 import traceback
 import warnings
-import bisect
-
 from collections import defaultdict, namedtuple
-from packaging.version import Version
 
 import numpy as np
 import param
+from packaging.version import Version
 
 from ..core import (
-    HoloMap, DynamicMap, CompositeOverlay, Layout, Overlay, GridSpace,
-    NdLayout, NdOverlay, AdjointLayout
+    AdjointLayout,
+    CompositeOverlay,
+    DynamicMap,
+    GridSpace,
+    HoloMap,
+    Layout,
+    NdLayout,
+    NdOverlay,
+    Overlay,
 )
-from ..core.options import CallbackError, Cycle
-from ..core.operation import Operation
 from ..core.ndmapping import item_check
+from ..core.operation import Operation
+from ..core.options import CallbackError, Cycle
 from ..core.spaces import get_nested_streams
 from ..core.util import (
-    match_spec, wrap_tuple, get_overlay_spec, unique_iterator,
-    closest_match, is_number, isfinite, disable_constant,
-    arraylike_types
+    arraylike_types,
+    closest_match,
+    disable_constant,
+    get_overlay_spec,
+    is_number,
+    isfinite,
+    match_spec,
+    unique_iterator,
+    wrap_tuple,
 )
 from ..element import Points
 from ..streams import LinkedStream, Params
@@ -725,7 +737,7 @@ def _list_cmaps(provider=None, records=False):
             pass
     if 'colorcet' in provider:
         try:
-            from colorcet import palette_n, glasbey_hv
+            from colorcet import glasbey_hv, palette_n
             cet_maps = palette_n.copy()
             cet_maps['glasbey_hv'] = glasbey_hv # Add special hv-specific map
             cmaps += info('colorcet', cet_maps)
@@ -1315,7 +1327,8 @@ class categorical_legend(Operation):
 
     def _process(self, element, key=None):
         import datashader as ds
-        from ..operation.datashader import shade, rasterize, datashade
+
+        from ..operation.datashader import datashade, rasterize, shade
         rasterize_op = element.pipeline.find(rasterize, skip_nonlinked=False)
         if isinstance(rasterize_op, datashade):
             shade_op = rasterize_op

--- a/holoviews/pyodide.py
+++ b/holoviews/pyodide.py
@@ -1,7 +1,6 @@
 import asyncio
 import sys
 
-
 from bokeh.document import Document
 from bokeh.embed.elements import script_for_render_items
 from bokeh.embed.util import standalone_docs_json_and_render_items
@@ -12,7 +11,6 @@ from panel.pane import panel as as_panel
 from .core.dimension import LabelledData
 from .core.options import Store
 from .util import extension as _extension
-
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -2,19 +2,23 @@ from collections import namedtuple
 
 import numpy as np
 import param
-
 from param.parameterized import bothmethod
 
 from .core.data import Dataset
 from .core.dimension import OrderedDict
 from .core.element import Element, Layout
+from .core.layout import AdjointLayout
 from .core.options import CallbackError, Store
 from .core.overlay import NdOverlay, Overlay
-from .core.layout import AdjointLayout
 from .core.spaces import GridSpace
 from .streams import (
-    Stream, SelectionExprSequence, CrossFilterSet,
-    Derived, PlotReset, SelectMode, Pipe
+    CrossFilterSet,
+    Derived,
+    Pipe,
+    PlotReset,
+    SelectionExprSequence,
+    SelectMode,
+    Stream,
 )
 from .util import DynamicMap
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -6,17 +6,17 @@ server-side or in Javascript in the Jupyter notebook (client-side).
 
 import sys
 import weakref
-from numbers import Number
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import partial
 from itertools import groupby
+from numbers import Number
 from types import FunctionType
-from packaging.version import Version
 
-import param
-import pandas as pd
 import numpy as np
+import pandas as pd
+import param
+from packaging.version import Version
 
 from .core import util
 from .core.ndmapping import UniformNdMapping
@@ -544,7 +544,10 @@ class Buffer(Pipe):
                 loaded = True
             except ImportError:
                 try:
-                    from streamz.dataframe import DataFrame as StreamingDataFrame, Series as StreamingSeries
+                    from streamz.dataframe import (
+                        DataFrame as StreamingDataFrame,
+                        Series as StreamingSeries,
+                    )
                     loaded = True
                 except ImportError:
                     loaded = False
@@ -981,8 +984,8 @@ class SelectionExpr(Derived):
     region_element = param.Parameter(default=None, constant=True)
 
     def __init__(self, source, include_region=True, **params):
-        from .element import Element
         from .core.spaces import DynamicMap
+        from .element import Element
         from .plotting.util import initialize_dynamic
 
         self._index_cols = params.pop('index_cols', None)
@@ -1815,7 +1818,7 @@ class BoxEdit(CDSStream):
 
     @property
     def element(self):
-        from .element import Rectangles, Polygons
+        from .element import Polygons, Rectangles
         source = self.source
         if isinstance(source, UniformNdMapping):
             source = source.last

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from panel.io import state
 
 

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -3,19 +3,17 @@ Tests for the Dataset Element types.
 """
 
 import datetime
-
-import numpy as np
-
-from holoviews import Dataset, HoloMap, Dimension
-from holoviews.core.data import concat
-from holoviews.core.data.interface import DataError
-from holoviews.element import Scatter, Curve
-from holoviews.element.comparison import ComparisonTestCase
-from holoviews.util.transform import dim
-
 from collections import OrderedDict
 
+import numpy as np
 import pandas as pd
+
+from holoviews import Dataset, Dimension, HoloMap
+from holoviews.core.data import concat
+from holoviews.core.data.interface import DataError
+from holoviews.element import Curve, Scatter
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.util.transform import dim
 
 
 class DatatypeContext:

--- a/holoviews/tests/core/data/test_binneddatasets.py
+++ b/holoviews/tests/core/data/test_binneddatasets.py
@@ -6,10 +6,10 @@ from unittest import SkipTest
 
 import numpy as np
 
-from holoviews.core.dimension import Dimension
-from holoviews.core.spaces import HoloMap
 from holoviews.core.data import Dataset
 from holoviews.core.data.interface import DataError
+from holoviews.core.dimension import Dimension
+from holoviews.core.spaces import HoloMap
 from holoviews.core.util import OrderedDict
 from holoviews.element import Histogram, QuadMesh
 from holoviews.element.comparison import ComparisonTestCase

--- a/holoviews/tests/core/data/test_cudfinterface.py
+++ b/holoviews/tests/core/data/test_cudfinterface.py
@@ -1,5 +1,4 @@
 import logging
-
 from unittest import SkipTest
 
 import numpy as np

--- a/holoviews/tests/core/data/test_dictinterface.py
+++ b/holoviews/tests/core/data/test_dictinterface.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from holoviews.core.data import Dataset
 
-from .base import HeterogeneousColumnTests, ScalarColumnTests, InterfaceTests
+from .base import HeterogeneousColumnTests, InterfaceTests, ScalarColumnTests
 
 
 class DictDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTests):

--- a/holoviews/tests/core/data/test_gridinterface.py
+++ b/holoviews/tests/core/data/test_gridinterface.py
@@ -1,14 +1,14 @@
 import datetime as dt
-
 from collections import OrderedDict
 from itertools import product
 from unittest import SkipTest
 
 import numpy as np
 import pandas as pd
+
 from holoviews.core.data import Dataset
 from holoviews.core.util import date_range
-from holoviews.element import Image, Curve, RGB, HSV
+from holoviews.element import HSV, RGB, Curve, Image
 from holoviews.util.transform import dim
 
 try:
@@ -18,11 +18,15 @@ except ImportError:
 
 
 from .base import (
-    GriddedInterfaceTests, InterfaceTests, HomogeneousColumnTests, DatatypeContext
+    DatatypeContext,
+    GriddedInterfaceTests,
+    HomogeneousColumnTests,
+    InterfaceTests,
 )
 from .test_imageinterface import (
-    BaseImageElementInterfaceTests, BaseRGBElementInterfaceTests,
-    BaseHSVElementInterfaceTests
+    BaseHSVElementInterfaceTests,
+    BaseImageElementInterfaceTests,
+    BaseRGBElementInterfaceTests,
 )
 
 

--- a/holoviews/tests/core/data/test_ibisinterface.py
+++ b/holoviews/tests/core/data/test_ibisinterface.py
@@ -1,7 +1,6 @@
 import sqlite3
-from unittest import SkipTest
-
 from tempfile import NamedTemporaryFile
+from unittest import SkipTest
 
 try:
     import ibis
@@ -13,10 +12,10 @@ import numpy as np
 import pandas as pd
 
 from holoviews.core.data import Dataset
-from holoviews.core.spaces import HoloMap
 from holoviews.core.data.ibis import IbisInterface
+from holoviews.core.spaces import HoloMap
 
-from .base import HeterogeneousColumnTests, ScalarColumnTests, InterfaceTests
+from .base import HeterogeneousColumnTests, InterfaceTests, ScalarColumnTests
 
 
 def create_temp_db(df, name, index=False):

--- a/holoviews/tests/core/data/test_imageinterface.py
+++ b/holoviews/tests/core/data/test_imageinterface.py
@@ -2,9 +2,10 @@ import datetime as dt
 from unittest import SkipTest
 
 import numpy as np
-from holoviews import Dimension, Image, Curve, RGB, HSV, Dataset, Table
-from holoviews.core.util import date_range
+
+from holoviews import HSV, RGB, Curve, Dataset, Dimension, Image, Table
 from holoviews.core.data.interface import DataError
+from holoviews.core.util import date_range
 
 from .base import DatatypeContext, GriddedInterfaceTests, InterfaceTests
 

--- a/holoviews/tests/core/data/test_multiinterface.py
+++ b/holoviews/tests/core/data/test_multiinterface.py
@@ -6,11 +6,11 @@ import logging
 
 import numpy as np
 import pandas as pd
+from param import get_logger
 
 from holoviews.core.data import Dataset, MultiInterface
 from holoviews.element import Path, Points, Polygons
 from holoviews.element.comparison import ComparisonTestCase
-from param import get_logger
 
 try:
     import dask.dataframe as dd

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -1,12 +1,11 @@
 import numpy as np
 import pandas as pd
 
-from holoviews.core.dimension import Dimension
 from holoviews.core.data import Dataset
 from holoviews.core.data.interface import DataError
+from holoviews.core.dimension import Dimension
 from holoviews.core.spaces import HoloMap
-from holoviews.element import Scatter, Points, Distribution
-
+from holoviews.element import Distribution, Points, Scatter
 
 from .base import HeterogeneousColumnTests, InterfaceTests
 

--- a/holoviews/tests/core/data/test_spatialpandas.py
+++ b/holoviews/tests/core/data/test_spatialpandas.py
@@ -8,8 +8,13 @@ import numpy as np
 try:
     import spatialpandas
     from spatialpandas.geometry import (
-        MultiPolygonArray, LineDtype, PointDtype, PolygonDtype,
-        MultiLineDtype, MultiPointDtype, MultiPolygonDtype
+        LineDtype,
+        MultiLineDtype,
+        MultiPointDtype,
+        MultiPolygonArray,
+        MultiPolygonDtype,
+        PointDtype,
+        PolygonDtype,
     )
 except ImportError:
     spatialpandas = None
@@ -20,7 +25,9 @@ except ImportError:
     dd = None
 
 from holoviews.core.data import (
-    Dataset, SpatialPandasInterface, DaskSpatialPandasInterface
+    DaskSpatialPandasInterface,
+    Dataset,
+    SpatialPandasInterface,
 )
 from holoviews.core.data.interface import DataError
 from holoviews.element import Path, Points, Polygons

--- a/holoviews/tests/core/data/test_xarrayinterface.py
+++ b/holoviews/tests/core/data/test_xarrayinterface.py
@@ -1,5 +1,4 @@
 import datetime as dt
-
 from collections import OrderedDict
 from unittest import SkipTest
 
@@ -14,13 +13,14 @@ except ImportError:
 from holoviews.core.data import Dataset, concat
 from holoviews.core.dimension import Dimension
 from holoviews.core.spaces import HoloMap
-from holoviews.element import Image, RGB, HSV, QuadMesh
+from holoviews.element import HSV, RGB, Image, QuadMesh
 
-from .test_imageinterface import (
-    BaseImageElementInterfaceTests, BaseRGBElementInterfaceTests,
-    BaseHSVElementInterfaceTests
-)
 from .test_gridinterface import BaseGridInterfaceTests
+from .test_imageinterface import (
+    BaseHSVElementInterfaceTests,
+    BaseImageElementInterfaceTests,
+    BaseRGBElementInterfaceTests,
+)
 
 
 class XArrayInterfaceTests(BaseGridInterfaceTests):

--- a/holoviews/tests/core/test_apply.py
+++ b/holoviews/tests/core/test_apply.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 import param
 import pytest
-
 from panel.widgets import IntSlider, RadioButtonGroup, TextInput
 
 from holoviews import Dataset, util

--- a/holoviews/tests/core/test_archives.py
+++ b/holoviews/tests/core/test_archives.py
@@ -2,14 +2,16 @@
 Unit test of the archive system, namely FileArchive with different
 exporters (not including renderers).
 """
+import json
 import os
 import shutil
-import json
-import zipfile
 import tarfile
+import zipfile
+
 import numpy as np
+
 from holoviews import Image
-from holoviews.core.io import Serializer, FileArchive
+from holoviews.core.io import FileArchive, Serializer
 from holoviews.element.comparison import ComparisonTestCase
 
 

--- a/holoviews/tests/core/test_boundingregion.py
+++ b/holoviews/tests/core/test_boundingregion.py
@@ -4,7 +4,8 @@ Test cases for boundingregion
 
 import unittest
 
-from holoviews.core import BoundingBox, AARectangle
+from holoviews.core import AARectangle, BoundingBox
+
 
 class TestAARectangle(unittest.TestCase):
     def setUp(self):

--- a/holoviews/tests/core/test_callable.py
+++ b/holoviews/tests/core/test_callable.py
@@ -6,14 +6,15 @@ from functools import partial
 
 import param
 
-from holoviews.element.comparison import ComparisonTestCase
-from holoviews.element import Scatter
 from holoviews import streams
-from holoviews.core.spaces import Callable, Generator, DynamicMap
 from holoviews.core.operation import OperationCallable
+from holoviews.core.spaces import Callable, DynamicMap, Generator
+from holoviews.element import Scatter
+from holoviews.element.comparison import ComparisonTestCase
 from holoviews.operation import contours
 
 from ..utils import LoggingComparisonTestCase
+
 
 class CallableClass:
 

--- a/holoviews/tests/core/test_collation.py
+++ b/holoviews/tests/core/test_collation.py
@@ -2,9 +2,10 @@
 Test cases for Collator
 """
 import itertools
+
 import numpy as np
 
-from holoviews.core import Collator, HoloMap, NdOverlay, Overlay, GridSpace
+from holoviews.core import Collator, GridSpace, HoloMap, NdOverlay, Overlay
 from holoviews.element import Curve
 from holoviews.element.comparison import ComparisonTestCase
 

--- a/holoviews/tests/core/test_composites.py
+++ b/holoviews/tests/core/test_composites.py
@@ -3,7 +3,7 @@ Test cases for the composite types built with + and *, i.e. Layout
 and Overlay (does *not* test HoloMaps).
 """
 
-from holoviews import Element, Layout, Overlay, HoloMap
+from holoviews import Element, HoloMap, Layout, Overlay
 from holoviews.element.comparison import ComparisonTestCase
 
 

--- a/holoviews/tests/core/test_datasetproperty.py
+++ b/holoviews/tests/core/test_datasetproperty.py
@@ -8,13 +8,13 @@ try:
 except ImportError:
     dd = None
 
-from holoviews import Dataset, Curve, Dimension, Scatter, Distribution
+from holoviews import Curve, Dataset, Dimension, Distribution, Scatter
 from holoviews.core import Apply, Redim
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.operation import histogram, function
+from holoviews.operation import function, histogram
 
 try:
-    from holoviews.operation.datashader import dynspread, datashade, rasterize
+    from holoviews.operation.datashader import datashade, dynspread, rasterize
 except ImportError:
     dynspread = datashade = rasterize = None
 

--- a/holoviews/tests/core/test_decollation.py
+++ b/holoviews/tests/core/test_decollation.py
@@ -2,13 +2,13 @@ from unittest import skipIf
 
 import param
 
-from holoviews.core import HoloMap, NdOverlay, Overlay, GridSpace, DynamicMap
+from holoviews.core import DynamicMap, GridSpace, HoloMap, NdOverlay, Overlay
 from holoviews.element import Points
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.streams import Stream, PlotSize, RangeXY
+from holoviews.streams import PlotSize, RangeXY, Stream
 
 try:
-    from holoviews.operation.datashader import spread, datashade
+    from holoviews.operation.datashader import datashade, spread
 except ImportError:
     spread = datashade = None
 

--- a/holoviews/tests/core/test_dimensioned.py
+++ b/holoviews/tests/core/test_dimensioned.py
@@ -1,8 +1,9 @@
 import gc
 
-from holoviews.core.spaces import HoloMap
 from holoviews.core.element import Element
-from holoviews.core.options import Store, Keywords, Options, OptionTree
+from holoviews.core.options import Keywords, Options, OptionTree, Store
+from holoviews.core.spaces import HoloMap
+
 from ..utils import LoggingComparisonTestCase
 
 

--- a/holoviews/tests/core/test_dimensions.py
+++ b/holoviews/tests/core/test_dimensions.py
@@ -1,12 +1,14 @@
 """
 Test cases for Dimension and Dimensioned object behaviour.
 """
-from holoviews.core import Dimensioned, Dimension
-from holoviews.element.comparison import ComparisonTestCase
-from ..utils import LoggingComparisonTestCase
-
 import numpy as np
 import pandas as pd
+
+from holoviews.core import Dimension, Dimensioned
+from holoviews.element.comparison import ComparisonTestCase
+
+from ..utils import LoggingComparisonTestCase
+
 
 class DimensionNameLabelTest(LoggingComparisonTestCase):
 

--- a/holoviews/tests/core/test_dynamic.py
+++ b/holoviews/tests/core/test_dynamic.py
@@ -1,19 +1,29 @@
-import uuid
 import time
+import uuid
 from collections import deque
 
-import pytest
-import param
 import numpy as np
-from holoviews import Dimension, NdLayout, GridSpace, Layout, NdOverlay
-from holoviews.core.spaces import DynamicMap, HoloMap, Callable
+import param
+import pytest
+
+from holoviews import Dimension, GridSpace, Layout, NdLayout, NdOverlay
 from holoviews.core.options import Store
-from holoviews.element import Image, Scatter, Curve, Text, Points
+from holoviews.core.spaces import Callable, DynamicMap, HoloMap
+from holoviews.element import Curve, Image, Points, Scatter, Text
+from holoviews.element.comparison import ComparisonTestCase
 from holoviews.operation import histogram
 from holoviews.plotting.util import initialize_dynamic
-from holoviews.streams import Stream, LinkedStream, PointerXY, PointerX, PointerY, RangeX, Buffer, pointer_types
+from holoviews.streams import (
+    Buffer,
+    LinkedStream,
+    PointerX,
+    PointerXY,
+    PointerY,
+    RangeX,
+    Stream,
+    pointer_types,
+)
 from holoviews.util import Dynamic
-from holoviews.element.comparison import ComparisonTestCase
 
 from ..utils import LoggingComparisonTestCase
 from .test_dimensioned import CustomBackendTestCase, ExampleElement

--- a/holoviews/tests/core/test_importexport.py
+++ b/holoviews/tests/core/test_importexport.py
@@ -3,9 +3,11 @@ Unit test of the (non-rendering) exporters and importers.
 """
 
 import os
+
 import numpy as np
+
 from holoviews import Image, Layout
-from holoviews.core.io import Serializer, Pickler, Unpickler, Deserializer
+from holoviews.core.io import Deserializer, Pickler, Serializer, Unpickler
 from holoviews.element.comparison import ComparisonTestCase
 
 

--- a/holoviews/tests/core/test_layers.py
+++ b/holoviews/tests/core/test_layers.py
@@ -2,7 +2,8 @@ import unittest
 
 import numpy as np
 
-from holoviews import NdOverlay, Element
+from holoviews import Element, NdOverlay
+
 
 class CompositeTest(unittest.TestCase):
     "For testing of basic composite element types"

--- a/holoviews/tests/core/test_layouts.py
+++ b/holoviews/tests/core/test_layouts.py
@@ -1,8 +1,16 @@
 """
 Tests of Layout and related classes
 """
-from holoviews import AdjointLayout, NdLayout, GridSpace, Layout, Element, HoloMap, Overlay
-from holoviews.element import HLine, Curve
+from holoviews import (
+    AdjointLayout,
+    Element,
+    GridSpace,
+    HoloMap,
+    Layout,
+    NdLayout,
+    Overlay,
+)
+from holoviews.element import Curve, HLine
 from holoviews.element.comparison import ComparisonTestCase
 
 

--- a/holoviews/tests/core/test_ndmapping.py
+++ b/holoviews/tests/core/test_ndmapping.py
@@ -1,12 +1,16 @@
 from collections import OrderedDict
 
+import numpy as np
+
+from holoviews import Dataset, HoloMap
 from holoviews.core import Dimension
 from holoviews.core.ndmapping import (
-    MultiDimensionalMapping, NdMapping, UniformNdMapping
+    MultiDimensionalMapping,
+    NdMapping,
+    UniformNdMapping,
 )
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews import HoloMap, Dataset
-import numpy as np
+
 
 class DimensionTest(ComparisonTestCase):
 

--- a/holoviews/tests/core/test_operation.py
+++ b/holoviews/tests/core/test_operation.py
@@ -3,7 +3,7 @@ import param
 from holoviews.core.operation import Operation
 from holoviews.element import Curve
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.streams import Stream, Params
+from holoviews.streams import Params, Stream
 
 
 class ExampleOperation(Operation):

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -4,13 +4,26 @@ import pickle
 import numpy as np
 import pytest
 
-from holoviews import util
-from holoviews import Store, Histogram, Image, Curve, Points, DynamicMap, opts
+from holoviews import (
+    Curve,
+    DynamicMap,
+    Histogram,
+    Image,
+    Points,
+    Store,
+    opts,
+    plotting,
+    util,
+)
 from holoviews.core.options import (
-    OptionError, Cycle, Options, OptionTree, StoreOptions, options_policy
+    Cycle,
+    OptionError,
+    Options,
+    OptionTree,
+    StoreOptions,
+    options_policy,
 )
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews import plotting
 
 Options.skip_invalid = False
 
@@ -921,9 +934,9 @@ class TestLookupOptions(ComparisonTestCase):
     def test_lookup_options_honors_backend(self):
         points = Points([[1, 2], [3, 4]])
 
-        import holoviews.plotting.mpl
         import holoviews.plotting.bokeh
-        import holoviews.plotting.plotly # noqa
+        import holoviews.plotting.mpl
+        import holoviews.plotting.plotly  # noqa
 
         backends = Store.loaded_backends()
 

--- a/holoviews/tests/core/test_prettyprint.py
+++ b/holoviews/tests/core/test_prettyprint.py
@@ -3,9 +3,9 @@ Test cases for the pretty printing system.
 """
 
 
-from holoviews.element.comparison import ComparisonTestCase
-from holoviews import Store, Element, Curve, Overlay, Layout
+from holoviews import Curve, Element, Layout, Overlay, Store
 from holoviews.core.pprint import PrettyPrinter
+from holoviews.element.comparison import ComparisonTestCase
 
 from .test_dimensioned import CustomBackendTestCase, ExampleElement
 

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -4,11 +4,10 @@ Store as used by the %opts magic.
 """
 import numpy as np
 
-from holoviews.plotting import mpl # noqa Register backend
-
-from holoviews import Overlay, Curve, Image, HoloMap
+from holoviews import Curve, HoloMap, Image, Overlay
 from holoviews.core.options import Store, StoreOptions
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.plotting import mpl  # noqa Register backend
 
 
 class TestStoreOptionsMerge(ComparisonTestCase):

--- a/holoviews/tests/core/test_traversal.py
+++ b/holoviews/tests/core/test_traversal.py
@@ -1,4 +1,4 @@
-from holoviews import HoloMap, DynamicMap, Curve
+from holoviews import Curve, DynamicMap, HoloMap
 from holoviews.core.traversal import unique_dimkeys
 from holoviews.element.comparison import ComparisonTestCase
 

--- a/holoviews/tests/core/test_utils.py
+++ b/holoviews/tests/core/test_utils.py
@@ -4,22 +4,34 @@ Unit tests of the helper functions in core.utils
 import datetime
 import math
 import unittest
-
-from itertools import product
 from collections import OrderedDict
+from itertools import product
 
 import numpy as np
 import pandas as pd
 
-from holoviews.core.util import (
-    sanitize_identifier_fn, find_range, max_range, wrap_tuple_streams,
-    deephash, merge_dimensions, get_path, make_path_unique, compute_density,
-    date_range, dt_to_int, compute_edges, isfinite, cross_index, closest_match,
-    dimension_range, tree_attribute
-)
 from holoviews import Dimension, Element
-from holoviews.streams import PointerXY
+from holoviews.core.util import (
+    closest_match,
+    compute_density,
+    compute_edges,
+    cross_index,
+    date_range,
+    deephash,
+    dimension_range,
+    dt_to_int,
+    find_range,
+    get_path,
+    isfinite,
+    make_path_unique,
+    max_range,
+    merge_dimensions,
+    sanitize_identifier_fn,
+    tree_attribute,
+    wrap_tuple_streams,
+)
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.streams import PointerXY
 
 sanitize_identifier = sanitize_identifier_fn.instance()
 

--- a/holoviews/tests/element/test_annotations.py
+++ b/holoviews/tests/element/test_annotations.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
 
-from holoviews import HLine, VLine, Text, Arrow, Annotation, Spline
-from holoviews.element.comparison import ComparisonTestCase
+from holoviews import Annotation, Arrow, HLine, Spline, Text, VLine
 from holoviews.element import Points
+from holoviews.element.comparison import ComparisonTestCase
 
 
 class AnnotationTests(ComparisonTestCase):

--- a/holoviews/tests/element/test_comparisonchart.py
+++ b/holoviews/tests/element/test_comparisonchart.py
@@ -3,7 +3,8 @@ Test cases for the Comparisons class over the Chart elements
 """
 
 import numpy as np
-from holoviews import Dimension, Curve, Bars, Histogram, Scatter, Points, VectorField
+
+from holoviews import Bars, Curve, Dimension, Histogram, Points, Scatter, VectorField
 from holoviews.element.comparison import ComparisonTestCase
 
 

--- a/holoviews/tests/element/test_comparisonpath.py
+++ b/holoviews/tests/element/test_comparisonpath.py
@@ -2,7 +2,7 @@
 Test cases for the Comparisons class over the Path elements
 """
 
-from holoviews import Path, Box, Bounds, Contours, Ellipse
+from holoviews import Bounds, Box, Contours, Ellipse, Path
 from holoviews.element.comparison import ComparisonTestCase
 
 

--- a/holoviews/tests/element/test_comparisonraster.py
+++ b/holoviews/tests/element/test_comparisonraster.py
@@ -3,11 +3,10 @@ Test cases for the Comparisons class over the Raster types.
 """
 import numpy as np
 
-
+from holoviews import Image
 from holoviews.core import BoundingBox, Dimension
 from holoviews.core.element import HoloMap
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews import Image
 
 
 class RasterTestCase(ComparisonTestCase):

--- a/holoviews/tests/element/test_comparisonsimple.py
+++ b/holoviews/tests/element/test_comparisonsimple.py
@@ -5,6 +5,7 @@ Int, float, numpy array and BoundingBox comparisons are tested.
 """
 
 import numpy as np
+
 from holoviews.core import BoundingBox
 from holoviews.element.comparison import ComparisonTestCase
 

--- a/holoviews/tests/element/test_elementconstructors.py
+++ b/holoviews/tests/element/test_elementconstructors.py
@@ -1,14 +1,37 @@
-import param
 import numpy as np
+import param
 
 from holoviews import (
-    Dimension, Dataset, Element, Annotation, Curve, Path, Histogram,
-    HeatMap, Contours, Scatter, Points, Polygons, VectorField, Spikes,
-    Area, Bars, ErrorBars, BoxWhisker, Raster, Image, QuadMesh, RGB,
-    Graph, TriMesh, Div, Tiles
+    RGB,
+    Annotation,
+    Area,
+    Bars,
+    BoxWhisker,
+    Contours,
+    Curve,
+    Dataset,
+    Dimension,
+    Div,
+    Element,
+    ErrorBars,
+    Graph,
+    HeatMap,
+    Histogram,
+    Image,
+    Path,
+    Points,
+    Polygons,
+    QuadMesh,
+    Raster,
+    Scatter,
+    Spikes,
+    Tiles,
+    TriMesh,
+    VectorField,
 )
-from holoviews.element.path import BaseShape
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.element.path import BaseShape
+
 
 class ElementConstructorTest(ComparisonTestCase):
     """

--- a/holoviews/tests/element/test_elementranges.py
+++ b/holoviews/tests/element/test_elementranges.py
@@ -2,7 +2,7 @@
 Test cases for computing ranges on elements which are not simply
 the (min, max) of the dimension values array.
 """
-from holoviews import Dimension, Histogram, ErrorBars
+from holoviews import Dimension, ErrorBars, Histogram
 from holoviews.element.comparison import ComparisonTestCase
 
 

--- a/holoviews/tests/element/test_elementselect.py
+++ b/holoviews/tests/element/test_elementselect.py
@@ -1,11 +1,13 @@
-from itertools import product
 import datetime as dt
+from itertools import product
+
 import numpy as np
 import pandas as pd
 
 from holoviews.core import HoloMap
-from holoviews.element import Image, Contours, Curve
+from holoviews.element import Contours, Curve, Image
 from holoviews.element.comparison import ComparisonTestCase
+
 
 class DimensionedSelectionTest(ComparisonTestCase):
 

--- a/holoviews/tests/element/test_ellipsis.py
+++ b/holoviews/tests/element/test_ellipsis.py
@@ -2,9 +2,9 @@
 Unit tests of Ellipsis (...) in __getitem__
 """
 import numpy as np
+
 import holoviews as hv
 from holoviews.element.comparison import ComparisonTestCase
-
 
 
 class TestEllipsisCharts(ComparisonTestCase):

--- a/holoviews/tests/element/test_graphelement.py
+++ b/holoviews/tests/element/test_graphelement.py
@@ -8,11 +8,10 @@ import pandas as pd
 
 from holoviews.core.data import Dataset
 from holoviews.element.chart import Points
-from holoviews.element.graphs import (
-    Graph, Nodes, TriMesh, Chord)
-from holoviews.element.sankey import Sankey
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.element.util import connect_edges, connect_edges_pd, circular_layout
+from holoviews.element.graphs import Chord, Graph, Nodes, TriMesh
+from holoviews.element.sankey import Sankey
+from holoviews.element.util import circular_layout, connect_edges, connect_edges_pd
 
 
 class GraphTests(ComparisonTestCase):

--- a/holoviews/tests/element/test_image.py
+++ b/holoviews/tests/element/test_image.py
@@ -3,8 +3,10 @@ Unit tests of Image elements
 """
 
 import numpy as np
+
 import holoviews as hv
-from holoviews.element import  Image, Curve
+from holoviews.element import Curve, Image
+
 from ..utils import LoggingComparisonTestCase
 
 

--- a/holoviews/tests/element/test_paths.py
+++ b/holoviews/tests/element/test_paths.py
@@ -2,7 +2,8 @@
 Unit tests of Path types.
 """
 import numpy as np
-from holoviews import Dataset, Ellipse, Box, Polygons, Path
+
+from holoviews import Box, Dataset, Ellipse, Path, Polygons
 from holoviews.core.data.interface import DataError
 from holoviews.element.comparison import ComparisonTestCase
 

--- a/holoviews/tests/element/test_raster.py
+++ b/holoviews/tests/element/test_raster.py
@@ -3,8 +3,10 @@ Unit tests of Raster elements
 """
 
 import numpy as np
-from holoviews.element import Raster, Image, Curve, QuadMesh, RGB
+
+from holoviews.element import RGB, Curve, Image, QuadMesh, Raster
 from holoviews.element.comparison import ComparisonTestCase
+
 
 class TestRaster(ComparisonTestCase):
 

--- a/holoviews/tests/element/test_selection.py
+++ b/holoviews/tests/element/test_selection.py
@@ -11,9 +11,22 @@ import pytest
 from holoviews.core import NdOverlay
 from holoviews.core.options import Store
 from holoviews.element import (
-    Area, BoxWhisker, Curve, Distribution, HSpan, Image, Points,
-    Rectangles, RGB, Scatter, Segments, Violin, VSpan, Path,
-    QuadMesh, Polygons
+    RGB,
+    Area,
+    BoxWhisker,
+    Curve,
+    Distribution,
+    HSpan,
+    Image,
+    Path,
+    Points,
+    Polygons,
+    QuadMesh,
+    Rectangles,
+    Scatter,
+    Segments,
+    Violin,
+    VSpan,
 )
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.element.selection import spatial_select_columnar

--- a/holoviews/tests/element/test_statselements.py
+++ b/holoviews/tests/element/test_statselements.py
@@ -1,13 +1,21 @@
 from unittest import SkipTest
 
 import numpy as np
-import holoviews as hv
 import pandas as pd
 
+import holoviews as hv
 from holoviews.core.dimension import Dimension
 from holoviews.core.options import Compositor, Store
-from holoviews.element import (Distribution, Bivariate, Points, Image,
-                               Curve, Area, Contours, Polygons)
+from holoviews.element import (
+    Area,
+    Bivariate,
+    Contours,
+    Curve,
+    Distribution,
+    Image,
+    Points,
+    Polygons,
+)
 from holoviews.element.comparison import ComparisonTestCase
 
 

--- a/holoviews/tests/element/test_tiles.py
+++ b/holoviews/tests/element/test_tiles.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
-from holoviews import Tiles
 
+from holoviews import Tiles
 from holoviews.element.comparison import ComparisonTestCase
 
 

--- a/holoviews/tests/ipython/test_displayhooks.py
+++ b/holoviews/tests/ipython/test_displayhooks.py
@@ -1,5 +1,5 @@
-from holoviews import Store, Curve
-from holoviews.ipython import notebook_extension, IPTestCase
+from holoviews import Curve, Store
+from holoviews.ipython import IPTestCase, notebook_extension
 
 
 class TestDisplayHooks(IPTestCase):

--- a/holoviews/tests/ipython/test_magics.py
+++ b/holoviews/tests/ipython/test_magics.py
@@ -2,14 +2,17 @@ from unittest import SkipTest
 
 import holoviews as hv
 from holoviews.core.options import Store
+
 try:
     from holoviews import ipython            # noqa (Import test)
     from holoviews.ipython import IPTestCase
 except ImportError:
     raise SkipTest("Required dependencies not satisfied for testing magics")
 
-from holoviews.operation import Compositor
 from pyviz_comms import CommManager
+
+from holoviews.operation import Compositor
+
 
 class ExtensionTestCase(IPTestCase):
 

--- a/holoviews/tests/ipython/test_optscompleter.py
+++ b/holoviews/tests/ipython/test_optscompleter.py
@@ -3,6 +3,7 @@ Tests the OptsCompleter class for tab-completion in the opts magic.
 """
 
 from unittest import SkipTest
+
 try:
     from holoviews.ipython import IPTestCase
     from holoviews.ipython.magics import OptsCompleter

--- a/holoviews/tests/ipython/test_parsers.py
+++ b/holoviews/tests/ipython/test_parsers.py
@@ -1,8 +1,9 @@
 """
 Tests of the parsers implemented in ipython.parsers
 """
-from holoviews.element.comparison import ComparisonTestCase
 from unittest import SkipTest
+
+from holoviews.element.comparison import ComparisonTestCase
 
 try:
     import pyparsing     # noqa (import test)
@@ -11,8 +12,7 @@ except ImportError:
     raise SkipTest("Required dependencies not satisfied for testing parsers")
 
 
-from holoviews.core.options import Options, Cycle
-
+from holoviews.core.options import Cycle, Options
 
 
 class OptsSpecPlotOptionsTests(ComparisonTestCase):

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1,29 +1,55 @@
 import datetime as dt
-
 from unittest import SkipTest, skipIf
 
 import numpy as np
 import pandas as pd
 import pytest
-
-from holoviews import (
-    Dimension, Curve, Points, Image, Dataset, RGB, Path, Graph, TriMesh,
-    QuadMesh, NdOverlay, Contours, Spikes, Spread, Area, Rectangles,
-    Segments, Polygons, Nodes
-)
-from holoviews.streams import Tap
-from holoviews.element.comparison import ComparisonTestCase
 from numpy import nan
 from packaging.version import Version
 
+from holoviews import (
+    RGB,
+    Area,
+    Contours,
+    Curve,
+    Dataset,
+    Dimension,
+    Graph,
+    Image,
+    NdOverlay,
+    Nodes,
+    Path,
+    Points,
+    Polygons,
+    QuadMesh,
+    Rectangles,
+    Segments,
+    Spikes,
+    Spread,
+    TriMesh,
+)
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.streams import Tap
+
 try:
-    import datashader as ds
     import dask.dataframe as dd
+    import datashader as ds
     import xarray as xr
+
     from holoviews.operation.datashader import (
-        aggregate, regrid, ds_version, stack, directly_connect_edges,
-        shade, spread, rasterize, datashade, AggregationOperation,
-        inspect, inspect_points, inspect_polygons
+        AggregationOperation,
+        aggregate,
+        datashade,
+        directly_connect_edges,
+        ds_version,
+        inspect,
+        inspect_points,
+        inspect_polygons,
+        rasterize,
+        regrid,
+        shade,
+        spread,
+        stack,
     )
 except ImportError:
     raise SkipTest('Datashader not available')

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -1,23 +1,43 @@
 import datetime as dt
 from unittest import skipIf
-import pytest
 
 import numpy as np
 import pandas as pd
+import pytest
 
 try:
     import dask.array as da
 except ImportError:
     da = None
 
-from holoviews import (HoloMap, NdOverlay, NdLayout, GridSpace, Image,
-                       Contours, Polygons, Points, Histogram, Curve, Area,
-                       QuadMesh, Dataset, renderer)
+from holoviews import (
+    Area,
+    Contours,
+    Curve,
+    Dataset,
+    GridSpace,
+    Histogram,
+    HoloMap,
+    Image,
+    NdLayout,
+    NdOverlay,
+    Points,
+    Polygons,
+    QuadMesh,
+    renderer,
+)
 from holoviews.core.data.grid import GridInterface
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.operation.element import (operation, transform, threshold,
-                                         gradient, contours, histogram,
-                                         interpolate_curve, decimate)
+from holoviews.operation.element import (
+    contours,
+    decimate,
+    gradient,
+    histogram,
+    interpolate_curve,
+    operation,
+    threshold,
+    transform,
+)
 
 da_skip = skipIf(da is None, "dask.array is not available")
 

--- a/holoviews/tests/operation/test_statsoperations.py
+++ b/holoviews/tests/operation/test_statsoperations.py
@@ -7,9 +7,9 @@ except ImportError:
 
 import numpy as np
 
-from holoviews import Distribution, Bivariate, Area, Image, Contours, Polygons
+from holoviews import Area, Bivariate, Contours, Distribution, Image, Polygons
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.operation.stats import (univariate_kde, bivariate_kde)
+from holoviews.operation.stats import bivariate_kde, univariate_kde
 
 
 class KDEOperationTests(ComparisonTestCase):

--- a/holoviews/tests/operation/test_timeseriesoperations.py
+++ b/holoviews/tests/operation/test_timeseriesoperations.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from holoviews import Curve, Scatter
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.operation.timeseries import (rolling, resample, rolling_outlier_std)
+from holoviews.operation.timeseries import resample, rolling, rolling_outlier_std
 
 
 class TimeseriesOperationTests(ComparisonTestCase):

--- a/holoviews/tests/plotting/__init__.py
+++ b/holoviews/tests/plotting/__init__.py
@@ -1,6 +1,6 @@
 from itertools import combinations
 
-from holoviews.core.options import Store, Options
+from holoviews.core.options import Options, Store
 
 
 def option_intersections(backend):

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -1,8 +1,6 @@
 import numpy as np
 
-from holoviews.element import (
-    HLine, VLine, Text, Labels, Arrow, HSpan, VSpan, Slope
-)
+from holoviews.element import Arrow, HLine, HSpan, Labels, Slope, Text, VLine, VSpan
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -1,10 +1,9 @@
 import numpy as np
+from bokeh.models import CategoricalColorMapper, LinearColorMapper
 
 from holoviews.core.overlay import NdOverlay
 from holoviews.element import Bars
 from holoviews.plotting.bokeh.util import property_to_dict
-
-from bokeh.models import CategoricalColorMapper, LinearColorMapper
 
 from ..utils import ParamLogStream
 from .test_plot import TestBokehPlot, bokeh_renderer

--- a/holoviews/tests/plotting/bokeh/test_boxwhiskerplot.py
+++ b/holoviews/tests/plotting/bokeh/test_boxwhiskerplot.py
@@ -1,13 +1,12 @@
 import datetime as dt
 
 import numpy as np
+from bokeh.models import CategoricalColorMapper, ColumnDataSource, LinearColorMapper
 
 from holoviews.element import BoxWhisker
 from holoviews.plotting.bokeh.util import property_to_dict
 
 from .test_plot import TestBokehPlot, bokeh_renderer
-
-from bokeh.models import ColumnDataSource, CategoricalColorMapper, LinearColorMapper
 
 
 class TestBoxWhiskerPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -1,5 +1,4 @@
 import datetime as dt
-
 from collections import deque, namedtuple
 from unittest import SkipTest
 
@@ -7,24 +6,39 @@ import numpy as np
 import pandas as pd
 import pytest
 import pyviz_comms as comms
+from bokeh.events import Tap
+from bokeh.io.doc import set_curdoc
+from bokeh.models import ColumnDataSource, Plot, PolyEditTool, Range1d, Selection
 
 from holoviews.core import DynamicMap
 from holoviews.core.options import Store
-from holoviews.element import Points, Polygons, Box, Curve, Table, Rectangles
+from holoviews.element import Box, Curve, Points, Polygons, Rectangles, Table
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.streams import (
-    PointDraw, PolyDraw, PolyEdit, BoxEdit, PointerXY, PointerX,
-    PlotReset, Selection1D, RangeXY, PlotSize, CDSStream, SingleTap
-)
-
-from bokeh.events import Tap
-from bokeh.io.doc import set_curdoc
-from bokeh.models import Range1d, Plot, ColumnDataSource, Selection, PolyEditTool
 from holoviews.plotting.bokeh.callbacks import (
-    Callback, CDSCallback, PointDrawCallback, PolyDrawCallback, PolyEditCallback,
-    BoxEditCallback, PointerXCallback, TapCallback
+    BoxEditCallback,
+    Callback,
+    CDSCallback,
+    PointDrawCallback,
+    PointerXCallback,
+    PolyDrawCallback,
+    PolyEditCallback,
+    TapCallback,
 )
 from holoviews.plotting.bokeh.renderer import BokehRenderer
+from holoviews.streams import (
+    BoxEdit,
+    CDSStream,
+    PlotReset,
+    PlotSize,
+    PointDraw,
+    PointerX,
+    PointerXY,
+    PolyDraw,
+    PolyEdit,
+    RangeXY,
+    Selection1D,
+    SingleTap,
+)
 
 bokeh_server_renderer = BokehRenderer.instance(mode='server')
 bokeh_renderer = BokehRenderer.instance()

--- a/holoviews/tests/plotting/bokeh/test_curveplot.py
+++ b/holoviews/tests/plotting/bokeh/test_curveplot.py
@@ -2,18 +2,17 @@ import datetime as dt
 
 import numpy as np
 import pandas as pd
+from bokeh.models import FactorRange, FixedTicker
 
-from holoviews.core import NdOverlay, HoloMap, DynamicMap
+from holoviews.core import DynamicMap, HoloMap, NdOverlay
 from holoviews.core.options import Cycle, Palette
 from holoviews.element import Curve
+from holoviews.plotting.bokeh.callbacks import Callback, PointerXCallback
 from holoviews.plotting.util import rgb2hex
 from holoviews.streams import PointerX
 from holoviews.util.transform import dim
 
 from .test_plot import TestBokehPlot, bokeh_renderer
-
-from bokeh.models import FactorRange, FixedTicker
-from holoviews.plotting.bokeh.callbacks import Callback, PointerXCallback
 
 
 class TestCurvePlot(TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -1,28 +1,30 @@
 import datetime as dt
-
-from unittest import SkipTest
 from collections import OrderedDict
+from unittest import SkipTest
 
 import numpy as np
+import panel as pn
+from bokeh.document import Document
+from bokeh.models import (
+    EqHistColorMapper,
+    LinearColorMapper,
+    LogColorMapper,
+    LogTicker,
+    NumeralTickFormatter,
+    PrintfTickFormatter,
+    tools,
+)
 
-from holoviews.core import Dimension, DynamicMap, NdOverlay, HoloMap
+from holoviews.core import Dimension, DynamicMap, HoloMap, NdOverlay
 from holoviews.core.util import dt_to_int
-from holoviews.element import Curve, Image, Scatter, Labels
-from holoviews.streams import Stream, PointDraw
-from holoviews.plotting.util import process_cmap
+from holoviews.element import Curve, Image, Labels, Scatter
 from holoviews.plotting.bokeh.util import bokeh3
+from holoviews.plotting.util import process_cmap
+from holoviews.streams import PointDraw, Stream
 from holoviews.util import render
 
-from .test_plot import TestBokehPlot, bokeh_renderer
 from ...utils import LoggingComparisonTestCase
-
-import panel as pn
-
-from bokeh.document import Document
-from bokeh.models import tools
-from bokeh.models import (PrintfTickFormatter,
-                            NumeralTickFormatter, LogTicker,
-                            LinearColorMapper, LogColorMapper, EqHistColorMapper)
+from .test_plot import TestBokehPlot, bokeh_renderer
 
 if bokeh3:
     from bokeh.models.formatters import CustomJSTickFormatter

--- a/holoviews/tests/plotting/bokeh/test_errorbarplot.py
+++ b/holoviews/tests/plotting/bokeh/test_errorbarplot.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from bokeh.models import CategoricalColorMapper, LinearColorMapper
 
 from holoviews.element import ErrorBars

--- a/holoviews/tests/plotting/bokeh/test_geomplot.py
+++ b/holoviews/tests/plotting/bokeh/test_geomplot.py
@@ -1,11 +1,10 @@
 import pandas as pd
+from bokeh.models import FactorRange
 
 from holoviews.core import NdOverlay
 from holoviews.element import Segments
 
 from .test_plot import TestBokehPlot, bokeh_renderer
-
-from bokeh.models import FactorRange
 
 
 class TestSegmentPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_graphplot.py
+++ b/holoviews/tests/plotting/bokeh/test_graphplot.py
@@ -1,12 +1,11 @@
 import numpy as np
+from bokeh.models import EdgesAndLinkedNodes, NodesAndLinkedEdges, NodesOnly, Patches
+from bokeh.models.mappers import CategoricalColorMapper, LinearColorMapper
 
 from holoviews.core.data import Dataset
-from holoviews.element import Graph, Nodes, TriMesh, Chord, VLine, circular_layout
+from holoviews.element import Chord, Graph, Nodes, TriMesh, VLine, circular_layout
+from holoviews.plotting.bokeh.util import bokeh3, property_to_dict
 from holoviews.util.transform import dim
-from holoviews.plotting.bokeh.util import property_to_dict, bokeh3
-
-from bokeh.models import (NodesAndLinkedEdges, EdgesAndLinkedNodes, NodesOnly, Patches)
-from bokeh.models.mappers import CategoricalColorMapper, LinearColorMapper
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 

--- a/holoviews/tests/plotting/bokeh/test_gridplot.py
+++ b/holoviews/tests/plotting/bokeh/test_gridplot.py
@@ -1,16 +1,21 @@
 import numpy as np
-
-from holoviews.core import (HoloMap, GridSpace, NdOverlay, Dataset,
-                            DynamicMap, GridMatrix)
-from holoviews.element import Curve, Image, Points
-from holoviews.operation import gridmatrix
-from holoviews.streams import Stream
-from holoviews.plotting.bokeh.util import bokeh3
-
-from .test_plot import TestBokehPlot, bokeh_renderer
-
 from bokeh.layouts import Column
 from bokeh.models import Div
+
+from holoviews.core import (
+    Dataset,
+    DynamicMap,
+    GridMatrix,
+    GridSpace,
+    HoloMap,
+    NdOverlay,
+)
+from holoviews.element import Curve, Image, Points
+from holoviews.operation import gridmatrix
+from holoviews.plotting.bokeh.util import bokeh3
+from holoviews.streams import Stream
+
+from .test_plot import TestBokehPlot, bokeh_renderer
 
 if bokeh3:
     from bokeh.models import Toolbar

--- a/holoviews/tests/plotting/bokeh/test_heatmapplot.py
+++ b/holoviews/tests/plotting/bokeh/test_heatmapplot.py
@@ -1,8 +1,7 @@
 import numpy as np
-
-from holoviews.element import HeatMap, Points, Image
-
 from bokeh.models import FactorRange, HoverTool, Range1d
+
+from holoviews.element import HeatMap, Image, Points
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 

--- a/holoviews/tests/plotting/bokeh/test_histogramplot.py
+++ b/holoviews/tests/plotting/bokeh/test_histogramplot.py
@@ -1,13 +1,12 @@
 import datetime as dt
 
 import numpy as np
+from bokeh.models import CategoricalColorMapper, DatetimeAxis, LinearColorMapper
 
 from holoviews.core.overlay import NdOverlay
-from holoviews.element import Image, Points, Dataset, Histogram
+from holoviews.element import Dataset, Histogram, Image, Points
 from holoviews.operation import histogram
 from holoviews.plotting.bokeh.util import property_to_dict
-
-from bokeh.models import DatetimeAxis, CategoricalColorMapper, LinearColorMapper
 
 from ...utils import LoggingComparisonTestCase
 from .test_plot import TestBokehPlot, bokeh_renderer

--- a/holoviews/tests/plotting/bokeh/test_labels.py
+++ b/holoviews/tests/plotting/bokeh/test_labels.py
@@ -1,10 +1,9 @@
 import numpy as np
+from bokeh.models import CategoricalColorMapper, LinearColorMapper
 
 from holoviews.core.dimension import Dimension
 from holoviews.element import Labels
 from holoviews.plotting.bokeh.util import property_to_dict
-
-from bokeh.models import LinearColorMapper, CategoricalColorMapper
 
 from ..utils import ParamLogStream
 from .test_plot import TestBokehPlot, bokeh_renderer

--- a/holoviews/tests/plotting/bokeh/test_layoutplot.py
+++ b/holoviews/tests/plotting/bokeh/test_layoutplot.py
@@ -1,32 +1,41 @@
 import datetime as dt
 import re
 
-import pytest
 import numpy as np
+import pytest
+from bokeh.models import Column, Div, GlyphRenderer, Row, Spacer, Tabs, Title
 
-from holoviews.core import (HoloMap, GridSpace, Layout, Empty, Dataset,
-                            NdOverlay, NdLayout, DynamicMap, Dimension)
-from holoviews.element import Curve, Image, Points, Histogram, Scatter
-from holoviews.streams import Stream
-from holoviews.util import render, opts
-from holoviews.util.transform import dim
+from holoviews.core import (
+    Dataset,
+    Dimension,
+    DynamicMap,
+    Empty,
+    GridSpace,
+    HoloMap,
+    Layout,
+    NdLayout,
+    NdOverlay,
+)
+from holoviews.element import Curve, Histogram, Image, Points, Scatter
 from holoviews.plotting.bokeh.util import bokeh3
-
-from bokeh.models import Div, GlyphRenderer, Tabs, Spacer, Title, Row, Column
+from holoviews.streams import Stream
+from holoviews.util import opts, render
+from holoviews.util.transform import dim
 
 from ...utils import LoggingComparisonTestCase
 from .test_plot import TestBokehPlot, bokeh_renderer
 
 if bokeh3:
+    from bokeh.models import GridPlot, Toolbar
     from bokeh.models.layouts import TabPanel
     from bokeh.plotting import figure
-    from bokeh.models import GridPlot
-    from bokeh.models import Toolbar
 else:
+    from bokeh.models import (
+        GridBox as GridPlot,  # Not completely correct
+        ToolbarBox as Toolbar,  # Not completely correct
+    )
     from bokeh.models.layouts import Panel as TabPanel
     from bokeh.plotting import Figure as figure
-    from bokeh.models import ToolbarBox as Toolbar  # Not completely correct
-    from bokeh.models import GridBox as GridPlot  # Not completely correct
 
 
 class TestLayoutPlot(LoggingComparisonTestCase, TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -1,10 +1,9 @@
 import numpy as np
+from bokeh.models import ColumnDataSource
 
 from holoviews.core.spaces import DynamicMap
-from holoviews.element import Curve, Polygons, Table, Scatter, Path, Points
-from holoviews.plotting.links import (Link, RangeToolLink, DataLink)
-
-from bokeh.models import ColumnDataSource
+from holoviews.element import Curve, Path, Points, Polygons, Scatter, Table
+from holoviews.plotting.links import DataLink, Link, RangeToolLink
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 

--- a/holoviews/tests/plotting/bokeh/test_overlayplot.py
+++ b/holoviews/tests/plotting/bokeh/test_overlayplot.py
@@ -1,17 +1,26 @@
 import numpy as np
 import panel as pn
+from bokeh.models import FactorRange, FixedTicker, HoverTool, Range1d, Span
 
-from holoviews.core import NdOverlay, HoloMap, DynamicMap, Overlay
+from holoviews.core import DynamicMap, HoloMap, NdOverlay, Overlay
 from holoviews.core.options import Cycle
-from holoviews.element import Bars, Box, Curve, ErrorBars, HLine, Points, Scatter, Text, VLine
+from holoviews.element import (
+    Bars,
+    Box,
+    Curve,
+    ErrorBars,
+    HLine,
+    Points,
+    Scatter,
+    Text,
+    VLine,
+)
+from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.streams import Stream, Tap
 from holoviews.util import Dynamic
-from holoviews.plotting.bokeh.util import property_to_dict
 
 from ...utils import LoggingComparisonTestCase
 from .test_plot import TestBokehPlot, bokeh_renderer
-
-from bokeh.models import FixedTicker, HoverTool, FactorRange, Span, Range1d
 
 
 class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_pathplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pathplot.py
@@ -2,17 +2,16 @@ import datetime as dt
 
 import numpy as np
 import pandas as pd
+from bokeh.models import CategoricalColorMapper, LinearColorMapper
 
-from holoviews.core import NdOverlay, HoloMap
+from holoviews.core import HoloMap, NdOverlay
 from holoviews.core.options import Cycle
-from holoviews.element import Path, Polygons, Contours
+from holoviews.element import Contours, Path, Polygons
+from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.streams import PolyDraw
 from holoviews.util.transform import dim
-from holoviews.plotting.bokeh.util import property_to_dict
 
 from .test_plot import TestBokehPlot, bokeh_renderer
-
-from bokeh.models import LinearColorMapper, CategoricalColorMapper
 
 
 class TestPathPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -1,16 +1,13 @@
 import pyviz_comms as comms
-
+from bokeh.models import ColumnDataSource, HoverTool, LinearColorMapper, LogColorMapper
 from param import concrete_descendents
 
 from holoviews.core.element import Element
 from holoviews.core.options import Store
 from holoviews.element.comparison import ComparisonTestCase
-
-from bokeh.models import (
-    ColumnDataSource, LinearColorMapper, LogColorMapper, HoverTool
-)
 from holoviews.plotting.bokeh.callbacks import Callback
 from holoviews.plotting.bokeh.element import ElementPlot
+
 bokeh_renderer = Store.renderers['bokeh']
 
 from .. import option_intersections

--- a/holoviews/tests/plotting/bokeh/test_pointplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pointplot.py
@@ -2,18 +2,16 @@ import datetime as dt
 
 import numpy as np
 import pandas as pd
+from bokeh.models import CategoricalColorMapper, FactorRange, LinearColorMapper, Scatter
 
 from holoviews.core import NdOverlay
 from holoviews.core.options import Cycle
 from holoviews.element import Points
-from holoviews.streams import Stream
 from holoviews.plotting.bokeh.util import property_to_dict
+from holoviews.streams import Stream
 
-from .test_plot import TestBokehPlot, bokeh_renderer
 from ..utils import ParamLogStream
-
-from bokeh.models import FactorRange, LinearColorMapper, CategoricalColorMapper
-from bokeh.models import Scatter
+from .test_plot import TestBokehPlot, bokeh_renderer
 
 
 class TestPointPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
@@ -1,10 +1,9 @@
 import numpy as np
+from bokeh.models import ColorBar
 
-from holoviews.element import QuadMesh, Image
+from holoviews.element import Image, QuadMesh
 
 from .test_plot import TestBokehPlot, bokeh_renderer
-
-from bokeh.models import ColorBar
 
 
 class TestQuadMeshPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_radialheatmap.py
+++ b/holoviews/tests/plotting/bokeh/test_radialheatmap.py
@@ -1,11 +1,10 @@
 from itertools import product
 
 import numpy as np
+from bokeh.models import ColorBar
 
 from holoviews.core.spaces import HoloMap
 from holoviews.element.raster import HeatMap
-
-from bokeh.models import ColorBar
 from holoviews.plotting.bokeh import RadialHeatMapPlot
 
 from .test_plot import TestBokehPlot, bokeh_renderer

--- a/holoviews/tests/plotting/bokeh/test_rasterplot.py
+++ b/holoviews/tests/plotting/bokeh/test_rasterplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Raster, Image, RGB
+from holoviews.element import RGB, Image, Raster
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 

--- a/holoviews/tests/plotting/bokeh/test_renderer.py
+++ b/holoviews/tests/plotting/bokeh/test_renderer.py
@@ -3,23 +3,20 @@ from io import BytesIO
 from unittest import SkipTest
 
 import numpy as np
+import panel as pn
 import param
-
-from holoviews import DynamicMap, HoloMap, Image, GridSpace, Table, Curve
-from holoviews.streams import Stream
-from holoviews.plotting import Renderer
-from holoviews.element.comparison import ComparisonTestCase
-from holoviews.plotting.bokeh.util import bokeh3
-
+from bokeh.io import curdoc
+from bokeh.themes.theme import Theme
+from panel.widgets import DiscreteSlider, FloatSlider, Player
 from pyviz_comms import CommManager
 
-import panel as pn
-
-from bokeh.io import curdoc
+from holoviews import Curve, DynamicMap, GridSpace, HoloMap, Image, Table
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.plotting import Renderer
 from holoviews.plotting.bokeh import BokehRenderer
-from bokeh.themes.theme import Theme
+from holoviews.plotting.bokeh.util import bokeh3
+from holoviews.streams import Stream
 
-from panel.widgets import DiscreteSlider, Player, FloatSlider
 
 class BokehRendererTest(ComparisonTestCase):
 

--- a/holoviews/tests/plotting/bokeh/test_sankey.py
+++ b/holoviews/tests/plotting/bokeh/test_sankey.py
@@ -5,8 +5,8 @@ from holoviews import render
 from holoviews.core.data import Dataset, Dimension
 from holoviews.element import Sankey
 
-
 from .test_plot import TestBokehPlot, bokeh_renderer
+
 
 class TestSankeyPlot(TestBokehPlot):
 

--- a/holoviews/tests/plotting/bokeh/test_server.py
+++ b/holoviews/tests/plotting/bokeh/test_server.py
@@ -1,26 +1,22 @@
 import time
 
 import param
-
-from holoviews.core.spaces import DynamicMap
-from holoviews.core.options import Store
-from holoviews.element import Curve, Polygons, Path, HLine
-from holoviews.element.comparison import ComparisonTestCase
-from holoviews.plotting import Renderer
-from holoviews.streams import Stream, RangeXY, PlotReset
-
 from bokeh.client import pull_session
 from bokeh.document import Document
 from bokeh.io.doc import curdoc, set_curdoc
 from bokeh.models import ColumnDataSource
-
-from holoviews.plotting.bokeh.callbacks import (
-    Callback, RangeXYCallback, ResetCallback
-)
-from holoviews.plotting.bokeh.renderer import BokehRenderer
-from panel.widgets import DiscreteSlider, FloatSlider
-from panel.io.state import state
 from panel import serve
+from panel.io.state import state
+from panel.widgets import DiscreteSlider, FloatSlider
+
+from holoviews.core.options import Store
+from holoviews.core.spaces import DynamicMap
+from holoviews.element import Curve, HLine, Path, Polygons
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.plotting import Renderer
+from holoviews.plotting.bokeh.callbacks import Callback, RangeXYCallback, ResetCallback
+from holoviews.plotting.bokeh.renderer import BokehRenderer
+from holoviews.streams import PlotReset, RangeXY, Stream
 
 bokeh_renderer = BokehRenderer.instance(mode='server')
 

--- a/holoviews/tests/plotting/bokeh/test_spikesplot.py
+++ b/holoviews/tests/plotting/bokeh/test_spikesplot.py
@@ -1,10 +1,10 @@
 import datetime as dt
 
 import numpy as np
+from bokeh.models import CategoricalColorMapper, LinearColorMapper
+
 from holoviews.core import NdOverlay
 from holoviews.element import Spikes
-
-from bokeh.models import CategoricalColorMapper, LinearColorMapper
 from holoviews.plotting.bokeh.util import property_to_dict
 
 from ..utils import ParamLogStream

--- a/holoviews/tests/plotting/bokeh/test_tabular.py
+++ b/holoviews/tests/plotting/bokeh/test_tabular.py
@@ -1,9 +1,15 @@
 from datetime import datetime as dt
 
 from bokeh.models.widgets import (
-        NumberEditor, NumberFormatter, DateFormatter,
-    DateEditor, StringFormatter, StringEditor, IntEditor
+    DateEditor,
+    DateFormatter,
+    IntEditor,
+    NumberEditor,
+    NumberFormatter,
+    StringEditor,
+    StringFormatter,
 )
+
 from holoviews.core.options import Store
 from holoviews.core.spaces import DynamicMap
 from holoviews.element import Table

--- a/holoviews/tests/plotting/bokeh/test_tiles.py
+++ b/holoviews/tests/plotting/bokeh/test_tiles.py
@@ -4,6 +4,7 @@ from holoviews.element import Tiles
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
+
 class TestTilePlot(TestBokehPlot):
 
     def test_xyzservices_tileprovider(self):

--- a/holoviews/tests/plotting/bokeh/test_utils.py
+++ b/holoviews/tests/plotting/bokeh/test_utils.py
@@ -1,7 +1,7 @@
 from holoviews.core import Store
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.plotting.bokeh.util import filter_batched_data, glyph_order
 from holoviews.plotting.bokeh.styles import expand_batched_style
+from holoviews.plotting.bokeh.util import filter_batched_data, glyph_order
 
 bokeh_renderer = Store.renderers['bokeh']
 

--- a/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
@@ -3,11 +3,11 @@ import numpy as np
 from holoviews.element import VectorField
 from holoviews.plotting.bokeh.util import property_to_dict
 
-from .test_plot import TestBokehPlot, bokeh_renderer
 from ..utils import ParamLogStream
+from .test_plot import TestBokehPlot, bokeh_renderer
 
 try:
-    from bokeh.models import LinearColorMapper, CategoricalColorMapper
+    from bokeh.models import CategoricalColorMapper, LinearColorMapper
 except ImportError:
     pass
 

--- a/holoviews/tests/plotting/bokeh/test_violinplot.py
+++ b/holoviews/tests/plotting/bokeh/test_violinplot.py
@@ -1,15 +1,14 @@
 from unittest import SkipTest
 
 import numpy as np
+from bokeh.models import CategoricalColorMapper, LinearColorMapper
 
 from holoviews.element import Violin
 from holoviews.operation.stats import univariate_kde
-from holoviews.util.transform import dim
 from holoviews.plotting.bokeh.util import property_to_dict
+from holoviews.util.transform import dim
 
 from .test_plot import TestBokehPlot, bokeh_renderer
-
-from bokeh.models import LinearColorMapper, CategoricalColorMapper
 
 
 class TestBokehViolinPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/matplotlib/test_callbacks.py
+++ b/holoviews/tests/plotting/matplotlib/test_callbacks.py
@@ -3,9 +3,8 @@ from collections import deque
 import numpy as np
 
 from holoviews.core import DynamicMap
-from holoviews.element import Points, Curve
-from holoviews.streams import PointerXY, PointerX
-
+from holoviews.element import Curve, Points
+from holoviews.streams import PointerX, PointerXY
 
 from .test_plot import TestMPLPlot, mpl_renderer
 

--- a/holoviews/tests/plotting/matplotlib/test_elementplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_elementplot.py
@@ -1,14 +1,13 @@
 import numpy as np
 from matplotlib import style
+from matplotlib.projections import PolarAxes
+from matplotlib.ticker import FormatStrFormatter, FuncFormatter, PercentFormatter
 
 from holoviews.core.spaces import DynamicMap
-from holoviews.element import Image, Curve, Scatter, Scatter3D
+from holoviews.element import Curve, Image, Scatter, Scatter3D
 from holoviews.streams import Stream
 
 from .test_plot import TestMPLPlot, mpl_renderer
-
-from matplotlib.ticker import FormatStrFormatter, FuncFormatter, PercentFormatter
-from matplotlib.projections import PolarAxes
 
 
 class TestElementPlot(TestMPLPlot):

--- a/holoviews/tests/plotting/matplotlib/test_graphplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_graphplot.py
@@ -1,12 +1,12 @@
 import numpy as np
+from matplotlib.collections import LineCollection, PolyCollection
+from packaging.version import Version
 
 from holoviews.core.data import Dataset
 from holoviews.core.options import Cycle
 from holoviews.core.spaces import HoloMap
-from holoviews.element import Graph, Nodes, TriMesh, Chord, circular_layout
+from holoviews.element import Chord, Graph, Nodes, TriMesh, circular_layout
 from holoviews.util.transform import dim
-from matplotlib.collections import LineCollection, PolyCollection
-from packaging.version import Version
 
 from .test_plot import TestMPLPlot, mpl_renderer
 

--- a/holoviews/tests/plotting/matplotlib/test_hextilesplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_hextilesplot.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from holoviews.element import HexTiles
 
-
 from .test_plot import TestMPLPlot, mpl_renderer
 
 

--- a/holoviews/tests/plotting/matplotlib/test_layoutplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_layoutplot.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from holoviews.core import HoloMap, NdOverlay, DynamicMap
-from holoviews.element import Image, Curve
+from holoviews.core import DynamicMap, HoloMap, NdOverlay
+from holoviews.element import Curve, Image
 from holoviews.streams import Stream
 
 from ...utils import LoggingComparisonTestCase

--- a/holoviews/tests/plotting/matplotlib/test_overlayplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_overlayplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.core import Overlay, NdOverlay, DynamicMap, HoloMap
+from holoviews.core import DynamicMap, HoloMap, NdOverlay, Overlay
 from holoviews.element import Curve, Scatter
 
 from ...utils import LoggingComparisonTestCase

--- a/holoviews/tests/plotting/matplotlib/test_pathplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pathplot.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from holoviews.core import NdOverlay
 from holoviews.core.spaces import HoloMap
-from holoviews.element import Polygons, Contours, Path
+from holoviews.element import Contours, Path, Polygons
 
 from .test_plot import TestMPLPlot, mpl_renderer
 

--- a/holoviews/tests/plotting/matplotlib/test_plot.py
+++ b/holoviews/tests/plotting/matplotlib/test_plot.py
@@ -1,10 +1,10 @@
 import matplotlib.pyplot as plt
 import pyviz_comms as comms
+from param import concrete_descendents
 
 from holoviews.core.options import Store
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.plotting.mpl.element import ElementPlot
-from param import concrete_descendents
 
 from .. import option_intersections
 

--- a/holoviews/tests/plotting/matplotlib/test_pointplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pointplot.py
@@ -1,13 +1,12 @@
 import numpy as np
+from matplotlib import pyplot
 
 from holoviews.core.overlay import NdOverlay
 from holoviews.core.spaces import HoloMap
 from holoviews.element import Points
 
-from .test_plot import TestMPLPlot, mpl_renderer
 from ..utils import ParamLogStream
-
-from matplotlib import pyplot
+from .test_plot import TestMPLPlot, mpl_renderer
 
 
 class TestPointPlot(TestMPLPlot):

--- a/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import QuadMesh, Image, Dataset
+from holoviews.element import Dataset, Image, QuadMesh
 
 from .test_plot import TestMPLPlot, mpl_renderer
 

--- a/holoviews/tests/plotting/matplotlib/test_rasterplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_rasterplot.py
@@ -1,10 +1,9 @@
 import numpy as np
+from matplotlib.colors import ListedColormap
 
-from holoviews.element import Raster, Image
+from holoviews.element import Image, Raster
 
 from .test_plot import TestMPLPlot, mpl_renderer
-
-from matplotlib.colors import ListedColormap
 
 
 class TestRasterPlot(TestMPLPlot):

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -2,25 +2,23 @@
 Test cases for rendering exporters
 """
 import subprocess
-
 from collections import OrderedDict
 from unittest import SkipTest
 
 import numpy as np
-import param
 import panel as pn
+import param
 from matplotlib import style
 from packaging.version import Version
-
-from holoviews import (DynamicMap, HoloMap, Image, ItemTable,
-                       GridSpace, Table, Curve)
-from holoviews.element.comparison import ComparisonTestCase
-from holoviews.streams import Stream
-from holoviews.plotting.mpl import MPLRenderer, CurvePlot
-from holoviews.plotting.renderer import Renderer
-from holoviews.plotting.mpl.util import mpl_version
-from panel.widgets import DiscreteSlider, Player, FloatSlider
+from panel.widgets import DiscreteSlider, FloatSlider, Player
 from pyviz_comms import CommManager
+
+from holoviews import Curve, DynamicMap, GridSpace, HoloMap, Image, ItemTable, Table
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.plotting.mpl import CurvePlot, MPLRenderer
+from holoviews.plotting.mpl.util import mpl_version
+from holoviews.plotting.renderer import Renderer
+from holoviews.streams import Stream
 
 
 class MPLRendererTest(ComparisonTestCase):

--- a/holoviews/tests/plotting/matplotlib/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_vectorfieldplot.py
@@ -3,8 +3,8 @@ import numpy as np
 from holoviews.core.spaces import HoloMap
 from holoviews.element import VectorField
 
-from .test_plot import TestMPLPlot, mpl_renderer
 from ..utils import ParamLogStream
+from .test_plot import TestMPLPlot, mpl_renderer
 
 
 class TestVectorFieldPlot(TestMPLPlot):

--- a/holoviews/tests/plotting/plotly/test_callbacks.py
+++ b/holoviews/tests/plotting/plotly/test_callbacks.py
@@ -1,18 +1,27 @@
 import uuid
-
 from unittest import TestCase
 from unittest.mock import Mock
 
 import plotly.graph_objs as go
 
 from holoviews import Tiles
-from holoviews.streams import (
-    BoundsXY, BoundsX, BoundsY, RangeXY, RangeX, RangeY, Selection1D
-)
 from holoviews.plotting.plotly.callbacks import (
-    RangeXYCallback, RangeXCallback, RangeYCallback,
-    BoundsXYCallback, BoundsXCallback, BoundsYCallback,
-    Selection1DCallback
+    BoundsXCallback,
+    BoundsXYCallback,
+    BoundsYCallback,
+    RangeXCallback,
+    RangeXYCallback,
+    RangeYCallback,
+    Selection1DCallback,
+)
+from holoviews.streams import (
+    BoundsX,
+    BoundsXY,
+    BoundsY,
+    RangeX,
+    RangeXY,
+    RangeY,
+    Selection1D,
 )
 
 

--- a/holoviews/tests/plotting/plotly/test_dash.py
+++ b/holoviews/tests/plotting/plotly/test_dash.py
@@ -2,17 +2,23 @@ from unittest.mock import MagicMock, patch
 
 from dash._callback_context import CallbackContext
 
-from .test_plot import TestPlotlyPlot
+from holoviews import Bounds, DynamicMap, Scatter
 from holoviews.plotting.plotly.dash import (
-    to_dash, DashComponents, encode_store_data, decode_store_data
+    DashComponents,
+    decode_store_data,
+    encode_store_data,
+    to_dash,
 )
-from holoviews import Scatter, DynamicMap, Bounds
 from holoviews.streams import BoundsXY, RangeXY, Selection1D
+
+from .test_plot import TestPlotlyPlot
+
 try:
     from dash_core_components import Store
 except ImportError:
     from dash.dcc import Store
 import plotly.io as pio
+
 pio.templates.default = None
 
 

--- a/holoviews/tests/plotting/plotly/test_dynamic.py
+++ b/holoviews/tests/plotting/plotly/test_dynamic.py
@@ -1,15 +1,17 @@
 from unittest.mock import Mock
 
-import holoviews as hv
-import panel as pn
 import numpy as np
-
-from holoviews.streams import (
-    Stream, Selection1D, RangeXY, BoundsXY,
-)
-
+import panel as pn
 from bokeh.document import Document
 from pyviz_comms import Comm
+
+import holoviews as hv
+from holoviews.streams import (
+    BoundsXY,
+    RangeXY,
+    Selection1D,
+    Stream,
+)
 
 from .test_plot import TestPlotlyPlot
 

--- a/holoviews/tests/plotting/plotly/test_elementplot.py
+++ b/holoviews/tests/plotting/plotly/test_elementplot.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from holoviews.core.spaces import DynamicMap
-from holoviews.element import Curve, Scatter3D, Path3D
+from holoviews.element import Curve, Path3D, Scatter3D
 from holoviews.streams import PointerX
 
 from .test_plot import TestPlotlyPlot, plotly_renderer

--- a/holoviews/tests/plotting/plotly/test_figuresize.py
+++ b/holoviews/tests/plotting/plotly/test_figuresize.py
@@ -1,4 +1,5 @@
 from holoviews.element import Points
+
 from .test_plot import TestPlotlyPlot
 
 

--- a/holoviews/tests/plotting/plotly/test_gridplot.py
+++ b/holoviews/tests/plotting/plotly/test_gridplot.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from holoviews.core.spaces import GridSpace
-from holoviews.element import Scatter, Curve
+from holoviews.element import Curve, Scatter
 
 from .test_plot import TestPlotlyPlot
 

--- a/holoviews/tests/plotting/plotly/test_plot.py
+++ b/holoviews/tests/plotting/plotly/test_plot.py
@@ -1,7 +1,6 @@
-from param import concrete_descendents
-
 import plotly.graph_objs as go
 import pyviz_comms as comms
+from param import concrete_descendents
 
 from holoviews.core import Store
 from holoviews.element.comparison import ComparisonTestCase

--- a/holoviews/tests/plotting/plotly/test_renderer.py
+++ b/holoviews/tests/plotting/plotly/test_renderer.py
@@ -5,14 +5,14 @@ from collections import OrderedDict
 
 import panel as pn
 import param
+from panel.widgets import DiscreteSlider, FloatSlider, Player
+from pyviz_comms import CommManager
 
-from holoviews import (DynamicMap, HoloMap, Store, Curve)
+from holoviews import Curve, DynamicMap, HoloMap, Store
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.plotting.plotly import PlotlyRenderer
 from holoviews.plotting.renderer import Renderer
 from holoviews.streams import Stream
-from panel.widgets import DiscreteSlider, Player, FloatSlider
-from pyviz_comms import CommManager
 
 
 class PlotlyRendererTest(ComparisonTestCase):

--- a/holoviews/tests/plotting/plotly/test_rgb.py
+++ b/holoviews/tests/plotting/plotly/test_rgb.py
@@ -1,8 +1,8 @@
 import numpy as np
 import PIL.Image
-from holoviews.element import RGB, Tiles
-
 import plotly.graph_objs as go
+
+from holoviews.element import RGB, Tiles
 
 from .test_plot import TestPlotlyPlot, plotly_renderer
 

--- a/holoviews/tests/plotting/plotly/test_shapeplots.py
+++ b/holoviews/tests/plotting/plotly/test_shapeplots.py
@@ -1,7 +1,16 @@
-from holoviews.element import (
-    VLine, HLine, Bounds, Box, Rectangles, Segments, Tiles, Path
-)
 import numpy as np
+
+from holoviews.element import (
+    Bounds,
+    Box,
+    HLine,
+    Path,
+    Rectangles,
+    Segments,
+    Tiles,
+    VLine,
+)
+
 from .test_plot import TestPlotlyPlot
 
 default_shape_color = '#2a3f5f'

--- a/holoviews/tests/plotting/plotly/test_tiles.py
+++ b/holoviews/tests/plotting/plotly/test_tiles.py
@@ -1,8 +1,10 @@
-from holoviews.element import RGB, Tiles, Points, Bounds
-from holoviews.element.tiles import StamenTerrain, _ATTRIBUTIONS
-from .test_plot import TestPlotlyPlot, plotly_renderer
 import numpy as np
 import pytest
+
+from holoviews.element import RGB, Bounds, Points, Tiles
+from holoviews.element.tiles import _ATTRIBUTIONS, StamenTerrain
+
+from .test_plot import TestPlotlyPlot, plotly_renderer
 
 
 class TestMapboxTilesPlot(TestPlotlyPlot):

--- a/holoviews/tests/plotting/test_comms.py
+++ b/holoviews/tests/plotting/test_comms.py
@@ -1,5 +1,6 @@
-from holoviews.element.comparison import ComparisonTestCase
 from pyviz_comms import Comm, JupyterComm
+
+from holoviews.element.comparison import ComparisonTestCase
 
 
 class TestComm(ComparisonTestCase):

--- a/holoviews/tests/plotting/test_plotutils.py
+++ b/holoviews/tests/plotting/test_plotutils.py
@@ -2,21 +2,37 @@ from unittest import SkipTest
 
 import numpy as np
 
-from holoviews import NdOverlay, Overlay, Dimension
+from holoviews import Dimension, NdOverlay, Overlay
+from holoviews.core.options import Cycle, Store
 from holoviews.core.spaces import DynamicMap, HoloMap
-from holoviews.core.options import Store, Cycle
+from holoviews.element import (
+    Area,
+    Curve,
+    HLine,
+    Image,
+    Path,
+    Points,
+    Scatter,
+    VectorField,
+)
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.element import (Image, Scatter, Curve, Points,
-                               Area, VectorField, HLine, Path)
 from holoviews.operation import operation
+from holoviews.plotting.bokeh import util
 from holoviews.plotting.util import (
-    compute_overlayable_zorders, get_min_distance, process_cmap,
-    initialize_dynamic, split_dmap_overlay, _get_min_distance_numpy,
-    bokeh_palette_to_palette, mplcmap_to_palette, color_intervals,
-    get_range, get_axis_padding)
+    _get_min_distance_numpy,
+    bokeh_palette_to_palette,
+    color_intervals,
+    compute_overlayable_zorders,
+    get_axis_padding,
+    get_min_distance,
+    get_range,
+    initialize_dynamic,
+    mplcmap_to_palette,
+    process_cmap,
+    split_dmap_overlay,
+)
 from holoviews.streams import PointerX
 
-from holoviews.plotting.bokeh import util
 bokeh_renderer = Store.renderers['bokeh']
 
 

--- a/holoviews/tests/plotting/utils.py
+++ b/holoviews/tests/plotting/utils.py
@@ -1,5 +1,5 @@
-from io import StringIO
 import logging
+from io import StringIO
 
 import param
 

--- a/holoviews/tests/test_annotators.py
+++ b/holoviews/tests/test_annotators.py
@@ -1,8 +1,7 @@
 from holoviews import Overlay
-from holoviews.annotators import annotate, PointAnnotator, PathAnnotator
-from holoviews.element import Points, Path, Table
+from holoviews.annotators import PathAnnotator, PointAnnotator, annotate
+from holoviews.element import Path, Points, Table
 from holoviews.element.tiles import EsriStreet, Tiles
-
 from holoviews.tests.plotting.bokeh.test_plot import TestBokehPlot
 
 

--- a/holoviews/tests/test_selection.py
+++ b/holoviews/tests/test_selection.py
@@ -1,14 +1,14 @@
 from unittest import skip, skipIf
 
-import holoviews as hv
 import pandas as pd
 
+import holoviews as hv
 from holoviews.core.options import Cycle, Store
 from holoviews.element import ErrorBars, Points, Rectangles, Table, VSpan
+from holoviews.element.comparison import ComparisonTestCase
 from holoviews.plotting.util import linear_gradient
 from holoviews.selection import link_selections
 from holoviews.streams import SelectionXY
-from holoviews.element.comparison import ComparisonTestCase
 
 try:
     from holoviews.operation.datashader import datashade, dynspread

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -10,9 +10,9 @@ from panel.widgets import IntSlider
 
 from holoviews.core.spaces import DynamicMap
 from holoviews.core.util import Version
-from holoviews.element import Points, Scatter, Curve, Histogram, Polygons
+from holoviews.element import Curve, Histogram, Points, Polygons, Scatter
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.streams import * # noqa (Test all available streams)
+from holoviews.streams import *  # noqa (Test all available streams)
 from holoviews.util import Dynamic, extension
 from holoviews.util.transform import dim
 

--- a/holoviews/tests/util/test_help.py
+++ b/holoviews/tests/util/test_help.py
@@ -1,5 +1,6 @@
 import holoviews as hv
 
+
 def test_help_pattern(capsys):
     import holoviews.plotting.bokeh  # noqa
     hv.help(hv.Curve, pattern='border')

--- a/holoviews/tests/util/test_transform.py
+++ b/holoviews/tests/util/test_transform.py
@@ -3,7 +3,6 @@ Unit tests for dim transforms
 """
 import pickle
 import warnings
-
 from collections import OrderedDict
 from unittest import skipIf
 
@@ -12,8 +11,8 @@ import pandas as pd
 import param
 
 try:
-    import dask.dataframe as dd
     import dask.array as da
+    import dask.dataframe as dd
 except ImportError:
     da, dd = None, None
 

--- a/holoviews/tests/util/test_utils.py
+++ b/holoviews/tests/util/test_utils.py
@@ -3,16 +3,13 @@ Unit tests of the helper functions in utils
 """
 from collections import OrderedDict
 
-from holoviews import notebook_extension
-from holoviews.element.comparison import ComparisonTestCase
-from holoviews import Store
-from holoviews.util import output, opts, OutputSettings, Options
-
-from holoviews.core.options import OptionTree
 from pyviz_comms import CommManager
 
-from holoviews.plotting import mpl
-from holoviews.plotting import bokeh
+from holoviews import Store, notebook_extension
+from holoviews.core.options import OptionTree
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.plotting import bokeh, mpl
+from holoviews.util import Options, OutputSettings, opts, output
 
 BACKENDS = ['matplotlib', 'bokeh']
 

--- a/holoviews/tests/utils.py
+++ b/holoviews/tests/utils.py
@@ -1,7 +1,8 @@
+import logging
 import os
 import sys
+
 import param
-import logging
 
 from holoviews.element.comparison import ComparisonTestCase
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -1,30 +1,32 @@
-import os
-import sys
 import inspect
+import os
 import shutil
-
+import sys
 from collections import defaultdict
 from inspect import Parameter, Signature
-from types import FunctionType
 from pathlib import Path
+from types import FunctionType
 
 import param
-
 from pyviz_comms import extension as _pyviz_extension
 
 from ..core import (
-    Dataset, DynamicMap, HoloMap, Dimensioned, ViewableElement,
-    StoreOptions, Store
+    Dataset,
+    Dimensioned,
+    DynamicMap,
+    HoloMap,
+    Store,
+    StoreOptions,
+    ViewableElement,
+    util,
 )
+from ..core.operation import Operation, OperationCallable
 from ..core.options import Keywords, Options, options_policy
-from ..core.operation import Operation
 from ..core.overlay import Overlay
-from ..core.util import merge_options_to_dict, OrderedDict
-from ..core.operation import OperationCallable
-from ..core import util
+from ..core.util import OrderedDict, merge_options_to_dict
 from ..operation.element import function
-from ..streams import Stream, Params, streams_list_from_dict
-from .settings import OutputSettings, list_formats, list_backends
+from ..streams import Params, Stream, streams_list_from_dict
+from .settings import OutputSettings, list_backends, list_formats
 
 Store.output_settings = OutputSettings
 

--- a/holoviews/util/_exception.py
+++ b/holoviews/util/_exception.py
@@ -1,5 +1,5 @@
-import os
 import inspect
+import os
 from functools import lru_cache
 from warnings import warn
 
@@ -10,8 +10,9 @@ def deprecation_warning(msg, warning=FutureWarning):
 
     # Finding the first stacklevel outside holoviews and param
     # Inspired by: pandas.util._exceptions.find_stack_level
-    import holoviews as hv
     import param
+
+    import holoviews as hv
 
     pkg_dir = os.path.dirname(hv.__file__)
     test_dir = os.path.join(pkg_dir, "tests")

--- a/holoviews/util/command.py
+++ b/holoviews/util/command.py
@@ -5,23 +5,29 @@ OR
 holoviews Conversion_Example.ipynb
 """
 
-import sys
-import os
 import argparse
+import os
+import sys
 from argparse import RawTextHelpFormatter
 
 try:
-    import nbformat
     import nbconvert
+    import nbformat
 except ImportError:
     print('nbformat, nbconvert and ipython need to be installed to use the holoviews command')
     sys.exit()
 try:
-    from ..ipython.preprocessors import OptsMagicProcessor, OutputMagicProcessor
-    from ..ipython.preprocessors import StripMagicsProcessor
+    from ..ipython.preprocessors import (
+        OptsMagicProcessor,
+        OutputMagicProcessor,
+        StripMagicsProcessor,
+    )
 except ImportError:
-    from holoviews.ipython.preprocessors import OptsMagicProcessor, OutputMagicProcessor
-    from holoviews.ipython.preprocessors import StripMagicsProcessor
+    from holoviews.ipython.preprocessors import (
+        OptsMagicProcessor,
+        OutputMagicProcessor,
+        StripMagicsProcessor,
+    )
 
 from . import examples
 

--- a/holoviews/util/parser.py
+++ b/holoviews/util/parser.py
@@ -14,7 +14,7 @@ import numpy as np
 import param
 import pyparsing as pp
 
-from ..core.options import Options, Cycle, Palette
+from ..core.options import Cycle, Options, Palette
 from ..core.util import merge_option_dicts
 from ..operation import Compositor
 from .transform import dim

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -1,4 +1,5 @@
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
+
 from ..core import Store
 
 
@@ -242,7 +243,7 @@ class OutputSettings(KeywordSettings):
 
     @classmethod
     def _generate_signature(cls):
-        from inspect import Signature, Parameter
+        from inspect import Parameter, Signature
         keywords = ['backend', 'fig', 'holomap', 'widgets', 'fps', 'max_frames',
                     'size', 'dpi', 'filename', 'info', 'css', 'widget_location']
         return Signature([Parameter(kw, Parameter.KEYWORD_ONLY) for kw in keywords])

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -1,6 +1,5 @@
 import operator
 import sys
-
 from types import BuiltinFunctionType, BuiltinMethodType, FunctionType, MethodType
 
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ target-version = "py37"
 select = [
     "E",
     "F",
+    "I",
     "ICN",
     "PLC",
     "PLE",
@@ -60,3 +61,8 @@ unfixable = [
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F403"]
+
+[tool.ruff.isort]
+known-first-party = ["holoviews"]
+force-wrap-aliases = true
+combine-as-imports = true


### PR DESCRIPTION
This PR adds sorting of the import.  

- cf2d73009bc8f0144c3b0dd1503bf1502e2f075a removed conditional imports below the "normal" import block and also removed old IPython version checks.
- 5c282c2b01e93ca4730e284e53906f04460b3c0a removed the sensitivity of the `..util` import by giving it a namespace alias.
- 6a76250824b91c3aed856dd7241f4817586ef1f9 is running the sorting.