### PR TITLE
Merge tools in grid and layout plots

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -587,7 +587,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                         sizing_mode=self.sizing_mode,
                         toolbar_location=self.toolbar)
         plot = self._make_axes(plot)
-        if bokeh3:
+        if bokeh3 and hasattr(plot, "toolbar"):
             plot.toolbar = merge_tools(plots)
 
         title = self._get_title_div(self.keys[-1])

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -639,10 +639,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             if self.shared_yaxis:
                 x_axis.margin = (0, 0, 0, 50)
                 r1, r2 = r1[::-1], r2[::-1]
-            if bokeh3:
-                plot = gridplot([r1, r2], toolbar_location=None)
-            else:
-                plot = gridplot([r1, r2])
+            plot = gridplot([r1, r2])
         elif y_axis:
             models = [y_axis, plot]
             if self.shared_yaxis: models = models[::-1]

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -31,7 +31,7 @@ from ..util import attach_streams, displayable, collate
 from .links import LinkCallback
 from .util import (
     bokeh3, filter_toolboxes, make_axis, update_shared_sources, empty_plot,
-    decode_bytes, theme_attr_json, cds_column_replace, get_default
+    decode_bytes, theme_attr_json, cds_column_replace, get_default, merge_tools
 )
 
 if bokeh3:
@@ -582,11 +582,13 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             else:
                 passed_plots.append(None)
 
-        toolbar_location = None if bokeh3 else self.toolbar
-        plot = gridplot(plots[::-1], merge_tools=self.merge_tools,
+        plot = gridplot(plots[::-1],
+                        merge_tools=self.merge_tools,
                         sizing_mode=self.sizing_mode,
-                        toolbar_location=toolbar_location)
+                        toolbar_location=self.toolbar)
         plot = self._make_axes(plot)
+        if bokeh3:
+            plot.toolbar = merge_tools(plots)
 
         title = self._get_title_div(self.keys[-1])
         if title:
@@ -917,15 +919,14 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
 
                     if nsubplots == 1:
                         grid = subplots[0]
-                    elif nsubplots == 2:
-                        grid = gridplot([subplots], merge_tools=self.merge_tools,
-                                        toolbar_location=self.toolbar,
-                                        sizing_mode=sizing_mode)
                     else:
