### PR TITLE
Replace "three" with "four" for consistency

### DIFF
--- a/examples/user_guide/Customizing_Plots.ipynb
+++ b/examples/user_guide/Customizing_Plots.ipynb
@@ -265,7 +265,7 @@
    "source": [
     "## Customizing axes\n",
     "\n",
-    "Controlling the axis scales is one of the most common changes to make to a plot, so we will provide a quick overview of the three main types of axes and then go into some more detail on how to control the axis labels, ranges, ticks and orientation."
+    "Controlling the axis scales is one of the most common changes to make to a plot, so we will provide a quick overview of the four main types of axes and then go into some more detail on how to control the axis labels, ranges, ticks and orientation."
    ]
   },
   {


### PR DESCRIPTION
There are four different types of axes discussed now, so this should be "four" instead of "three".