### PR TITLE
Minor changes to prepare for Param 2.0

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -570,7 +570,7 @@ class Renderer(Exporter):
             raise Exception('Renderer does not support saving metadata to file.')
 
         if kwargs:
-            param.main.warning("Supplying plot, style or norm options "
+            param.main.param.warning("Supplying plot, style or norm options "
                                "as keyword arguments to the Renderer.save "
                                "method is deprecated and will error in "
                                "the next minor release.")


### PR DESCRIPTION
This PR updates the calls to Param's main warning as in Param 2 the `warning` method will be removed from the Parameterized namespace and will be made available only in the `.param` namespace.