### PR TITLE
Fix typo in Getting Started section text

### DIFF
--- a/examples/getting_started/2-Customization.ipynb
+++ b/examples/getting_started/2-Customization.ipynb
@@ -162,7 +162,7 @@
    "source": [
     "# Discovering options\n",
     "\n",
-    "In the above cell, the result of calling `opts.Curve()` is passed into the `.opts` method returning an `Options` object. `opts.Curve()` and the other option builders aren't always needed, but the are very helpful for validating options and offer tab completion to help you discover possible values:"
+    "In the above cell, the result of calling `opts.Curve()` is passed into the `.opts` method returning an `Options` object. `opts.Curve()` and the other option builders aren't always needed, but they are very helpful for validating options and offer tab completion to help you discover possible values:"
    ]
   },
   {


### PR DESCRIPTION
examples/getting_started/2-Customization.ipynb