### PR TITLE
Bugbear lint

### DIFF
--- a/holoviews/core/boundingregion.py
+++ b/holoviews/core/boundingregion.py
@@ -350,7 +350,9 @@ class BoundingRegionParameter(param.Parameter):
     __slots__ = ['set_hook']
 
 
-    def __init__(self, default=BoundingBox(radius=0.5), **params):
+    def __init__(self, default=None, **params):
+        if default is None:
+            default = BoundingBox(radius=0.5)
         self.set_hook = identity_hook
         super().__init__(default=default, instantiate=True, **params)
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -923,7 +923,7 @@ argument to specify a selection specification""")
             ndims = len(vdims)
             error = self.clone(error, kdims=kdims, new_type=Dataset)
             combined = self.clone(aggregated, kdims=kdims, new_type=Dataset)
-            for i, d in enumerate(vdims):
+            for d in vdims:
                 dim = d.clone(f'{d.name}_{spread_name}')
                 dvals = error.dimension_values(d, flat=False)
                 idx = vdims.index(d)

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -255,7 +255,7 @@ class DaskInterface(PandasInterface):
         mask = None
         for sample in samples:
             if np.isscalar(sample): sample = [sample]
-            for i, (c, v) in enumerate(zip(dims, sample)):
+            for c, v in zip(dims, sample):
                 dim_mask = data[c]==v
                 if mask is None:
                     mask = dim_mask

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -375,7 +375,7 @@ class GridInterface(DictInterface):
         selected = {}
         adjusted_inds = []
         all_scalar = True
-        for i, (kd, ind) in enumerate(zip(dataset.kdims[::-1], indices)):
+        for kd, ind in zip(dataset.kdims[::-1], indices):
             coords = cls.coords(dataset, kd.name, True)
             if np.isscalar(ind):
                 ind = [ind]

--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -266,7 +266,7 @@ class SpatialPandasInterface(MultiInterface):
         if not isinstance(column.dtype, MultiPointDtype) and geom_type != 'Point':
             return cls.base_interface.length(dataset)
         length = 0
-        for i, geom in enumerate(column):
+        for geom in column:
             if isinstance(geom, Point):
                 length += 1
             else:

--- a/holoviews/core/data/util.py
+++ b/holoviews/core/data/util.py
@@ -60,7 +60,7 @@ def cached(method):
     Decorates an Interface method and using a cached version
     """
     def cached(*args, **kwargs):
-        cache = getattr(args[1], '_cached')
+        cache = args[1]._cached
         if cache is None:
             return method(*args, **kwargs)
         else:

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -1365,7 +1365,7 @@ class ViewableTree(AttrTree, Dimensioned):
 
         new_items = []
         counts = defaultdict(lambda: 0)
-        for i, (path, item) in enumerate(items):
+        for path, item in items:
             if counter[path] > 1:
                 path = path + (util.int_to_roman(counts[path]+1),)
             else:

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1516,7 +1516,7 @@ class StoreOptions:
         applied = []
         def propagate(o):
             if o.id == match_id or (o.__class__.__name__ == 'DynamicMap'):
-                setattr(o, 'id', new_id)
+                o.id = new_id
                 applied.append(o)
         obj.traverse(propagate, specs=set(applied_keys) | {'DynamicMap'})
 
