### PR TITLE
Pie lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,8 @@ repos:
       - id: end-of-file-fixer
         exclude: \.min\.js$
       - id: trailing-whitespace
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.272
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.276
     hooks:
       - id: ruff
         args: [holoviews]
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: clean-notebook
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.2.5
     hooks:
     - id: codespell
       additional_dependencies:

--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -246,7 +246,7 @@ class AttrTree:
             pass
 
         # Attributes starting with __ get name mangled
-        if identifier.startswith('_' + type(self).__name__) or identifier.startswith('__'):
+        if identifier.startswith(('_' + type(self).__name__, '__')):
             raise AttributeError(f'Attribute {identifier} not found.')
         elif self.fixed==True:
             raise AttributeError(self._fixed_error % identifier)

--- a/holoviews/element/tiles.py
+++ b/holoviews/element/tiles.py
@@ -19,7 +19,7 @@ class Tiles(Element2D):
 
       * Bounding box tile sources containing {XMIN}, {XMAX}, {YMIN}, {YMAX} variables
 
-      * Quadkey tile sources containin a {Q} variable
+      * Quadkey tile sources containing a {Q} variable
 
     Tiles are defined in a pseudo-Mercator projection (EPSG:3857)
     defined as eastings and northings. Any data overlaid on a tile

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -779,7 +779,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             return
         replace = ['bounds', 'bands', 'visible', 'level', 'ticker', 'visible']
         style_items = list(self.gridstyle.items())
