### PR TITLE
Looking at failing docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -57,7 +57,7 @@ jobs:
         run: |
           conda config --remove channels defaults
           conda config --set channel_priority strict
-          conda create -n test-environment python=3.9 pyctdev
+          conda create -n test-environment python=3.10 pyctdev
           conda create -n push-environment python=3.9 awscli
       - name: conda info and show sources
         run: |


### PR DESCRIPTION
On Python 3.9, the solve for these packages are very slow `"matplotlib >=3" "networkx" "netcdf4" "shapely" "mpl_sample_data >=3.1.3" `, there does not seem to be a single "problematic" package.

``` bash
time (mamba install "networkx" "netcdf4" "shapely" "mpl_sample_data >=3.1.3" --dry-run --offline &>/dev/null)
# 1,11s user 0,13s system 99% cpu 1,238 total
time (mamba install "matplotlib >=3" "netcdf4" "shapely" "mpl_sample_data >=3.1.3" --dry-run --offline &>/dev/null)
# 4,33s user 0,19s system 99% cpu 4,529 total
time (mamba install "matplotlib >=3" "networkx" "shapely" "mpl_sample_data >=3.1.3" --dry-run --offline &>/dev/null)
# 2,49s user 0,14s system 99% cpu 2,634 total
time (mamba install "matplotlib >=3" "networkx" "netcdf4" "mpl_sample_data >=3.1.3" --dry-run --offline &>/dev/null)
# 21,06s user 0,30s system 99% cpu 21,383 total
time (mamba install "matplotlib >=3" "networkx" "netcdf4" "shapely" --dry-run --offline &>/dev/null)
# 1,37s user 0,13s system 99% cpu 1,505 total
time (mamba install "matplotlib >=3" "networkx" "netcdf4" "shapely" "mpl_sample_data >=3.1.3" --dry-run --offline &>/dev/null)
# 156,81s user 0,69s system 99% cpu 2:37,72 total

```

Testing locally, I did not see the same problem with Python 3.10.