### PR TITLE
Implement multi-yaxis support

### DIFF
--- a/examples/user_guide/Customizing_Plots.ipynb
+++ b/examples/user_guide/Customizing_Plots.ipynb
@@ -698,9 +698,9 @@
     "### Twin axes\n",
     "*(Available in HoloViews > 1.17)*\n",
     "\n",
-    "HoloViews now supports displaying overlays containing two different value dimensions as twin axes for chart elements. To maintain backwards compatibility, this feature is only enabled by setting the `multi_y=True` option on the overlay:\n",
+    "HoloViews now supports displaying overlays containing two different value dimensions as twin axes for chart elements. To maintain backwards compatibility, this feature is only enabled by setting the `multi_y=True` option on the overlay.\n",
     "\n",
-    "To illustrate, here is an overlay containing three curves with two value dimensions ('A' and 'B'). The following shows the default, backwards compatible behavior:"
+    "To illustrate, here is an overlay containing three curves with two value dimensions ('A' and 'B'). Setting `multi_y=True` then maps these two value dimensions to twin-axes:"
    ]
   },
   {
@@ -710,7 +710,7 @@
    "outputs": [],
    "source": [
     "overlay = hv.Curve([1, 2, 3], vdims=['A']) * hv.Curve([2, 3, 4], vdims=['A']) * hv.Curve([3, 2, 1], vdims=['B'])\n",
-    "overlay"
+    "overlay.opts(multi_y=True)"
    ]
   },
   {
@@ -719,24 +719,6 @@
    "source": [
     "Additional value dimensions do map to additional axes but be aware that support of multi axes beyond twin axes is currently considered experimental.\n",
     "\n",
-    "#### Setting `multi_y=True`\n",
-    "\n",
-    "We can now enable twin axes by setting `multi_y=True` on the overlay:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "overlay.opts(multi_y=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "The first value dimension is mapped to the left-hand axis and the second value dimension maps to the right axis. Note that the two axes are individually zoomable by hovering over them and using the Bokeh wheelzoom tool.\n",
     "\n",
     "\n",

--- a/examples/user_guide/Customizing_Plots.ipynb
+++ b/examples/user_guide/Customizing_Plots.ipynb
@@ -44,7 +44,8 @@
     "    - [Inverting axes](#inverting-axes): Flipping the x-/y-axes and inverting an axis\n",
     "    - [Axis labels](#axis-labels): Setting axis labels using dimensions and options\n",
     "    - [Axis ranges](#axis-ranges): Controlling axes ranges using dimensions, padding and options\n",
-    "    - [Axis ticks](#axis-ticks): Controlling axis tick locations, labels and formatting"
+    "    - [Axis ticks](#axis-ticks): Controlling axis tick locations, labels and formatting\n",
+    "    - [Twin axes](#twin-axes): Enabling twin axes"
    ]
   },
   {
@@ -688,6 +689,88 @@
    "outputs": [],
    "source": [
     "bars.opts(xrotation=45)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Twin axes\n",
+    "*(Available in HoloViews > 1.17)*\n",
+    "\n",
+    "HoloViews now supports displaying overlays containing two different value dimensions as twin axes for chart elements. To maintain backwards compatibility, this feature is only enabled by setting the `multi_y=True` option on the overlay:\n",
+    "\n",
+    "To illustrate, here is an overlay containing three curves with two value dimensions ('A' and 'B'). The following shows the default, backwards compatible behavior:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "overlay = hv.Curve([1, 2, 3], vdims=['A']) * hv.Curve([2, 3, 4], vdims=['A']) * hv.Curve([3, 2, 1], vdims=['B'])\n",
+    "overlay"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Additional value dimensions do map to additional axes but be aware that support of multi axes beyond twin axes is currently considered experimental.\n",
+    "\n",
+    "#### Setting `multi_y=True`\n",
+    "\n",
+    "We can now enable twin axes by setting `multi_y=True` on the overlay:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "overlay.opts(multi_y=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first value dimension is mapped to the left-hand axis and the second value dimension maps to the right axis. Note that the two axes are individually zoomable by hovering over them and using the Bokeh wheelzoom tool.\n",
+    "\n",
+    "\n",
+    "#### Supported `multi_y` options\n",
+    "\n",
+    "When `multi_y` is enabled, you can set individual axis options on the elements of the overlay.\n",
+    "\n",
+    "In this example, the left axis uses the default options while the right axis is an inverted, autoranged, log axis with a set `ylim`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "(hv.Curve([1, 2, 3], vdims=['A']) * hv.Curve([2, 3, 4], vdims=['B']).opts(autorange='y', invert_yaxis=True, logy=True, ylim=(1,10))).opts(multi_y=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Supported options for customizing individual axes are `apply_ranges`, `autorange='y'`, `invert_yaxis`, `logy` and `ylim`.\n",
+    "\n",
+    "Note that as of HoloViews 1.17.0, `multi_y` does not have streaming plot support"
    ]
   }
  ],

--- a/examples/user_guide/Customizing_Plots.ipynb
+++ b/examples/user_guide/Customizing_Plots.ipynb
@@ -706,9 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "overlay = hv.Curve([1, 2, 3], vdims=['A']) * hv.Curve([2, 3, 4], vdims=['A']) * hv.Curve([3, 2, 1], vdims=['B'])\n",
@@ -717,9 +715,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "Additional value dimensions do map to additional axes but be aware that support of multi axes beyond twin axes is currently considered experimental.\n",
     "\n",
@@ -731,9 +727,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "overlay.opts(multi_y=True)"
@@ -756,9 +750,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "(hv.Curve([1, 2, 3], vdims=['A']) * hv.Curve([2, 3, 4], vdims=['B']).opts(autorange='y', invert_yaxis=True, logy=True, ylim=(1,10))).opts(multi_y=True)"
@@ -781,5 +773,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/user_guide/Customizing_Plots.ipynb
+++ b/examples/user_guide/Customizing_Plots.ipynb
@@ -762,7 +762,7 @@
    "source": [
     "Supported options for customizing individual axes are `apply_ranges`, `autorange='y'`, `invert_yaxis`, `logy` and `ylim`.\n",
     "\n",
-    "Note that as of HoloViews 1.17.0, `multi_y` does not have streaming plot support"
+    "Note that as of HoloViews 1.17.0, `multi_y` does not have streaming plot support and that linked streams are not yet aware of additional y-axes."
    ]
   }
  ],

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -64,7 +64,7 @@ class TextPlot(ElementPlot, AnnotationPlot):
                 data[k].extend(eld)
         return data, elmapping, style
 
-    def get_extents(self, element, ranges=None, range_type='combined'):
+    def get_extents(self, element, ranges=None, range_type='combined', **kwargs):
         return None, None, None, None
 
 
@@ -161,7 +161,7 @@ class LineAnnotationPlot(ElementPlot, AnnotationPlot):
         plot.renderers.append(box)
         return None, box
 
-    def get_extents(self, element, ranges=None, range_type='combined'):
+    def get_extents(self, element, ranges=None, range_type='combined', **kwargs):
         loc = element.data
         if isinstance(element, VLine):
             dim = 'x'
@@ -241,7 +241,7 @@ class SlopePlot(ElementPlot, AnnotationPlot):
         plot.add_layout(slope)
         return None, slope
 
-    def get_extents(self, element, ranges=None, range_type='combined'):
+    def get_extents(self, element, ranges=None, range_type='combined', **kwargs):
         return None, None, None, None
 
 
@@ -366,7 +366,7 @@ class ArrowPlot(CompositeElementPlot, AnnotationPlot):
         plot.renderers.append(renderer)
         return renderer, glyph
 
-    def get_extents(self, element, ranges=None, range_type='combined'):
+    def get_extents(self, element, ranges=None, range_type='combined', **kwargs):
         return None, None, None, None
 
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -693,11 +693,6 @@ class SpikesPlot(SpikesMixin, ColorbarPlot):
     _nonvectorized_styles = base_properties + ['cmap']
     _plot_methods = dict(single='segment')
 
-    def _get_axis_dims(self, element):
-        if 'spike_length' in self.lookup_options(element, 'plot').options:
-            return  [element.dimensions()[0], None, None]
-        return super()._get_axis_dims(element)
-
     def get_data(self, element, ranges, style):
         dims = element.dimensions()
 
@@ -814,13 +809,6 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
                 props['group_text_align'] = 'right'
                 props['group_text_baseline'] = 'middle'
         return props
-
-    def _get_axis_dims(self, element):
-        if element.ndims > 1 and not (self.stacked or not self.multi_level):
-            xdims = element.kdims
-        else:
-            xdims = element.kdims[0]
-        return (xdims, element.vdims[0])
 
     def _get_factors(self, element, ranges):
         xvals, gvals = self._get_coords(element, ranges)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -434,7 +434,7 @@ class HistogramPlot(ColorbarPlot):
             self._get_hover_data(data, element)
         return (data, mapping, style)
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         ydim = element.get_dimension(1)
         s0, s1 = ranges[ydim.name]['soft']
         s0 = min(s0, 0) if isfinite(s0) else 0

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1293,10 +1293,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         Returns a Bokeh glyph object.
         """
-        try:
-            from bokeh.transform import Field
-        except ImportError:
-            from bokeh.core.property.vectorization import Field
         mapping['tags'] = ['apply_ranges' if self.apply_ranges else 'no_apply_ranges']
         properties = mpl_to_bokeh(properties)
         plot_method = self._plot_methods.get('batched' if self.batched else 'single')
@@ -1307,16 +1303,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             del properties['legend_label']
 
         # ALERT: This only handles XYGlyph types right now
+        mapping = property_to_dict(mapping)
         if 'x' in mapping:
             x = mapping['x']
-            if isinstance(x, Field):
-                x = x.field
             if x in plot.extra_x_ranges:
                 properties['x_range_name'] = mapping['x']
         if 'y' in mapping:
             y = mapping['y']
-            if isinstance(y, Field):
-                y = y.field
             if y in plot.extra_y_ranges:
                 properties['y_range_name'] = mapping['y']
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -478,7 +478,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         elif categorical:
             axis_type = 'auto'
             dim_range = FactorRange()
-        elif None in [v0, v1] or any(True if isinstance(el, (str, bytes)) else np.isnan(el) for el in [v0, v1]):
+        elif None in [v0, v1] or any(True if isinstance(el, (str, bytes)+util.cftime_types) else np.isnan(el) for el in [v0, v1]):
            dim_range = range_type()
         else:
             dim_range = range_type(start=v0, end=v1, name=dim.name if dim else None)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -47,7 +47,7 @@ from .styles import (
 )
 from .tabular import TablePlot
 from .util import (
-    TOOL_TYPES, bokeh_version, bokeh3, date_to_integer, decode_bytes, get_tab_title,
+    TOOL_TYPES, bokeh_version, bokeh3, bokeh32, date_to_integer, decode_bytes, get_tab_title,
     glyph_order, py2js_tickformatter, recursive_model_update,
     theme_attr_json, cds_column_replace, hold_policy, match_dim_specs,
     compute_layout_properties, wrap_formatter, match_ax_type,
@@ -322,6 +322,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             tools.HoverTool(tooltips=tooltips, tags=['hv_created'], mode=tl, **hover_opts)
             if tl in ['vline', 'hline'] else tl for tl in tool_list
         ]
+
+        if bokeh32:
+            tool_list = [
+                tools.WheelZoomTool(zoom_together='none', tags=['hv_created'])
+                if tl in ['wheel_zoom', 'xwheel_zoom', 'ywheel_zoom'] else tl for tl in tool_list
+            ]
 
         copied_tools = []
         for tool in tool_list:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1070,7 +1070,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self.param.warning(
                 "Logarithmic axis range encountered value less "
                 "than or equal to zero, please supply explicit "
-                "lower-bound to override default of %.3f." % low)
+                "lower bound to override default of %.3f." % low)
         updates = {}
         if util.isfinite(low):
             updates['start'] = (axis_range.start, low)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -894,7 +894,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         # ALERT: extra ranges need shared, logx, and stream handling
         streaming, log, shared = False, False, False
-        for dim, extra_y_range in self.handles['extra_y_ranges'].items():
+        multi_dim = 'x' if self.invert_axes else 'y'
+        for dim, extra_y_range in self.handles[f'extra_{multi_dim}_ranges'].items():
             _, b, _, t = self.get_extents(element, ranges, dimension=dim)
             factors = self._get_dimension_factors(element, ranges, dim)
             self._update_range(

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -436,7 +436,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             else:
                 specs = None
 
-            xlabel, ylabel, zlabel = self._get_axis_labels(dims)
+            xlabel, ylabel, zlabel = self._get_axis_labels((None, None) if (dim is None) else dims)
             if self.invert_axes:
                 xlabel, ylabel = ylabel, xlabel
                 dims = dims[:2][::-1]
@@ -480,9 +480,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         #if self._shared['x']:
         #    pass
+
+
+
         if categorical:
             axis_type = 'auto'
             dim_range = FactorRange()
+        elif None in [v0, v1] or any(True if isinstance(el, (str, bytes)) else np.isnan(el) for el in [v0, v1]):
+           dim_range = range_type()
         else:
             dim_range = range_type(start=v0, end=v1, name=dim.name if dim else None)
 
@@ -889,6 +894,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     def _update_ranges(self, element, ranges):
         x_range = self.handles['x_range']
         y_range = self.handles['y_range']
+
+        if isinstance(self, OverlayPlot):
+            x_range, y_range = (y_range, x_range) if self.invert_axes else (x_range, y_range)
+
         self._update_main_ranges(element, x_range, y_range, ranges)
 
         # ALERT: extra ranges need shared, logx, and stream handling
@@ -1253,7 +1262,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         Get factors for categorical axes.
         """
         xdim, ydim = element.dimensions()[:2]