-        both = {k: v for k, v in style_items if k.startswith('grid_') or k.startswith('minor_grid')}
+        both = {k: v for k, v in style_items if k.startswith(('grid_', 'minor_grid'))}
         xgrid = {k.replace('xgrid', 'grid'): v for k, v in style_items if 'xgrid' in k}
         ygrid = {k.replace('ygrid', 'grid'): v for k, v in style_items if 'ygrid' in k}
         xopts = {k.replace('grid_', '') if any(r in k for r in replace) else k: v

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1883,9 +1883,6 @@ class ColorbarPlot(ElementPlot):
         True, uses 2nd and 98th percentile; otherwise uses the specified
         numerical percentile value.""")
 
-    cformatter = param.ClassSelector(
-        default=None, class_=(str, TickFormatter, FunctionType), doc="""
-        Formatter for ticks along the colorbar axis.""")
 
     cnorm = param.ObjectSelector(default='linear', objects=['linear', 'log', 'eq_hist'], doc="""
         Color normalization to be applied during colormapping.""")

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -845,12 +845,17 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
 
     _nonvectorized_styles = ['visible']
 
-    legend_specs = dict(LegendPlot.legend_specs, **{
-        'top':    dict(bbox_to_anchor=(0., 1.02, 1., .102),
-                       ncol=3, loc=3, mode="expand", borderaxespad=0.),
-        'bottom': dict(ncol=3, mode="expand", loc=2,
-                       bbox_to_anchor=(0., -0.4, 1., .102),
-                       borderaxespad=0.1)})
+    legend_specs = dict(
+        LegendPlot.legend_specs,
+        top=dict(
+            bbox_to_anchor=(0., 1.02, 1., .102),
+            ncol=3, loc=3, mode="expand", borderaxespad=0.
+        ),
+        bottom=dict(
+            bbox_to_anchor=(0., -0.4, 1., .102),
+            ncol=3, loc=2, mode="expand", borderaxespad=0.1
+        )
+    )
 
     def _get_values(self, element, ranges):
         """

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -245,7 +245,6 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         Allows extending the _finalize_axis method with Element
         specific options.
         """
-        pass
 
     def _set_labels(self, axes, dimensions, xlabel=None, ylabel=None, zlabel=None):
         """

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -428,7 +428,6 @@ class DimensionedPlot(Plot):
         Required on each MPLPlot type to get the data corresponding
         just to the current frame out from the object.
         """
-        pass
 
     def matches(self, spec):
         """

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -198,7 +198,6 @@ class BarPlot(BarsMixin, ElementPlot):
     show_legend = param.Boolean(default=True, doc="""
         Whether to show legend for the plot.""")
 
-    stacked = param.Boolean(default=False)
 
     style_opts = ['visible']
 

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -47,7 +47,7 @@ def get_layout_ranges(plot):
     layout_ranges = {}
     fig_dict = plot.state
     for k in fig_dict['layout']:
-        if k.startswith('xaxis') or k.startswith('yaxis'):
+        if k.startswith(("xaxis", "yaxis")):
             if "range" in fig_dict['layout'][k]:
                 layout_ranges[k] = {"range": fig_dict['layout'][k]["range"]}
 
@@ -87,7 +87,7 @@ def plot_to_figure(
     # Remove range specification so plotly.js autorange + uirevision is in control
     if layout_ranges and use_ranges:
         for k in fig_dict['layout']:
-            if k.startswith('xaxis') or k.startswith('yaxis'):
+            if k.startswith(("xaxis", "yaxis")):
                 fig_dict['layout'][k].pop('range', None)
             if k.startswith('mapbox'):
                 fig_dict['layout'][k].pop('zoom', None)

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -59,9 +59,6 @@ class LayoutPlot(PlotlyPlot, GenericLayoutPlot):
     adjoint_spacing = param.Number(default=20, bounds=(0, None))
 
     shared_axes = param.Boolean(default=True, doc="""
-            Whether axes should be shared across plots""")
-
-    shared_axes = param.Boolean(default=True, doc="""
         Whether axes ranges should be shared across the layout, if
         disabled switches axiswise normalization option on globally.""")
 

--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -150,7 +150,7 @@ class PlotlyRenderer(Renderer):
         options = plot.lookup_options(obj, 'plot').options
         width = options.get('width', plot.width) * factor
         height = options.get('height', plot.height) * factor
-        return dict(options, **{'width':int(width), 'height': int(height)})
+        return dict(options, width=int(width), height=int(height))
 
 
     @classmethod

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -24,7 +24,7 @@ from .core.ndmapping import UniformNdMapping
 # Types supported by Pointer derived streams
 pointer_types = (Number, str, tuple)+util.datetime_types
 
-class _SkipTrigger(): pass
+class _SkipTrigger: pass
 
 
 @contextmanager

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -513,7 +513,7 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         redim_df = pd.DataFrame({'X': range(10), 'y': range(0,20,2)})
         dataset_redim = Dataset(redim_df, kdims=['X'], vdims=['y'])
         self.assertEqual(dataset.redim(**{'X-label':'X'}), dataset_redim)
-        self.assertEqual(dataset.redim(**{'x':'X'}), dataset_redim)
+        self.assertEqual(dataset.redim(x='X'), dataset_redim)
 
     def test_dataset_mixed_type_range(self):
         ds = Dataset((['A', 'B', 'C', None],), 'A')

--- a/holoviews/tests/core/data/test_xarrayinterface.py
+++ b/holoviews/tests/core/data/test_xarrayinterface.py
@@ -44,8 +44,10 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
             attrs={'transform': (3, 0, 2, 0, -2, -2)})
         xs, ys = (np.tile(x[:, np.newaxis], len(y)).T,
                   np.tile(y[:, np.newaxis], len(x)))
-        return da.assign_coords(**{'xc': xr.DataArray(xs, dims=('y','x')),
-                                   'yc': xr.DataArray(ys, dims=('y','x')),})
+        return da.assign_coords(
+            xc=xr.DataArray(xs, dims=('y','x')),
+            yc=xr.DataArray(ys, dims=('y','x')),
+        )
 
     def get_multi_dim_irregular_dataset(self):
         temp = 15 + 8 * np.random.randn(2, 2, 4, 3)

--- a/holoviews/tests/util/test_transform.py
+++ b/holoviews/tests/util/test_transform.py
@@ -540,7 +540,7 @@ def test_dataset_transform_by_spatial_select_expr_index_not_0_based():
     )
     spatial_expr = hv.dim('a', hv.element.selection.spatial_select, hv.dim('b'), geometry=geometry)
     dataset = hv.Dataset(df)
-    df_out = dataset.transform(**{'flag': spatial_expr}).dframe()
+    df_out = dataset.transform(flag=spatial_expr).dframe()
     expected_series = pd.Series(
         {
             101: False,

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -25,7 +25,6 @@ class KeywordSettings:
         Allows updating options depending on class attributes
         and unvalidated options.
         """
-        pass
 
     @classmethod
     def get_options(cls, items, options, warnfn):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ ignore = [
     "PLR2004",  # Magic value used in comparison
     "PLW2901",  # `for` loop variable is overwritten
     "RUF005",   # Consider {expr} instead of concatenation
+    "RUF012",   # Mutable class attributes should use `typing.ClassVar`
 ]
 
 fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ select = [
     "FLY",
     "ICN",
     "NPY",
+    "PIE",
     "PLC",
     "PLE",
     "PLR",


### PR DESCRIPTION
This enables the Flake8-PIE rule: https://beta.ruff.rs/docs/rules/#flake8-pie-pie

The main motivation is to have [duplicate-class-field-definition](https://beta.ruff.rs/docs/rules/duplicate-class-field-definition/) enabled, as this could lead to potential headaches in the future. 