### PR TITLE
Improve build setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,178 @@
 requires = [
     "param >=1.7.0",
     "pyct >=0.4.4",
-    "setuptools >=30.3.0",
+    "setuptools>=61.2",
 ]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "holoviews"
+readme = "README.md"
+authors = [{name = "Jean-Luc Stevens and Philipp Rudiger", email = "holoviews@gmail.com"}]
+maintainers = [{name = "HoloViz Developers", email = "developers@pyviz.org"}]
+license = {text = "BSD"}
+description = "Stop plotting your data - annotate your data and let it visualize itself."
+classifiers = [
+    "License :: OSI Approved :: BSD License",
+    "Development Status :: 5 - Production/Stable",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Framework :: Matplotlib",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development :: Libraries",
+]
+requires-python = ">=3.7"
+dependencies = [
+    "param >=1.9.3,<2.0",
+    "numpy >=1.0",
+    "pyviz_comms >=0.7.4",
+    "panel >=0.13.1",
+    "colorcet",
+    "packaging",
+    "pandas >=0.20.0",
+]
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://www.holoviews.org"
+Source = "https://github.com/holoviz/holoviews"
+
+[project.optional-dependencies]
+lint = [
+    "ruff",
+    "pre-commit",
+]
+tests_core = [
+    # Test requirements
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+    "flaky",
+    "matplotlib >=3",
+    "nbconvert",
+    "bokeh",
+    "pillow",
+    "plotly >=4.0",
+    "dash >=1.16",
+    "codecov",
+    "ipython >=5.4.0",
+    # Issues with comm (see https://github.com/ipython/ipykernel/issues/1026)
+    "ipykernel <6.18.0",
+]
+tests = [
+    # Optional tests dependencies, i.e. one should be able
+    # to run and pass the test suite without installing any
+    # of those.
+    "holoviews[tests_core]",
+    "dask",
+    "ibis-framework", # Mapped to ibis-sqlite in setup.cfg for conda
+    "xarray >=0.10.4",
+    "networkx",
+    "shapely",
+    "ffmpeg",
+    "cftime",
+    "scipy",
+    "selenium",
+    "numpy <1.24", # Upper pin because of numba error
+    # Packages not working on python 3.11 because of numba
+    "spatialpandas; python_version < '3.11'",
+    "datashader >=0.11.1; python_version < '3.11'",
+]
+tests_gpu = [
+    "holoviews[tests]",
+    "cudf",
+]
+tests_nb = ["nbval"]
+notebook = [
+    # Notebook dependencies
+    "ipython >=5.4.0",
+    "notebook",
+]
+recommended = [
+    # IPython Notebook + pandas + matplotlib + bokeh
+    "holoviews[notebook]",
+    "matplotlib >=3",
+    "bokeh >=2.4.3",
+]
+examples = [
+    # Requirements to run all examples
+    "holoviews[recommended]",
+    "networkx",
+    "pillow",
+    "xarray >=0.10.4",
+    "plotly >=4.0",
+    "dash >=1.16",
+    "streamz >=0.5.0",
+    "ffmpeg",
+    "cftime",
+    "netcdf4",
+    "dask",
+    "scipy",
+    "shapely",
+    "scikit-image",
+    "pyarrow",
+    "pooch",
+    "numpy <1.24", # Upper pin because of numba error
+    # Packages not working on python 3.11 because of numba
+    "datashader >=0.11.1; python_version < '3.11'",
+]
+examples_tests = [
+    "holoviews[examples]",
+    "holoviews[tests_nb]",
+]
+extras = [
+    # Extra third-party libraries
+    "holoviews[examples]",
+    "pscript ==0.7.1",
+]
+unit_tests = [
+    # Not used in tox.ini or elsewhere, kept for backwards compatibility.
+    "holoviews[examples]",
+    "holoviews[tests]",
+    "holoviews[lint]",
+]
+doc = [
+    "holoviews[examples]",
+    "nbsite ==0.8.0rc2",
+    "mpl_sample_data >=3.1.3",
+    "pscript",
+    "graphviz",
+    "bokeh >2.2",
+    "pydata-sphinx-theme ==0.9.0",
+    "sphinx-copybutton",
+    "pooch",
+    "selenium",
+]
+all = [
+    "holoviews[lint]",
+    "holoviews[tests]",
+    "holoviews[tests_gpu]",
+    "holoviews[tests_nb]",
+    "holoviews[notebook]",
+    "holoviews[recommended]",
+    "holoviews[examples]",
+    "holoviews[extras]",
+    "holoviews[doc]",
+]
+build = [
+    "param >=1.7.0",
+    "setuptools>=61.2",
+    "pyct >=0.4.4",
+]
+
+[project.scripts]
+holoviews = "holoviews.util.command:main"
+
+[tool.setuptools]
+license-files = ["LICENSE.txt"]
+platforms = ["Windows", "Mac OS X", "Linux"]
 
 [tool.pytest.ini_options]
 addopts = "-p no:dash"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[metadata]
