### PR TITLE
Only merge changed instance params with rasterize 

### DIFF
--- a/holoviews/core/data/util.py
+++ b/holoviews/core/data/util.py
@@ -67,17 +67,3 @@ def cached(method):
             args = (cache,)+args[2:]
             return getattr(cache.interface, method.__name__)(*args, **kwargs)
     return cached
-
-
-def compare(value1, value2):
-    """Compare two values, returning a boolean.
-
-    Will apply the comparison to all elements of an array/dataframe.
-    """
-    try:
-        check = value1 == value2
-        if not isinstance(check, bool) and hasattr(check, "all"):
-            check = check.all()
-        return bool(check)
-    except Exception:
-        return False

--- a/holoviews/core/data/util.py
+++ b/holoviews/core/data/util.py
@@ -67,3 +67,17 @@ def cached(method):
             args = (cache,)+args[2:]
             return getattr(cache.interface, method.__name__)(*args, **kwargs)
     return cached
+
+
+def compare(value1, value2):
+    """Compare two values, returning a boolean.
+
+    Will apply the comparison to all elements of an array/dataframe.
+    """
+    try:
+        check = value1 == value2
+        if not isinstance(check, bool) and hasattr(check, "all"):
+            check = check.all()
+        return bool(check)
+    except Exception:
+        return False

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -803,6 +803,20 @@ def isnumeric(val):
         return False
 
 
+def isequal(value1, value2):
+    """Compare two values, returning a boolean.
+
+    Will apply the comparison to all elements of an array/dataframe.
+    """
+    try:
+        check = value1 == value2
+        if not isinstance(check, bool) and hasattr(check, "all"):
+            check = check.all()
+        return bool(check)
+    except Exception:
+        return False
+
+
 def asarray(arraylike, strict=True):
     """
     Converts arraylike objects to NumPy ndarray types. Errors if

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -809,7 +809,7 @@ def isequal(value1, value2):
     Will apply the comparison to all elements of an array/dataframe.
     """
     try:
-        check = value1 == value2
+        check = (value1 is value2) or (value1 == value2)
         if not isinstance(check, bool) and hasattr(check, "all"):
             check = check.all()
         return bool(check)

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -29,10 +29,9 @@ from ..core import (
 from ..core.data import (
     Dataset, PandasInterface, XArrayInterface, DaskInterface, cuDFInterface
 )
-from ..core.data.util import compare
 from ..core.util import (
     cast_array_to_int64, cftime_types, cftime_to_timestamp,
-    datetime_types, dt_to_int, get_param_values
+    datetime_types, dt_to_int, get_param_values, isequal
 )
 from ..element import (Image, Path, Curve, RGB, Graph, TriMesh,
                        QuadMesh, Contours, Spikes, Area, Rectangles,
@@ -1381,7 +1380,7 @@ class rasterize(AggregationOperation):
         all_supplied_kws = set()
         non_default_params = {
             k: v for k, v in self.param.values().items()
-            if not compare(v, self.param[k].default)
+            if not isequal(v, self.param[k].default)
         }
         for predicate, transform in self._transforms:
             merged_param_values = dict(non_default_params, **self.p)

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -29,6 +29,7 @@ from ..core import (
 from ..core.data import (
     Dataset, PandasInterface, XArrayInterface, DaskInterface, cuDFInterface
 )
+from ..core.data.util import compare
 from ..core.util import (
     cast_array_to_int64, cftime_types, cftime_to_timestamp,
     datetime_types, dt_to_int, get_param_values
@@ -1378,8 +1379,12 @@ class rasterize(AggregationOperation):
         # Potentially needs traverse to find element types first?
         all_allowed_kws = set()
         all_supplied_kws = set()
+        non_default_params = {
+            k: v for k, v in self.param.values().items()
+            if not compare(v, self.param[k].default)
+        }
         for predicate, transform in self._transforms:
-            merged_param_values = dict(self.param.values(), **self.p)
+            merged_param_values = dict(non_default_params, **self.p)
 
             # If aggregator or interpolation are 'default', pop parameter so
             # datashader can choose the default aggregator itself

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1150,6 +1150,24 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         expected = Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
         self.assertEqual(regridded, expected)
 
+    def test_rasterize_image_expand_default(self):
+        # Should use expand=False by default
+        assert not regrid.expand
+
+        data = np.arange(100.0).reshape(10, 10)
+        c = np.arange(10.0)
+        da = xr.DataArray(data, coords=dict(x=c, y=c))
+        rast_input = dict(x_range=(-1, 10), y_range=(-1, 10), precompute=True, dynamic=False)
+        img = rasterize(Image(da), **rast_input)
+        output = img.data["z"].to_numpy()
+
+        np.testing.assert_array_equal(output, data.T)
+        assert not np.isnan(output).any()
+
+        # Setting expand=True with the {x,y}_ranges will expand the data with nan's
+        img = rasterize(Image(da), expand=True, **rast_input)
+        output = img.data["z"].to_numpy()
+        assert np.isnan(output).any()
 
 class DatashaderSpreadTests(ComparisonTestCase):
 


### PR DESCRIPTION
Supersedes #5351
Fixes #5358

`rasterize` has `expand=True` as default, whereas  `regrid` has it as `expand=False`. When applying all the parameters from the rasterize class, `regrid` was set to have `expand=True`. 

This change makes it so only non-default values are used. 