### PR TITLE
Add real legend_cols support for Bokeh

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2174,8 +2174,8 @@ class ColorbarPlot(ElementPlot):
 
 class LegendPlot(ElementPlot):
 
-    legend_cols = param.Integer(default=False, doc="""
-        Whether to lay out the legend as columns.""")
+    legend_cols = param.Integer(default=0, bounds=(0, None), doc="""
+        Number of columns for legend.""")
 
     legend_labels = param.Dict(default=None, doc="""
         Label overrides.""")
@@ -2218,12 +2218,16 @@ class LegendPlot(ElementPlot):
             or not self.show_legend):
             legend.items[:] = []
         else:
-            plot.legend.orientation = 'horizontal' if self.legend_cols else 'vertical'
+            if bokeh3 and self.legend_cols:
+                plot.legend.nrows = self.legend_cols
+            else:
+                plot.legend.orientation = 'horizontal' if self.legend_cols else 'vertical'
+
             pos = self.legend_position
             if pos in self.legend_specs:
                 plot.legend[:] = []
                 legend.location = self.legend_offset
-                if pos in ['top', 'bottom']:
+                if pos in ['top', 'bottom'] and not self.legend_cols:
                     plot.legend.orientation = 'horizontal'
                 plot.add_layout(legend, self.legend_specs[pos])
             else:
@@ -2311,10 +2315,10 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             options[k] = v
 
         pos = self.legend_position
-        orientation = 'horizontal' if self.legend_cols else 'vertical'
-        if pos in ['top', 'bottom']:
-            orientation = 'horizontal'
-        options['orientation'] = orientation
+        if not bokeh3:
+            options['orientation'] = 'horizontal' if self.legend_cols else 'vertical'
+        if pos in ['top', 'bottom'] and not self.legend_cols:
+            options['orientation'] = 'horizontal'
 
         if overlay is not None and overlay.kdims:
             title = ', '.join([d.label for d in overlay.kdims])
@@ -2322,6 +2326,8 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
 
         options.update(self._fontsize('legend', 'label_text_font_size'))
         options.update(self._fontsize('legend_title', 'title_text_font_size'))
+        if bokeh3 and self.legend_cols:
+            options.update({"ncols": self.legend_cols})
         legend.update(**options)
 
         if pos in self.legend_specs:


### PR DESCRIPTION
In Bokeh 3.1 support for `ncols` and `nrows` was added. This PR implements that. Before that `legend_cols` was only used to determine if the legend should be horizontal or vertical.

###  Current behavior
![current_bokeh](https://user-images.githubusercontent.com/19758978/227152019-462be73d-ed9c-4caf-8555-b8e5010d6efb.png)

### Behavior after this PR
![pr_bokeh](https://user-images.githubusercontent.com/19758978/227152067-76571497-dd73-474e-8030-3b1d18112c69.png)

### Matplotlib behavior
![matplotlib](https://user-images.githubusercontent.com/19758978/227152056-3dd8318f-4a40-4fac-94d5-af9d21fb1b8f.png)

``` python
import holoviews as hv
import panel as pn

hv.extension("bokeh")
# hv.extension("matplotlib")


curves = [hv.Curve([i] * 10, label=str(i)) for i in range(10)]
data = [(0, 0, "A"), (1, 1, "B"), (2, 2, "C")]
optss = [
    dict(show_legend=True, legend_cols=2),
    dict(show_legend=True, legend_cols=2, legend_position="top"),
    dict(show_legend=True),
    dict(show_legend=True, legend_position="top"),
]


plots = []
for opts in optss:
    ol = hv.Overlay(curves).opts(**opts)
    bar = hv.Points(data, vdims=["y", "color"]).opts(color="color", **opts)
    plots.append(pn.Column(ol, bar))

pn.Row(*plots).servable()
```
