### PR TITLE
Enable changing dtypes for decimate

### DIFF
--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -354,9 +354,9 @@ class Interface(param.Parameterized):
             if isinstance(sel, slice):
                 with warnings.catch_warnings():
                     warnings.filterwarnings('ignore', r'invalid value encountered')
-                    if sel.start is not None:
+                    if sel.start is not None and sel.start is not np.nan:
                         mask &= sel.start <= arr
-                    if sel.stop is not None:
+                    if sel.stop is not None and sel.stop is not np.nan:
                         mask &= arr < sel.stop
             elif isinstance(sel, (set, list)):
                 iter_slcs = []

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -899,8 +899,8 @@ class decimate(Operation):
         if element.interface not in column_interfaces:
             element = element.clone(tuple(element.columns().values()))
 
-        xstart, xend = self.p.x_range if self.p.x_range else element.range(0)
-        ystart, yend = self.p.y_range if self.p.y_range else element.range(1)
+        xstart, xend = element.range(0)
+        ystart, yend = element.range(1)
 
         # Slice element to current ranges
         xdim, ydim = element.dimensions(label=True)[0:2]


### PR DESCRIPTION
This fixes the issues uncovered in #5789 : Select_mask & decimate fail when dtype changes from numeric to date time. Note that without the workaround in #5789, the two bugs are first hidden by the issue in #5405..

This PR:
- updates the element interface mask to allow for ```np.nan```
  - The mask initialization fails to catch changing dtype (e.g., np.nans from datetime objects). "None" types will not account for these
- changes the decimate xy lims to current element ranges
  - For decimate, the plot range updates slower than the element range (e.g., whenever the x, y dtypes change from a dynamic map). The element range reflect the current ranges in the new dtype, whereas the self.p.range reflects the previous dtype


