### PR TITLE
Handle nodata option for rasterized RGB image

### DIFF
--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -179,15 +179,16 @@ class RGBPlot(LegendPlot):
         img = np.dstack([element.dimension_values(d, flat=False)
                          for d in element.vdims])
 
-        # Converting any nan to 0
         nan_mask = np.isnan(img)
         img[nan_mask] = 0
 
         if img.ndim == 3:
+            img_max = img.max()
             # Can be 0 to 255 if nodata has been used
-            if img.dtype.kind == 'f' and img.max() <= 1:
+            if img.dtype.kind == 'f' and img_max <= 1:
                 img = img*255
-            if img.size and (img.min() < 0 or img.max() > 255):
+                # img_max * 255 <- have no effect
+            if img.size and (img.min() < 0 or img_max > 255):
                 self.param.warning('Clipping input data to the valid '
                                    'range for RGB data ([0..1] for '
                                    'floats or [0..255] for integers).')

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -183,7 +183,7 @@ class RGBPlot(LegendPlot):
         img[nan_mask] = 0
 
         if img.ndim == 3:
-            img_max = img.max()
+            img_max = img.max() if img.size else np.nan
             # Can be 0 to 255 if nodata has been used
             if img.dtype.kind == 'f' and img_max <= 1:
                 img = img*255

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -178,8 +178,14 @@ class RGBPlot(LegendPlot):
 
         img = np.dstack([element.dimension_values(d, flat=False)
                          for d in element.vdims])
+
+        # Converting any nan to 0
+        nan_mask = np.isnan(img)
+        img[nan_mask] = 0
+
         if img.ndim == 3:
-            if img.dtype.kind == 'f':
+            # Can be 0 to 255 if nodata has been used
+            if img.dtype.kind == 'f' and img.max() <= 1:
                 img = img*255
             if img.size and (img.min() < 0 or img.max() > 255):
                 self.param.warning('Clipping input data to the valid '
@@ -197,6 +203,8 @@ class RGBPlot(LegendPlot):
             if not img.flags['C_CONTIGUOUS']:
                 img = img.copy()
             img = img.view(dtype=np.uint32).reshape((N, M))
+
+        img[nan_mask.any(-1)] = 0
 
         # Ensure axis inversions are handled correctly
         l, b, r, t = element.bounds.lbrt()

--- a/holoviews/tests/element/test_raster.py
+++ b/holoviews/tests/element/test_raster.py
@@ -55,6 +55,19 @@ class TestRGB(ComparisonTestCase):
             assert i is not c
             assert i == c
 
+    def test_nodata(self):
+        N = 2
+        rgb_d = np.linspace(0, 1, N * N * 3).reshape(N, N, 3)
+        rgb = RGB(rgb_d)
+        assert sum(np.isnan(rgb["R"])) == 0
+        assert sum(np.isnan(rgb["G"])) == 0
+        assert sum(np.isnan(rgb["B"])) == 0
+
+        rgb_n = rgb.redim.nodata(R=0)
+        assert sum(np.isnan(rgb_n["R"])) == 1
+        assert sum(np.isnan(rgb_n["G"])) == 0
+        assert sum(np.isnan(rgb_n["B"])) == 0
+
 class TestHSV(ComparisonTestCase):
 
     def setUp(self):

--- a/holoviews/tests/plotting/bokeh/test_rasterplot.py
+++ b/holoviews/tests/plotting/bokeh/test_rasterplot.py
@@ -42,6 +42,15 @@ class TestRasterPlot(TestBokehPlot):
         self.assertEqual(source.data['image'][0],
                          np.array([[2, np.NaN], [np.NaN, 1]]))
 
+    def test_nodata_rgb(self):
+        N = 2
+        rgb_d = np.linspace(0, 1, N * N * 3).reshape(N, N, 3)
+        rgb = RGB(rgb_d).redim.nodata(R=0)
+        plot = bokeh_renderer.get_plot(rgb)
+        image_data = plot.handles["source"].data["image"][0]
+        # Image sets nan-values to 0
+        assert (image_data == 0).sum() == 1
+
     def test_raster_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4,  5]])
         raster = Raster(arr).opts(invert_axes=True)


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/1091

This will make it possible to do the following:
``` python
import hvplot.xarray  # noqa
import xarray as xr
import rioxarray as rxr

rgb_data = xr.load_dataarray("/home/shh/Downloads/sentinel2_seattle.nc")
rgb_data = xr.load_dataarray("https://github.com/ivandorte/datasets_samples/raw/main/sentinel2_seattle.nc")
rgb_plot = rgb_data.hvplot.rgb(x="x", y="y", bands="band", rasterize=True, tiles="OSM")
rgb_plot + rgb_plot.redim.nodata(R=0)

cog_url = "/home/shh/Downloads/5d7dad0becaf880008a9bc89.tif"
cog_url = "https://oin-hotosm.s3.amazonaws.com/5d7dad0becaf880008a9bc88/0/5d7dad0becaf880008a9bc89.tif"
da = rxr.open_rasterio(cog_url)
plot = da.hvplot.rgb(x="x", y="y", rasterize=True, tiles=True)
plot + plot.redim.nodata(R=0)
```

![image](https://github.com/holoviz/holoviews/assets/19758978/fe2cb0b5-a412-4d93-8bad-32c7d4ab19be)

Todo: 
- [x] Add test
- [ ] Maybe automatically detect `nodata` in xarray DataArray/Dataset (this could be done in `hvplot`)