-        xvals, yvals = self._get_dimension_factors(xdim, ydim)
+        #xvals, yvals = self._get_dimension_factors(xdim, ydim)
+        xvals = self._get_dimension_factors(element, ranges, xdim)
+        yvals = self._get_dimension_factors(element, ranges, ydim)
         coords = (xvals, yvals)
         if self.invert_axes: coords = coords[::-1]
         return coords

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -569,11 +569,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             fig = figure(title=title, **properties)
 
         multi_ax = 'x' if self.invert_axes else 'y'
-        for dim, range_obj in properties.get(f'extra_{multi_ax}_ranges', {}).items():
-            axis_type, axis_label, _ = axis_specs[multi_ax][dim]
+        for axis_dim, range_obj in properties.get(f'extra_{multi_ax}_ranges', {}).items():
+            axis_type, axis_label, _ = axis_specs[multi_ax][axis_dim]
             ax_cls, ax_kwargs = _get_axis_class(axis_type, range_obj, dim=1)
-            ax_kwargs[f'{multi_ax}_range_name'] = dim
-            fig.add_layout(ax_cls(axis_label=axis_label, **ax_kwargs), yaxes[dim])
+            ax_kwargs[f'{multi_ax}_range_name'] = axis_dim
+            fig.add_layout(ax_cls(axis_label=axis_label, **ax_kwargs), yaxes[axis_dim])
         return fig
 
     def _plot_properties(self, key, element):
@@ -894,9 +894,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         # ALERT: extra ranges need shared, logx, and stream handling
         streaming, log, shared = False, False, False
         multi_dim = 'x' if self.invert_axes else 'y'
