### PR TITLE
Add support for extra hovertool variables in a Bokeh QuadMesh with 2-D coordinates (with tests)

### DIFF
--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -298,7 +298,7 @@ class QuadMeshPlot(ColorbarPlot):
             if 'hover' in self.handles:
                 if not self.static_source:
                     hover_data = self._collect_hover_data(
-                            element, mask, transpose=self.invert_axes)
+                            element, mask, irregular=True)
                 hover_data[x] = np.array(xc)
                 hover_data[y] = np.array(yc)
         else:
@@ -312,8 +312,7 @@ class QuadMeshPlot(ColorbarPlot):
                     'bottom': y0, 'top': y1}
 
             if 'hover' in self.handles and not self.static_source:
-                hover_data = self._collect_hover_data(
-                        element, transpose=(not self.invert_axes))
+                hover_data = self._collect_hover_data(element)
                 hover_data[x] = element.dimension_values(x)
                 hover_data[y] = element.dimension_values(y)
 
@@ -321,17 +320,18 @@ class QuadMeshPlot(ColorbarPlot):
 
         return data, mapping, style
 
-    @staticmethod
-    def _collect_hover_data(element, mask=(), transpose=False):
+    def _collect_hover_data(self, element, mask=(), irregular=False):
         """
         Returns a dict mapping hover dimension names to flattened arrays.
 
-        Note that `Quad` glyphs are used when given 1-D coords but `Patches`
-        are used for 2-D coords, and Bokeh inserts data into these glyphs in
-        the opposite order such that the relationship b/w the `invert_axis`
+        Note that `Quad` glyphs are used when given 1-D coords but `Patches` are
+        used for "irregular" 2-D coords, and Bokeh inserts data into these glyphs
+        in the opposite order such that the relationship b/w the `invert_axes`
         parameter and the need to transpose the arrays before flattening is
         reversed.
         """
+        transpose = self.invert_axes if irregular else not self.invert_axes
+
         hover_dims = element.dimensions()[3:]
         hover_vals = [element.dimension_values(hover_dim, flat=False)
                       for hover_dim in hover_dims]

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -269,6 +269,7 @@ class QuadMeshPlot(ColorbarPlot):
         x, y = dimension_sanitizer(x.name), dimension_sanitizer(y.name)
 
         zdata = element.dimension_values(z, flat=False)
+        hover_data = {}
 
         if irregular:
             dims = element.kdims
@@ -291,11 +292,15 @@ class QuadMeshPlot(ColorbarPlot):
                         yc.append(ys.mean())
                 else:
                     mask.append(False)
+            mask = np.array(mask)
 
-            data = {'xs': XS, 'ys': YS, z.name: zvals[np.array(mask)]}
+            data = {'xs': XS, 'ys': YS, z.name: zvals[mask]}
             if 'hover' in self.handles:
-                data[x] = np.array(xc)
-                data[y] = np.array(yc)
+                if not self.static_source:
+                    hover_data = self._collect_hover_data(
+                            element, mask, transpose=self.invert_axes)
+                hover_data[x] = np.array(xc)
+                hover_data[y] = np.array(yc)
         else:
             xc, yc = (element.interface.coords(element, x, edges=True, ordered=True),
                       element.interface.coords(element, y, edges=True, ordered=True))
@@ -311,7 +316,8 @@ class QuadMeshPlot(ColorbarPlot):
                         element, transpose=(not self.invert_axes))
                 hover_data[x] = element.dimension_values(x)
                 hover_data[y] = element.dimension_values(y)
