### PR TITLE
{H,V}Span hide None values

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -200,6 +200,10 @@ class BoxAnnotationPlot(ElementPlot, AnnotationPlot):
         mapping[kwd_dim2] = locs[1]
         return (data, mapping, style)
 
+    def _update_glyph(self, renderer, properties, mapping, glyph, source, data):
+        glyph.visible = any(v is not None for v in mapping.values())
+        return super()._update_glyph(renderer, properties, mapping, glyph, source, data)
+
     def _init_glyph(self, plot, mapping, properties):
         """
         Returns a Bokeh glyph object.

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -49,6 +49,7 @@ class TestHVSpanPlot(TestBokehPlot):
         self.assertEqual(span.right, 1.5)
         self.assertEqual(span.bottom, None)
         self.assertEqual(span.top, None)
+        self.assertEqual(span.visible, True)
 
     def test_hspan_plot(self):
         hspan = HSpan(1.1, 1.5)
@@ -58,6 +59,13 @@ class TestHVSpanPlot(TestBokehPlot):
         self.assertEqual(span.right, None)
         self.assertEqual(span.bottom, 1.1)
         self.assertEqual(span.top, 1.5)
+        self.assertEqual(span.visible, True)
+
+    def test_hspan_empty(self):
+        vline = HSpan(None)
+        plot = bokeh_renderer.get_plot(vline)
+        span = plot.handles['glyph']
+        self.assertEqual(span.visible, False)
 
     def test_vspan_invert_axes(self):
         vspan = VSpan(1.1, 1.5).opts(invert_axes=True)
@@ -67,6 +75,7 @@ class TestHVSpanPlot(TestBokehPlot):
         self.assertEqual(span.right, None)
         self.assertEqual(span.bottom, 1.1)
         self.assertEqual(span.top, 1.5)
+        self.assertEqual(span.visible, True)
 
     def test_vspan_plot(self):
         vspan = VSpan(1.1, 1.5)
@@ -76,7 +85,13 @@ class TestHVSpanPlot(TestBokehPlot):
         self.assertEqual(span.right, 1.5)
         self.assertEqual(span.bottom, None)
         self.assertEqual(span.top, None)
+        self.assertEqual(span.visible, True)
 
+    def test_vspan_empty(self):
+        vline = VSpan(None)
+        plot = bokeh_renderer.get_plot(vline)
+        span = plot.handles['glyph']
+        self.assertEqual(span.visible, False)
 
 
 class TestSlopePlot(TestBokehPlot):


### PR DESCRIPTION
Bokeh 3's BoxAnnotation will highlight all of the plot if all the inputs are `None`.

This PR will make it so that if no value is given to `HSpan`/`VSpan,` it will not show anything, like how it worked in Bokeh 2. 

 ``` python
import holoviews as hv
import panel as pn

hv.extension("bokeh")

a = hv.VSpan(None)
b = hv.VSpan(0.1, 0.5)
c = hv.VSpan(0.1, None)
d = hv.HSpan(None)
e = hv.HSpan(0.1, 0.5)
f = hv.HSpan(0.1, None)

pn.panel(a + b + c + d + e + f).servable()
```

Before this PR:
![image](https://user-images.githubusercontent.com/19758978/233965693-03d44292-6101-49e8-9abe-24bd9b8e48fd.png)


After this PR:
![image](https://user-images.githubusercontent.com/19758978/233965743-7c1b4625-b1e2-4a86-9235-f7bed2db66df.png)


@jlstevens will you give this a try?