### PR TITLE
Add `__init__` to hv.Output to not overwrite ParameterizedFunction signature

### DIFF
--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -573,6 +573,10 @@ class output(param.ParameterizedFunction):
     the cell magic respectively.
     """
 
+    def __init__(self, *args, **kwargs):
+        # To not overwrite param.ParameterizedFunction signature below
+        super().__init__(*args, **kwargs)
+
     @classmethod
     def info(cls):
         deprecate = ['filename', 'info', 'mode']


### PR DESCRIPTION
Follow up to the problem seen in https://github.com/holoviz/param/issues/785

Right below this class we do `output.__init__.__signature__ = Store.output_settings._generate_signature()`, which, before the PR overwrote `param.ParameterizedFunction` signature. 