-                        grid = [[subplots[2], None], subplots[:2]]
-                        grid = gridplot(children=grid, merge_tools=self.merge_tools,
+                        children = [subplots] if nsubplots == 2 else [[subplots[2], None], subplots[:2]]
+                        grid = gridplot(children,
+                                        merge_tools=self.merge_tools,
                                         toolbar_location=self.toolbar,
                                         sizing_mode=sizing_mode)
+                        if bokeh3:
+                            grid.toolbar = merge_tools(children)
                     tab_plots.append((title, grid))
                     continue
 
@@ -958,10 +959,14 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             layout_plot = Tabs(tabs=panels, sizing_mode=sizing_mode)
         else:
             plot_grid = filter_toolboxes(plot_grid)
-            layout_plot = gridplot(children=plot_grid,
-                                   toolbar_location=self.toolbar,
-                                   merge_tools=self.merge_tools,
-                                   sizing_mode=sizing_mode)
+            layout_plot = gridplot(
+                children=plot_grid,
+                toolbar_location=self.toolbar,
+                merge_tools=self.merge_tools,
+                sizing_mode=sizing_mode
+            )
+            if bokeh3:
+                layout_plot.toolbar = merge_tools(plot_grid)
 
         title = self._get_title_div(self.keys[-1])
         if title:

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -375,12 +375,17 @@ def compute_layout_properties(
     return aspect_info, dimension_info
 
 
-def merge_tools(plot_grid):
+def merge_tools(plot_grid, disambiguation_properties=None):
+    """
+    Merges tools defined on a grid of plots into a single toolbar.
+    All tools of the same type are merged unless they define one
+    of the disambiguation properties. By default `name`, `icon`, `tags`
+    and `description` can be used to prevent tools from being merged.
+    """
     tools = []
     for row in plot_grid:
         for item in row:
             if isinstance(item, LayoutDOM):
-                print(item)
                 for p in item.select(dict(type=Plot)):
                     tools.extend(p.toolbar.tools)
 
@@ -390,7 +395,14 @@ def merge_tools(plot_grid):
         else:
             return None
 
-    ignore = {'js_property_callbacks', 'renderers', 'overlay', 'zoom_on_axis', 'match_aspect'}
+    if not disambiguation_properties:
+        disambiguation_properties = {'name', 'icon', 'tags', 'description'}
+
+    ignore = set()
+    for tool in tools:
+        for p in tool.properties_with_values():
+            if p not in disambiguation_properties:
+                ignore.add(p)
 
     return Toolbar(tools=group_tools(tools, merge=merge, ignore=ignore) if merge_tools else tools)
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -607,6 +607,8 @@ def filter_toolboxes(plots):
     """
     if isinstance(plots, list):
         plots = [filter_toolboxes(plot) for plot in plots]
+    elif hasattr(plots, 'toolbar'):
+        plots.toolbar_location = None
     elif hasattr(plots, 'children'):
         plots.children = [filter_toolboxes(child) for child in plots.children
                           if not isinstance(child, Toolbar)]

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -41,8 +41,9 @@ bokeh_version = Version(bokeh.__version__)
 bokeh3 = bokeh_version >= Version("3.0")
 
 if bokeh3:
+    from bokeh.layouts import group_tools
     from bokeh.models.formatters import CustomJSTickFormatter
-    from bokeh.models import Toolbar, Tabs, GridPlot
+    from bokeh.models import Toolbar, Tabs, GridPlot, SaveTool, CopyTool, ExamineTool, FullscreenTool, LayoutDOM
     from bokeh.plotting import figure
     class WidgetBox: pass  # Does not exist in Bokeh 3
 
@@ -373,6 +374,25 @@ def compute_layout_properties(
 
     return aspect_info, dimension_info
 
+
+def merge_tools(plot_grid):
+    tools = []
+    for row in plot_grid:
+        for item in row:
+            if isinstance(item, LayoutDOM):
+                print(item)
+                for p in item.select(dict(type=Plot)):
+                    tools.extend(p.toolbar.tools)
+
+    def merge(cls, group):
+        if issubclass(cls, (SaveTool, CopyTool, ExamineTool, FullscreenTool)):
+            return cls()
+        else:
+            return None
+
+    ignore = {'js_property_callbacks', 'renderers', 'overlay', 'zoom_on_axis', 'match_aspect'}
+
+    return Toolbar(tools=group_tools(tools, merge=merge, ignore=ignore) if merge_tools else tools)
 
 @contextmanager
 def silence_warnings(*warnings):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -388,6 +388,8 @@ def merge_tools(plot_grid, disambiguation_properties=None):
             if isinstance(item, LayoutDOM):
                 for p in item.select(dict(type=Plot)):
                     tools.extend(p.toolbar.tools)
+            if isinstance(item, GridPlot):
+                item.toolbar_location = None
 
     def merge(tool, group):
         if issubclass(tool, (SaveTool, CopyTool, ExamineTool, FullscreenTool)):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -389,9 +389,9 @@ def merge_tools(plot_grid, disambiguation_properties=None):
                 for p in item.select(dict(type=Plot)):
                     tools.extend(p.toolbar.tools)
 
-    def merge(cls, group):
-        if issubclass(cls, (SaveTool, CopyTool, ExamineTool, FullscreenTool)):
-            return cls()
+    def merge(tool, group):
+        if issubclass(tool, (SaveTool, CopyTool, ExamineTool, FullscreenTool)):
+            return tool()
         else:
             return None
 


### PR DESCRIPTION
In bokeh3 the tool merging is a lot more flexible but by default it is also a lot more conservative. The basic idea behind the new approach is:

> If the properties of the tools match then merge them otherwise don't.

There is a list of properties that are excluded from this logic which covers the 'renderer' and 'overlay' properties by default. Looking at a specific example we see this:

<img width="1571" alt="Screen_Shot_2023-03-06_at_11 34 41" src="https://user-images.githubusercontent.com/1550771/223091715-789f0e31-9594-40a6-b6bf-c3b1d9f8cc05.png">

- `BoxZoomTool` does not merge because the geo plot has set `match_aspect`
- `WheelZoomTool` does not merge because the geo plot has disabled  `zoom_on_axis`  (because the axes aren't rendered)
- `HoverTool` does not merge because the `tooltips` don't match
- The box select and lasso select tools don't merge because they have different `js_property_callbacks`

With this PR applied we avoid also skip `match_aspect`, `js_property_callbacks` and `zoom_axis` and I'm also considering adding `tooltips` to the list:

<img width="1570" alt="Screen Shot 2023-03-06 at 11 59 54" src="https://user-images.githubusercontent.com/1550771/223092089-cedf54c2-d1ae-470e-a666-d1ba7020da67.png">

