### PR TITLE
Have min_height set to 300 by default in Bokeh backend

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -120,7 +120,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     min_width = param.Integer(default=None, bounds=(0, None), doc="""
         Minimal width of the component (in pixels) if width is adjustable.""")
 
-    min_height = param.Integer(default=None, bounds=(0, None), doc="""
+    min_height = param.Integer(default=300, bounds=(0, None), doc="""
         Minimal height of the component (in pixels) if height is adjustable.""")
 
     max_width = param.Integer(default=None, bounds=(0, None), doc="""


### PR DESCRIPTION
This is mainly not to collapse the figure when having `responsive=True` in a notebook environment. It will look like this in a notebook:

![image](https://github.com/holoviz/holoviews/assets/19758978/8e7d336c-5a30-4af1-9bf2-ca0478e6d1b7)


Where it before looked like this:
![image](https://github.com/holoviz/holoviews/assets/19758978/256a7713-e793-452f-a96b-099ca730beb0)
