### PR TITLE
Don't try to find closest match if input is empty

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -2204,6 +2204,8 @@ def closest_match(match, specs, depth=0):
     Recursively iterates over type, group, label and overlay key,
     finding the closest matching spec.
     """
+    if len(match) == 0:
+        return None
     new_specs = []
     match_lengths = []
     for i, spec in specs:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -2228,11 +2228,10 @@ def closest_match(match, specs, depth=0):
     elif new_specs:
         depth = depth+1
         return closest_match(match[1:], new_specs, depth)
+    elif depth == 0 or not match_lengths:
+        return None
     else:
-        if depth == 0 or not match_lengths:
-            return None
-        else:
-            return sorted(match_lengths, key=lambda x: -x[1])[0][0]
+        return sorted(match_lengths, key=lambda x: -x[1])[0][0]
 
 
 def cast_array_to_int64(array):


### PR DESCRIPTION
Fixes #5694 

The function is recursive, and if the input arguments are not the same length, it will raise the error described in the issue.

This PR just adds a check to see if the `match` is not empty. There seems to be a problem with the coloring when having 1 vs 2 or 3. I will not fix that in this PR.

<details>

  <summary>Code </summary>

``` python
import holoviews as hv
import numpy as np
import panel as pn

pn.extension()

def sine(ncurves):
    hv_curves = []
    for i in range(ncurves):
        frequency = 2.0
        xs = np.linspace(0.0, 1.0, 500)
        ys = np.sin((i + 1) * frequency * xs) # just a sine wave

        curve = hv.Curve((xs, ys), label="A")
        hv_curves.append(curve)

        ys = 1.1 * np.sin((i + 1) * frequency * xs)  # another, bigger amplitude
        curve = hv.Curve((xs, ys), label="B")
        hv_curves.append(curve)

        ys = 1.2 * np.sin((i + 1) * frequency * xs)  # still another
        curve = hv.Curve((xs, ys), label="C")
        hv_curves.append(curve)

    overlay = hv.Overlay(hv_curves)
    return overlay


ncurves = pn.widgets.IntSlider(name="NCurves", start=1, end=3, value=1).servable()
col = pn.Column(
    ncurves, hv.DynamicMap(pn.bind(sine, ncurves=ncurves)), width=500, height=500
).servable()
```

</details>


https://user-images.githubusercontent.com/19758978/235101316-679508dd-c680-4a75-b942-81a2cdeb5be9.mp4


