### PR TITLE
Revert "Have min_height set to 300 by default in Bokeh backend"

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -120,7 +120,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     min_width = param.Integer(default=None, bounds=(0, None), doc="""
         Minimal width of the component (in pixels) if width is adjustable.""")
 
-    min_height = param.Integer(default=300, bounds=(0, None), doc="""
+    min_height = param.Integer(default=None, bounds=(0, None), doc="""
         Minimal height of the component (in pixels) if height is adjustable.""")
 
     max_width = param.Integer(default=None, bounds=(0, None), doc="""


### PR DESCRIPTION
Reverts holoviz/holoviews#5762

This does not behave correctly with GridMatrix as seen in https://github.com/holoviz/holoviews/issues/5784#issuecomment-1604616264