### PR TITLE
Fix legend display when using categorical datashade on GPU

### DIFF
--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -1334,7 +1334,7 @@ class categorical_legend(Operation):
                 cats = list(hvds.data.dtypes[column].categories)
             except TypeError:
                 # Issue #5619, cudf.core.index.StringIndex is not iterable.
-                cats = list(hvds.data.dtypes[column].categories.values_host)
+                cats = list(hvds.data.dtypes[column].categories.to_pandas())
             if cats == ['__UNKNOWN_CATEGORIES__']:
                 cats = list(hvds.data[column].cat.as_known().categories)
         else:

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -1330,7 +1330,11 @@ class categorical_legend(Operation):
             return
         column = agg.column
         if hasattr(hvds.data, 'dtypes'):
-            cats = list(hvds.data.dtypes[column].categories)
+            try:
+                cats = list(hvds.data.dtypes[column].categories)
+            except TypeError:
+                # Issue #5619, cudf.core.index.StringIndex is not iterable.
+                cats = list(hvds.data.dtypes[column].categories.values_host)
             if cats == ['__UNKNOWN_CATEGORIES__']:
                 cats = list(hvds.data[column].cat.as_known().categories)
         else:


### PR DESCRIPTION
Fixes #5619.

When attempting a categorical datashade using a `cudf.DataFrame` the legend was not displayed. This was caused by the following line
https://github.com/holoviz/holoviews/blob/029ba951eaefff03d59f44195b6b466f70a584d0/holoviews/plotting/util.py#L1333
which gave the error
```
TypeError: StringIndex object is not iterable. Consider using `.to_arrow()`, `.to_pandas()` or `.values_host` if you wish to iterate over the values.
```
which explains the problem and offers a solution. I have chosen to wrap the offending line in a `try` block and use the `values_host` attribute if it fails. The use of `values_host` is consistent with that in `core/data/cudf.py`.

I have tested locally using `pandas`, `dask`, `cudf` and `dask-cudf` dataframes and they all give the correct result now. I have not added a test to this PR as we don't use `cudf` in github actions CI, but if one is required and someone can direct me to where it should be located I will happily do so.