### PR TITLE
Fix active_tools to only be set for enabled tools

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           conda activate test-environment
           conda uninstall panel bokeh --force -y --offline || echo "packages already removed"
-          pip install "git+https://github.com/holoviz/panel.git@branch-1.0"
+          pip install "git+https://github.com/holoviz/panel.git"
       - name: doit test_unit
         run: |
           conda activate test-environment

--- a/holoviews/tests/core/test_dynamic.py
+++ b/holoviews/tests/core/test_dynamic.py
@@ -990,7 +990,7 @@ class TestPeriodicStreamUpdate(ComparisonTestCase):
         dmap.periodic(0.01, 100, param_fn=lambda i: {'x':i})
         self.assertEqual(xval.x, 100)
 
-    @pytest.mark.flaky
+    @pytest.mark.flaky(max_runs=3)
     def test_periodic_param_fn_non_blocking(self):
         def callback(x): return Curve([1,2,3])
         xval = Stream.define('x',x=0)()

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -287,7 +287,7 @@ class TestEditToolCallbacks(CallbackTestCase):
         plot = bokeh_server_renderer.get_plot(boxes)
         assert 'data' in plot.handles['cds']._callbacks
 
-    @pytest.mark.flaky
+    @pytest.mark.flaky(max_runs=3)
     def test_poly_edit_callback(self):
         polys = Polygons([[(0, 0), (2, 2), (4, 0)]])
         poly_edit = PolyEdit(source=polys)

--- a/holoviews/tests/plotting/bokeh/test_server.py
+++ b/holoviews/tests/plotting/bokeh/test_server.py
@@ -1,6 +1,7 @@
 import time
 
 import param
+import pytest
 
 from holoviews.core.spaces import DynamicMap
 from holoviews.core.options import Store
@@ -123,6 +124,7 @@ class TestBokehServer(ComparisonTestCase):
         self.assertEqual(cb.streams, [stream])
         assert 'rangesupdate' in plot.state._event_callbacks
 
+    @pytest.mark.flaky(max_runs=3)
     def test_launch_server_with_complex_plot(self):
         dmap = DynamicMap(lambda x_range, y_range: Curve([]), streams=[RangeXY()])
         overlay = dmap * HLine(0)

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands = pytest holoviews --cov=./holoviews -vv
 [_examples]
 description = Test that default examples run
 deps = .[examples_tests]
-commands = pytest -n auto --dist loadscope --nbval-lax examples -k "not Plotting_with_Bokeh and not 17-Dashboards and not Plots_and_Renderers"
+commands = pytest -n auto --dist loadscope --nbval-lax examples --force-flaky --max-runs=5 -k "not Plotting_with_Bokeh and not 17-Dashboards and not Plots_and_Renderers"
 # 'Plotting_with_Bokeh' needs selenium, phantomjs, firefox and geckodriver to save a png picture.
 # '17-Dashboards' can give a timeout error.
 # 'Plots_and_Renderers' can give file not found here.


### PR DESCRIPTION
Fixes #5614 

This PR makes it so that the default `activate_tools` is only used if the tools are enabled. It also handles an edge case where a wrong-spelled `active_tools` will give a `KeyError`.