@@ -1533,7 +1533,7 @@ class StoreOptions:
         Given an list of ids, capture a list of ids that can be
         restored using the restore_ids.
         """
-        return obj.traverse(lambda o: getattr(o, 'id'))
+        return obj.traverse(lambda o: o.id)
 
     @classmethod
     def restore_ids(cls, obj, ids):

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -400,7 +400,7 @@ class PrettyPrinter(param.Parameterized):
             return level, lines
         # .last has different semantics for GridSpace
         last = list(node.data.values())[-1]
-        if last is not None and getattr(last, '_deep_indexable') and not hasattr(last, 'children'):
+        if last is not None and last._deep_indexable and not hasattr(last, 'children'):
             level, additional_lines = cls_or_slf.ndmapping_info(last, [], level, value_dims)
         else:
             additional_lines = cls_or_slf.recurse(last, level=level, value_dims=value_dims)

--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -74,9 +74,9 @@ def unique_dimkeys(obj, default_dim='Frame'):
 
     ndims = len(all_dims)
     unique_keys = []
-    for group, keys in zip(dim_groups, keys):
+    for group, subkeys in zip(dim_groups, keys):
         dim_idxs = [all_dims.index(dim) for dim in group]
-        for key in keys:
+        for key in subkeys:
             padded_key = create_ndkey(ndims, dim_idxs, key)
             matches = [item for item in unique_keys
                        if padded_key == tuple(k if k is None else i

--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -215,7 +215,7 @@ class AttrTree:
             self._propagate(split_label, '_DELETE')
         else:
             path_item = self
-            for i, identifier in enumerate(split_label[:-1]):
+            for identifier in split_label[:-1]:
                 path_item = path_item[identifier]
             del path_item[split_label[-1]]
 

--- a/holoviews/element/sankey.py
+++ b/holoviews/element/sankey.py
@@ -85,10 +85,10 @@ class _layout_sankey(Operation):
                            for d in element.nodes.vdims))
         else:
             values = cycle([tuple()])
-        for index, vals in zip(element.nodes.dimension_values(index), values):
-            node = {'index': index, 'sourceLinks': [], 'targetLinks': [], 'values': vals}
+        for idx, vals in zip(element.nodes.dimension_values(index), values):
+            node = {'index': idx, 'sourceLinks': [], 'targetLinks': [], 'values': vals}
             graph['nodes'].append(node)
-            node_map[index] = node
+            node_map[idx] = node
 
         links = [element.dimension_values(d) for d in element.dimensions()[:3]]
         for i, (src, tgt, value) in enumerate(zip(*links)):

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -217,7 +217,7 @@ class chain(Operation):
 
     def _process(self, view, key=None):
         processed = view
-        for i, operation in enumerate(self.p.operations):
+        for operation in self.p.operations:
             processed = operation.process_element(
                 processed, key, input_ranges=self.p.input_ranges
             )

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -56,7 +56,7 @@ class TextPlot(ElementPlot, AnnotationPlot):
     def get_batched_data(self, element, ranges=None):
         data = defaultdict(list)
         zorders = self._updated_zorders(element)
-        for (key, el), zorder in zip(element.data.items(), zorders):
+        for (_key, el), zorder in zip(element.data.items(), zorders):
             style = self.lookup_options(element.last, 'style')
             style = style.max_cycles(len(self.ordering))[zorder]
             eldata, elmapping, style = self.get_data(el, ranges, style)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -969,7 +969,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         # Iterate over stacks and groups and accumulate data
         data = defaultdict(list)
         baselines = defaultdict(lambda: {'positive': bottom, 'negative': 0})
-        for i, (k, ds) in enumerate(grouped.items()):
+        for k, ds in grouped.items():
             k = k[0] if isinstance(k, tuple) else k
             if group_dim:
                 gval = k if isinstance(k, str) else group_dim.pprint_value(k)

--- a/holoviews/plotting/bokeh/links.py
+++ b/holoviews/plotting/bokeh/links.py
@@ -165,7 +165,7 @@ class DataLinkCallback(LinkCallback):
         src_len = [len(v) for v in src_cds.data.values()]
         tgt_len = [len(v) for v in tgt_cds.data.values()]
         if src_len and tgt_len and (src_len[0] != tgt_len[0]):
-            raise Exception('DataLink source data length must match target '
+            raise ValueError('DataLink source data length must match target '
                             'data length, found source length of %d and '
                             'target length of %d.' % (src_len[0], tgt_len[0]))
 

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -545,7 +545,7 @@ class ViolinPlot(BoxWhiskerPlot):
         kde_data, line_data, seg_data, bar_data, scatter_data = (
             defaultdict(list) for i in range(5)
         )
-        for i, (key, g) in enumerate(groups.items()):
+        for key, g in groups.items():
             key = decode_bytes(key)
             if element.kdims:
                 key = tuple(d.pprint_value(k) for d, k in zip(element.kdims, key))

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -593,7 +593,7 @@ class ViolinPlot(BoxWhiskerPlot):
             if self.show_legend:
                 kde_map['legend_field'] = repr(split_dim)
 
-        for k, v in list(style.items()):
+        for k in style.copy():
             if k.startswith('violin_line'):
                 style[k.replace('violin', 'outline')] = style.pop(k)
         style['violin_line_width'] = 0

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -566,8 +566,8 @@ def pad_width(model, table_padding=0.85, tabs_padding=1.2):
     elif isinstance(model, Tabs):
         vals = [pad_width(t) for t in model.tabs]
         width = np.max([v for v in vals if v is not None])
-        for model in model.tabs:
-            model.width = width
+        for submodel in model.tabs:
+            submodel.width = width
             width = int(tabs_padding*width)
     elif isinstance(model, DataTable):
         width = model.width
@@ -868,8 +868,8 @@ def attach_periodic(plot):
     Attaches plot refresh to all streams on the object.
     """
     def append_refresh(dmap):
