### PR TITLE
Remove deprecated np.product

### DIFF
--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -230,7 +230,7 @@ class GridInterface(DictInterface):
         if gridded:
             return shape
         else:
-            return (np.product(shape, dtype=np.intp), len(dataset.dimensions()))
+            return (np.prod(shape, dtype=np.intp), len(dataset.dimensions()))
 
 
     @classmethod

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -91,7 +91,7 @@ class ImageInterface(GridInterface):
 
     @classmethod
     def length(cls, dataset):
-        return np.product(dataset.data.shape[:2], dtype=np.intp)
+        return np.prod(dataset.data.shape[:2], dtype=np.intp)
 
 
     @classmethod

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -65,7 +65,7 @@ class XArrayInterface(GridInterface):
         else:
             array = dataset.data[dataset.vdims[0].name]
         if not gridded:
-            return (np.product(array.shape, dtype=np.intp), len(dataset.dimensions()))
+            return (np.prod(array.shape, dtype=np.intp), len(dataset.dimensions()))
         shape_map = dict(zip(array.dims, array.shape))
         return tuple(shape_map.get(kd.name, np.nan) for kd in dataset.kdims[::-1])
 
@@ -626,7 +626,7 @@ class XArrayInterface(GridInterface):
 
     @classmethod
     def length(cls, dataset):
-        return np.product([len(dataset.data[d.name]) for d in dataset.kdims], dtype=np.intp)
+        return np.prod([len(dataset.data[d.name]) for d in dataset.kdims], dtype=np.intp)
 
     @classmethod
     def dframe(cls, dataset, dimensions):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1931,13 +1931,13 @@ def cross_index(values, index):
     the cross product of the values at the supplied index.
     """
     lengths = [len(v) for v in values]
-    length = np.product(lengths)
+    length = np.prod(lengths)
     if index >= length:
         raise IndexError('Index %d out of bounds for cross-product of size %d'
                          % (index, length))
     indexes = []
     for i in range(1, len(values))[::-1]:
-        p = np.product(lengths[-i:])
+        p = np.prod(lengths[-i:])
         indexes.append(index//p)
         index -= indexes[-1] * p
     indexes.append(index)

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -192,7 +192,7 @@ class Raster(Element2D):
         return int(round(coord[1])), int(round(coord[0]))
 
     def __len__(self):
-        return np.product(self._zdata.shape)
+        return np.prod(self._zdata.shape)
 
 
 
@@ -755,7 +755,7 @@ class QuadMesh(Selection2DExpr, Dataset, Element2D):
         # Generate triangle simplexes
         shape = self.dimension_values(2, flat=False).shape
         s0 = shape[0]
-        t1 = np.arange(np.product(shape))
+        t1 = np.arange(np.prod(shape))
         js = (t1//s0)
         t1s = js*(s0+1)+t1%s0
         t2s = t1s+1

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -170,7 +170,7 @@ class categorical_aggregate2d(Operation):
         vdims = obj.dimensions()[2:]
         xdim, ydim = dim_labels[:2]
         shape = (len(ycoords), len(xcoords))
-        nsamples = np.product(shape)
+        nsamples = np.prod(shape)
         grid_data = {xdim: xcoords, ydim: ycoords}
 
         ys, xs = cartesian_product([ycoords, xcoords], copy=True)

--- a/holoviews/util/_versions.py
+++ b/holoviews/util/_versions.py
@@ -26,7 +26,7 @@ PACKAGES = [
     "geoviews",
     "hvplot",
     "matplotlib",
-    "pillow",
+    "PIL",
     "plotly",
     # Jupyter
     "IPython",
@@ -44,7 +44,7 @@ def show_versions():
     print(f"Operating system    :  {platform.platform()}")
     _package_version("holoviews")
     print()
-    for p in sorted(PACKAGES):
+    for p in sorted(PACKAGES, key=lambda x: x.lower()):
         _package_version(p)
 
 


### PR DESCRIPTION
Removes warning seen in numpy 1.25:

```
❯ python -Wdefault -c "import numpy as np; np.product([1])"
sys:1: DeprecationWarning: `product` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `prod` instead.
``` 

Also fixes a small bug in  `show_versions()`