-        for dim, extra_y_range in self.handles[f'extra_{multi_dim}_ranges'].items():
-            _, b, _, t = self.get_extents(element, ranges, dimension=dim)
-            factors = self._get_dimension_factors(element, ranges, dim)
+        for axis_dim, extra_y_range in self.handles[f'extra_{multi_dim}_ranges'].items():
+            _, b, _, t = self.get_extents(element, ranges, dimension=axis_dim)
+            factors = self._get_dimension_factors(element, ranges, axis_dim)
             self._update_range(
                 extra_y_range, b, t, factors, self.invert_yaxis,
                 shared, log, streaming

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -414,20 +414,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if isinstance(el, Graph):
             el = el.nodes
 
-        # ALERT: Cannot just ask for join axis_dims
-        dims = self._get_axis_dims(el)[pos]
-        if dims:
-            if not isinstance(dims, list):
-                dims = [dims]
-            specs = tuple((d.name, d.label, d.unit) for d in dims)
-        else:
-            specs = None
-
         range_el = el if self.batched and not isinstance(self, OverlayPlot) else element
-        if pos and self.multi_y:
-            # ALERT: Handle invert_axes and we have to not use combined but manually compute hard (or soft) + padding
+        if pos and dim:
+            dims = [dim]
             v0, v1 = util.max_range([elrange.get(dim, {'combined': (None, None)})['combined'] for elrange in ranges.values()])
             axis_label = str(dim)
+            specs = ((dim.name, dim.label, dim.unit),)
         else:
             if isinstance(self, OverlayPlot):
                 l, b, r, t = self.get_extents(range_el, ranges, dim)
@@ -436,6 +428,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if self.invert_axes:
                 l, b, r, t = b, l, t, r
             v0, v1 = (l, r) if pos == 0 else (b, t)
+
+            dims = self._get_axis_dims(el)[pos]
+            if dims:
+                if not isinstance(dims, list):
+                    dims = [dims]
+                specs = tuple((d.name, d.label, d.unit) for d in dims)
+            else:
+                specs = None
 
             xlabel, ylabel, zlabel = self._get_axis_labels(dims)
             if self.invert_axes:
@@ -459,7 +459,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if len(dims) > 1 or range_type is FactorRange:
                 axis_type = 'auto'
                 categorical = True
-            else:
+            elif el.get_dimension(dims[0]):
                 dim_type = el.get_dimension_type(dims[0])
                 if ((dim_type is np.object_ and issubclass(type(v0), util.datetime_types)) or
                     dim_type in util.datetime_types):
@@ -485,7 +485,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             axis_type = 'auto'
             dim_range = FactorRange()
         else:
-            dim_range = range_type(start=v0, end=v1, name=dim)
+            dim_range = range_type(start=v0, end=v1, name=dim.name if dim else None)
 
         if not dim_range.tags and specs is not None:
             dim_range.tags.append(specs)
@@ -501,19 +501,28 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         subplots = list(self.subplots.values()) if self.subplots else []
 
         axis_specs = {'x': {}, 'y': {}}
-        axis_specs['x']['x'] = self._axis_props(plots, subplots, element, ranges, pos=0)
+        if self.invert_axes:
+            x, y = 'y', 'x'
+            axpos0, axpos1 = 'below', 'above'
+        else:
+            x, y = 'x', 'y'
+            axpos0, axpos1 = 'left', 'right'
+        axis_specs[x]['x'] = self._axis_props(plots, subplots, element, ranges, pos=0)
         if self.multi_y:
-            yaxes = {}
+            yaxes, dimensions = {}, {}
             for el in element:
                 yd = el.get_dimension(1)
+                dimensions[yd.name] = yd
                 opts = el.opts.get('plot', backend='bokeh').kwargs
                 if yd.name not in yaxes:
-                    yaxes[yd.name] = opts.get('yaxis', 'right' if len(yaxes) else 'left')
+                    yaxes[yd.name] = opts.get(f'{y}axis', axpos1 if len(yaxes) else axpos0)
 
             for ydim, position in yaxes.items():
-                axis_specs['y'][ydim] = self._axis_props(plots, subplots, element, ranges, pos=1, dim=ydim)
+                axis_specs[y][ydim] = self._axis_props(
+                    plots, subplots, element, ranges, pos=1, dim=dimensions[ydim]
+                )
         else:
-            axis_specs['y']['y'] = self._axis_props(plots, subplots, element, ranges, pos=1)
+            axis_specs[y]['y'] = self._axis_props(plots, subplots, element, ranges, pos=1)
 
         properties = {}
         for axis, axis_spec in axis_specs.items():
@@ -560,9 +569,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             warnings.simplefilter('ignore', UserWarning)
             fig = figure(title=title, **properties)
 
-            for dim, range_obj in properties.get('extra_y_ranges', {}).items():
-                ax_cls, ax_kwargs = _get_axis_class(axis_specs['y'][dim][0], range_obj, dim=1)
-                fig.add_layout(ax_cls(y_range_name=dim, axis_label=dim, **ax_kwargs), yaxes[dim])
+        multi_ax = 'x' if self.invert_axes else 'y'
+        for dim, range_obj in properties.get(f'extra_{multi_ax}_ranges', {}).items():
+            axis_type, axis_label, _ = axis_specs[multi_ax][dim]
+            ax_cls, ax_kwargs = _get_axis_class(axis_type, range_obj, dim=1)
+            ax_kwargs[f'{multi_ax}_range_name'] = dim
+            fig.add_layout(ax_cls(axis_label=axis_label, **ax_kwargs), yaxes[dim])
         return fig
 
     def _plot_properties(self, key, element):
@@ -882,13 +894,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         # ALERT: extra ranges need shared, logx, and stream handling
         streaming, log, shared = False, False, False
-        for dim, extra_x_range in self.handles['extra_x_ranges'].items():
-            l, _, r, _ = self.get_extents(element, ranges, dimension=dim)
-            factors = self._get_dimension_factors(element, ranges, dim)
-            self._update_range(
-                extra_x_range, l, r, factors, self.invert_xaxis,
-                shared, log, streaming
-            )
         for dim, extra_y_range in self.handles['extra_y_ranges'].items():
             _, b, _, t = self.get_extents(element, ranges, dimension=dim)
             factors = self._get_dimension_factors(element, ranges, dim)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -122,7 +122,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     align = param.ObjectSelector(default='start', objects=['start', 'center', 'end'], doc="""
         Alignment (vertical or horizontal) of the plot in a layout.""")
 
-    autorange = param.ObjectSelector(default=None, objects=['x', 'y'], doc="""
+    autorange = param.ObjectSelector(default=None, objects=['x', 'y', None], doc="""
         Whether to auto-range along either the x- or y-axis, i.e.
         when panning or zooming along the orthogonal axis it will
         ensure all the data along the selected axis remains visible.""")

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -432,7 +432,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 l, b, r, t = b, l, t, r
             v0, v1 = (l, r) if pos == 0 else (b, t)
 
-            dims = self._get_axis_dims(el)[pos]
+            axis_dims = self._get_axis_dims(el)
+            if self.invert_axes:
+                axis_dims = axis_dims[:2][::-1] + [axis_dims[2]]
+            dims = axis_dims[pos]
             if dims:
                 if not isinstance(dims, list):
                     dims = [dims]

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2472,17 +2472,21 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
 
     _propagate_options = ['width', 'height', 'xaxis', 'yaxis', 'labelled',
                           'bgcolor', 'fontsize', 'invert_axes', 'show_frame',
-                          'show_grid', 'logx',  'xticks', 'toolbar',
+                          'show_grid', 'logx', 'logy',  'xticks', 'toolbar',
                           'yticks', 'xrotation', 'yrotation', 'lod',
                           'border', 'invert_xaxis', 'invert_yaxis', 'sizing_mode',
                           'title', 'title_format', 'legend_position', 'legend_offset',
                           'legend_cols', 'gridstyle', 'legend_muted', 'padding',
-                          'xlabel', 'ylabel', 'xlim', 'zlim',
+                          'xlabel', 'ylabel', 'xlim', 'ylim', 'zlim',
                           'xformatter', 'yformatter', 'active_tools',
                           'min_height', 'max_height', 'min_width', 'min_height',
                           'margin', 'aspect', 'data_aspect', 'frame_width',
-                          'frame_height', 'responsive', 'fontscale', 'multix',
-                          'multiy']
+                          'frame_height', 'responsive', 'fontscale']
+
+    def __init__(self, overlay, **kwargs):
+        self._multi_y_propagation = self.lookup_options(overlay, 'plot').options.get('multi_y', False)
+        super().__init__(overlay, **kwargs)
+        self._multi_y_propagation = False
 
     @property
     def _x_range_type(self):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -410,7 +410,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self._shared['x' if pos == 0 else 'y'] = True
         return dim_range
 
-    def _axis_props(self, plots, subplots, element, ranges, pos, *, dim=None):
+    def _axis_props(self, plots, subplots, element, ranges, pos, *, dim=None, extra_range_tags=[]):
 
         el = element.traverse(lambda x: x, [lambda el: isinstance(el, Element) and not isinstance(el, (Annotation, Tiles))])
         el = el[0] if el else element
@@ -488,6 +488,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         if not dim_range.tags and specs is not None:
             dim_range.tags.append(specs)
+            dim_range.tags.extend(extra_range_tags)
 
         return axis_type, axis_label, dim_range
 
@@ -512,14 +513,17 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 dimensions[yd.name] = yd
                 opts = el.opts.get('plot', backend='bokeh').kwargs
                 if yd.name not in yaxes:
-                    yaxes[yd.name] = opts.get('yaxis', axpos1 if len(yaxes) else axpos0)
+                    yaxes[yd.name] = {'position':opts.get('yaxis', axpos1 if len(yaxes) else axpos0),
+                                      'autorange':opts.get('autorange', None)}
 
-            for ydim, position in yaxes.items():
+            for ydim, info in yaxes.items():
                 axis_specs['y'][ydim] = self._axis_props(
-                    plots, subplots, element, ranges, pos=1, dim=dimensions[ydim]
+                    plots, subplots, element, ranges, pos=1, dim=dimensions[ydim],
+                    extra_range_tags=[] if info['autorange']=='y' else ['no-autorange']
                 )
         else:
-            axis_specs['y']['y'] = self._axis_props(plots, subplots, element, ranges, pos=1)
+            axis_specs['y']['y'] = self._axis_props(plots, subplots, element, ranges, pos=1,
+                    extra_range_tags=[] if self.autorange =='y' else ['no-autorange'])
 
         properties = {}
         for axis, axis_spec in axis_specs.items():
@@ -571,7 +575,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             axis_type, axis_label, _ = axis_specs[multi_ax][axis_dim]
             ax_cls, ax_kwargs = _get_axis_class(axis_type, range_obj, dim=1)
             ax_kwargs[f'{multi_ax}_range_name'] = axis_dim
-            fig.add_layout(ax_cls(axis_label=axis_label, **ax_kwargs), yaxes[axis_dim])
+            fig.add_layout(ax_cls(axis_label=axis_label,
+                                  **ax_kwargs), yaxes[axis_dim]['position'])
         return fig
 
     def _plot_properties(self, key, element):
@@ -1188,7 +1193,17 @@ class ElementPlot(BokehPlot, GenericElementPlot):
           }}
 
           if (start_finite && end_finite)  {{
-            plot.{dim}_range.setv({{start, end}})
+            if (!plot.{dim}_range.tags.includes('no-autorange')) {{
+              console.log(plot.{dim}_range.tags)
+              plot.{dim}_range.setv({{start, end}})
+            }}
+
+            for (let key in plot.extra_{dim}_ranges) {{
+              const extra_range = plot.extra_{dim}_ranges[key];
+              if (!extra_range.tags.includes('no-autorange')) {{
+                plot.extra_{dim}_ranges[key].setv({{start, end}})
+               }}
+            }}
           }}
         }}
         // The plot changes will not propagate to the glyph until

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -414,7 +414,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 not (categorical and not isinstance(dim_range, FactorRange))
             ):
                 dim_range = plot_range
-                
+
             if dim_range is not None:
                 break
 
@@ -426,7 +426,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 ):
                     dim_range = extra_range
                     break
-        
+
         return dim_range
 
     def _axis_props(self, plots, subplots, element, ranges, pos, *, dim=None,
@@ -525,7 +525,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             axpos0, axpos1 = 'below', 'above'
         else:
             axpos0, axpos1 = 'left', 'right'
-        
+
         ax_specs, yaxes, dimensions = {}, {}, {}
         for el in element:
             yd = el.get_dimension(1)
@@ -576,7 +576,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         axis_specs = {'x': {}, 'y': {}}
         axis_specs['x']['x'] = self._axis_props(plots, subplots, element, ranges, pos=0)
         if self.multi_y:
-            yaxes, extra_axis_specs = self._create_extra_axes(plots, subplots, element, ranges) 
+            yaxes, extra_axis_specs = self._create_extra_axes(plots, subplots, element, ranges)
             axis_specs['y'].update(extra_axis_specs)
         else:
             range_tags_extras={'invert_yaxis':self.invert_yaxis}
@@ -2490,7 +2490,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
 
     _propagate_options = ['width', 'height', 'xaxis', 'yaxis', 'labelled',
                           'bgcolor', 'fontsize', 'invert_axes', 'show_frame',
-                          'show_grid', 'logx', 'logy',  'xticks', 'toolbar',
+                          'show_grid', 'logx', 'logy', 'xticks', 'toolbar',
                           'yticks', 'xrotation', 'yrotation', 'lod',
                           'border', 'invert_xaxis', 'invert_yaxis', 'sizing_mode',
                           'title', 'title_format', 'legend_position', 'legend_offset',

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -438,7 +438,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 l, b, r, t = b, l, t, r
             v0, v1 = (l, r) if pos == 0 else (b, t)
 
-            axis_dims = self._get_axis_dims(el)
+            axis_dims = list(self._get_axis_dims(el))
             if self.invert_axes:
                 axis_dims = axis_dims[:2][::-1] + [(axis_dims[2],) if len(axis_dims) == 3 else ()]
             dims = axis_dims[pos]
@@ -452,7 +452,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             xlabel, ylabel, zlabel = self._get_axis_labels((None, None) if (dim is None) else dims)
             if self.invert_axes:
                 xlabel, ylabel = ylabel, xlabel
-                dims = dims[:2][::-1]
+                if dims:
+                    dims = dims[:2][::-1]
             axis_label = ylabel if pos else xlabel
 
         # ALERT: Cannot just traverse all subplots

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -410,7 +410,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self._shared['x' if pos == 0 else 'y'] = True
         return dim_range
 
-    def _axis_props(self, plots, subplots, element, ranges, pos, dim=None):
+    def _axis_props(self, plots, subplots, element, ranges, pos, *, dim=None):
 
         el = element.traverse(lambda x: x, [lambda el: isinstance(el, Element) and not isinstance(el, (Annotation, Tiles))])
         el = el[0] if el else element
@@ -418,7 +418,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             el = el.nodes
 
         range_el = el if self.batched and not isinstance(self, OverlayPlot) else element
-        if pos and dim:
+        if pos and dim:  # NEEDS COMMENT WHY THIS DOESN'T APPLY WITH POS=0
             dims = [dim]
             v0, v1 = util.max_range([elrange.get(dim, {'combined': (None, None)})['combined'] for elrange in ranges.values()])
             axis_label = str(dim)
@@ -447,7 +447,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             axis_label = ylabel if pos else xlabel
 
         # ALERT: Cannot just traverse all subplots
-        categorical = any(self.traverse(lambda x: x._categorical))
+        categorical = any(self.traverse(lambda plot: plot._categorical))
         if dims is not None and any(dim.name in ranges and 'factors' in ranges[dim.name] for dim in dims):
             categorical = True
         else:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -739,7 +739,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             opts['text_font_size'] = title_font
         return opts
 
-
     def _init_axes(self, plot):
         if self.xaxis is None:
             plot.xaxis.visible = False
@@ -750,10 +749,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self.handles['xaxis'] = plot.xaxis[0]
         self.handles['x_range'] = plot.x_range
         self.handles['extra_x_ranges'] = plot.extra_x_ranges
+        self.handles['extra_x_scales'] = plot.extra_x_scales
 
         if self.yaxis is None:
             plot.yaxis.visible = False
-        elif isinstance(self.yaxis, str) and'right' in self.yaxis:
+        elif isinstance(self.yaxis, str) and 'right' in self.yaxis:
             plot.right = [plot.yaxis[0]] + [ax for ax in plot.right if ax is not plot.yaxis[0]]
             plot.left = [ax for ax in plot.left if ax is not plot.yaxis[0]]
             plot.yaxis[:] = list(plot.left) + list(plot.right)
@@ -761,7 +761,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self.handles['y_range'] = plot.y_range
         self.handles['extra_y_ranges'] = plot.extra_y_ranges
         self.handles['extra_y_scales'] = plot.extra_y_scales
-
 
     def _axis_properties(self, axis, key, plot, dimension=None,
                          ax_mapping={'x': 0, 'y': 1}):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -416,7 +416,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self._shared['x' if pos == 0 else 'y'] = True
         return dim_range
 
-    def _axis_props(self, plots, subplots, element, ranges, pos, *, dim=None, extra_range_tags=[]):
+    def _axis_props(self, plots, subplots, element, ranges, pos, *, dim=None, range_tags_extras=[]):
 
         el = element.traverse(lambda x: x, [lambda el: isinstance(el, Element) and not isinstance(el, (Annotation, Tiles))])
         el = el[0] if el else element
@@ -495,7 +495,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         if not dim_range.tags and specs is not None:
             dim_range.tags.append(specs)
-            dim_range.tags.extend(extra_range_tags)
+            dim_range.tags.extend(range_tags_extras)
 
         return axis_type, axis_label, dim_range
 
@@ -526,11 +526,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             for ydim, info in yaxes.items():
                 axis_specs['y'][ydim] = self._axis_props(
                     plots, subplots, element, ranges, pos=1, dim=dimensions[ydim],
-                    extra_range_tags=[] if info['autorange']=='y' else ['no-autorange']
+                    range_tags_extras=[] if info['autorange']=='y' else ['no-autorange']
                 )
         else:
             axis_specs['y']['y'] = self._axis_props(plots, subplots, element, ranges, pos=1,
-                    extra_range_tags=[] if self.autorange =='y' else ['no-autorange'])
+                    range_tags_extras=[] if self.autorange =='y' else ['no-autorange'])
 
         properties = {}
         for axis, axis_spec in axis_specs.items():

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -440,7 +440,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
             axis_dims = self._get_axis_dims(el)
             if self.invert_axes:
-                axis_dims = axis_dims[:2][::-1] + [axis_dims[2]]
+                axis_dims = axis_dims[:2][::-1] + ((axis_dims[2],) if len(axis_dims) == 3 else ())
             dims = axis_dims[pos]
             if dims:
                 if not isinstance(dims, list):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -273,20 +273,25 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     cb_tools.append(tool)
                     self.handles[handle] = tool
 
-        tool_list = [
-            t for t in cb_tools + self.default_tools + self.tools
-            if t not in tool_names]
-
-        tool_list = [
-            tools.HoverTool(tooltips=tooltips, tags=['hv_created'], mode=tl, **hover_opts)
-            if tl in ['vline', 'hline'] else tl for tl in tool_list
-        ]
-
-        if bokeh32:
-            tool_list = [
-                tools.WheelZoomTool(zoom_together='none', tags=['hv_created'])
-                if tl in ['wheel_zoom', 'xwheel_zoom', 'ywheel_zoom'] else tl for tl in tool_list
-            ]
+        tool_list = []
+        for tool in cb_tools + self.default_tools + self.tools:
+            if tool in tool_names:
+                continue
+            if tool in ['vline', 'hline']:
+                tool = tools.HoverTool(
+                    tooltips=tooltips, tags=['hv_created'], mode=tool, **hover_opts
+                )
+            elif bokeh32 and tool in ['wheel_zoom', 'xwheel_zoom', 'ywheel_zoom']:
+                if tool.startswith('x'):
+                    zoom_dims = 'width'
+                elif tool.startswith('y'):
+                    zoom_dims = 'height'
+                else:
+                    zoom_dims = 'both'
+                tool = tools.WheelZoomTool(
+                    zoom_together='none', dimensions=zoom_dims, tags=['hv_created']
+                )
+            tool_list.append(tool)
 
         copied_tools = []
         for tool in tool_list:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -458,7 +458,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
             axis_dims = list(self._get_axis_dims(el))
             if self.invert_axes:
-                axis_dims[0], axis_dims[1] = axis_dims[:2]
+                axis_dims[0], axis_dims[1] = axis_dims[:2][::-1]
             dims = axis_dims[pos]
             if dims:
                 if not isinstance(dims, list):
@@ -856,7 +856,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         return axis_props
 
-
     def _update_plot(self, key, plot, element=None):
         """
         Updates plot parameters on every frame
@@ -865,7 +864,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self._update_labels(key, plot, element)
         self._update_title(key, plot, element)
         self._update_grid(plot)
-
 
     def _update_labels(self, key, plot, element):
         el = element.traverse(lambda x: x, [Element])
@@ -881,13 +879,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         recursive_model_update(plot.xaxis[0], props.get('x', {}))
         recursive_model_update(plot.yaxis[0], props.get('y', {}))
 
-
     def _update_title(self, key, plot, element):
         if plot.title:
             plot.title.update(**self._title_properties(key, plot, element))
         else:
             plot.title = Title(**self._title_properties(key, plot, element))
-
 
     def _update_backend_opts(self):
         plot = self.handles["plot"]
@@ -980,7 +976,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 range_dim = x_range.name if self.invert_axes else y_range.name
             else:
                 range_dim = None
-            l, b, r, t = self.get_extents(element, ranges, dimension=range_dim)
+            try:
+                l, b, r, t = self.get_extents(element, ranges, dimension=range_dim)
+            except Exception:
+                # Backward compatibility for e.g. GeoViews=<1.10.1 since dimension
+                # is a newly added keyword argument
+                l, b, r, t = self.get_extents(element, ranges)
             if self.invert_axes:
                 l, b, r, t = b, l, t, r
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -908,7 +908,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         l, b, r, t = None, None, None, None
         if any(isinstance(r, (Range1d, DataRange1d)) for r in [x_range, y_range]):
-            l, b, r, t = self.get_extents(element, ranges, dimension=y_range.name)
+            if self.multi_y:
+                range_dim = x_range.name if self.invert_axes else y_range.name
+            else:
+                range_dim = None
+            l, b, r, t = self.get_extents(element, ranges, dimension=range_dim)
             if self.invert_axes:
                 l, b, r, t = b, l, t, r
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1262,7 +1262,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         Get factors for categorical axes.
         """
         xdim, ydim = element.dimensions()[:2]
-        #xvals, yvals = self._get_dimension_factors(xdim, ydim)
         xvals = self._get_dimension_factors(element, ranges, xdim)
         yvals = self._get_dimension_factors(element, ranges, ydim)
         coords = (xvals, yvals)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -538,13 +538,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                                       'logy': opts.get('logy', False),
                                       # 'xlim': opts.get('xlim', (np.nan, np.nan)), # TODO
                                       'ylim': opts.get('ylim', (np.nan, np.nan))}
-
             for ydim, info in yaxes.items():
                 range_tags_extras=[]
                 if info['autorange']=='y':
                     lowerlim, upperlim = info['ylim'][0], info['ylim'][1]
-                    if not np.isnan(lowerlim): range_tags_extras.append(f'lowerlim:{lowerlim}')
-                    if not np.isnan(upperlim): range_tags_extras.append(f'upperlim:{upperlim}')
+                    if not ((lowerlim is None) or np.isnan(lowerlim)):
+                        range_tags_extras.append(f'lowerlim:{lowerlim}')
+                    if not ((upperlim is None) or np.isnan(upperlim)):
+                        range_tags_extras.append(f'upperlim:{upperlim}')
                 else:
                     range_tags_extras.append('no-autorange')
 
@@ -560,8 +561,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             range_tags_extras=[]
             if self.autorange=='y':
                 lowerlim, upperlim = self.ylim
-                if not np.isnan(lowerlim): range_tags_extras.append(f'lowerlim:{lowerlim}')
-                if not np.isnan(upperlim): range_tags_extras.append(f'upperlim:{upperlim}')
+                if not ((lowerlim is None) or np.isnan(lowerlim)):
+                    range_tags_extras.append(f'lowerlim:{lowerlim}')
+                if not ((upperlim is None) or np.isnan(upperlim)):
+                    range_tags_extras.append(f'upperlim:{upperlim}')
             else:
                 range_tags_extras.append('no-autorange')
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1,6 +1,5 @@
 import warnings
 
-from collections import defaultdict
 from itertools import chain
 from types import FunctionType
 
@@ -79,9 +78,9 @@ def get_scale(range_input, axis_type):
         raise ValueError(f"Unable to determine proper scale for: '{range_input}'")
 
 from bokeh.core.property.datetime import Datetime
-from bokeh.models import CategoricalAxis, LinearAxis, LogAxis
-    
-def _get_axis_class(axis_type, range_input, dim):
+from bokeh.models import LinearAxis, LogAxis, MercatorAxis
+
+def _get_axis_class(axis_type, range_input, dim): # Copied from bokeh
     if axis_type is None:
         return None, {}
     elif axis_type == "linear":
@@ -443,7 +442,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 dims = dims[:2][::-1]
             axis_label = ylabel if pos else xlabel
 
-        # ALERT: Cannot just traverse all subplots 
+        # ALERT: Cannot just traverse all subplots
         categorical = any(self.traverse(lambda x: x._categorical))
         if dims is not None and any(dim.name in ranges and 'factors' in ranges[dim.name] for dim in dims):
             categorical = True
@@ -526,13 +525,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         properties = {}
         for axis, axis_spec in axis_specs.items():
-            for (dim, (axis_type, axis_label, axis_range)) in axis_spec.items():
+            for (axis_dim, (axis_type, axis_label, axis_range)) in axis_spec.items():
                 scale = get_scale(axis_range, axis_type)
                 if f'{axis}_range' in properties:
                     properties[f'extra_{axis}_ranges'] = extra_ranges = properties.get(f'extra_{axis}_ranges', {})
                     properties[f'extra_{axis}_scales'] = extra_scales = properties.get(f'extra_{axis}_scales', {})
-                    extra_ranges[dim] = axis_range
-                    extra_scales[dim] = scale
+                    extra_ranges[axis_dim] = axis_range
+                    extra_scales[axis_dim] = scale
                 else:
                     properties[f'{axis}_range'] = axis_range
                     properties[f'{axis}_scale'] = scale

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -536,11 +536,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                                       'autorange':opts.get('autorange', None),
                                       'logx': opts.get('logx', False),
                                       'logy': opts.get('logy', False),
+                                      'invert_yaxis':opts.get('invert_yaxis',False),
                                       # 'xlim': opts.get('xlim', (np.nan, np.nan)), # TODO
                                       'ylim': opts.get('ylim', (np.nan, np.nan))}
 
             for ydim, info in yaxes.items():
-                range_tags_extras={}
+                range_tags_extras={'invert_yaxis':info['invert_yaxis']}
                 if info['autorange']=='y':
                     range_tags_extras['autorange'] = True
                     lowerlim, upperlim = info['ylim'][0], info['ylim'][1]
@@ -561,7 +562,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 ax_props = ('log' if log_enabled else ax_props[0], ax_props[1], ax_props[2])
                 axis_specs['y'][ydim] = ax_props
         else:
-            range_tags_extras={}
+            range_tags_extras={'invert_yaxis':self.invert_yaxis}
             if self.autorange=='y':
                 range_tags_extras['autorange'] = True
                 lowerlim, upperlim = self.ylim
@@ -956,7 +957,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             extra_scale = self.handles[f'extra_{multi_dim}_scales'][axis_dim] # Assumes scales and ranges zip
             log = isinstance(extra_scale, LogScale)
             self._update_range(
-                extra_y_range, b, t, factors, self.invert_yaxis,
+                extra_y_range, b, t, factors,
+                extra_y_range.tags[1]['invert_yaxis'] if extra_y_range.tags else False,
                 self._shared.get(extra_y_range.name, False), log, streaming
             )
 
@@ -1097,7 +1099,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self._update_range(x_range, l, r, xfactors, self.invert_xaxis,
                                self._shared['x-main-range'], self.logx, streaming)
         if not self.drawn or yupdate:
-            self._update_range(y_range, b, t, yfactors, self.invert_yaxis,
+            self._update_range(y_range, b, t, yfactors,
+                               y_range.tags[1]['invert_yaxis'] if y_range.tags else False,
                                self._shared['y-main-range'], self.logy, streaming)
 
 
@@ -1161,11 +1164,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if dim == 'x':
             didx = 0
             odim = 'y'
-            invert = self.invert_xaxis
         else:
             didx = 1
             odim = 'x'
-            invert = self.invert_yaxis
         if not self.padding:
             p0, p1 = 0, 0
         elif isinstance(self.padding, tuple):
@@ -1181,7 +1182,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         callback = CustomJS(code=f"""
         const cb = function() {{
 
-          function get_padded_range(key, lowerlim, upperlim) {{
+          function get_padded_range(key, lowerlim, upperlim, invert) {{
             let vmin = range_limits[key][0]
             let vmax = range_limits[key][1]
 
@@ -1193,7 +1194,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
              vmax = upperlim
             }}
 
-            const invert = {str(invert).lower()}
             const span = vmax-vmin
             const lower = vmin-(span*{p0})
             const upper = vmax+(span*{p1})
@@ -1253,7 +1253,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
            if (range_tags_extras['autorange']) {{
              let lowerlim = range_tags_extras['y-lowerlim'] ?? null
              let upperlim = range_tags_extras['y-upperlim'] ?? null
-             let [start, end] = get_padded_range('default', lowerlim, upperlim)
+             let [start, end] = get_padded_range('default', lowerlim, upperlim, range_tags_extras['invert_yaxis'])
              if ((start != end) && window.Number.isFinite(start) && window.Number.isFinite(end)) {{
                plot.{dim}_range.setv({{start, end}})
              }}
@@ -1262,11 +1262,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
           for (let key in plot.extra_{dim}_ranges) {{
             const extra_range = plot.extra_{dim}_ranges[key]
             let range_tags_extras = extra_range.tags[1]
+
             let lowerlim = range_tags_extras['y-lowerlim'] ?? null
             let upperlim = range_tags_extras['y-upperlim'] ?? null
 
             if (range_tags_extras['autorange']) {{
-             let [start, end] = get_padded_range(key, lowerlim, upperlim)
+             let [start, end] = get_padded_range(key, lowerlim, upperlim, range_tags_extras['invert_yaxis'])
              if ((start != end) && window.Number.isFinite(start) && window.Number.isFinite(end)) {{
               extra_range.setv({{start, end}})
               }}

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -440,7 +440,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
             axis_dims = self._get_axis_dims(el)
             if self.invert_axes:
-                axis_dims = axis_dims[:2][::-1] + ((axis_dims[2],) if len(axis_dims) == 3 else ())
+                axis_dims = axis_dims[:2][::-1] + [(axis_dims[2],) if len(axis_dims) == 3 else ()]
             dims = axis_dims[pos]
             if dims:
                 if not isinstance(dims, list):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -682,9 +682,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if self.xaxis is None:
             plot.xaxis.visible = False
         elif isinstance(self.xaxis, str) and 'top' in self.xaxis:
-            plot.above = plot.below
-            plot.below = []
-            plot.xaxis[:] = plot.above
+            plot.above = [plot.xaxis[0]] + [ax for ax in plot.above if ax is not plot.xaxis[0]]
+            plot.below = [ax for ax in plot.below if ax is not plot.xaxis[0]]
+            plot.xaxis[:] = list(plot.above) + list(plot.below)
         self.handles['xaxis'] = plot.xaxis[0]
         self.handles['x_range'] = plot.x_range
         self.handles['extra_x_ranges'] = plot.extra_x_ranges
@@ -692,9 +692,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if self.yaxis is None:
             plot.yaxis.visible = False
         elif isinstance(self.yaxis, str) and'right' in self.yaxis:
-            plot.right = plot.left
-            plot.left = []
-            plot.yaxis[:] = plot.right
+            plot.right = [plot.yaxis[0]] + [ax for ax in plot.right if ax is not plot.yaxis[0]]
+            plot.left = [ax for ax in plot.left if ax is not plot.yaxis[0]]
+            plot.yaxis[:] = list(plot.left) + list(plot.right)
         self.handles['yaxis'] = plot.yaxis[0]
         self.handles['y_range'] = plot.y_range
         self.handles['extra_y_ranges'] = plot.extra_y_ranges

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -27,6 +27,7 @@ from bokeh.models.tickers import (
     Ticker, BasicTicker, FixedTicker, LogTicker, MercatorTicker
 )
 from bokeh.models.tools import Tool
+from bokeh.transform import Field
 
 from packaging.version import Version
 
@@ -1302,10 +1303,19 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             del properties['legend_label']
 
         # ALERT: This only handles XYGlyph types right now
-        if 'x' in mapping and mapping['x'] in plot.extra_x_ranges:
-            properties['x_range_name'] = mapping['x']
-        if 'y' in mapping and mapping['y'] in plot.extra_y_ranges:
-            properties['y_range_name'] = mapping['y']
+        if 'x' in mapping:
+            x = mapping['x']
+            if isinstance(x, Field):
+                x = x.field
+            if x in plot.extra_x_ranges:
+                properties['x_range_name'] = mapping['x']
+        if 'y' in mapping:
+            y = mapping['y']
+            if isinstance(y, Field):
+                y = y.field
+            if y in plot.extra_y_ranges:
+                properties['y_range_name'] = mapping['y']
+
         renderer = getattr(plot, plot_method)(**dict(properties, **mapping))
         return renderer, renderer.glyph
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -274,7 +274,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self.projection = 'mercator'
 
         # Whether axes are shared between plots
-        self._shared = {'x': False, 'y': False}
+        self._shared = {'x-main-range': False, 'y-main-range': False}
         self._js_on_data_callbacks = []
 
         # Flag to check whether plot has been updated
@@ -420,7 +420,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                                 dim_range = extra_range
 
         if dim_range and not (range_type is FactorRange and not isinstance(dim_range, FactorRange)):
-            shared_name = extra_range_name or ('x' if pos == 0 else 'y')
+            shared_name = extra_range_name or ('x-main-range' if pos == 0 else 'y-main-range')
             self._shared[shared_name] = True
 
         return dim_range
@@ -493,7 +493,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if plots and self.shared_axes and not norm_opts.get('axiswise', False):
             dim_range = self._shared_axis_range(plots, specs, range_type, axis_type, pos, extra_range_name)
 
-        if self._shared['x' if pos==0 else 'y'] or (extra_range_name in self._shared):
+        if self._shared['x-main-range' if pos==0 else 'y-main-range'] or (extra_range_name in self._shared):
             pass
         elif categorical:
             axis_type = 'auto'
@@ -1061,10 +1061,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         if not self.drawn or xupdate:
             self._update_range(x_range, l, r, xfactors, self.invert_xaxis,
-                               self._shared['x'], self.logx, streaming)
+                               self._shared['x-main-range'], self.logx, streaming)
         if not self.drawn or yupdate:
             self._update_range(y_range, b, t, yfactors, self.invert_yaxis,
-                               self._shared['y'], self.logy, streaming)
+                               self._shared['y-main-range'], self.logy, streaming)
 
 
     def _update_range(self, axis_range, low, high, factors, invert, shared, log, streaming=False):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -144,7 +144,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         be specified as a two-tuple of the form (vertical, horizontal)
         or a four-tuple (top, right, bottom, left).""")
 
-    multi_y = param.Boolean(default=False)
+    multi_y = param.Boolean(default=False, doc="""
+       Enables multiple axes (one per value dimension) in
+       overlays and useful for creating twin-axis plots.
+
+       When enabled, axis options are no longer propagated between the
+       elements and the overlay container, allowing customization on a
+       per-axis basis.""")
 
     responsive = param.ObjectSelector(default=False, objects=[False, True, 'width', 'height'])
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -27,7 +27,6 @@ from bokeh.models.tickers import (
     Ticker, BasicTicker, FixedTicker, LogTicker, MercatorTicker
 )
 from bokeh.models.tools import Tool
-from bokeh.transform import Field
 
 from packaging.version import Version
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -506,12 +506,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         axis_specs = {'x': {}, 'y': {}}
         if self.invert_axes:
-            x, y = 'y', 'x'
             axpos0, axpos1 = 'below', 'above'
         else:
-            x, y = 'x', 'y'
             axpos0, axpos1 = 'left', 'right'
-        axis_specs[x]['x'] = self._axis_props(plots, subplots, element, ranges, pos=0)
+        axis_specs['x']['x'] = self._axis_props(plots, subplots, element, ranges, pos=0)
         if self.multi_y:
             yaxes, dimensions = {}, {}
             for el in element:
@@ -519,14 +517,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 dimensions[yd.name] = yd
                 opts = el.opts.get('plot', backend='bokeh').kwargs
                 if yd.name not in yaxes:
-                    yaxes[yd.name] = opts.get(f'{y}axis', axpos1 if len(yaxes) else axpos0)
+                    yaxes[yd.name] = opts.get('yaxis', axpos1 if len(yaxes) else axpos0)
 
             for ydim, position in yaxes.items():
-                axis_specs[y][ydim] = self._axis_props(
+                axis_specs['y'][ydim] = self._axis_props(
                     plots, subplots, element, ranges, pos=1, dim=dimensions[ydim]
                 )
         else:
-            axis_specs[y]['y'] = self._axis_props(plots, subplots, element, ranges, pos=1)
+            axis_specs['y']['y'] = self._axis_props(plots, subplots, element, ranges, pos=1)
 
         properties = {}
         for axis, axis_spec in axis_specs.items():
@@ -894,9 +892,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     def _update_ranges(self, element, ranges):
         x_range = self.handles['x_range']
         y_range = self.handles['y_range']
-
-        if isinstance(self, OverlayPlot):
-            x_range, y_range = (y_range, x_range) if self.invert_axes else (x_range, y_range)
 
         self._update_main_ranges(element, x_range, y_range, ranges)
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1292,6 +1292,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         Returns a Bokeh glyph object.
         """
+        try:
+            from bokeh.transform import Field
+        except ImportError:
+            from bokeh.core.property.vectorization import Field
         mapping['tags'] = ['apply_ranges' if self.apply_ranges else 'no_apply_ranges']
         properties = mpl_to_bokeh(properties)
         plot_method = self._plot_methods.get('batched' if self.batched else 'single')

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -385,29 +385,33 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if dim not in data:
                 data[dim] = [v for _ in range(len(list(data.values())[0]))]
 
-    def _merge_ranges(self, plots, xspecs, yspecs, xtype, ytype):
+    def _shared_axis_range(self, plots, specs, range_type, axis_type, pos):
         """
-        Given a list of other plots return axes that are shared
-        with another plot by matching the dimensions specs stored
-        as tags on the dimensions.
+        Given a list of other plots return the shared axis from another
+        plot by matching the dimensions specs stored as tags on the
+        dimensions. Returns None if there is no such axis.
         """
-        plot_ranges = {}
+        dim_range = None
         for plot in plots:
             if plot is None:
                 continue
-            if hasattr(plot, 'x_range') and plot.x_range.tags and xspecs is not None:
-                if match_dim_specs(plot.x_range.tags[0], xspecs) and match_ax_type(plot.xaxis, xtype):
-                    plot_ranges['x_range'] = plot.x_range
-                if match_dim_specs(plot.x_range.tags[0], yspecs) and match_ax_type(plot.xaxis, ytype):
-                    plot_ranges['y_range'] = plot.x_range
-            if hasattr(plot, 'y_range') and plot.y_range.tags and yspecs is not None:
-                if match_dim_specs(plot.y_range.tags[0], yspecs) and match_ax_type(plot.yaxis, ytype):
-                    plot_ranges['y_range'] = plot.y_range
-                if match_dim_specs(plot.y_range.tags[0], xspecs) and match_ax_type(plot.yaxis, xtype):
-                    plot_ranges['x_range'] = plot.y_range
-        return plot_ranges
+
+            if pos==0:
+                if hasattr(plot, 'x_range') and plot.x_range.tags and specs is not None:
+                    if match_dim_specs(plot.x_range.tags[0], specs) and match_ax_type(plot.xaxis, axis_type):
+                        dim_range= plot.x_range
+
+            if pos==1:
+                if hasattr(plot, 'y_range') and plot.y_range.tags and specs is not None:
+                    if match_dim_specs(plot.y_range.tags[0], specs) and match_ax_type(plot.yaxis, axis_type):
+                        dim_range= plot.y_range
+
+        if dim_range and not (range_type is FactorRange and not isinstance(dim_range, FactorRange)):
+            self._shared['x' if pos == 0 else 'y'] = True
+        return dim_range
 
     def _axis_props(self, plots, subplots, element, ranges, pos, dim=None):
+
         el = element.traverse(lambda x: x, [lambda el: isinstance(el, Element) and not isinstance(el, (Annotation, Tiles))])
         el = el[0] if el else element
         if isinstance(el, Graph):
@@ -453,7 +457,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if self.invert_axes: range_types = range_types[::-1]
         range_type = range_types[pos]
         # If multi_x/y then grab opts from element
-        axis_type = 'log' if (self.logx, self.logy)[pos] else 'linear'
+        axis_type = 'log' if (self.logx, self.logy)[pos] else 'auto'
         if dims:
             if len(dims) > 1 or range_type is FactorRange:
                 axis_type = 'auto'
@@ -464,26 +468,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     dim_type in util.datetime_types):
                     axis_type = 'datetime'
 
-        # ALERT: Rewrite _merge_ranges to handle axes separately
-        # Try finding shared ranges in other plots in the same Layout
-        #plot_ranges = {}
-        #norm_opts = self.lookup_options(el, 'norm').options
-        #if plots and self.shared_axes and not norm_opts.get('axiswise', False):
-        #    plot_ranges = self._merge_ranges(plots, xspecs, yspecs, x_axis_type, y_axis_type)
 
-        # Declare shared axes
-        # x_range, y_range = plot_ranges.get('x_range'), plot_ranges.gext('y_range')
-        #if x_range and not (x_range_type is FactorRange and not isinstance(x_range, FactorRange)):
-        #    self._shared['x'] = True
-        #if y_range and not (y_range_type is FactorRange and not isinstance(y_range, FactorRange)):
-        #    self._shared['y'] = True
+        norm_opts = self.lookup_options(el, 'norm').options
+        if plots and self.shared_axes and not norm_opts.get('axiswise', False):
+            dim_range = self._shared_axis_range(plots, specs, range_type, axis_type, pos)
 
-        #if self._shared['x']:
-        #    pass
-
-
-
-        if categorical:
+        if self._shared['x' if pos==0 else 'y']:
+            pass
+        elif categorical:
             axis_type = 'auto'
             dim_range = FactorRange()
         elif None in [v0, v1] or any(True if isinstance(el, (str, bytes)) else np.isnan(el) for el in [v0, v1]):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2474,7 +2474,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                           'bgcolor', 'fontsize', 'invert_axes', 'show_frame',
                           'show_grid', 'logx',  'xticks', 'toolbar',
                           'yticks', 'xrotation', 'yrotation', 'lod',
-                          'border', 'invert_xaxis', 'sizing_mode',
+                          'border', 'invert_xaxis', 'invert_yaxis', 'sizing_mode',
                           'title', 'title_format', 'legend_position', 'legend_offset',
                           'legend_cols', 'gridstyle', 'legend_muted', 'padding',
                           'xlabel', 'ylabel', 'xlim', 'zlim',

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -50,7 +50,7 @@ from .util import (
     TOOL_TYPES, bokeh_version, bokeh3, bokeh32, date_to_integer, decode_bytes, get_tab_title,
     glyph_order, py2js_tickformatter, recursive_model_update,
     theme_attr_json, cds_column_replace, hold_policy, match_dim_specs,
-    compute_layout_properties, wrap_formatter, match_ax_type,
+    compute_layout_properties, wrap_formatter, match_ax_type, match_yaxis_type_to_range,
     prop_is_none, remove_legend, property_to_dict, dtype_fix_hook
 )
 
@@ -391,7 +391,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if dim not in data:
                 data[dim] = [v for _ in range(len(list(data.values())[0]))]
 
-    def _shared_axis_range(self, plots, specs, range_type, axis_type, pos):
+    def _shared_axis_range(self, plots, specs, range_type, axis_type, pos, extra_range_name):
         """
         Given a list of other plots return the shared axis from another
         plot by matching the dimensions specs stored as tags on the
@@ -404,19 +404,29 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
             if pos==0:
                 if hasattr(plot, 'x_range') and plot.x_range.tags and specs is not None:
-                    if match_dim_specs(plot.x_range.tags[0], specs) and match_ax_type(plot.xaxis, axis_type):
-                        dim_range= plot.x_range
+                    if match_dim_specs(plot.x_range.tags[0], specs) and match_ax_type(plot.xaxis[0], axis_type):
+                        dim_range = plot.x_range
 
             if pos==1:
                 if hasattr(plot, 'y_range') and plot.y_range.tags and specs is not None:
-                    if match_dim_specs(plot.y_range.tags[0], specs) and match_ax_type(plot.yaxis, axis_type):
-                        dim_range= plot.y_range
+                    if match_dim_specs(plot.y_range.tags[0], specs) and match_ax_type(plot.yaxis[0], axis_type):
+                        dim_range = plot.y_range
+
+                if hasattr(plot, 'extra_y_ranges'):
+                    for extra_range in plot.extra_y_ranges.values():
+                        if extra_range.tags and specs is not None:
+                            if (match_dim_specs(extra_range.tags[0], specs) and
+                                match_yaxis_type_to_range(plot.yaxis, axis_type, extra_range.name)):
+                                dim_range = extra_range
 
         if dim_range and not (range_type is FactorRange and not isinstance(dim_range, FactorRange)):
-            self._shared['x' if pos == 0 else 'y'] = True
+            shared_name = extra_range_name or ('x' if pos == 0 else 'y')
+            self._shared[shared_name] = True
+
         return dim_range
 
-    def _axis_props(self, plots, subplots, element, ranges, pos, *, dim=None, range_tags_extras=[]):
+    def _axis_props(self, plots, subplots, element, ranges, pos, *, dim=None,
+                    range_tags_extras=[], extra_range_name=None):
 
         el = element.traverse(lambda x: x, [lambda el: isinstance(el, Element) and not isinstance(el, (Annotation, Tiles))])
         el = el[0] if el else element
@@ -481,9 +491,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         norm_opts = self.lookup_options(el, 'norm').options
         if plots and self.shared_axes and not norm_opts.get('axiswise', False):
-            dim_range = self._shared_axis_range(plots, specs, range_type, axis_type, pos)
+            dim_range = self._shared_axis_range(plots, specs, range_type, axis_type, pos, extra_range_name)
 
-        if self._shared['x' if pos==0 else 'y']:
+        if self._shared['x' if pos==0 else 'y'] or (extra_range_name in self._shared):
             pass
         elif categorical:
             axis_type = 'auto'
@@ -497,6 +507,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             dim_range.tags.append(specs)
             dim_range.tags.extend(range_tags_extras)
 
+        if extra_range_name:
+            dim_range.name = extra_range_name
         return axis_type, axis_label, dim_range
 
     def _init_plot(self, key, element, plots, ranges=None):
@@ -526,7 +538,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             for ydim, info in yaxes.items():
                 axis_specs['y'][ydim] = self._axis_props(
                     plots, subplots, element, ranges, pos=1, dim=dimensions[ydim],
-                    range_tags_extras=[] if info['autorange']=='y' else ['no-autorange']
+                    range_tags_extras=[] if info['autorange']=='y' else ['no-autorange'],
+                    extra_range_name=ydim
                 )
         else:
             axis_specs['y']['y'] = self._axis_props(plots, subplots, element, ranges, pos=1,
@@ -903,14 +916,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self._update_main_ranges(element, x_range, y_range, ranges)
 
         # ALERT: extra ranges need shared, logx, and stream handling
-        streaming, log, shared = False, False, False
+        streaming, log = False, False
         multi_dim = 'x' if self.invert_axes else 'y'
         for axis_dim, extra_y_range in self.handles[f'extra_{multi_dim}_ranges'].items():
             _, b, _, t = self.get_extents(element, ranges, dimension=axis_dim)
             factors = self._get_dimension_factors(element, ranges, axis_dim)
             self._update_range(
                 extra_y_range, b, t, factors, self.invert_yaxis,
-                shared, log, streaming
+                self._shared.get(extra_y_range.name, False), log, streaming
             )
 
     def _update_main_ranges(self, element, x_range, y_range, ranges):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1369,14 +1369,15 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             del properties['legend_label']
 
         # ALERT: This only handles XYGlyph types right now
+        # and note guard against Field (unhashable) when using FactorRanges
         mapping = property_to_dict(mapping)
         if 'x' in mapping:
             x = mapping['x']
-            if x in plot.extra_x_ranges:
+            if plot.extra_x_ranges and (x in plot.extra_x_ranges):
                 properties['x_range_name'] = mapping['x']
         if 'y' in mapping:
             y = mapping['y']
-            if y in plot.extra_y_ranges:
+            if plot.extra_y_ranges and (y in plot.extra_y_ranges):
                 properties['y_range_name'] = mapping['y']
 
         renderer = getattr(plot, plot_method)(**dict(properties, **mapping))

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -10,7 +10,6 @@ from bokeh.models import (
 from ...core.data import Dataset
 from ...core.options import Cycle, abbreviated_exception
 from ...core.util import dimension_sanitizer, unique_array
-from ...element import Graph
 from ...util.transform import dim
 from ..mixins import ChordMixin, GraphMixin
 from ..util import process_cmap, get_directed_graph_paths

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -12,7 +12,7 @@ from ...core.options import Cycle, abbreviated_exception
 from ...core.util import dimension_sanitizer, unique_array
 from ...element import Graph
 from ...util.transform import dim
-from ..mixins import ChordMixin
+from ..mixins import ChordMixin, GraphMixin
 from ..util import process_cmap, get_directed_graph_paths
 from .chart import ColorbarPlot, PointPlot
 from .element import CompositeElementPlot, LegendPlot
@@ -23,7 +23,7 @@ from .styles import (
 from .util import bokeh3
 
 
-class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
+class GraphPlot(GraphMixin, CompositeElementPlot, ColorbarPlot, LegendPlot):
 
     arrowhead_length = param.Number(default=0.025, doc="""
       If directed option is enabled this determines the length of the
@@ -94,14 +94,6 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         else:
             dims = []
         return dims, {}
-
-    def get_extents(self, element, ranges, range_type='combined'):
-        return super().get_extents(element.nodes, ranges, range_type)
-
-    def _get_axis_dims(self, element):
-        if isinstance(element, Graph):
-            element = element.nodes
-        return element.dimensions()[:2]
 
     def _get_edge_colors(self, element, ranges, edge_data, edge_mapping, style):
         cdim = element.get_dimension(self.edge_color_index)

--- a/holoviews/plotting/bokeh/heatmap.py
+++ b/holoviews/plotting/bokeh/heatmap.py
@@ -286,7 +286,7 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
         if isinstance(renderer.glyph, AnnularWedge):
             super()._postprocess_hover(renderer, source)
 
-    def get_extents(self, view, ranges, range_type='combined'):
+    def get_extents(self, view, ranges, range_type='combined', **kwargs):
         """Supply custom, static extents because radial heatmaps always have
         the same boundaries.
         """

--- a/holoviews/plotting/bokeh/hex_tiles.py
+++ b/holoviews/plotting/bokeh/hex_tiles.py
@@ -149,7 +149,7 @@ class HexTilesPlot(ColorbarPlot):
     _nonvectorized_styles = base_properties + ['cmap', 'line_dash']
     _plot_methods = dict(single='hex_tile')
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         xdim, ydim = element.kdims[:2]
         ranges[xdim.name]['data'] = xdim.range
         ranges[ydim.name]['data'] = ydim.range

--- a/holoviews/plotting/bokeh/sankey.py
+++ b/holoviews/plotting/bokeh/sankey.py
@@ -229,7 +229,7 @@ class SankeyPlot(GraphPlot):
         data['patches_1'][src] = [lookup.get(v, v) for v in src_vals]
         data['patches_1'][tgt] = [lookup.get(v, v) for v in tgt_vals]
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         """Return the extents of the Sankey box"""
         if range_type == 'extents':
             return element.nodes.extents

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -16,6 +16,7 @@ from ...core.util import (
 )
 from ...operation.stats import univariate_kde
 from ...util.transform import dim
+from ..mixins import MultiDistributionMixin
 from .chart import AreaPlot
 from .element import CompositeElementPlot, ColorbarPlot, LegendPlot
 from .path import PolygonPlot
@@ -63,7 +64,7 @@ class BivariatePlot(PolygonPlot):
     selection_display = BokehOverlaySelectionDisplay(color_prop='cmap', is_cmap=True)
 
 
-class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
+class BoxWhiskerPlot(MultiDistributionMixin, CompositeElementPlot, ColorbarPlot, LegendPlot):
 
     show_legend = param.Boolean(default=False, doc="""
         Whether to show legend for the plot.""")
@@ -90,14 +91,6 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
     _stream_data = False # Plot does not support streaming data
 
     selection_display = BokehOverlaySelectionDisplay(color_prop='box_color')
-
-    def get_extents(self, element, ranges, range_type='combined'):
-        return super().get_extents(
-            element, ranges, range_type, 'categorical', element.vdims[0]
-        )
-
-    def _get_axis_dims(self, element):
-        return element.kdims, element.vdims[0]
 
     def _glyph_properties(self, plot, element, source, ranges, style, group=None):
         properties = dict(style, source=source)

--- a/holoviews/plotting/bokeh/tiles.py
+++ b/holoviews/plotting/bokeh/tiles.py
@@ -12,7 +12,7 @@ class TilePlot(ElementPlot):
     style_opts = ['alpha', 'render_parents', 'level', 'smoothing', 'min_zoom', 'max_zoom']
     selection_display = None
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         extents = super().get_extents(element, ranges, range_type)
         if (not self.overlaid and all(e is None or not np.isfinite(e) for e in extents)
             and range_type in ('combined', 'data')):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -1001,12 +1001,20 @@ def match_ax_type(ax, range_type):
     """
     Ensure the range_type matches the axis model being matched.
     """
-    if isinstance(ax[0], CategoricalAxis):
+    if isinstance(ax, CategoricalAxis):
         return range_type == 'categorical'
-    elif isinstance(ax[0], DatetimeAxis):
+    elif isinstance(ax, DatetimeAxis):
         return range_type == 'datetime'
     else:
         return range_type in ('auto', 'log')
+
+
+def match_yaxis_type_to_range(yax, range_type, range_name):
+    "Apply match_ax_type to the y-axis found by the given range name "
+    for axis in yax:
+        if axis.y_range_name == range_name:
+            return match_ax_type(axis, range_type)
+    raise Exception('No axis with given range found')
 
 
 def wrap_formatter(formatter, axis):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -40,6 +40,7 @@ from ...util.warnings import deprecated
 
 bokeh_version = Version(bokeh.__version__)
 bokeh3 = bokeh_version >= Version("3.0")
+bokeh32 = bokeh_version >= Version("3.2")
 
 if bokeh3:
     from bokeh.layouts import group_tools

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -1014,7 +1014,7 @@ def match_yaxis_type_to_range(yax, range_type, range_name):
     for axis in yax:
         if axis.y_range_name == range_name:
             return match_ax_type(axis, range_type)
-    raise Exception('No axis with given range found')
+    raise ValueError('No axis with given range found')
 
 
 def wrap_formatter(formatter, axis):

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -76,6 +76,11 @@ class HeatMapMixin:
 
 class SpikesMixin:
 
+    def _get_axis_dims(self, element):
+        if 'spike_length' in self.lookup_options(element, 'plot').options:
+            return  [element.dimensions()[0], None, None]
+        return super()._get_axis_dims(element)
+
     def get_extents(self, element, ranges, range_type='combined'):
         opts = self.lookup_options(element, 'plot').options
         if len(element.dimensions()) > 1 and 'spike_length' not in opts:
@@ -129,6 +134,13 @@ class AreaMixin:
 
 
 class BarsMixin:
+
+    def _get_axis_dims(self, element):
+        if element.ndims > 1 and not (self.stacked or not self.multi_level):
+            xdims = element.kdims
+        else:
+            xdims = element.kdims[0]
+        return (xdims, element.vdims[0])
 
     def get_extents(self, element, ranges, range_type='combined'):
         """
@@ -223,3 +235,25 @@ class BarsMixin:
             c_is_str = xvals.dtype.kind in 'SU' or not as_string
             xvals = [x if c_is_str else xdim.pprint_value(x) for x in xvals]
             return xvals, None
+
+
+class MultiDistributionMixin:
+    
+    def _get_axis_dims(self, element):
+        return element.kdims, element.vdims[0]
+
+    def get_extents(self, element, ranges, range_type='combined'):
+        return super().get_extents(
+            element, ranges, range_type, 'categorical', element.vdims[0]
+        )
+
+
+class GraphMixin:
+
+    def _get_axis_dims(self, element):
+        if isinstance(element, Graph):
+            element = element.nodes
+        return element.dimensions()[:2]
+
+    def get_extents(self, element, ranges, range_type='combined'):
+        return super().get_extents(element.nodes, ranges, range_type)

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -238,7 +238,7 @@ class BarsMixin:
 
 
 class MultiDistributionMixin:
-    
+
     def _get_axis_dims(self, element):
         return element.kdims, element.vdims[0]
 

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -8,7 +8,7 @@ from .util import get_axis_padding
 
 class GeomMixin:
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         """
         Use first two key dimensions to set names, and all four
         to set the data range.
@@ -38,7 +38,7 @@ class GeomMixin:
 
 class ChordMixin:
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         """
         A Chord plot is always drawn on a unit circle.
         """
@@ -55,7 +55,7 @@ class ChordMixin:
 
 class HeatMapMixin:
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         if range_type in ('data', 'combined'):
             agg = element.gridded
             xtype = agg.interface.dtype(agg, 0)
@@ -81,7 +81,7 @@ class SpikesMixin:
             return  [element.dimensions()[0], None, None]
         return super()._get_axis_dims(element)
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         opts = self.lookup_options(element, 'plot').options
         if len(element.dimensions()) > 1 and 'spike_length' not in opts:
             ydim = element.get_dimension(1)
@@ -116,7 +116,7 @@ class SpikesMixin:
 
 class AreaMixin:
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         vdims = element.vdims[:2]
         vdim = vdims[0].name
         if len(vdims) > 1:
@@ -142,7 +142,7 @@ class BarsMixin:
             xdims = element.kdims[0]
         return (xdims, element.vdims[0])
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         """
         Make adjustments to plot extents by computing
         stacked bar heights, adjusting the bar baseline
@@ -242,7 +242,7 @@ class MultiDistributionMixin:
     def _get_axis_dims(self, element):
         return element.kdims, element.vdims[0]
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         return super().get_extents(
             element, ranges, range_type, 'categorical', element.vdims[0]
         )
@@ -255,5 +255,5 @@ class GraphMixin:
             element = element.nodes
         return element.dimensions()[:2]
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         return super().get_extents(element.nodes, ranges, range_type)

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -243,9 +243,10 @@ class MultiDistributionMixin:
         return element.kdims, element.vdims[0]
 
     def get_extents(self, element, ranges, range_type='combined', **kwargs):
-        return super().get_extents(
+        l,b,r,t =  super().get_extents(
             element, ranges, range_type, 'categorical', element.vdims[0]
         )
+        return b,l,t,r  # WHY IS THIS NEEDED FOR BOXWHISKER AND VIOLIN?
 
 
 class GraphMixin:

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -243,11 +243,9 @@ class MultiDistributionMixin:
         return element.kdims, element.vdims[0]
 
     def get_extents(self, element, ranges, range_type='combined', **kwargs):
-        l,b,r,t =  super().get_extents(
-            element, ranges, range_type, 'categorical', element.vdims[0]
+        return super().get_extents(
+            element, ranges, range_type, 'categorical', ydim=element.vdims[0]
         )
-        return b,l,t,r  # WHY IS THIS NEEDED FOR BOXWHISKER AND VIOLIN?
-
 
 class GraphMixin:
 

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..core import util, Dataset, Dimension
-from ..element import Bars
+from ..element import Bars, Graph
 from ..element.util import categorical_aggregate2d
 from .util import get_axis_padding
 

--- a/holoviews/plotting/mpl/graphs.py
+++ b/holoviews/plotting/mpl/graphs.py
@@ -9,13 +9,13 @@ from ...core.data import Dataset
 from ...core.options import Cycle, abbreviated_exception
 from ...core.util import unique_array, search_indices, is_number, isscalar
 from ...util.transform import dim
-from ..mixins import ChordMixin
+from ..mixins import ChordMixin, GraphMixin
 from ..util import process_cmap, get_directed_graph_paths
 from .element import ColorbarPlot
 from .util import filter_styles
 
 
-class GraphPlot(ColorbarPlot):
+class GraphPlot(GraphMixin, ColorbarPlot):
 
     arrowhead_length = param.Number(default=0.025, doc="""
       If directed option is enabled this determines the length of the
@@ -142,9 +142,6 @@ class GraphPlot(ColorbarPlot):
         if self.invert_axes:
             paths = [p[:, ::-1] for p in paths]
         return {'nodes': (pxs, pys), 'edges': paths}, style, {'dimensions': dims}
-
-    def get_extents(self, element, ranges, range_type='combined'):
-        return super().get_extents(element.nodes, ranges, range_type)
 
     def init_artists(self, ax, plot_args, plot_kwargs):
         # Draw edges

--- a/holoviews/plotting/mpl/stats.py
+++ b/holoviews/plotting/mpl/stats.py
@@ -2,6 +2,7 @@ import param
 import numpy as np
 
 from ...core.ndmapping import sorted_context
+from ..mixins import MultiDistributionMixin
 from .chart import AreaPlot, ChartPlot
 from .path import PolygonPlot
 from .plot import AdjoinedPlot
@@ -43,7 +44,7 @@ class BivariatePlot(PolygonPlot):
         A list of scalar values used to specify the contour levels.""")
 
 
-class BoxPlot(ChartPlot):
+class BoxPlot(MultiDistributionMixin, ChartPlot):
     """
     BoxPlot plots the ErrorBar Element type and supporting
     both horizontal and vertical error bars via the 'horizontal'
@@ -59,11 +60,6 @@ class BoxPlot(ChartPlot):
     _nonvectorized_styles = style_opts
 
     _plot_methods = dict(single='boxplot')
-
-    def get_extents(self, element, ranges, range_type='combined'):
-        return super().get_extents(
-            element, ranges, range_type, 'categorical', element.vdims[0]
-        )
 
     def get_data(self, element, ranges, style):
         if element.kdims:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1697,6 +1697,13 @@ class GenericOverlayPlot(GenericElementPlot):
         super().__init__(overlay, ranges=ranges, keys=keys,
                          batched=batched, **params)
 
+        if ('multi_y' in self.param) and self.multi_y:
+            for s in self.streams:
+                intersection =  set(s.param) & set(['y', 'y_selection', 'y_range', 'bounds', 'boundsy'])
+                if intersection:
+                    self.param.warning(f'{type(s).__name__} stream parameters'
+                                       f' {list(intersection)} not yet supported with multi_y=True')
+
         # Apply data collapse
         self.hmap = self._apply_compositor(self.hmap, ranges, self.keys)
         self.map_lengths = Counter()
@@ -2002,7 +2009,7 @@ class GenericOverlayPlot(GenericElementPlot):
 
         # Apply xlim, ylim, zlim plot option
         x0, x1 = util.dimension_range(x0, x1, self.xlim, (None, None))
-        if not self.multi_y:
+        if not (('multi_y' in self.param) and self.multi_y):
             y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))
 
         if isinstance(self.projection, str) and self.projection == '3d':

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1262,7 +1262,7 @@ class GenericElementPlot(DimensionedPlot):
             dimension in ds if isinstance(ds, list) else dimension == ds
             for ds in dims
         )
-    
+
     def _get_frame(self, key):
         if isinstance(self.hmap, DynamicMap) and self.overlaid and self.current_frame:
             self.current_key = key

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1400,7 +1400,7 @@ class GenericElementPlot(DimensionedPlot):
 
         return (x0, y0, x1, y1)
 
-    def get_extents(self, element, ranges, range_type='combined', xdim=None, ydim=None, zdim=None):
+    def get_extents(self, element, ranges, range_type='combined', dimension=None, xdim=None, ydim=None, zdim=None):
         """
         Gets the extents for the axes from the current Element. The globally
         computed ranges can optionally override the extents.

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -2002,7 +2002,11 @@ class GenericOverlayPlot(GenericElementPlot):
 
         # Apply xlim, ylim, zlim plot option
         x0, x1 = util.dimension_range(x0, x1, self.xlim, (None, None))
-        y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))
+        if self.multi_y:
+            y0, y1 = util.dimension_range(y0, y1, (None, None), (None, None))
+        else:
+            y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))
+
         if isinstance(self.projection, str) and self.projection == '3d':
             z0, z1 = util.dimension_range(z0, z1, getattr(self, 'zlim', (None, None)), (None, None))
             return (x0, y0, z0, x1, y1, z1)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -2002,9 +2002,7 @@ class GenericOverlayPlot(GenericElementPlot):
 
         # Apply xlim, ylim, zlim plot option
         x0, x1 = util.dimension_range(x0, x1, self.xlim, (None, None))
-        if self.multi_y:
-            y0, y1 = util.dimension_range(y0, y1, (None, None), (None, None))
-        else:
+        if not self.multi_y:
             y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))
 
         if isinstance(self.projection, str) and self.projection == '3d':

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1166,6 +1166,8 @@ class GenericElementPlot(DimensionedPlot):
 
     _selection_display = NoOpSelectionDisplay()
 
+    _multi_y_propagation = False
+
     def __init__(self, element, keys=None, ranges=None, dimensions=None,
                  batched=False, overlaid=0, cyclic_index=0, zorder=0, style=None,
                  overlay_dims={}, stream_sources={}, streams=None, **params):
@@ -1197,9 +1199,14 @@ class GenericElementPlot(DimensionedPlot):
 
         self.style = self.lookup_options(plot_element, 'style') if style is None else style
         plot_opts = self.lookup_options(plot_element, 'plot').options
+
+        propagate_options = self._propagate_options[:]
+        if self._multi_y_propagation:
+            propagate_options = list(set(propagate_options) - set(GenericOverlayPlot._multi_y_unpropagated))
+
         if self.v17_option_propagation:
             inherited = self._traverse_options(plot_element, 'plot',
-                                               self._propagate_options,
+                                               propagate_options,
                                                defaults=False)
             plot_opts.update(**{k: v[0] for k, v in inherited.items()
                                 if k not in plot_opts})
@@ -1679,6 +1686,9 @@ class GenericOverlayPlot(GenericElementPlot):
         group, and a value of 3 will group by the full specification.""")
 
     _passed_handles = []
+
+    # Options not to be propagated in multi_y mode to allow independent control of y-axes
+    _multi_y_unpropagated = ['ylim', 'invert_yaxis', 'logy']
 
     def __init__(self, overlay, ranges=None, batched=True, keys=None, group_counter=None, **params):
         if 'projection' not in params:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1200,7 +1200,7 @@ class GenericElementPlot(DimensionedPlot):
         self.style = self.lookup_options(plot_element, 'style') if style is None else style
         plot_opts = self.lookup_options(plot_element, 'plot').options
 
-        propagate_options = self._propagate_options[:]
+        propagate_options = self._propagate_options.copy()
         if self._multi_y_propagation:
             propagate_options = list(set(propagate_options) - set(GenericOverlayPlot._multi_y_unpropagated))
 
@@ -1699,7 +1699,7 @@ class GenericOverlayPlot(GenericElementPlot):
 
         if ('multi_y' in self.param) and self.multi_y:
             for s in self.streams:
-                intersection =  set(s.param) & set(['y', 'y_selection', 'y_range', 'bounds', 'boundsy'])
+                intersection =  set(s.param) & {'y', 'y_selection', 'y_range', 'bounds', 'boundsy'}
                 if intersection:
                     self.param.warning(f'{type(s).__name__} stream parameters'
                                        f' {list(intersection)} not yet supported with multi_y=True')
@@ -1966,7 +1966,7 @@ class GenericOverlayPlot(GenericElementPlot):
                 extents[rt].append(extent)
         return extents
 
-    def get_extents(self, overlay, ranges, range_type='combined', dimension=None):
+    def get_extents(self, overlay, ranges, range_type='combined', dimension=None, **kwargs):
         subplot_extents = self._get_subplot_extents(overlay, ranges, range_type, dimension)
         zrange = isinstance(self.projection, str) and self.projection == '3d'
         extents = {k: util.max_extents(rs, zrange) for k, rs in subplot_extents.items()}

--- a/holoviews/plotting/plotly/stats.py
+++ b/holoviews/plotting/plotly/stats.py
@@ -1,5 +1,6 @@
 import param
 
+from ..mixins import MultiDistributionMixin
 from .selection import PlotlyOverlaySelectionDisplay
 from .chart import ChartPlot
 from .element import ElementPlot, ColorbarPlot
@@ -75,10 +76,7 @@ class DistributionPlot(ElementPlot):
         return {'type': 'scatter', 'mode': 'lines'}
 
 
-class MultiDistributionPlot(ElementPlot):
-
-    def _get_axis_dims(self, element):
-        return element.kdims, element.vdims[0]
+class MultiDistributionPlot(MultiDistributionMixin, ElementPlot):
 
     def get_data(self, element, ranges, style, **kwargs):
         if element.kdims:
@@ -96,10 +94,6 @@ class MultiDistributionPlot(ElementPlot):
             plots.append(data)
         return plots
 
-    def get_extents(self, element, ranges, range_type='combined'):
-        return super().get_extents(
-            element, ranges, range_type, 'categorical', element.vdims[0]
-        )
 
 
 class BoxWhiskerPlot(MultiDistributionPlot):

--- a/holoviews/tests/plotting/bokeh/test_geomplot.py
+++ b/holoviews/tests/plotting/bokeh/test_geomplot.py
@@ -93,7 +93,7 @@ class TestSegmentPlot(TestBokehPlot):
         self.assertIsInstance(y_range, FactorRange)
         self.assertEqual(y_range.factors, ['A', 'B', 'C', 'D'])
 
-    def test_segments_overlay_categorical_yaxis_invert_axis(self):
+    def test_segments_overlay_categorical_yaxis_invert_yaxis(self):
         segments = Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C'])).opts(invert_yaxis=True)
         segments2 = Segments(([1, 2, 3], ['B', 'C', 'D'], [4, 5, 6], ['B', 'C', 'D']))
         plot = bokeh_renderer.get_plot(segments*segments2)
@@ -101,7 +101,7 @@ class TestSegmentPlot(TestBokehPlot):
         self.assertIsInstance(y_range, FactorRange)
         self.assertEqual(y_range.factors, ['A', 'B', 'C', 'D'][::-1])
 
-    def test_segments_overlay_categorical_yaxis_invert_axes(self):
+    def test_segments_overlay_categorical_xaxis_invert_axes(self):
         segments = Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C'])).opts(invert_axes=True)
         segments2 = Segments(([1, 2, 3], ['B', 'C', 'D'], [4, 5, 6], ['B', 'C', 'D']))
         plot = bokeh_renderer.get_plot(segments*segments2)

--- a/holoviews/tests/plotting/bokeh/test_multiaxis.py
+++ b/holoviews/tests/plotting/bokeh/test_multiaxis.py
@@ -1,0 +1,201 @@
+from holoviews.element import Curve
+from .test_plot import TestBokehPlot, bokeh_renderer
+from bokeh.models import LinearScale, LogScale, LinearAxis, LogAxis
+
+from ...utils import LoggingComparisonTestCase
+
+class TestCurveTwinAxes(LoggingComparisonTestCase, TestBokehPlot):
+
+    def test_multi_y_disabled(self):
+        overlay = (Curve(range(10)) * Curve(range(10)))
+        plot = bokeh_renderer.get_plot(overlay).state
+        self.assertEqual(len(plot.yaxis), 1)
+
+    def test_multi_y_enabled_two_curves_one_vdim(self):
+        overlay = (Curve(range(10)) * Curve(range(10))).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay).state
+        self.assertEqual(len(plot.yaxis), 1)
+
+    def test_multi_y_enabled_two_curves_two_vdim(self):
+        overlay = (Curve(range(10), vdims=['A'])
+                   * Curve(range(10), vdims=['B'])).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertEqual(len(plot.state.yaxis), 2)
+        y_range = plot.handles['y_range']
+        self.assertEqual(y_range.start, 0)
+        self.assertEqual(y_range.end, 9)
+        extra_y_ranges = plot.handles['extra_y_ranges']
+        self.assertEqual(list(extra_y_ranges.keys()), ['B'])
+        self.assertEqual(extra_y_ranges['B'].start, 0)
+        self.assertEqual(extra_y_ranges['B'].end, 9)
+
+    def test_multi_y_enabled_three_curves_two_vdim(self):
+        curve_1A = Curve(range(10), vdims=['A'])
+        curve_2B = Curve(range(11), vdims=['B'])
+        curve_3A = Curve(range(12), vdims=['A'])
+        overlay = (curve_1A * curve_2B * curve_3A ).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay).state
+        self.assertEqual(len(plot.yaxis), 2)
+
+    # Testing independent y-lims
+
+    def test_multi_y_lims_left_axis(self):
+        overlay = (Curve(range(10), vdims=['A']).opts(ylim=(-10,20))
+                   * Curve(range(10), vdims=['B'])).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        y_range = plot.handles['y_range']
+        self.assertEqual(y_range.start, -10)
+        self.assertEqual(y_range.end, 20)
+        extra_y_ranges = plot.handles['extra_y_ranges']
+        self.assertEqual(list(extra_y_ranges.keys()), ['B'])
+        self.assertEqual(extra_y_ranges['B'].start, 0)
+        self.assertEqual(extra_y_ranges['B'].end, 9)
+
+    def test_multi_y_lims_right_axis(self):
+        overlay = (Curve(range(10), vdims=['A'])
+                   * Curve(range(10), vdims=['B']).opts(ylim=(-10,20))).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        y_range = plot.handles['y_range']
+        self.assertEqual(y_range.start, 0)
+        self.assertEqual(y_range.end, 9)
+        extra_y_ranges = plot.handles['extra_y_ranges']
+        self.assertEqual(list(extra_y_ranges.keys()), ['B'])
+        self.assertEqual(extra_y_ranges['B'].start, -10)
+        self.assertEqual(extra_y_ranges['B'].end, 20)
+
+    def test_multi_y_lims_both_axes(self):
+        overlay = (Curve(range(10), vdims=['A']).opts(ylim=(-15,25))
+                   * Curve(range(10), vdims=['B']).opts(ylim=(-10,20))).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        y_range = plot.handles['y_range']
+        self.assertEqual(y_range.start, -15)
+        self.assertEqual(y_range.end, 25)
+        extra_y_ranges = plot.handles['extra_y_ranges']
+        self.assertEqual(list(extra_y_ranges.keys()), ['B'])
+        self.assertEqual(extra_y_ranges['B'].start, -10)
+        self.assertEqual(extra_y_ranges['B'].end, 20)
+
+    # Testing independent logy
+
+    def test_multi_log_left_axis(self):
+        overlay = (Curve(range(1,9), vdims=['A']).opts(logy=True)
+                   * Curve(range(10), vdims=['B'])).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertEqual(len(plot.state.yaxis), 2)
+        self.assertTrue(isinstance(plot.state.yaxis[0], LogAxis))
+        self.assertTrue(isinstance(plot.state.yaxis[1], LinearAxis))
+        extra_y_ranges = plot.handles['extra_y_scales']
+        self.assertTrue(isinstance(extra_y_ranges['B'], LinearScale))
+
+    def test_multi_log_right_axis(self):
+        overlay = (Curve(range(1,9), vdims=['A'])
+                   * Curve(range(1, 9), vdims=['B']).opts(logy=True)).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertEqual(len(plot.state.yaxis), 2)
+        self.assertTrue(isinstance(plot.state.yaxis[0], LinearAxis))
+        self.assertTrue(isinstance(plot.state.yaxis[1], LogAxis))
+        extra_y_ranges = plot.handles['extra_y_scales']
+        self.assertTrue(isinstance(extra_y_ranges['B'], LogScale))
+
+
+    def test_multi_log_both_axes(self):
+        overlay = (Curve(range(1,9), vdims=['A']).opts(logy=True)
+                   * Curve(range(1, 9), vdims=['B']).opts(logy=True)).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertEqual(len(plot.state.yaxis), 2)
+        self.assertTrue(isinstance(plot.state.yaxis[0], LogAxis))
+        self.assertTrue(isinstance(plot.state.yaxis[1], LogAxis))
+        extra_y_ranges = plot.handles['extra_y_scales']
+        self.assertTrue(isinstance(extra_y_ranges['B'], LogScale))
+
+    # BUG! left_axis is not warning (main axis)
+
+    def test_multi_log_right_axis_warn(self):
+        overlay = (Curve(range(10), vdims=['A'])
+                   * Curve(range(10), vdims=['B']).opts(logy=True)).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertEqual(len(plot.state.yaxis), 2)
+        self.assertTrue(isinstance(plot.state.yaxis[0], LinearAxis))
+        self.assertTrue(isinstance(plot.state.yaxis[1], LogAxis))
+        extra_y_ranges = plot.handles['extra_y_scales']
+        self.assertTrue(isinstance(extra_y_ranges['B'], LogScale))
+        #print(self.log_handler)
+        substr = "Logarithmic axis range encountered value less than or equal to zero, please supply explicit lower bound to override default of 0.010."
+        self.log_handler.assertEndsWith('WARNING', substr)
+
+    # Testing invert_yaxis
+
+    def test_multi_invert_left_axis(self):
+        overlay = (Curve(range(10), vdims=['A']).opts(invert_yaxis=True)
+                   * Curve(range(10), vdims=['B'])).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        y_range = plot.handles['y_range']
+        self.assertEqual(y_range.start, 9)
+        self.assertEqual(y_range.end, 0)
+        extra_y_ranges = plot.handles['extra_y_ranges']
+        self.assertEqual(list(extra_y_ranges.keys()), ['B'])
+        self.assertEqual(extra_y_ranges['B'].start, 0)
+        self.assertEqual(extra_y_ranges['B'].end, 9)
+
+    def test_multi_invert_right_axis(self):
+        overlay = (Curve(range(10), vdims=['A'])
+                   * Curve(range(10), vdims=['B']).opts(invert_yaxis=True)).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        y_range = plot.handles['y_range']
+        self.assertEqual(y_range.start, 0)
+        self.assertEqual(y_range.end, 9)
+        extra_y_ranges = plot.handles['extra_y_ranges']
+        self.assertEqual(list(extra_y_ranges.keys()), ['B'])
+        self.assertEqual(extra_y_ranges['B'].start, 9)
+        self.assertEqual(extra_y_ranges['B'].end, 0)
+
+
+    def test_multi_invert_both_axes(self):
+        overlay = (Curve(range(10), vdims=['A']).opts(invert_yaxis=True)
+                   * Curve(range(10), vdims=['B']).opts(invert_yaxis=True)).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        y_range = plot.handles['y_range']
+        self.assertEqual(y_range.start, 9)
+        self.assertEqual(y_range.end, 0)
+        extra_y_ranges = plot.handles['extra_y_ranges']
+        self.assertEqual(list(extra_y_ranges.keys()), ['B'])
+        self.assertEqual(extra_y_ranges['B'].start, 9)
+        self.assertEqual(extra_y_ranges['B'].end, 0)
+
+
+    # Combination test
+
+    def test_inverted_log_ylim_right_axis(self):
+        overlay = (Curve(range(10), vdims=['A'])
+                   * Curve(range(10), vdims=['B']
+                           ).opts(invert_yaxis=True, logy=True, ylim=(2,20))).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        y_range = plot.handles['y_range']
+        self.assertEqual(y_range.start, 0)
+        self.assertEqual(y_range.end, 9)
+        extra_y_ranges = plot.handles['extra_y_ranges']
+        self.assertEqual(list(extra_y_ranges.keys()), ['B'])
+        print(extra_y_ranges['B'].start, extra_y_ranges['B'].end)
+        self.assertEqual(extra_y_ranges['B'].start, 20)
+        self.assertEqual(extra_y_ranges['B'].end, 2)
+        self.assertTrue(isinstance(plot.handles['extra_y_scales']['B'], LogScale))
+
+
+    # Test axis sharing in layouts
+
+    def test_shared_multi_axes(self):
+        curve1A = Curve([9, 8, 7, 6, 5], vdims='A')
+        curve2B = Curve([1, 2, 3], vdims='B')
+        overlay1 = (curve1A * curve2B).opts(multi_y=True)
+
+        curve3A = Curve([19, 18, 17, 16, 15], vdims='A')
+        curve4B = Curve([11, 12, 13], vdims='B')
+        overlay2 = (curve3A * curve4B).opts(multi_y=True)
+
+        plot = bokeh_renderer.get_plot(overlay1 + overlay2)
+        plot = plot.subplots[(0, 1)].subplots['main']
+        y_range = plot.handles['y_range']
+        extra_y_ranges = plot.handles['extra_y_ranges']
+
+        self.assertEqual((y_range.start, y_range.end), (5, 19))
+        self.assertEqual((extra_y_ranges['B'].start, extra_y_ranges['B'].end), (1, 13))

--- a/holoviews/tests/plotting/bokeh/test_multiaxis.py
+++ b/holoviews/tests/plotting/bokeh/test_multiaxis.py
@@ -1,3 +1,4 @@
+import pytest
 from holoviews.element import Curve
 from .test_plot import TestBokehPlot, bokeh_renderer
 from bokeh.models import LinearScale, LogScale, LinearAxis, LogAxis
@@ -199,3 +200,41 @@ class TestCurveTwinAxes(LoggingComparisonTestCase, TestBokehPlot):
 
         self.assertEqual((y_range.start, y_range.end), (5, 19))
         self.assertEqual((extra_y_ranges['B'].start, extra_y_ranges['B'].end), (1, 13))
+
+    @pytest.mark.xfail
+    def test_swapped_position_label(self):
+        overlay = (Curve(range(10), vdims=['A']).opts(yaxis='right')
+                   * Curve(range(10), vdims=['B']).opts(yaxis='left')
+                   ).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+
+        self.assertEqual(plot.state.yaxis[0].axis_label, 'B')
+        self.assertEqual(plot.state.yaxis[1].axis_label, 'A')
+
+
+    @pytest.mark.xfail
+    def test_swapped_position_custom_label(self):
+        overlay = (Curve(range(10), vdims=['A']).opts(yaxis='right', ylabel='A-custom')
+                   * Curve(range(10), vdims=['B']).opts(yaxis='left', ylabel='B-custom')
+                   ).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+
+        self.assertEqual(plot.state.yaxis[0].axis_label, 'B-custom')
+        self.assertEqual(plot.state.yaxis[1].axis_label, 'A-custom')
+
+    @pytest.mark.xfail
+    def test_position_custom_size_label(self):
+        overlay = (Curve(range(10), vdims='A').opts(fontsize={'ylabel': '13pt'})
+                   * Curve(range(10), vdims='B').opts(fontsize={'ylabel': '15pt'})).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertEqual(plot.state.yaxis[0].axis_label_text_font_size, '13pt')
+        self.assertEqual(plot.state.yaxis[1].axis_label_text_font_size, '15pt')
+
+    @pytest.mark.xfail
+    def test_swapped_position_custom_size_label(self):
+        overlay = (Curve(range(10), vdims='A').opts(yaxis='right', fontsize={'ylabel': '13pt'})
+                   * Curve(range(10), vdims='B').opts(yaxis='left',
+                                                      fontsize={'ylabel': '15pt'})).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertEqual(plot.state.yaxis[0].axis_label_text_font_size, '15pt')
+        self.assertEqual(plot.state.yaxis[1].axis_label_text_font_size, '13pt')

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require['tests_core'] = [
 # to run and pass the test suite without installing any
 # of those.
 extras_require['tests'] = extras_require['tests_core'] + [
-    'dask',
+    'dask <2023.7',
     'ibis-framework',  # Mapped to ibis-sqlite in setup.cfg for conda
     'xarray >=0.10.4',
     'networkx',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require['tests_core'] = [
 # to run and pass the test suite without installing any
 # of those.
 extras_require['tests'] = extras_require['tests_core'] + [
-    'dask <2023.7',
+    'dask',
     'ibis-framework',  # Mapped to ibis-sqlite in setup.cfg for conda
     'xarray >=0.10.4',
     'networkx',


### PR DESCRIPTION
This adds multi-yaxis support to the Bokeh backend.

<img width="689" alt="Screen Shot 2023-02-10 at 16 21 11" src="https://user-images.githubusercontent.com/1550771/218128470-d75e4ce9-d889-45aa-bcd4-b09cc27bce74.png">

# ToDo

- [x] Clean up utilities
- [x] Add autorange support for multi-axes 
- [x] Fix linking of shared axes
- [x] Implement axis labels correctly
- [x] Handle correct logx/logy mappings
- [x] Correctly determine categorical axis creation per axis
- [x] Clean up `_get_factors`
- [ ] Handle dynamic axis creation when DynamicMap OverlayPlot adds new elements