### PR TITLE
Update Image/RGB invert_{x,y}axis to work with Bokeh 3

### DIFF
--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -12,7 +12,7 @@ from .chart import PointPlot
 from .element import ColorbarPlot, LegendPlot
 from .selection import BokehOverlaySelectionDisplay
 from .styles import base_properties, fill_properties, line_properties, mpl_to_bokeh
-from .util import colormesh
+from .util import bokeh3, colormesh
 
 
 class RasterPlot(ColorbarPlot):
@@ -102,9 +102,9 @@ class RasterPlot(ColorbarPlot):
                 l, b, r, t = b, l, t, r
 
         dh, dw = t-b, r-l
-        if self.invert_xaxis:
+        if self.invert_xaxis and not bokeh3:
             l, r = r, l
-        if self.invert_yaxis:
+        if self.invert_yaxis and not bokeh3:
             b, t = t, b
         data = dict(x=[l], y=[b], dw=[dw], dh=[dh])
 
@@ -119,9 +119,9 @@ class RasterPlot(ColorbarPlot):
             if ((self.invert_axes and type(element) is not Raster) or
                 (not self.invert_axes and type(element) is Raster)):
                 img = img.T
-            if self.invert_xaxis:
+            if self.invert_xaxis and not bokeh3:
                 img = img[:, ::-1]
-            if self.invert_yaxis:
+            if self.invert_yaxis and not bokeh3:
                 img = img[::-1]
             key = 'image' if i == 2 else dimension_sanitizer(vdim.name)
             data[key] = [img]
@@ -205,10 +205,10 @@ class RGBPlot(LegendPlot):
             l, b, r, t = b, l, t, r
 
         dh, dw = t-b, r-l
-        if self.invert_xaxis:
+        if self.invert_xaxis and not bokeh3:
             l, r = r, l
             img = img[:, ::-1]
-        if self.invert_yaxis:
+        if self.invert_yaxis and not bokeh3:
             img = img[::-1]
             b, t = t, b
 

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -116,8 +116,7 @@ class RasterPlot(ColorbarPlot):
                 img = img.astype(np.int8)
             if 0 in img.shape:
                 img = np.array([[np.NaN]])
-            if ((self.invert_axes and type(element) is not Raster) or
-                (not self.invert_axes and type(element) is Raster)):
+            if self.invert_axes ^ (type(element) is Raster):
                 img = img.T
             if self.invert_xaxis and not bokeh3:
                 img = img[:, ::-1]

--- a/holoviews/tests/plotting/bokeh/test_rasterplot.py
+++ b/holoviews/tests/plotting/bokeh/test_rasterplot.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from holoviews.element import Raster, Image, RGB
+from holoviews.plotting.bokeh.util import bokeh3
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
@@ -46,11 +47,19 @@ class TestRasterPlot(TestBokehPlot):
         raster = Raster(arr).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(raster)
         source = plot.handles['source']
-        self.assertEqual(source.data['image'][0], np.rot90(arr))
-        self.assertEqual(source.data['x'][0], 0)
-        self.assertEqual(source.data['y'][0], 3)
-        self.assertEqual(source.data['dw'][0], 2)
-        self.assertEqual(source.data['dh'][0], 3)
+
+        if bokeh3:
+            self.assertEqual(source.data['image'][0], arr.T)
+            self.assertEqual(source.data['x'][0], 0)
+            self.assertEqual(source.data['y'][0], 0)
+            self.assertEqual(source.data['dw'][0], 2)
+            self.assertEqual(source.data['dh'][0], 3)
+        else:
+            self.assertEqual(source.data['image'][0], np.rot90(arr))
+            self.assertEqual(source.data['x'][0], 0)
+            self.assertEqual(source.data['y'][0], 3)
+            self.assertEqual(source.data['dw'][0], 2)
+            self.assertEqual(source.data['dh'][0], 3)
 
     def test_image_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4,  5]])
@@ -71,11 +80,16 @@ class TestRasterPlot(TestBokehPlot):
         self.assertEqual(x_range.start, 0.5)
         self.assertEqual(x_range.end, -0.5)
         cdata = plot.handles['source'].data
-        self.assertEqual(cdata['x'], [0.5])
         self.assertEqual(cdata['y'], [-0.5])
         self.assertEqual(cdata['dh'], [1.0])
         self.assertEqual(cdata['dw'], [1.0])
