### PR TITLE
Update to Google Analytics 4

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,8 +47,7 @@ html_theme_options = {
         "copyright",
         "last-updated",
     ],
-    "navbar_end": ["navbar-icon-links"],
-    'google_analytics_id': 'UA-61554933-1',
+    "analytics": {"google_analytics_id": 'G-91EZMMHSF7'}
 }
 
 nbbuild_cell_timeout = 360


### PR DESCRIPTION
Updates tracking ID to the new GA4 since the old Universal Tracking is shutting down and we haven't yet decided to move away from GA.