### PR TITLE
Don't distribute `/examples` twice

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,5 +9,4 @@ global-exclude *.py[co]
 global-exclude __pycache__
 global-exclude *~
 global-exclude *.ipynb_checkpoints/*
-graft examples
 graft holoviews/examples


### PR DESCRIPTION
I haven't yet figured out how to solve this. It's not a major issue anyway for HoloViews, but it's a sign that something is wrong in how it's packages. I've asked a question there to try to get more info https://github.com/pypa/setuptools/discussions/3841. It's likely we'll need to update `pyctdev` not to run `python setup.py ...` anymore, it's unrelated to this though (I think) as I've been able to reproduce the issue running `python -m build` to build the *sdist* and *wheel*.