-                data.update(hover_data)
+
+        data.update(hover_data)
 
         return data, mapping, style
 

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -325,6 +325,12 @@ class QuadMeshPlot(ColorbarPlot):
     def _collect_hover_data(element, mask=(), transpose=False):
         """
         Returns a dict mapping hover dimension names to flattened arrays.
+
+        Note that `Quad` glyphs are used when given 1-D coords but `Patches`
+        are used for 2-D coords, and Bokeh inserts data into these glyphs in
+        the opposite order such that the relationship b/w the `invert_axis`
+        parameter and the need to transpose the arrays before flattening is
+        reversed.
         """
         hover_dims = element.dimensions()[3:]
         hover_vals = [element.dimension_values(hover_dim, flat=False)

--- a/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
@@ -66,6 +66,27 @@ class TestQuadMeshPlot(TestBokehPlot):
         source = plot.handles['source']
         self.assertEqual(source.data['z'], flattened)
 
+    def test_quadmesh_regular_centers(self):
+        X = [0.5, 1.5]
+        Y = [0.5, 1.5, 2.5]
+        Z = np.array([[1., 2., 3.], [4., 5., np.nan]]).T
+        LABELS = np.array([['0-0', '0-1', '0-2'], ['1-0', '1-1', '1-2']]).T
+        qmesh = QuadMesh((X, Y, Z, LABELS), vdims=['Value', 'Label'])
+        plot = bokeh_renderer.get_plot(qmesh.opts(tools=['hover']))
+        source = plot.handles['source']
+        expected = {
+                'left': [0., 0., 0., 1., 1., 1.],
+                'right': [1., 1., 1., 2., 2., 2.],
+                'Value': [ 1.,  2.,  3.,  4.,  5., np.nan],
+                'bottom': [0., 1., 2., 0., 1., 2.],
+                'top': [1., 2., 3., 1., 2., 3.],
+                'Label': ['0-0', '0-1', '0-2', '1-0', '1-1', '1-2'],
+                'x': [0.5, 0.5, 0.5, 1.5, 1.5, 1.5],
+                'y': [0.5, 1.5, 2.5, 0.5, 1.5, 2.5]}
+        self.assertEqual(source.data.keys(), expected.keys())
+        for key in expected:
+            self.assertEqual(list(source.data[key]), expected[key])
+
     def test_quadmesh_irregular_centers(self):
         X = [[0.5, 0.5, 0.5], [1.5, 1.5, 1.5]]
         Y = [[0.5, 1.5, 2.5], [0.5, 1.5, 2.5]]

--- a/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
@@ -65,3 +65,43 @@ class TestQuadMeshPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(qmesh)
         source = plot.handles['source']
         self.assertEqual(source.data['z'], flattened)
+
+    def test_quadmesh_irregular_centers(self):
+        X = [[0.5, 0.5, 0.5], [1.5, 1.5, 1.5]]
+        Y = [[0.5, 1.5, 2.5], [0.5, 1.5, 2.5]]
+        Z = np.array([[1., 2., 3.], [4., 5., np.nan]])
+        LABELS = np.array([['0-0', '0-1', '0-2'], ['1-0', '1-1', '1-2']])
+        qmesh = QuadMesh((X, Y, Z, LABELS), vdims=['Value', 'Label'])
+        plot = bokeh_renderer.get_plot(qmesh.opts(tools=['hover']))
+        source = plot.handles['source']
+        expected = {'xs': [[0., 1., 1., 0.], [0., 1., 1., 0.], [0., 1., 1., 0.],
+                           [1., 2., 2., 1.], [1., 2., 2., 1.]],
+                    'ys': [[0., 0., 1., 1.], [1., 1., 2., 2.], [2., 2., 3., 3.],
+                           [0., 0., 1., 1.], [1., 1., 2., 2.]],
+                    'Value': [1., 2., 3., 4., 5.],
+                    'Label': ['0-0', '0-1', '0-2', '1-0', '1-1'],
+                    'x': [0.5, 0.5, 0.5, 1.5, 1.5],
+                    'y': [0.5, 1.5, 2.5, 0.5, 1.5]}
+        self.assertEqual(source.data.keys(), expected.keys())
+        for key in expected:
+            self.assertEqual(list(source.data[key]), expected[key])
+
+    def test_quadmesh_irregular_edges(self):
+        X = [[0., 0., 0., 0.], [1., 1., 1., 1.], [2., 2., 2., 2.]]
+        Y = [[0., 1., 2., 3.], [0., 1., 2., 3.], [0., 1., 2., 3.]]
+        Z = np.array([[1., 2., 3.], [4., 5., np.nan]])
+        LABELS = np.array([['0-0', '0-1', '0-2'], ['1-0', '1-1', '1-2']])
+        qmesh = QuadMesh((X, Y, Z, LABELS), vdims=['Value', 'Label'])
+        plot = bokeh_renderer.get_plot(qmesh.opts(tools=['hover']))
+        source = plot.handles['source']
+        expected = {'xs': [[0., 1., 1., 0.], [0., 1., 1., 0.], [0., 1., 1., 0.],
+                           [1., 2., 2., 1.], [1., 2., 2., 1.]],
+                    'ys': [[0., 0., 1., 1.], [1., 1., 2., 2.], [2., 2., 3., 3.],
+                           [0., 0., 1., 1.], [1., 1., 2., 2.]],
+                    'Value': [1., 2., 3., 4., 5.],
+                    'Label': ['0-0', '0-1', '0-2', '1-0', '1-1'],
+                    'x': [0.5, 0.5, 0.5, 1.5, 1.5],
+                    'y': [0.5, 1.5, 2.5, 0.5, 1.5]}
+        self.assertEqual(source.data.keys(), expected.keys())
+        for key in expected:
+            self.assertEqual(list(source.data[key]), expected[key])


### PR DESCRIPTION
When creating a Bokeh `QuadMesh` in the current version of HoloViews, you can supply additional data variables that will appear in the hovertool; however, this is only works for rectilinear geometries where the given coordinate arrays are 1-dimensional. When 2-dimensional coordinate arrays are given, any extra data variables are silently discarded and their values are displayed as "???" in the generated hovertool.

This pull request implements a simple fix that extends this functionality to support both 1-D and 2-D coordinates, which will allows `QuadMesh` plots to be created for non-rectilinear geometries without giving up the ability to add additional variables to the hovertool. 

Three new unit tests were also added to verify this change; one for testing that the existing functionality for 1-D coordinates is not affected, and the other two for testing the new functionality for 2-D coordinates.

See the screenshot below for a comparison of the hovertool behavior in a Jupyter notebook before and after implementing the fix:

<img width="675" alt="irregular_quadmesh_before_after" src="https://user-images.githubusercontent.com/31031841/222977047-39d8a78d-c465-4b8e-958d-55cb47279622.png">