### PR TITLE
Add simple option to tox.ini to fix PyPi build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: env setup
         run: |
           conda activate test-environment
-          doit develop_install $CHANS_DEV -o flakes
+          doit develop_install $CHANS_DEV
           pip uninstall -y holoviews
           doit pip_on_conda
       - name: doit env_capture
@@ -93,7 +93,7 @@ jobs:
       - name: pip build
         run: |
           conda activate test-environment
-          doit ecosystem=pip package_build --test-group=flakes
+          doit ecosystem=pip package_build --test-group=simple
       - name: pip upload
         if: github.event_name == 'push'
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,12 @@
 
 [tox]
 #          python version             test group                  extra envs  extra commands
-envlist = {py37,py38,py39,py310,py311}-{unit,examples,all_recommended}-{default}-{dev,pkg}
+envlist = {py37,py38,py39,py310,py311}-{unit,examples,all_recommended,simple}-{default}-{dev,pkg}
+
+[_simple]
+description = Install holoviews without any optional dependencies
+deps = .
+commands = echo holoviews
 
 [_unit_core]
 description = Run unit tests with coverage but no optional test dependency
@@ -47,6 +52,7 @@ commands = examples-pkg: {[_pkg]commands}
            unit: {[_unit]commands}
            unit_core: {[_unit_core]commands}
            unit_gpu: {[_unit_gpu]commands}
+           simple: {[_simple]commands}
            examples: {[_examples]commands}
            all_recommended: {[_all_recommended]commands}
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = {py37,py38,py39,py310,py311}-{unit,examples,all_recommended,simple}-{d
 [_simple]
 description = Install holoviews without any optional dependencies
 deps = .
-commands = echo holoviews
+commands = python -c "import holoviews as hv; print(hv.__version__)"
 
 [_unit_core]
 description = Run unit tests with coverage but no optional test dependency


### PR DESCRIPTION
The Pypi build is failing because `flakes` has been removed. This adds a simple option that only installs holoviews with no optional dependencies. 