### PR TITLE
Use dask-core in the CI and name fix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,9 +41,6 @@ jobs:
             # Bokeh 3 does not support Python 3.7
           - bokeh-version: '3'
             python-version: '3.7'
-            # Bokeh 3 cannot be installed together with Dask yet
-          - bokeh-version: '3'
-            python-version: '3.11'
     timeout-minutes: 120  # Because slow conda solve on Python 3.7
     defaults:
       run:

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -275,7 +275,7 @@ class Callback:
             self._active = True
             self._set_busy(True)
             task = asyncio.create_task(self.process_on_change())
-            self.background_task.add(task)
+            self._background_task.add(task)
             task.add_done_callback(self._baskground_task.discard)
 
     async def on_event(self, event):
@@ -288,7 +288,7 @@ class Callback:
             self._active = True
             self._set_busy(True)
             task = asyncio.create_task(self.process_on_event())
-            self.background_task.add(task)
+            self._background_task.add(task)
             task.add_done_callback(self._baskground_task.discard)
 
     async def process_on_event(self, timeout=None):
@@ -316,7 +316,7 @@ class Callback:
                 msg[attr] = self.resolve_attr_spec(path, event, model_obj)
             self.on_msg(msg)
         task = asyncio.create_task(self.process_on_event())
-        self.background_task.add(task)
+        self._background_task.add(task)
         task.add_done_callback(self._baskground_task.discard)
 
     async def process_on_change(self):
@@ -351,7 +351,7 @@ class Callback:
             self.on_msg(msg)
             self._prev_msg = msg
         task = asyncio.create_task(self.process_on_change())
-        self.background_task.add(task)
+        self._background_task.add(task)
         task.add_done_callback(self._baskground_task.discard)
 
     def set_callback(self, handle):

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,5 @@ license_file = LICENSE.txt
 [tool:pyctdev.conda]
 namespace_map =
     ibis-framework=ibis-sqlite
+    ; dask pins to bokeh<3 right now
+    dask=dask-core


### PR DESCRIPTION
Our current CI only runs Bokeh 3 on Python 3.9 because of Dask pinning of Bokeh. I feel that is on the low end, so I have changed `dask` to `dask-core`. 

In #5627 I added `_background_task` but wrongfully used the `background_task` in the code. 