### PR TITLE
Deprecate functionality

### DIFF
--- a/holoviews/core/boundingregion.py
+++ b/holoviews/core/boundingregion.py
@@ -10,6 +10,7 @@ File originally part of the Topographica project.
 import param
 from param.parameterized import get_occupied_slots
 from .util import datetime_types
+from ..util.warnings import deprecated
 
 
 class BoundingRegion:
@@ -351,6 +352,7 @@ class BoundingRegionParameter(param.Parameter):
 
 
     def __init__(self, default=None, **params):
+        deprecated("1.18", "BoundingRegionParameter")
         if default is None:
             default = BoundingBox(radius=0.5)
         self.set_hook = identity_hook

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -44,7 +44,7 @@ from .resample import LinkableOperation, ResampleOperation2D
 def __getattr__(name):
     if name == "ResamplingOperation":
         from ..util.warnings import deprecated
-        deprecated("1.17", "ResamplingOperation", "ResampleOperation2D")
+        deprecated("1.18", "ResamplingOperation", "ResampleOperation2D")
         return ResampleOperation2D
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -36,6 +36,7 @@ from ...core.util import (
 )
 from ...core.spaces import get_nested_dmaps, DynamicMap
 from ..util import dim_axis_label
+from ...util.warnings import deprecated
 
 bokeh_version = Version(bokeh.__version__)
 bokeh3 = bokeh_version >= Version("3.0")
@@ -620,6 +621,7 @@ def py2js_tickformatter(formatter, msg=''):
     """
     Uses py2js to compile a python tick formatter to JS code
     """
+    deprecated("1.18", "py2js_tickformatter")
     try:
         from pscript import py2js
     except ImportError:


### PR DESCRIPTION
This PR deprecated two items: 
- `BoundingRegionParameter` as discussed [here](https://github.com/holoviz/holoviews/pull/5768#discussion_r1233685836)
- py2js support as`py2js_tickformatter` (which we are not even testing right now)
   - #5327 
   - #5517

I also bumped ResamplingOperation to 1.18. 