-license_file = LICENSE.txt
-
 [tool:pyctdev.conda]
 namespace_map =
     ibis-framework=ibis-sqlite

--- a/setup.py
+++ b/setup.py
@@ -2,142 +2,9 @@
 
 import json
 import os
-import sys
-import shutil
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
-import pyct.build
-
-setup_args = {}
-install_requires = [
-    "param >=1.9.3,<2.0",
-    "numpy >=1.0",
-    "pyviz_comms >=0.7.4",
-    "panel >=0.13.1",
-    "colorcet",
-    "packaging",
-    "pandas >=0.20.0",
-]
-
-extras_require = {}
-
-extras_require['lint'] = [
-    'ruff',
-    'pre-commit',
-]
-
-# Test requirements
-extras_require['tests_core'] = [
-    'pytest',
-    'pytest-cov',
-    'pytest-xdist',
-    'flaky',
-    'matplotlib >=3',
-    'nbconvert',
-    'bokeh',
-    'pillow',
-    'plotly >=4.0',
-    'dash >=1.16',
-    'codecov',
-    'ipython >=5.4.0',
-    # Issues with comm (see https://github.com/ipython/ipykernel/issues/1026)
-    'ipykernel <6.18.0',
-]
-
-# Optional tests dependencies, i.e. one should be able
-# to run and pass the test suite without installing any
-# of those.
-extras_require['tests'] = extras_require['tests_core'] + [
-    'dask',
-    'ibis-framework',  # Mapped to ibis-sqlite in setup.cfg for conda
-    'xarray >=0.10.4',
-    'networkx',
-    'shapely',
-    'ffmpeg',
-    'cftime',
-    'scipy',
-    'selenium',
-    'numpy <1.24',  # Upper pin because of numba error
-]
-
-# Packages not working on python 3.11 because of numba
-if sys.version_info < (3, 11):
-    extras_require['tests'] += [
-        'spatialpandas',
-        'datashader >=0.11.1',
-    ]
-
-extras_require['tests_gpu'] = extras_require['tests'] + [
-    'cudf',
-]
-
-extras_require['tests_nb'] = ['nbval']
-
-# Notebook dependencies
-extras_require["notebook"] = ["ipython >=5.4.0", "notebook"]
-
-# IPython Notebook + pandas + matplotlib + bokeh
-extras_require["recommended"] = extras_require["notebook"] + [
-    "matplotlib >=3",
-    "bokeh >=2.4.3",
-]
-
-# Requirements to run all examples
-extras_require["examples"] = extras_require["recommended"] + [
-    "networkx",
-    "pillow",
-    "xarray >=0.10.4",
-    "plotly >=4.0",
-    'dash >=1.16',
-    "streamz >=0.5.0",
-    "ffmpeg",
-    "cftime",
-    "netcdf4",
-    "dask",
-    "scipy",
-    "shapely",
-    "scikit-image",
-    "pyarrow",
-    "pooch",
-    "numpy <1.24",  # Upper pin because of numba error
-]
-
-if sys.version_info < (3, 11):
-    extras_require["examples"] += [
-        "datashader >=0.11.1",
-    ]
-
-
-extras_require["examples_tests"] = extras_require["examples"] + extras_require['tests_nb']
-
-# Extra third-party libraries
-extras_require["extras"] = extras_require["examples"] + [
-    "pscript ==0.7.1",
-]
-
-# Not used in tox.ini or elsewhere, kept for backwards compatibility.
-extras_require["unit_tests"] = extras_require["examples"] + extras_require["tests"] + extras_require['lint']
-
-extras_require['doc'] = extras_require['examples'] + [
-    'nbsite ==0.8.0rc2',
-    'mpl_sample_data >=3.1.3',
-    'pscript',
-    'graphviz',
-    'bokeh >2.2',
-    'pydata-sphinx-theme ==0.9.0',
-    'sphinx-copybutton',
-    'pooch',
-    'selenium',
-]
-
-extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
-
-extras_require["build"] = [
-    "param >=1.7.0",
-    "setuptools >=30.3.0",
-    "pyct >=0.4.4",
-]
 
 def get_setup_version(reponame):
     """
@@ -146,89 +13,23 @@ def get_setup_version(reponame):
     """
     basepath = os.path.split(__file__)[0]
     version_file_path = os.path.join(basepath, reponame, ".version")
