### PR TITLE
Set the bounds of the `kdims` List parameter

### DIFF
--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -215,7 +215,7 @@ class Spikes(Selection1DExpr, Chart):
 
     kdims = param.List(default=[Dimension('x')], bounds=(1, 1))
 
-    vdims = param.List(default=[])
+    vdims = param.List(default=[], bounds=(0, None))
 
     _auto_indexable_1d = False
 

--- a/holoviews/element/chart3d.py
+++ b/holoviews/element/chart3d.py
@@ -140,7 +140,7 @@ class Path3D(Element3D, Path):
 
     kdims = param.List(default=[Dimension('x'),
                                 Dimension('y'),
-                                Dimension('z')])
+                                Dimension('z')], bounds=(3, 3))
 
     vdims = param.List(default=[], doc="""
         Path3D can have optional value dimensions.""")

--- a/holoviews/element/chart3d.py
+++ b/holoviews/element/chart3d.py
@@ -118,7 +118,7 @@ class Scatter3D(Element3D, Points):
 
     kdims = param.List(default=[Dimension('x'),
                                 Dimension('y'),
-                                Dimension('z')])
+                                Dimension('z')], bounds=(3, 3))
 
     vdims = param.List(default=[], doc="""
         Scatter3D can have optional value dimensions,

--- a/holoviews/element/chart3d.py
+++ b/holoviews/element/chart3d.py
@@ -54,7 +54,7 @@ class TriSurface(Element3D, Points):
     group = param.String(default='TriSurface', constant=True)
 
     kdims = param.List(default=[
-        Dimension('x'), Dimension('y'), Dimension('z')], doc="""
+        Dimension('x'), Dimension('y'), Dimension('z')], bounds=(3, 3), doc="""
         The key dimensions of a TriSurface represent the 3D coordinates
         of each point.""")
 

--- a/holoviews/element/tabular.py
+++ b/holoviews/element/tabular.py
@@ -25,7 +25,7 @@ class ItemTable(Element):
        ItemTables hold an index Dimension for each value they contain, i.e.
        they are equivalent to the keys.""")
 
-    vdims = param.List(default=[Dimension('Default')], bounds=(00, None), doc="""
+    vdims = param.List(default=[Dimension('Default')], bounds=(0, None), doc="""
        ItemTables should have only index Dimensions.""")
 
     group = param.String(default="ItemTable", constant=True)


### PR DESCRIPTION
I just ran the unit test suite of HoloViews with Param installed from https://github.com/holoviz/param/pull/605 and a few tests failed. They failed when `kdims` `List` is overridden in a sub Parameterized class, and the overriding `List` is not defining explicitly the new `bounds`. In the current state of Param (1.x) , `bounds` is not inherited from any super class but is always the default of `(0, None)` (meaning a list of any length). With the tested PR `bounds` is inherited.

The change made in this PR was to set explicitly the `bounds` in the subclasses. Alternatively, one could have loosen `bounds` in the super classes. The commits list what change was made and why. For instance, one could have set  `bounds` of `Chart.kdims` (super class) to `(0, None)` instead of updating `bounds` on `Spikes.kdims` (sub class) to `(0, None)`. I didn't spend much time thinking about doing the alternative 

I noticed there are a few typos in the commits, here are the changes made:
- set bounds to `(0,None)` to `Spikes.vdims` to override `Chart.vdims` bounds of `(1, None)`
- set bounds to `(3,3)` to `Path3D.vdims` to override `Geometry.vdims` bounds of `(2, 2)`
- set bounds to `(3,3)` to `Scatter3D.vdims` to override `Geometry.vdims` bounds of `(2, 2)`
- set bounds to `(3,3)` to `TriSurface.vdims` to override `Geometry.vdims` bounds of `(2, 2)`