### PR TITLE
Allow vectorfield from U/V

### DIFF
--- a/holoviews/element/geom.py
+++ b/holoviews/element/geom.py
@@ -52,6 +52,35 @@ class VectorField(Selection2DExpr, Geometry):
     vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
                                 Dimension('Magnitude')], bounds=(1, None))
 
+    @classmethod
+    def from_uv(cls, data, kdims=None, vdims=None, **params):
+        if isinstance(data, tuple):
+            xs, ys, us, vs = data
+        else:
+            us = data[vdims[0]]
+            vs = data[vdims[1]]
+
+        uv_magnitudes = np.hypot(us, vs)  # unscaled
+        radians = np.pi / 2 - np.arctan2(us, vs)
+
+        if isinstance(data, tuple):
+            reorganized_data = (xs, ys, radians, uv_magnitudes)
+        else:
+            # calculations on this data could mutate the original data
+            # here we do not do any calculations; we only store the data
+            reorganized_data = {}
+            for kdim in kdims:
+                reorganized_data[kdim] = data[kdim]
+            reorganized_data["Angle"] = radians
+            reorganized_data["Magnitude"] = uv_magnitudes
+            for vdim in vdims[2:]:
+                reorganized_data[vdim] = data[vdim]
+            vdims = [
+                Dimension('Angle', cyclic=True, range=(0, 2 * np.pi)),
+                Dimension('Magnitude')
+            ] + vdims[2:]
+        return cls(reorganized_data, kdims=kdims, vdims=vdims, **params)
+
 
 class Segments(SelectionGeomExpr, Geometry):
     """

--- a/holoviews/tests/element/test_elementconstructors.py
+++ b/holoviews/tests/element/test_elementconstructors.py
@@ -1,5 +1,6 @@
 import param
 import numpy as np
+import pandas as pd
 
 from holoviews import (
     Dimension, Dataset, Element, Annotation, Curve, Path, Histogram,
@@ -152,6 +153,48 @@ class ElementSignatureTest(ComparisonTestCase):
         vectorfield = VectorField([], ['a', 'b'], ['c', 'd'])
         self.assertEqual(vectorfield.kdims, [Dimension('a'), Dimension('b')])
         self.assertEqual(vectorfield.vdims, [Dimension('c'), Dimension('d')])
+
+    def test_vectorfield_from_uv(self):
+        x = np.linspace(-1, 1, 4)
+        X, Y = np.meshgrid(x, x)
+        U, V = 5 * X, 5 * Y
+        vectorfield = VectorField.from_uv((X, Y, U, V))
+
+        angle = np.pi / 2 - np.arctan2(U, V)
+        mag = np.hypot(U, V)
+        kdims = [Dimension('x'), Dimension('y')]
+        vdims = [
+            Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
+            Dimension('Magnitude')
+        ]
+        self.assertEqual(vectorfield.kdims, kdims)
+        self.assertEqual(vectorfield.vdims, vdims)
+        self.assertEqual(vectorfield.dimension_values(2, flat=False), angle)
+        self.assertEqual(vectorfield.dimension_values(3, flat=False), mag)
+
+    def test_vectorfield_from_uv_dataframe(self):
+        x = np.linspace(-1, 1, 4)
+        X, Y = np.meshgrid(x, x)
+        U, V = 5 * X, 5 * Y
+        df = pd.DataFrame({
+            "x": X.flatten(),
+            "y": Y.flatten(),
+            "u": U.flatten(),
+            "v": V.flatten(),
+        })
+        vectorfield = VectorField.from_uv(df, ["x", "y"], ["u", "v"])
+
+        angle = np.pi / 2 - np.arctan2(U, V)
+        mag = np.hypot(U, V)
+        kdims = [Dimension('x'), Dimension('y')]
+        vdims = [
+            Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
+            Dimension('Magnitude')
+        ]
+        self.assertEqual(vectorfield.kdims, kdims)
+        self.assertEqual(vectorfield.vdims, vdims)
+        self.assertEqual(vectorfield.dimension_values(2, flat=False), angle.flat)
+        self.assertEqual(vectorfield.dimension_values(3, flat=False), mag.flat)
 
     def test_path_string_signature(self):
         path = Path([], ['a', 'b'])


### PR DESCRIPTION
Closes https://github.com/holoviz/holoviews/issues/3486

<img width="284" alt="image" src="https://github.com/holoviz/holoviews/assets/15331990/426b02f6-73c5-4aa3-91a1-bd4aa59ce141">

```python
import pandas as pd
import numpy as np
import holoviews as hv
hv.extension("bokeh")

x = np.linspace(-1, 1, 4)
X, Y = np.meshgrid(x, x)
U, V = 5 * X, 5 * Y

df = pd.DataFrame({
    "x": X.flatten(),
    "y": Y.flatten(),
    "u": U.flatten(),
    "v": V.flatten(),
})
angle = np.pi / 2 - np.arctan2(U, V)
mag = np.hypot(U, V)

hv.VectorField.from_uv(df, ["x", "y"], ["u", "v"])
```