### PR TITLE
add sep keyword to pd.read_csv in documentation page

### DIFF
--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -655,7 +655,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "macro_df = pd.read_csv('http://assets.holoviews.org/macro.csv', '\\t')"
+    "macro_df = pd.read_csv('http://assets.holoviews.org/macro.csv', sep='\\t')"
    ]
   },
   {


### PR DESCRIPTION
In this [documentation page](https://holoviews.org/user_guide/Plotting_with_Bokeh.html#selection-tool-with-shared-axes-and-linked-brushing)   the dataframe **macro_df** was not loaded because of an error in the pd.read_csv function, in the latest pandas version there is only one positional argument in that function. This is the fix:
Before:
```macro_df = pd.read_csv('http://assets.holoviews.org/macro.csv', '\t')```
Now:
```macro_df = pd.read_csv('http://assets.holoviews.org/macro.csv', sep='\t')```
