### PR TITLE
 Pass Parameter arguments by keyword only

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -248,7 +248,7 @@ class Dataset(Element, metaclass=PipelineMeta):
     function.
     """
 
-    datatype = param.List(datatypes, doc="""
+    datatype = param.List(default=datatypes, doc="""
         A priority list of the data types to be used for storage
         on the .data attribute. If the input supplied to the element
         constructor cannot be put into the requested format, the next

--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -103,7 +103,7 @@ class Exporter(param.ParameterizedFunction):
       literals that may be conveniently used for dictionary-style
       indexing. Returns an empty dictionary by default.""")
 
-    info_fn = param.Callable(lambda x: {'repr':repr(x)}, doc="""
+    info_fn = param.Callable(default=lambda x: {'repr':repr(x)}, doc="""
       Function that generates additional metadata information from the
       HoloViews object being saved.
 
@@ -229,7 +229,7 @@ class Importer(param.ParameterizedFunction):
 class Serializer(Exporter):
     "A generic exporter that supports any arbitrary serializer"
 
-    serializer=param.Callable(Store.dumps, doc="""
+    serializer=param.Callable(default=Store.dumps, doc="""
        The serializer function, set to Store.dumps by default. The
        serializer should take an object and output a serialization as
        a string or byte stream.
@@ -265,7 +265,7 @@ class Serializer(Exporter):
 class Deserializer(Importer):
     "A generic importer that supports any arbitrary de-serializer."
 
-    deserializer=param.Callable(Store.load, doc="""
+    deserializer=param.Callable(default=Store.load, doc="""
        The deserializer function, set to Store.load by default. The
        deserializer should take a file-like object that can be read
        from until the first object has been deserialized. If the file
@@ -567,7 +567,7 @@ class FileArchive(Archive):
         The root directory in which the output directory is
         located. May be an absolute or relative path.""")
 
-    archive_format = param.ObjectSelector('zip', objects=['zip', 'tar'], doc="""
+    archive_format = param.ObjectSelector(default='zip', objects=['zip', 'tar'], doc="""
         The archive format to use if there are multiple files and pack
         is set to True. Supported formats include 'zip' and 'tar'.""")
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -597,7 +597,7 @@ class sanitize_identifier_fn(param.ParameterizedFunction):
        in order to make sure paths aren't confused with method
        names.""")
 
-    eliminations = param.List(['extended', 'accent', 'small', 'letter', 'sign', 'digit',
+    eliminations = param.List(default=['extended', 'accent', 'small', 'letter', 'sign', 'digit',
                                'latin', 'greek', 'arabic-indic', 'with', 'dollar'], doc="""
        Lowercase strings to be eliminated from the unicode names in
        order to shorten the sanitized name ( lowercase). Redundant

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -463,5 +463,5 @@ class Labels(Dataset, Element2D):
 
     group = param.String(default='Labels', constant=True)
 
-    vdims = param.List([Dimension('Label')], bounds=(1, None), doc="""
+    vdims = param.List(default=[Dimension('Label')], bounds=(1, None), doc="""
         Defines the value dimension corresponding to the label text.""")

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -118,7 +118,7 @@ class categorical_aggregate2d(Operation):
             kdims=['Country', 'Year'], vdims=['Population'])
     """
 
-    datatype = param.List(['xarray', 'grid'], doc="""
+    datatype = param.List(default=['xarray', 'grid'], doc="""
         The grid interface types to use when constructing the gridded Dataset.""")
 
     @classmethod

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -46,7 +46,7 @@ class operation(Operation):
     data between Rasters in an Overlay.
     """
 
-    output_type = param.Parameter(None, doc="""
+    output_type = param.Parameter(default=None, doc="""
        The output element type which may be None to disable type
        checking.
 
@@ -78,7 +78,7 @@ class factory(Operation):
     created from overlays of Image elements.
     """
 
-    output_type = param.Parameter(RGB, doc="""
+    output_type = param.Parameter(default=RGB, doc="""
         The output type of the factor operation.
 
         By default, if three overlaid Images elements are supplied,
@@ -203,7 +203,7 @@ class chain(Operation):
     single argument.
     """
 
-    output_type = param.Parameter(Image, doc="""
+    output_type = param.Parameter(default=Image, doc="""
         The output type of the chain operation. Must be supplied if
         the chain is to be used as a channel operation.""")
 

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -49,7 +49,7 @@ class MPLRenderer(Renderer):
 
     backend = param.String('matplotlib', doc="The backend name.")
 
-    dpi=param.Integer(72, doc="""
+    dpi=param.Integer(default=72, doc="""
         The render resolution in dpi (dots per inch)""")
 
     fig = param.ObjectSelector(default='auto',

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -111,14 +111,14 @@ class Renderer(Exporter):
         The full, lowercase name of the rendering backend or third
         part plotting package used e.g. 'matplotlib' or 'cairo'.""")
 
-    dpi = param.Integer(None, doc="""
+    dpi = param.Integer(default=None, doc="""
         The render resolution in dpi (dots per inch)""")
 
     fig = param.ObjectSelector(default='auto', objects=['auto'], doc="""
         Output render format for static figures. If None, no figure
         rendering will occur. """)
 
-    fps = param.Number(20, doc="""
+    fps = param.Number(default=20, doc="""
         Rendered fps (frames per second) for animated formats.""")
 
     holomap = param.ObjectSelector(default='auto',
@@ -132,7 +132,7 @@ class Renderer(Exporter):
         mode a bokeh Document will be returned which can be served as a
         bokeh server app. By default renders all output is rendered to HTML.""")
 
-    size = param.Integer(100, doc="""
+    size = param.Integer(default=100, doc="""
         The rendered size as a percentage size""")
 
     widget_location = param.ObjectSelector(default=None, allow_None=True, objects=[
@@ -148,10 +148,10 @@ class Renderer(Exporter):
     css = param.Dict(default={}, doc="""
         Dictionary of CSS attributes and values to apply to HTML output.""")
 
-    info_fn = param.Callable(None, allow_None=True, constant=True,  doc="""
+    info_fn = param.Callable(default=None, allow_None=True, constant=True,  doc="""
         Renderers do not support the saving of object info metadata""")
 
-    key_fn = param.Callable(None, allow_None=True, constant=True,  doc="""
+    key_fn = param.Callable(default=None, allow_None=True, constant=True,  doc="""
         Renderers do not support the saving of object key metadata""")
 
     post_render_hooks = param.Dict(default={'svg':[], 'png':[]}, doc="""

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -250,7 +250,7 @@ class link_selections(_base_link_selections):
     """
 
     cross_filter_mode = param.Selector(
-        ['overwrite', 'intersect'], default='intersect', doc="""
+        objects=['overwrite', 'intersect'], default='intersect', doc="""
         Determines how to combine selections across different
         elements.""")
 
@@ -268,7 +268,7 @@ class link_selections(_base_link_selections):
         each element.""")
 
     selection_mode = param.Selector(
-        ['overwrite', 'intersect', 'union', 'inverse'], default='overwrite', doc="""
+        objects=['overwrite', 'intersect', 'union', 'inverse'], default='overwrite', doc="""
         Determines how to combine successive selections on the same
         element.""")
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -677,7 +677,7 @@ class Params(Stream):
                                         constant=True, allow_None=True, doc="""
         Parameterized instance to watch for parameter changes.""")
 
-    parameters = param.List([], constant=True, doc="""
+    parameters = param.List(default=[], constant=True, doc="""
         Parameters on the parameterized to watch.""")
 
     def __init__(self, parameterized=None, parameters=None, watch=True, watch_only=False, **params):
@@ -822,7 +822,7 @@ class ParamMethod(Params):
                                         constant=True, allow_None=True, doc="""
         Parameterized instance to watch for parameter changes.""")
 
-    parameters = param.List([], constant=True, doc="""
+    parameters = param.List(default=[], constant=True, doc="""
         Parameters on the parameterized to watch.""")
 
     def __init__(self, parameterized, parameters=None, watch=True, **params):
@@ -1425,9 +1425,9 @@ class PlotSize(LinkedStream):
     Returns the dimensions of a plot once it has been displayed.
     """
 
-    width = param.Integer(None, constant=True, doc="The width of the plot in pixels")
+    width = param.Integer(default=None, constant=True, doc="The width of the plot in pixels")
 
-    height = param.Integer(None, constant=True, doc="The height of the plot in pixels")
+    height = param.Integer(default=None, constant=True, doc="The height of the plot in pixels")
 
     scale = param.Number(default=1.0, constant=True, doc="""
        Scale factor to scale width and height values reported by the stream""")

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -169,7 +169,7 @@ class TestParamsStream(LoggingComparisonTestCase):
 
         class InnerAction(Inner):
 
-            action = param.Action(lambda o: o.param.trigger('action'))
+            action = param.Action(default=lambda o: o.param.trigger('action'))
 
         self.inner = Inner
         self.inner_action = InnerAction
@@ -335,7 +335,7 @@ class TestParamMethodStream(ComparisonTestCase):
 
         class Inner(param.Parameterized):
 
-            action = param.Action(lambda o: o.param.trigger('action'))
+            action = param.Action(default=lambda o: o.param.trigger('action'))
             x = param.Number(default = 0)
             y = param.Number(default = 0)
             count = param.Integer(default=0)


### PR DESCRIPTION
As per the title, to make things consistent and in preparation of an eventual change (later!) in Param.
