### PR TITLE
Add an extra try when resolving attributes lookup

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -15,7 +15,7 @@ from panel.io.state import state
 
 from ...core.options import CallbackError
 from ...core.util import (
-    datetime_types, dimension_sanitizer, dt64_to_dt
+    datetime_types, dimension_sanitizer, dt64_to_dt, isequal
 )
 from ...element import Table
 from ...streams import (
@@ -348,10 +348,7 @@ class Callback:
         if self.skip_change(msg):
             equal = True
         else:
-            try:
-                equal = msg == self._prev_msg
-            except Exception:
-                equal = False
+            equal = isequal(msg, self._prev_msg)
 
         if not equal or any(s.transient for s in self.streams):
             self.on_msg(msg)

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -337,13 +337,13 @@ class Callback:
             else:
                 obj_handle = attr_path[0]
             cb_obj = self.plot_handles.get(obj_handle)
-            for _ in range(5):
-                try:
-                    # To give BokehJS a chance to update the model
-                    # https://github.com/holoviz/holoviews/issues/5746
-                    msg[attr] = self.resolve_attr_spec(path, cb_obj)
-                except Exception:
-                    await asyncio.sleep(0.01)
+            try:
+                msg[attr] = self.resolve_attr_spec(path, cb_obj)
+            except Exception:
+                # To give BokehJS a chance to update the model
+                # https://github.com/holoviz/holoviews/issues/5746
+                await asyncio.sleep(0.05)
+                msg[attr] = self.resolve_attr_spec(path, cb_obj)
 
         if self.skip_change(msg):
             equal = True

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -234,7 +234,7 @@ class Callback:
         be the same as the model.
         """
         if not cb_obj:
-            raise Exception(f'Bokeh plot attribute {spec} could not be found')
+            raise AttributeError(f'Bokeh plot attribute {spec} could not be found')
         if model is None:
             model = cb_obj
         spec = spec.split('.')

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -339,7 +339,7 @@ class Callback:
             cb_obj = self.plot_handles.get(obj_handle)
             for _ in range(5):
                 try:
-                    # To give BokehJS a change to update the model
+                    # To give BokehJS a chance to update the model
                     # https://github.com/holoviz/holoviews/issues/5746
                     msg[attr] = self.resolve_attr_spec(path, cb_obj)
                 except Exception:

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -337,7 +337,13 @@ class Callback:
             else:
                 obj_handle = attr_path[0]
             cb_obj = self.plot_handles.get(obj_handle)
-            msg[attr] = self.resolve_attr_spec(path, cb_obj)
+            for _ in range(5):
+                try:
+                    # To give BokehJS a change to update the model
+                    # https://github.com/holoviz/holoviews/issues/5746
+                    msg[attr] = self.resolve_attr_spec(path, cb_obj)
+                except Exception:
+                    await asyncio.sleep(0.01)
 
         if self.skip_change(msg):
             equal = True


### PR DESCRIPTION
Fixes #5746

Giving 5 times to try to resolve the attribute with a delay of 0.01 seconds.

`asyncio.sleep(0.01)` is already used once before in the method, and 5 is an arbitrary choice that worked on my computer.

I also made minor changes by using `isequal` for comparison and setting an `Exception` to `AttributeError`, which are not related to the original issues.