-    try:
-        from param import version
-    except ImportError:
-        version = None
-    if version is not None:
-        return version.Version.setup_version(
-            basepath, reponame, archive_commit="$Format:%h$"
-        )
-    else:
-        print(
-            "WARNING: param>=1.6.0 unavailable. If you are installing a package, this warning can safely be ignored. If you are creating a package or otherwise operating in a git repository, you should install param>=1.6.0."
-        )
-        return json.load(open(version_file_path))["version_string"]
+
+    from param import version  # rely in pyproject.toml to install the right version
+    return json.load(open(version_file_path))["version_string"]
 
 
-setup_args.update(
-    dict(
-        name="holoviews",
-        version=get_setup_version("holoviews"),
-        python_requires=">=3.7",
-        install_requires=install_requires,
-        extras_require=extras_require,
-        description="Stop plotting your data - annotate your data and let it visualize itself.",
-        long_description=open("README.md").read(),
-        long_description_content_type="text/markdown",
-        author="Jean-Luc Stevens and Philipp Rudiger",
-        author_email="holoviews@gmail.com",
-        maintainer="HoloViz Developers",
-        maintainer_email="developers@pyviz.org",
-        platforms=["Windows", "Mac OS X", "Linux"],
-        license="BSD",
-        url="https://www.holoviews.org",
-        project_urls={
-            "Source": "https://github.com/holoviz/holoviews",
-        },
-        entry_points={"console_scripts": ["holoviews = holoviews.util.command:main"]},
-        packages=find_packages(),
-        include_package_data=True,
-        classifiers=[
-            "License :: OSI Approved :: BSD License",
-            "Development Status :: 5 - Production/Stable",
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3.11",
-            "Operating System :: OS Independent",
-            "Intended Audience :: Science/Research",
-            "Intended Audience :: Developers",
-            "Natural Language :: English",
-            "Framework :: Matplotlib",
-            "Topic :: Scientific/Engineering",
-            "Topic :: Software Development :: Libraries",
-        ],
-    )
+def find_all_packages():
+    regular_packages = find_namespace_packages()
+    example_subpackages = [
+        f"holoviews.examples.{p}"
+        for p in find_namespace_packages(where="examples")
+    ]
+    return [*regular_packages, "holoviews.examples", *example_subpackages]
+
+
+setup(
+    version=get_setup_version("holoviews"),
+    packages=find_all_packages(),
+    package_dir={"holoviews.examples": "examples"},  # remap subpackage directory
+    include_package_data=True,
 )
-
-
-if __name__ == "__main__":
-    example_path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "holoviews/examples"
-    )
-
-    if "develop" not in sys.argv and "egg_info" not in sys.argv:
-        pyct.build.examples(example_path, __file__, force=True)
-
-    if "install" in sys.argv:
-        header = "HOLOVIEWS INSTALLATION INFORMATION"
-        bars = "=" * len(header)
-
-        extras = "\n".join("holoviews[%s]" % e for e in setup_args["extras_require"])
-
-        print("%s\n%s\n%s" % (bars, header, bars))
-
-        print("\nHoloViews supports the following installation types:\n")
-        print("%s\n" % extras)
-        print("Users should consider using one of these options.\n")
-        print("By default only a core installation is performed and ")
-        print("only the minimal set of dependencies are fetched.\n\n")
-        print("For more information please visit http://holoviews.org/install.html\n")
-        print(bars + "\n")
-
-    setup(**setup_args)
-
-    if os.path.isdir(example_path):
-        shutil.rmtree(example_path)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def get_setup_version(reponame):
 
 
 def find_all_packages():
-    regular_packages = find_namespace_packages()
+    regular_packages = find_namespace_packages(include=["holoviews*"])
     example_subpackages = [
         f"holoviews.examples.{p}"
         for p in find_namespace_packages(where="examples")


### PR DESCRIPTION
Hi @maximlt and maintainers, this PR was created in response to https://github.com/pypa/setuptools/discussions/3841.

Please feel free to ignore/close or use parts of it in other PRs.

The main idea is to simplify `setup.py` to keep only configuration that needs to be dynamically computed (and `package_dir` since it is directly related them).

Everything else that is static can be moved to `pyproject.toml`.

Notes:

- You can use `package_dir` config to logic remap package directories to other locations (as long as they are inside the same project root).
  - This should obviate the need for copying the `examples` folder.
- Newer versions of `pip` / `setuptools` deprecate direct usage of `python setup.py ...`, these might even no longer be called.
  - Therefore it makes less sense to keep checks for `develop` and `install` in `sys.argv`.
- The installation environment should already come with both `param` and `pyct` pre-installed in the correct versions (specified in `pyproject.toml [build-system]`). Therefore version checks for those dependencies can be removed.
- As long as `pip` is relatively modern (released a couple of years ago), it should be possible for a package to depend on itself+extras.
  - This is a way of avoid repeating dependencies in extras, while still specifying them statically.


(If you have an intention of using this PR, please double check if I did not miss anything in `pyproject.toml` when doing the conversion...)

(I also believe that it should be OK to remove `graft holoviews/examples` from `MANIFEST.in`, but I haven't checked that).

---

Please note that when installing in editable mode some static analysis tools like vscode code intel and mypy may have trouble to find the package. This happens because static analysis tools may - understandably - have trouble to deal with dynamic parts of the Python language, such as `MetaPathFinder` and `PathEntryFinder`.

To workaround that you can use `pip install -e . --config-settings editable_mode=compat` for the installation. Note however that the package `holoviews.examples` will not be accessible for imports if the project is installed in that way.
