### PR TITLE
Fix bins option in autompg_histogram demo

### DIFF
--- a/examples/gallery/demos/bokeh/autompg_histogram.ipynb
+++ b/examples/gallery/demos/bokeh/autompg_histogram.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hist = autompg_ds.hist(dimension='mpg', groupby='cyl', bin_range=(9, 46), bins=40, adjoin=False)\n",
+    "hist = autompg_ds.hist(dimension='mpg', groupby='cyl', bin_range=(9, 46), num_bins=40, adjoin=False)\n",
     "\n",
     "hist.opts(opts.Histogram(alpha=0.9, width=600))"
    ]


### PR DESCRIPTION
To control the number of bins, the option to use is `num_bins` instead of `bins` as written in the example

Closes https://github.com/holoviz/holoviews/issues/4651