### PR TITLE
Fix default vdims in raster.RGB (round two)

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from operator import itemgetter
 
 import numpy as np
@@ -610,8 +611,8 @@ class RGB(Image):
             arrays = [(im.data - r[0]) / (r[1] - r[0]) for r,im in zip(ranges, images)]
             data = np.dstack(arrays)
         if vdims is None:
-            # Same as the class variables, put here to secure the class variable is not used
-            vdims = [Dimension(c, range=(0,1)) for c in "RGB"]
+            # Need to make a deepcopy of the value so the RGB.default is not shared across instances
+            vdims = deepcopy(self.vdims)
         else:
             vdims = list(vdims) if isinstance(vdims, list) else [vdims]
 

--- a/holoviews/tests/element/test_raster.py
+++ b/holoviews/tests/element/test_raster.py
@@ -3,7 +3,7 @@ Unit tests of Raster elements
 """
 
 import numpy as np
-from holoviews.element import Raster, Image, Curve, QuadMesh, RGB
+from holoviews.element import Raster, Image, Curve, QuadMesh, RGB, HSV
 from holoviews.element.comparison import ComparisonTestCase
 
 class TestRaster(ComparisonTestCase):
@@ -53,6 +53,19 @@ class TestRGB(ComparisonTestCase):
         cls_vdims = RGB.vdims
         for i, c in zip(init_vdims, cls_vdims):
             assert i is not c
+            assert i == c
+
+class TestHSV(ComparisonTestCase):
+
+    def setUp(self):
+        self.hsv_array = np.random.randint(0, 255, (3, 3, 4))
+
+    def test_not_using_class_variables_vdims(self):
+            init_vdims = HSV(self.hsv_array).vdims
+            cls_vdims = HSV.vdims
+            for i, c in zip(init_vdims, cls_vdims):
+                assert i is not c
+                assert i == c
 
 class TestQuadMesh(ComparisonTestCase):
 


### PR DESCRIPTION
Follow up to #5773

This is how RGB worked before:

``` python
import param

class Dim: pass

class RGB(param.Parameterized):
    value = param.List(default=[Dim(), Dim()])

    def __init__(self, value=None, **params):
        if value is None:
            value = list(self.value)

        super().__init__(value=value, **params)
```

So if `Example()` was run, `value` would use a copy of the `self.value` with the default values in it.  So running something like this would only change the id of the list, but not of the values inside of the list:

![image](https://github.com/holoviz/holoviews/assets/19758978/868f12c2-8a9d-4e45-abde-11587d2114f2)

By changing  `value = list(self.value)` to `value = copy.deepcopy(self.value)`, we get the expected behavior, a unique ID for everything. 

![image](https://github.com/holoviz/holoviews/assets/19758978/7ace42a3-99b6-4a68-9369-e26934c808fe)

And if we set `value = self.value`, we also get the same identity for the list, which is something we really do not want.
![image](https://github.com/holoviz/holoviews/assets/19758978/afb2f326-527d-49d3-8ee3-595fa7fd3cb3)

Because we are setting the value directly before calling `super()`, we are bypassing Param's mechanism for deep copying the default values. 