### PR TITLE
Update FileArchive repr for Param 2.0

### DIFF
--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -844,7 +844,7 @@ class FileArchive(Archive):
         return len(self._files)
 
     def __repr__(self):
-        return self.pprint()
+        return self.param.pprint()
 
     def contents(self, maxlen=70):
         "Print the current (unexported) contents of the archive"


### PR DESCRIPTION
Seen with @jlstevens when reviewing https://github.com/holoviz/param/pull/767, there was a remaining call to `Parameterized.pprint` that is going to be removed in Param 2.0. It's replaced by `Parameterized.param.pprint` that has been available since Param 1.12.0, 1.12.0 being the minimum version required by HoloViews currently so there's no need for any compatibility code.