### PR TITLE
Disable pan if active_tools=[]

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -578,6 +578,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             active_tools = self.active_tools
 
+        if active_tools == []:
+            # Removes Bokeh default behavior of having Pan enabled by default
+            plot.toolbar.active_drag = None
+
         for tool in active_tools:
             if isinstance(tool, str):
                 tool_type = TOOL_TYPES.get(tool, type(None))


### PR DESCRIPTION
Fixes #5753

If an empty list is added to `active_tools`, it will actively remove Pan as an active tool. 

![image](https://github.com/holoviz/holoviews/assets/19758978/79cfec9e-991b-4929-96f1-598bbb456fb0)