-        for dmap in get_nested_dmaps(dmap):
-            dmap.periodic._periodic_util = periodic(plot.document)
+        for subdmap in get_nested_dmaps(dmap):
+            subdmap.periodic._periodic_util = periodic(plot.document)
     return plot.hmap.traverse(append_refresh, [DynamicMap])
 
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -846,7 +846,7 @@ class ColorbarPlot(ElementPlot):
             self.handles['bbox_extra_artists'] += [cax, ylabel]
             ax_colorbars.append((artist, cax, spec, label))
 
-        for i, (artist, cax, spec, label) in enumerate(ax_colorbars):
+        for i, (_artist, cax, _spec, _label) in enumerate(ax_colorbars):
             scaled_w = w*width
             cax.set_position([l+w+padding+(scaled_w+padding+w*0.15)*i,
                               b, scaled_w, h])

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -1108,8 +1108,8 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
             for cbar_plot in colorbars:
                 if cbar_plot.colorbar:
                     cbar_plot._draw_colorbar(redraw=False)
-            adjoined = self.traverse(specs=[AdjointLayoutPlot])
-            for adjoined in adjoined:
+            adjoineds = self.traverse(specs=[AdjointLayoutPlot])
+            for adjoined in adjoineds:
                 if len(adjoined.subplots) > 1:
                     adjoined.adjust_positions(redraw=False)
         return self._finalize_axis(None)

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -188,9 +188,9 @@ def wrap_formatter(formatter):
 def unpack_adjoints(ratios):
     new_ratios = {}
     offset = 0
-    for k, (num, ratios) in sorted(ratios.items()):
+    for k, (num, ratio_values) in sorted(ratios.items()):
         unpacked = [[] for _ in range(num)]
-        for r in ratios:
+        for r in ratio_values:
             nr = len(r)
             for i in range(num):
                 unpacked[i].append(r[i] if i < nr else np.nan)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -928,7 +928,7 @@ class DimensionedPlot(Plot):
         projections = opts.get(from_overlay, {}).get('projection', [])
         custom_projs = [p for p in projections if p is not None]
         if len(set(custom_projs)) > 1:
