### PR TITLE
Don't disable Jedi completion by default

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -99,7 +99,7 @@ class notebook_extension(extension):
         using the matplotlib backend) may be used. This may be useful to
         export figures to other formats such as PDF with nbconvert.""")
 
-    allow_jedi_completion = param.Boolean(default=False, doc="""
+    allow_jedi_completion = param.Boolean(default=True, doc="""
        Whether to allow jedi tab-completion to be enabled in IPython.
        Disabled by default because many HoloViews features rely on
        tab-completion machinery not supported when using jedi.""")

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -235,8 +235,8 @@ class notebook_extension(extension):
 
         unmatched_args = set(args) - set(resources)
         if unmatched_args:
-            display(HTML('<b>Warning:</b> Unrecognized resources %s'
-                         % ', '.join(unmatched_args)))
+            display(HTML("<b>Warning:</b> Unrecognized resources '%s'"
+                         % "', '".join(unmatched_args)))
 
         resources = [r for r in resources if r not in disabled]
         if ('holoviews' not in disabled) and ('holoviews' not in resources):


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/2132#issuecomment-1514804613

This change means we don't inject `ip.run_line_magic('config', 'IPCompleter.use_jedi = False')` into the notebook. 

The original problem described in the issue had already been fixed previously. Though, I added quotations around the unmatched arguments in this PR.

![image](https://user-images.githubusercontent.com/19758978/235104771-92522924-3614-4a16-9d52-23bbeee75c38.png)
