### PR TITLE
Automatic detect comms without calling pn.extension()

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -102,7 +102,7 @@ class Callback:
     _transforms = []
 
     # Asyncio background task
-    _baskground_task = set()
+    _background_task = set()
 
     def __init__(self, plot, streams, source, **params):
         self.plot = plot
@@ -276,7 +276,7 @@ class Callback:
             self._set_busy(True)
             task = asyncio.create_task(self.process_on_change())
             self._background_task.add(task)
-            task.add_done_callback(self._baskground_task.discard)
+            task.add_done_callback(self._background_task.discard)
 
     async def on_event(self, event):
         """
@@ -289,7 +289,7 @@ class Callback:
             self._set_busy(True)
             task = asyncio.create_task(self.process_on_event())
             self._background_task.add(task)
-            task.add_done_callback(self._baskground_task.discard)
+            task.add_done_callback(self._background_task.discard)
 
     async def process_on_event(self, timeout=None):
         """
@@ -317,7 +317,7 @@ class Callback:
             self.on_msg(msg)
         task = asyncio.create_task(self.process_on_event())
         self._background_task.add(task)
-        task.add_done_callback(self._baskground_task.discard)
+        task.add_done_callback(self._background_task.discard)
 
     async def process_on_change(self):
         # Give on_change time to process new events
@@ -352,7 +352,7 @@ class Callback:
             self._prev_msg = msg
         task = asyncio.create_task(self.process_on_change())
         self._background_task.add(task)
-        task.add_done_callback(self._baskground_task.discard)
+        task.add_done_callback(self._background_task.discard)
 
     def set_callback(self, handle):
         """

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -9,7 +9,7 @@ from types import FunctionType
 from pathlib import Path
 
 import param
-
+import panel as pn
 from pyviz_comms import extension as _pyviz_extension
 
 from ..core import (
@@ -718,6 +718,18 @@ class extension(_pyviz_extension):
         if selected_backend is None:
             raise ImportError('None of the backends could be imported')
         Store.set_current_backend(selected_backend)
+
+        if pn.config.comms == "default":
+            try:
+                import google.colab  # noqa
+                pn.config.comms = "colab"
+                return
+            except ImportError:
+                pass
+
+            if "VSCODE_PID" in os.environ:
+                pn.config.comms = "vscode"
+                return
 
     @classmethod
     def register_backend_callback(cls, backend, callback):


### PR DESCRIPTION
Fixes #5642

This will automatically update comms, so it is unnecessary to call `pn.extension()` to run Holoviews in a VScode or Colab. 