-            raise Exception("An axis may only be assigned one projection type")
+            raise ValueError("An axis may only be assigned one projection type")
         return custom_projs[0] if custom_projs else None
 
     def update(self, key):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1719,7 +1719,7 @@ class GenericOverlayPlot(GenericElementPlot):
         """
         length = self.style_grouping
         group_fn = lambda x: (x.type.__name__, x.last.group, x.last.label)
-        for i, (k, obj) in enumerate(items):
+        for k, obj in items:
             vmap = self.hmap.clone([(key, obj)])
             self.map_lengths[group_fn(vmap)[:length]] += 1
             subplot = self._create_subplot(k, vmap, [], ranges)

--- a/holoviews/plotting/plotly/callbacks.py
+++ b/holoviews/plotting/plotly/callbacks.py
@@ -111,7 +111,7 @@ class BoundsCallback(PlotlyCallback):
 
         # Initialize event data by clearing box selection on everything
         event_data = {}
-        for trace_ind, trace in enumerate(traces):
+        for trace in traces:
             trace_uid = trace.get('uid', None)
             if cls.boundsx and cls.boundsy:
                 stream_data = dict(bounds=None)
@@ -133,7 +133,7 @@ class BoundsCallback(PlotlyCallback):
     @classmethod
     def update_event_data_xyaxis(cls, range_data, traces, event_data):
         # Process traces
-        for trace_ind, trace in enumerate(traces):
+        for trace in traces:
             trace_type = trace.get('type', 'scatter')
             trace_uid = trace.get('uid', None)
 
@@ -163,7 +163,7 @@ class BoundsCallback(PlotlyCallback):
     @classmethod
     def update_event_data_mapbox(cls, range_data, traces, event_data):
         # Process traces
-        for trace_ind, trace in enumerate(traces):
+        for trace in traces:
             trace_type = trace.get('type', 'scatter')
             trace_uid = trace.get('uid', None)
 
@@ -223,7 +223,7 @@ class RangeCallback(PlotlyCallback):
     def build_event_data_from_viewport(cls, traces, property_value):
         # Process traces
         event_data = {}
-        for trace_ind, trace in enumerate(traces):
+        for trace in traces:
             trace_type = trace.get('type', 'scatter')
             trace_uid = trace.get('uid', None)
 
@@ -262,7 +262,7 @@ class RangeCallback(PlotlyCallback):
     def build_event_data_from_relayout_data(cls, traces, property_value):
         # Process traces
         event_data = {}
-        for trace_ind, trace in enumerate(traces):
+        for trace in traces:
             trace_type = trace.get('type', 'scattermapbox')
             trace_uid = trace.get('uid', None)
 

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -533,7 +533,7 @@ def to_dash(
                 any_change = True
 
         # Update store_data with interactive stream values
-        for fig_ind, fig_dict in enumerate(initial_fig_dicts):
+        for fig_ind, _fig_dict in enumerate(initial_fig_dicts):
             graph_id = graph_ids[fig_ind]
             # plotly_stream_types
             for plotly_stream_type, uid_to_streams_for_type in uid_to_stream_ids.items():

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -533,7 +533,7 @@ def to_dash(
                 any_change = True
 
         # Update store_data with interactive stream values
-        for fig_ind, _fig_dict in enumerate(initial_fig_dicts):
+        for fig_ind in range(len(initial_fig_dicts)):
             graph_id = graph_ids[fig_ind]
             # plotly_stream_types
             for plotly_stream_type, uid_to_streams_for_type in uid_to_stream_ids.items():

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -310,7 +310,7 @@ class GridPlot(PlotlyPlot, GenericCompositePlot):
         frame_ranges = OrderedDict([(key, self.compute_ranges(layout, key, frame_ranges))
                                     for key in self.keys])
         collapsed_layout = layout.clone(shared_data=False, id=layout.id)
-        for i, coord in enumerate(layout.keys(full_grid=True)):
+        for coord in layout.keys(full_grid=True):
             if not isinstance(coord, tuple): coord = (coord,)
             view = layout.data.get(coord, None)
             # Create subplot

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -236,7 +236,7 @@ def split_dmap_overlay(obj, depth=0):
             layers.append(obj)
         return layers
     if isinstance(obj, Overlay):
-        for k, v in obj.items():
+        for _k, v in obj.items():
             layers.append(v)
     else:
         layers.append(obj)

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -662,7 +662,7 @@ class ColorListSelectionDisplay(SelectionDisplay):
 
             color_inds = np.zeros(n, dtype='int8')
 
-            for i, expr, color in zip(range(1, len(clrs)), selection_exprs, selected_colors):
+            for i, expr in zip(range(1, len(clrs)), selection_exprs):
                 if not expr:
                     color_inds[:] = i
                 else:

--- a/holoviews/tests/core/data/test_gridinterface.py
+++ b/holoviews/tests/core/data/test_gridinterface.py
@@ -7,6 +7,7 @@ from unittest import SkipTest
 import numpy as np
 import pandas as pd
 from holoviews.core.data import Dataset
+from holoviews.core.data.interface import DataError
 from holoviews.core.util import date_range
 from holoviews.element import Image, Curve, RGB, HSV
 from holoviews.util.transform import dim
@@ -31,12 +32,12 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
     __test__ = False
 
     def test_dataset_dataframe_init_hm(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(DataError):
             Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
                     kdims=['x'], vdims=['x2'])
 
     def test_dataset_dataframe_init_hm_alias(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(DataError):
             Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
                     kdims=['x'], vdims=['x2'])
 

--- a/holoviews/tests/core/test_dynamic.py
+++ b/holoviews/tests/core/test_dynamic.py
@@ -800,14 +800,12 @@ class DynamicCallableMemoize(ComparisonTestCase):
         # Add stream subscriber mocking plot
         x.add_subscriber(lambda **kwargs: dmap[()])
 
-        for i in range(2):
-            x.event(x=1)
-
+        x.event(x=1)
+        x.event(x=1)
         self.assertEqual(dmap[()], Curve([1]))
 
-        for i in range(2):
-            x.event(x=2)
-
+        x.event(x=2)
+        x.event(x=2)
         self.assertEqual(dmap[()], Curve([1, 2]))
 
 
@@ -825,12 +823,12 @@ class DynamicCallableMemoize(ComparisonTestCase):
         # Add stream subscriber mocking plot
         x.add_subscriber(lambda **kwargs: dmap[()])
 
-        for i in range(2):
-            x.event(x=1)
+        x.event(x=1)
+        x.event(x=1)
         self.assertEqual(dmap[()], Curve([1, 1, 1]))
 
-        for i in range(2):
-            x.event(x=2)
+        x.event(x=2)
+        x.event(x=2)
         self.assertEqual(dmap[()], Curve([1, 1, 1, 2, 2, 2]))
 
 
@@ -891,13 +889,12 @@ class DynamicStreamReset(ComparisonTestCase):
         # Add stream subscriber mocking plot
         x.add_subscriber(lambda **kwargs: dmap[()])
 
-        for i in range(2):
-            x.event(x=1)
+        x.event(x=1)
+        x.event(x=1)
         self.assertEqual(dmap[()], Curve([1, 1]))
 
-        for i in range(2):
-            x.event(x=2)
-
+        x.event(x=2)
+        x.event(x=2)
         self.assertEqual(dmap[()], Curve([1, 1, 2, 2]))
 
     def test_dynamic_stream_transients(self):
@@ -952,13 +949,12 @@ class DynamicStreamReset(ComparisonTestCase):
         # Add stream subscriber mocking plot
         x.add_subscriber(lambda **kwargs: dmap[()])
 
-        for i in range(2):
-            x.event(x=1)
+        x.event(x=1)
+        x.event(x=1)
         self.assertEqual(dmap[()], Curve([1, 1, 1]))
 
-        for i in range(2):
-            x.event(x=2)
-
+        x.event(x=2)
+        x.event(x=2)
         self.assertEqual(dmap[()], Curve([1, 1, 1, 2, 2, 2]))
 
 

--- a/holoviews/tests/plotting/bokeh/test_curveplot.py
+++ b/holoviews/tests/plotting/bokeh/test_curveplot.py
@@ -2,9 +2,10 @@ import datetime as dt
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from holoviews.core import NdOverlay, HoloMap, DynamicMap
-from holoviews.core.options import Cycle, Palette
+from holoviews.core.options import Cycle, Palette, AbbreviatedException
 from holoviews.element import Curve
 from holoviews.plotting.util import rgb2hex
 from holoviews.streams import PointerX
@@ -356,19 +357,22 @@ class TestCurvePlot(TestBokehPlot):
     def test_curve_color_op(self):
         curve = Curve([(0, 0, 'red'), (0, 1, 'blue'), (0, 2, 'red')],
                        vdims=['y', 'color']).opts(color='color')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "color" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             bokeh_renderer.get_plot(curve)
 
     def test_curve_alpha_op(self):
         curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
                        vdims=['y', 'alpha']).opts(alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             bokeh_renderer.get_plot(curve)
 
     def test_curve_line_width_op(self):
         curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
                        vdims=['y', 'linewidth']).opts(line_width='linewidth')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "line_width" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             bokeh_renderer.get_plot(curve)
 
     def test_curve_style_mapping_ndoverlay_dimensions(self):

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -4,6 +4,7 @@ from unittest import SkipTest
 from collections import OrderedDict
 
 import numpy as np
+import pytest
 
 from holoviews.core import Dimension, DynamicMap, NdOverlay, HoloMap
 from holoviews.core.util import dt_to_int
@@ -887,7 +888,8 @@ class TestOverlayPlot(TestBokehPlot):
 
     def test_overlay_projection_clashing(self):
         overlay = Curve([]).opts(projection='polar') * Curve([]).opts(projection='custom')
-        with self.assertRaises(Exception):
+        msg = "An axis may only be assigned one projection type"
+        with pytest.raises(ValueError, match=msg):
             bokeh_renderer.get_plot(overlay)
 
     def test_overlay_projection_propagates(self):

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from holoviews.core.spaces import DynamicMap
 from holoviews.element import Curve, Polygons, Table, Scatter, Path, Points
@@ -96,7 +97,8 @@ class TestLinkCallbacks(TestBokehPlot):
         table = Table([('A', 1), ('B', 2)], 'A', 'B')
         DataLink(polys, table)
         layout = polys + table
-        with self.assertRaises(Exception):
+        msg = "DataLink source data length must match target"
+        with pytest.raises(ValueError, match=msg):
             bokeh_renderer.get_plot(layout)
 
     def test_data_link_list(self):

--- a/holoviews/tests/plotting/matplotlib/test_curveplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_curveplot.py
@@ -2,10 +2,12 @@ import datetime as dt
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from holoviews.core.overlay import NdOverlay
 from holoviews.element import Curve
 from holoviews.util.transform import dim
+from holoviews.core.options import AbbreviatedException
 
 from .test_plot import TestMPLPlot, mpl_renderer
 
@@ -167,19 +169,22 @@ class TestCurvePlot(TestMPLPlot):
     def test_curve_color_op(self):
         curve = Curve([(0, 0, 'red'), (0, 1, 'blue'), (0, 2, 'red')],
                        vdims=['y', 'color']).opts(color='color')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "color" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(curve)
 
     def test_curve_alpha_op(self):
         curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
                        vdims=['y', 'alpha']).opts(alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(curve)
 
     def test_curve_linewidth_op(self):
         curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
                        vdims=['y', 'linewidth']).opts(linewidth='linewidth')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "linewidth" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(curve)
 
     def test_curve_style_mapping_ndoverlay_dimensions(self):

--- a/holoviews/tests/plotting/matplotlib/test_errorbarplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_errorbarplot.py
@@ -1,7 +1,9 @@
 import numpy as np
+import pytest
 
 from holoviews.core.spaces import HoloMap
 from holoviews.element import ErrorBars
+from holoviews.core.options import AbbreviatedException
 
 from .test_plot import TestMPLPlot, mpl_renderer
 
@@ -39,13 +41,15 @@ class TestErrorBarPlot(TestMPLPlot):
     def test_errorbars_linear_color_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 1), (0, 2, 0.6, 1.2, 2)],
                               vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a continuous or categorical dimension to a color'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(errorbars)
 
     def test_errorbars_categorical_color_op(self):
         errorbars = ErrorBars([(0, 0, 0.1, 0.2, 'A'), (0, 1, 0.2, 0.4, 'B'), (0, 2, 0.6, 1.2, 'C')],
                               vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a continuous or categorical dimension to a color'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(errorbars)
 
     def test_errorbars_line_color_op(self):
@@ -60,7 +64,8 @@ class TestErrorBarPlot(TestMPLPlot):
     def test_errorbars_alpha_op(self):
         errorbars = ErrorBars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(errorbars)
 
     def test_errorbars_line_width_op(self):

--- a/holoviews/tests/plotting/matplotlib/test_graphplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_graphplot.py
@@ -1,10 +1,12 @@
 import numpy as np
+import pytest
 
 from holoviews.core.data import Dataset
 from holoviews.core.options import Cycle
 from holoviews.core.spaces import HoloMap
 from holoviews.element import Graph, Nodes, TriMesh, Chord, circular_layout
 from holoviews.util.transform import dim
+from holoviews.core.options import AbbreviatedException
 from matplotlib.collections import LineCollection, PolyCollection
 from packaging.version import Version
 
@@ -272,7 +274,8 @@ class TestMplGraphPlot(TestMPLPlot):
     def test_graph_op_edge_alpha(self):
         edges = [(0, 1, 0.1), (0, 2, 0.5), (1, 3, 0.3)]
         graph = Graph(edges, vdims='alpha').opts(edge_alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "edge_alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(graph)
 
     def test_graph_op_edge_linewidth(self):
@@ -452,7 +455,8 @@ class TestMplTriMeshPlot(TestMPLPlot):
         edges = [(0, 1, 2, 0.7), (1, 2, 3, 0.3)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
         trimesh = TriMesh((edges, nodes), vdims='alpha').opts(edge_alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "edge_alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(trimesh)
 
     def test_trimesh_op_edge_line_width(self):

--- a/holoviews/tests/plotting/matplotlib/test_histogramplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_histogramplot.py
@@ -1,11 +1,13 @@
 import datetime as dt
 
 import numpy as np
+import pytest
 
 from holoviews.core.overlay import NdOverlay
 from holoviews.element import Dataset, Histogram
 from holoviews.operation import histogram
 from holoviews.plotting.util import hex2rgb
+from holoviews.core.options import AbbreviatedException
 
 from ...utils import LoggingComparisonTestCase
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -116,13 +118,15 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
     def test_histogram_linear_color_op(self):
         histogram = Histogram([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                               vdims=['y', 'color']).opts(color='color')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a continuous dimension to a color'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(histogram)
 
     def test_histogram_categorical_color_op(self):
         histogram = Histogram([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
                               vdims=['y', 'color']).opts(color='color')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a continuous dimension to a color'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(histogram)
 
     def test_histogram_line_color_op(self):
@@ -138,7 +142,8 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
     def test_histogram_alpha_op(self):
         histogram = Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(histogram)
 
     def test_histogram_line_width_op(self):

--- a/holoviews/tests/plotting/matplotlib/test_pathplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pathplot.py
@@ -1,8 +1,10 @@
 import numpy as np
+import pytest
 
 from holoviews.core import NdOverlay
 from holoviews.core.spaces import HoloMap
 from holoviews.element import Polygons, Contours, Path
+from holoviews.core.options import AbbreviatedException
 
 from .test_plot import TestMPLPlot, mpl_renderer
 
@@ -29,7 +31,8 @@ class TestPathPlot(TestMPLPlot):
         alpha = [0.1, 0.7, 0.3, 0.2]
         data = {'x': xs, 'y': ys, 'alpha': alpha}
         path = Path([data], vdims='alpha').opts(alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(path)
 
     def test_path_continuously_varying_line_width_op(self):
@@ -182,7 +185,8 @@ class TestPolygonPlot(TestMPLPlot):
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'alpha': 0.7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'alpha': 0.3}
         ], vdims='alpha').opts(alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(polygons)
 
     def test_polygons_line_width_op(self):
@@ -283,7 +287,8 @@ class TestContoursPlot(TestMPLPlot):
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'alpha': 0.7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'alpha': 0.3}
         ], vdims='alpha').opts(alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(contours)
 
     def test_contours_line_width_op(self):

--- a/holoviews/tests/plotting/matplotlib/test_pointplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pointplot.py
@@ -1,8 +1,10 @@
 import numpy as np
+import pytest
 
 from holoviews.core.overlay import NdOverlay
 from holoviews.core.spaces import HoloMap
 from holoviews.element import Points
+from holoviews.core.options import AbbreviatedException
 
 from .test_plot import TestMPLPlot, mpl_renderer
 from ..utils import ParamLogStream
@@ -293,13 +295,15 @@ class TestPointPlot(TestMPLPlot):
     def test_point_marker_op(self):
         points = Points([(0, 0, 'circle'), (0, 1, 'triangle'), (0, 2, 'square')],
                         vdims='marker').opts(marker='marker')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "marker" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(points)
 
     def test_point_alpha_op(self):
         points = Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                         vdims='alpha').opts(alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(points)
 
     def test_op_ndoverlay_value(self):

--- a/holoviews/tests/plotting/matplotlib/test_spikeplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_spikeplot.py
@@ -1,8 +1,10 @@
 import numpy as np
+import pytest
 
 from holoviews.core.overlay import NdOverlay
 from holoviews.core.spaces import HoloMap
 from holoviews.element import Spikes
+from holoviews.core.options import AbbreviatedException
 
 from ..utils import ParamLogStream
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -152,7 +154,8 @@ class TestSpikesPlot(TestMPLPlot):
     def test_spikes_alpha_op(self):
         spikes = Spikes([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(spikes)
 
     def test_spikes_line_width_op(self):

--- a/holoviews/tests/plotting/matplotlib/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_vectorfieldplot.py
@@ -1,7 +1,9 @@
 import numpy as np
+import pytest
 
 from holoviews.core.spaces import HoloMap
 from holoviews.element import VectorField
+from holoviews.core.options import AbbreviatedException
 
 from .test_plot import TestMPLPlot, mpl_renderer
 from ..utils import ParamLogStream
@@ -69,7 +71,8 @@ class TestVectorFieldPlot(TestMPLPlot):
     def test_vectorfield_alpha_op(self):
         vectorfield = VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 0.2), (0, 2, 0, 1, 0.7)],
                                   vdims=['A', 'M', 'alpha']).opts(alpha='alpha')
-        with self.assertRaises(Exception):
+        msg = 'ValueError: Mapping a dimension to the "alpha" style'
+        with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(vectorfield)
 
     def test_vectorfield_line_width_op(self):

--- a/holoviews/tests/plotting/plotly/test_callbacks.py
+++ b/holoviews/tests/plotting/plotly/test_callbacks.py
@@ -628,9 +628,9 @@ class TestCallbacks(TestCase):
         )
 
         # Check that all streams attached to the 'forth' plot were triggered
-        for stream, events in zip(streamss[3], sel_events[3]):
+        for stream, _events in zip(streamss[3], sel_events[3]):
             assert stream.index == [0, 2]
 
         # Check that streams attached to plots not in this figure are not called
-        for stream, events in zip(streamss[4], sel_events[4]):
+        for _stream, events in zip(streamss[4], sel_events[4]):
             assert len(events) == 0

--- a/holoviews/tests/plotting/plotly/test_callbacks.py
+++ b/holoviews/tests/plotting/plotly/test_callbacks.py
@@ -335,7 +335,7 @@ class TestCallbacks(TestCase):
                 xyevents[4], xevents[4], yevents[4]
         ):
             assert len(xyevent) == 0
-            assert len(yevent) == 0
+            assert len(xevent) == 0
             assert len(yevent) == 0
 
     def testBoundsXYCallbackEventData(self):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -238,8 +238,8 @@ class opts(param.ParameterizedFunction, metaclass=OptsMeta):
         if kwargs:
             options = cls._group_kwargs_to_options(obj, kwargs)
 
-        for backend, backend_opts in cls._grouped_backends(options, backend):
-            obj = cls._apply_groups_to_backend(obj, backend_opts, backend, clone)
+        for backend_loop, backend_opts in cls._grouped_backends(options, backend):
+            obj = cls._apply_groups_to_backend(obj, backend_opts, backend_loop, clone)
         return obj
 
     @classmethod
@@ -343,13 +343,13 @@ class opts(param.ParameterizedFunction, metaclass=OptsMeta):
         if isinstance(options, list):
             options = merge_options_to_dict(options)
 
-        for objspec, options in options.items():
+        for objspec, option_values in options.items():
             objtype = objspec.split('.')[0]
             if objtype not in backend_options:
                 raise ValueError(f'{objtype} type not found, could not apply options.')
             obj_options = backend_options[objtype]
             expanded[objspec] = {g: {} for g in obj_options.groups}
-            for opt, value in options.items():
+            for opt, value in option_values.items():
                 for g, group_opts in sorted(obj_options.groups.items()):
                     if opt in group_opts.allowed_keywords:
                         expanded[objspec][g][opt] = value

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -390,7 +390,7 @@ class opts(param.ParameterizedFunction, metaclass=OptsMeta):
             lb_options = Store.options(backend=lb).get(objtype)
             if lb_options is None:
                 continue
-            for g, group_opts in lb_options.groups.items():
+            for _g, group_opts in lb_options.groups.items():
                 if opt in group_opts.allowed_keywords:
                     found.append(lb)
         if found:
@@ -668,7 +668,7 @@ class extension(_pyviz_extension):
         util.config.param.update(**config)
         imports = [(arg, self._backends[arg]) for arg in args
                    if arg in self._backends]
-        for p, val in sorted(params.items()):
+        for p, _val in sorted(params.items()):
             if p in self._backends:
                 imports.append((p, self._backends[p]))
         if not imports:


### PR DESCRIPTION
Updates to codebase with Bugbear running: `ruff holoviews --select=B --ignore=B006,B904,B015,B018`. 

For now, I have not enabled it by default. 

Running the command will still give the following errors:
``` console
❯ ruff holoviews --select=B --ignore=B006,B904,B015,B018 
holoviews/plotting/util.py:226:17: B007 Loop control variable `v` not used within loop body
holoviews/plotting/util.py:233:21: B007 Loop control variable `v` not used within loop body
holoviews/tests/plotting/matplotlib/test_graphplot.py:209:13: B017 `assertRaises(Exception)` should be considered evil
holoviews/tests/plotting/matplotlib/test_graphplot.py:403:13: B017 `assertRaises(Exception)` should be considered evil
holoviews/util/command.py:60:25: B008 Do not perform function call `OptsMagicProcessor` in argument defaults
holoviews/util/command.py:61:25: B008 Do not perform function call `OutputMagicProcessor` in argument defaults
holoviews/util/command.py:62:25: B008 Do not perform function call `StripMagicsProcessor` in argument defaults
Found 7 errors.
```