-        self.assertEqual(cdata['image'][0], arr[::-1, ::-1])
+
+        if bokeh3:
+            self.assertEqual(cdata['x'], [-0.5])
+            self.assertEqual(cdata['image'][0], arr[::-1])
+        else:
+            self.assertEqual(cdata['x'], [0.5])
+            self.assertEqual(cdata['image'][0], arr[::-1, ::-1])
 
     def test_image_invert_yaxis(self):
         arr = np.random.rand(10, 10)
@@ -86,10 +100,15 @@ class TestRasterPlot(TestBokehPlot):
         self.assertEqual(y_range.end, -0.5)
         cdata = plot.handles['source'].data
         self.assertEqual(cdata['x'], [-0.5])
-        self.assertEqual(cdata['y'], [0.5])
         self.assertEqual(cdata['dh'], [1.0])
         self.assertEqual(cdata['dw'], [1.0])
-        self.assertEqual(cdata['image'][0], arr)
+
+        if bokeh3:
+            self.assertEqual(cdata['y'], [-0.5])
+            self.assertEqual(cdata['image'][0], arr[::-1])
+        else:
+            self.assertEqual(cdata['y'], [0.5])
+            self.assertEqual(cdata['image'][0], arr)
 
     def test_rgb_invert_xaxis(self):
         rgb = RGB(np.random.rand(10, 10, 3)).opts(invert_xaxis=True)
@@ -98,10 +117,14 @@ class TestRasterPlot(TestBokehPlot):
         self.assertEqual(x_range.start, 0.5)
         self.assertEqual(x_range.end, -0.5)
         cdata = plot.handles['source'].data
-        self.assertEqual(cdata['x'], [0.5])
         self.assertEqual(cdata['y'], [-0.5])
         self.assertEqual(cdata['dh'], [1.0])
         self.assertEqual(cdata['dw'], [1.0])
+
+        if bokeh3:
+            self.assertEqual(cdata['x'], [-0.5])
+        else:
+            self.assertEqual(cdata['x'], [0.5])
 
     def test_rgb_invert_yaxis(self):
         rgb = RGB(np.random.rand(10, 10, 3)).opts(invert_yaxis=True)
@@ -111,6 +134,10 @@ class TestRasterPlot(TestBokehPlot):
         self.assertEqual(y_range.end, -0.5)
         cdata = plot.handles['source'].data
         self.assertEqual(cdata['x'], [-0.5])
-        self.assertEqual(cdata['y'], [0.5])
         self.assertEqual(cdata['dh'], [1.0])
         self.assertEqual(cdata['dw'], [1.0])
+
+        if bokeh3:
+            self.assertEqual(cdata['y'], [-0.5])
+        else:
+            self.assertEqual(cdata['y'], [0.5])


### PR DESCRIPTION
Fixes #5727
Fixes #5795

There seems to have been a change in  Bokeh 3 and how it handles the inverted axis for images. The main takeaway is that our calculations to invert are no longer necessary. 

Below is example with `this branch + Bokeh 2` vs. `this branch + Bokeh 3` vs. `HoloViews 1.16.2 + Bokeh 3`.  Note that Raster does the opposite of what `invert_yaxis` does:
https://github.com/holoviz/holoviews/blob/53111a9f4a75f338067138da1b49789779e02c4a/holoviews/plotting/bokeh/raster.py#L82-L83

Results with `invert_yaxis=True`
![ Screenshot 2023-07-06 14 37 35](https://github.com/holoviz/holoviews/assets/19758978/b3ab312d-538b-4903-b3c3-a84f8e633551)

Results with `invert_yaxis=True`
![ Screenshot 2023-07-06 14 38 07](https://github.com/holoviz/holoviews/assets/19758978/bfca5e3e-fd0c-4f9b-8088-0f79ba21a665)

Code:

``` python
import bokeh
import holoviews as hv
import numpy as np
import panel as pn

hv.extension("bokeh")

invert_yaxis = False

N = 20
vector = np.arange(N).astype(dtype=np.uint32)
img_d = np.outer(vector, vector)
img = hv.Image((vector, vector, img_d)).opts(title="Image", invert_yaxis=invert_yaxis)
rgb_d = np.linspace(0, 1, N * N * 3).reshape(N, N, 3)
rgb = hv.RGB((vector, vector, rgb_d)).opts(title="RGB", invert_yaxis=invert_yaxis)
raster = hv.Raster(img_d.copy()).opts(title="Raster", invert_yaxis=invert_yaxis)

pn.Column(
    f"Bokeh: {bokeh.__version__}<br>HoloViews: {hv.__version__}<br>{invert_yaxis = }",
    (img + rgb + raster).opts(shared_axes=False).cols(1),
).servable()
```