### PR TITLE
Add workaround for numpy arrays with object dtype

### DIFF
--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -53,7 +53,10 @@ class ComparisonInterface:
         """
         Classmethod equivalent to unittest.TestCase method (longMessage = False.)
         """
-        if not first==second:
+        check = first==second
+        if not isinstance(check, bool) and hasattr(check, "all"):
+            check = check.all()
+        if not check:
             standardMsg = f'{safe_repr(first)} != {safe_repr(second)}'
             raise cls.failureException(msg or standardMsg)
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -50,7 +50,7 @@ from .util import (
     glyph_order, py2js_tickformatter, recursive_model_update,
     theme_attr_json, cds_column_replace, hold_policy, match_dim_specs,
     compute_layout_properties, wrap_formatter, match_ax_type,
-    prop_is_none, remove_legend, property_to_dict
+    prop_is_none, remove_legend, property_to_dict, dtype_fix_hook
 )
 
 if bokeh3:
@@ -1672,6 +1672,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         self._update_glyphs(element, ranges, self.style[self.cyclic_index])
         self._execute_hooks(element)
+
+
+    def _execute_hooks(self, element):
+        dtype_fix_hook(self, element)
+        super()._execute_hooks(element)
 
 
     def model_changed(self, model):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -1042,3 +1042,22 @@ def property_to_dict(x):
         pass
 
     return x
+
+
+def dtype_fix_hook(plot, element):
+    # Work-around for problems seen in:
+    # https://github.com/holoviz/holoviews/issues/5722
+    # https://github.com/holoviz/holoviews/issues/5726
+    # Should be fixed in Bokeh 3.2
+
+    if not bokeh3:
+        return
+    try:
+        renderers = plot.handles["plot"].renderers
+        for renderer in renderers:
+            data = renderer.data_source.data
+            for k, v in data.items():
+                if hasattr(v, "dtype") and v.dtype.kind == "U":
+                    data[k] = v.tolist()
+    except Exception:
+        pass


### PR DESCRIPTION
This adds a workaround for https://github.com/holoviz/holoviews/issues/5722 and https://github.com/holoviz/holoviews/issues/5726 until it is fixed upstream. 