### PR TITLE
Don't emit warnings when toolbar is disabled

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -569,7 +569,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
     def _set_active_tools(self, plot):
         "Activates the list of active tools"
-        if plot is None:
+        if plot is None or self.toolbar == "disable":
             return
 
         if self.active_tools is None:


### PR DESCRIPTION
Fixes #5688

If `self.toobar` is disabled do not try to set up active tools. 