### PR TITLE
Add args for initial ranges to RangeToolLink

### DIFF
--- a/examples/gallery/demos/bokeh/timeseries_range_tool.ipynb
+++ b/examples/gallery/demos/bokeh/timeseries_range_tool.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tgt = aapl_curve.relabel('AAPL close price').opts(width=800, labelled=['y'], toolbar='disable')\n",
+    "tgt = aapl_curve.relabel('AAPL close price').opts(width=800, height=300, labelled=['y'], toolbar='disable')\n",
     "src = aapl_curve.opts(width=800, height=100, yaxis=None, default_tools=[])\n",
     "\n",
     "RangeToolLink(src, tgt)\n",
@@ -71,14 +71,63 @@
     "layout = (tgt + src).cols(1)\n",
     "layout.opts(opts.Layout(shared_axes=False, merge_tools=False))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Specify range"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the `axes_start` and `axes_end` parameters to specify the initial range of the ``RangeTool``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tgt = aapl_curve.relabel('AAPL close price').opts(width=800, height=300, labelled=['y'], toolbar='disable')\n",
+    "src = aapl_curve.opts(width=800, height=100, yaxis=None, default_tools=[])\n",
+    "\n",
+    "RangeToolLink(src, tgt, axes_start={'x':pd.to_datetime('2010')}, axes_end={'x': pd.to_datetime('2012')})\n",
+    "\n",
+    "layout = (tgt + src).cols(1)\n",
+    "layout.opts(opts.Layout(shared_axes=False, merge_tools=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/bokeh/timeseries_range_tool.ipynb
+++ b/examples/gallery/demos/bokeh/timeseries_range_tool.ipynb
@@ -92,10 +92,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from datetime import datetime\n",
+    "\n",
     "tgt = aapl_curve.relabel('AAPL close price').opts(width=800, height=300, labelled=['y'], toolbar='disable')\n",
     "src = aapl_curve.opts(width=800, height=100, yaxis=None, default_tools=[])\n",
     "\n",
-    "RangeToolLink(src, tgt, axes=['x', 'y'], boundsx= (pd.to_datetime('2006'), pd.to_datetime('2010')), boundsy=(None, 400))\n",
+    "RangeToolLink(src, tgt, axes=['x', 'y'], boundsx=(datetime(2006, 1, 1) , datetime(2010, 1, 1)), boundsy=(None, 400))\n",
     "\n",
     "layout = (tgt + src).cols(1)\n",
     "layout.opts(opts.Layout(shared_axes=False, merge_tools=False))"

--- a/examples/gallery/demos/bokeh/timeseries_range_tool.ipynb
+++ b/examples/gallery/demos/bokeh/timeseries_range_tool.ipynb
@@ -100,32 +100,12 @@
     "layout = (tgt + src).cols(1)\n",
     "layout.opts(opts.Layout(shared_axes=False, merge_tools=False))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/timeseries_range_tool.ipynb
+++ b/examples/gallery/demos/bokeh/timeseries_range_tool.ipynb
@@ -100,32 +100,12 @@
     "layout = (tgt + src).cols(1)\n",
     "layout.opts(opts.Layout(shared_axes=False, merge_tools=False))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/timeseries_range_tool.ipynb
+++ b/examples/gallery/demos/bokeh/timeseries_range_tool.ipynb
@@ -76,14 +76,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Specify range"
+    "## Specify initial bounds"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Use the `axes_start` and `axes_end` parameters to specify the initial range of the ``RangeTool``:"
+    "Use the `boundsx` and `boundsy` parameters to specify the initial range of the ``RangeTool``:"
    ]
   },
   {
@@ -95,17 +95,37 @@
     "tgt = aapl_curve.relabel('AAPL close price').opts(width=800, height=300, labelled=['y'], toolbar='disable')\n",
     "src = aapl_curve.opts(width=800, height=100, yaxis=None, default_tools=[])\n",
     "\n",
-    "RangeToolLink(src, tgt, axes_start={'x':pd.to_datetime('2010')}, axes_end={'x': pd.to_datetime('2012')})\n",
+    "RangeToolLink(src, tgt, axes=['x', 'y'], boundsx= (pd.to_datetime('2006'), pd.to_datetime('2010')), boundsy=(None, 400))\n",
     "\n",
     "layout = (tgt + src).cols(1)\n",
     "layout.opts(opts.Layout(shared_axes=False, merge_tools=False))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/holoviews/plotting/bokeh/links.py
+++ b/holoviews/plotting/bokeh/links.py
@@ -141,11 +141,14 @@ class RangeToolLinkCallback(LinkCallback):
         for axis in ['x', 'y']:
             if axis in link.axes:
                 axes[f'{axis}_range'] = target_plot.handles[f'{axis}_range']
-                if axis in link.axes_start:
-                    axes[f'{axis}_range'].start = link.axes_start[axis]
-                if axis in link.axes_end:
-                    axes[f'{axis}_range'].end = link.axes_end[axis]
-        tool = RangeTool(**axes)
+                bounds = getattr(link, f'bounds{axis}', None)
+                if bounds is not None:
+                    start, end = bounds
+                    if start is not None:
+                        axes[f'{axis}_range'].start = start
+                    if end is not None:
+                        axes[f'{axis}_range'].end = end
+        tool = RangeTool(**axes)    
         source_plot.state.add_tools(tool)
         if bokeh3 and toolbars:
             toolbars[0].tools.append(tool)

--- a/holoviews/plotting/bokeh/links.py
+++ b/holoviews/plotting/bokeh/links.py
@@ -138,16 +138,22 @@ class RangeToolLinkCallback(LinkCallback):
     def __init__(self, root_model, link, source_plot, target_plot):
         toolbars = list(root_model.select({'type': Toolbar}))
         axes = {}
-        for axis in ['x', 'y']:
-            if axis in link.axes:
-                axes[f'{axis}_range'] = target_plot.handles[f'{axis}_range']
-                bounds = getattr(link, f'bounds{axis}', None)
-                if bounds is not None:
-                    start, end = bounds
-                    if start is not None:
-                        axes[f'{axis}_range'].start = start
-                    if end is not None:
-                        axes[f'{axis}_range'].end = end
+
+        for axis in ('x', 'y'):
+            if axis not in link.axes:
+                continue
+
+            axes[f'{axis}_range'] = target_plot.handles[f'{axis}_range']
+            bounds = getattr(link, f'bounds{axis}', None)
+            if bounds is None:
+                continue
+
+            start, end = bounds
+            if start is not None:
+                axes[f'{axis}_range'].start = start
+            if end is not None:
+                axes[f'{axis}_range'].end = end
+
         tool = RangeTool(**axes)
         source_plot.state.add_tools(tool)
         if bokeh3 and toolbars:

--- a/holoviews/plotting/bokeh/links.py
+++ b/holoviews/plotting/bokeh/links.py
@@ -138,10 +138,13 @@ class RangeToolLinkCallback(LinkCallback):
     def __init__(self, root_model, link, source_plot, target_plot):
         toolbars = list(root_model.select({'type': Toolbar}))
         axes = {}
-        if 'x' in link.axes:
-            axes['x_range'] = target_plot.handles['x_range']
-        if 'y' in link.axes:
-            axes['y_range'] = target_plot.handles['y_range']
+        for axis in ['x', 'y']:
+            if axis in link.axes:
+                axes[f'{axis}_range'] = target_plot.handles[f'{axis}_range']
+                if axis in link.axes_start:
+                    axes[f'{axis}_range'].start = link.axes_start[axis]
+                if axis in link.axes_end:
+                    axes[f'{axis}_range'].end = link.axes_end[axis]
         tool = RangeTool(**axes)
         source_plot.state.add_tools(tool)
         if bokeh3 and toolbars:

--- a/holoviews/plotting/bokeh/links.py
+++ b/holoviews/plotting/bokeh/links.py
@@ -148,7 +148,7 @@ class RangeToolLinkCallback(LinkCallback):
                         axes[f'{axis}_range'].start = start
                     if end is not None:
                         axes[f'{axis}_range'].end = end
-        tool = RangeTool(**axes)    
+        tool = RangeTool(**axes)
         source_plot.state.add_tools(tool)
         if bokeh3 and toolbars:
             toolbars[0].tools.append(tool)

--- a/holoviews/plotting/links.py
+++ b/holoviews/plotting/links.py
@@ -104,6 +104,12 @@ class RangeToolLink(Link):
     axes = param.ListSelector(default=['x'], objects=['x', 'y'], doc="""
         Which axes to link the tool to.""")
 
+    axes_start = param.Dict(default={}, doc="""
+        The range start values for the specified axes. Example: {'x':1, 'y':2}""")
+
+    axes_end = param.Dict(default={}, doc="""
+        The range end values for the specified axes. Example: {'x':3, 'y':4}""")
+
     _requires_target = True
 
 

--- a/holoviews/plotting/links.py
+++ b/holoviews/plotting/links.py
@@ -105,10 +105,10 @@ class RangeToolLink(Link):
         Which axes to link the tool to.""")
 
     boundsx = param.Tuple(default=None, length=2, doc="""
-        (start, end) bounds for the x axis""")
+        (start, end) bounds for the x-axis""")
 
     boundsy = param.Tuple(default=None, length=2, doc= """
-        (start, end) bounds for the y axis""")
+        (start, end) bounds for the y-axis""")
 
     _requires_target = True
 

--- a/holoviews/plotting/links.py
+++ b/holoviews/plotting/links.py
@@ -107,7 +107,7 @@ class RangeToolLink(Link):
     boundsx = param.Tuple(default=None, length=2, doc="""
         (start, end) bounds for the x-axis""")
 
-    boundsy = param.Tuple(default=None, length=2, doc= """
+    boundsy = param.Tuple(default=None, length=2, doc="""
         (start, end) bounds for the y-axis""")
 
     _requires_target = True

--- a/holoviews/plotting/links.py
+++ b/holoviews/plotting/links.py
@@ -104,11 +104,11 @@ class RangeToolLink(Link):
     axes = param.ListSelector(default=['x'], objects=['x', 'y'], doc="""
         Which axes to link the tool to.""")
 
-    axes_start = param.Dict(default={}, doc="""
-        The range start values for the specified axes. Example: {'x':1, 'y':2}""")
+    boundsx = param.Tuple(default=None, length=2, doc="""
+        (start, end) bounds for the x axis""")
 
-    axes_end = param.Dict(default={}, doc="""
-        The range end values for the specified axes. Example: {'x':3, 'y':4}""")
+    boundsy = param.Tuple(default=None, length=2, doc= """
+        (start, end) bounds for the y axis""")
 
     _requires_target = True
 

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -27,7 +27,6 @@ class TestLinkCallbacks(TestBokehPlot):
         self.assertIs(range_tool.y_range, None)
 
     def test_range_tool_link_callback_both_axes(self):
-        from bokeh.models import RangeTool
         array = np.random.rand(100, 2)
         src = Curve(array)
         target = Scatter(array)
@@ -41,7 +40,6 @@ class TestLinkCallbacks(TestBokehPlot):
         self.assertEqual(range_tool.y_range, tgt_plot.handles['y_range'])
 
     def test_range_tool_link_callback_start_arg(self):
-        from bokeh.models import RangeTool
         array = np.random.rand(100, 2)
         src = Curve(array)
         target = Scatter(array)

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -40,30 +40,30 @@ class TestLinkCallbacks(TestBokehPlot):
         self.assertEqual(range_tool.x_range, tgt_plot.handles['x_range'])
         self.assertEqual(range_tool.y_range, tgt_plot.handles['y_range'])
 
-    def test_range_tool_link_callback_start_arg(self):
+    def test_range_tool_link_callback_boundsx_arg(self):
         array = np.random.rand(100, 2)
         src = Curve(array)
         target = Scatter(array)
         x_start = 0.2
-        y_start = 0.3
-        RangeToolLink(src, target, axes=['x', 'y'], axes_start={'x': x_start, 'y': y_start})
+        x_end = 0.3
+        RangeToolLink(src, target, axes=['x', 'y'], boundsx=(x_start, x_end))
         layout = target + src
         plot = bokeh_renderer.get_plot(layout)
         tgt_plot = plot.subplots[(0, 0)].subplots['main']
         self.assertEqual(tgt_plot.handles['x_range'].start, x_start)
-        self.assertEqual(tgt_plot.handles['y_range'].start, y_start)
+        self.assertEqual(tgt_plot.handles['x_range'].end, x_end)
 
-    def test_range_tool_link_callback_end_arg(self):
+    def test_range_tool_link_callback_boundsy_arg(self):
         array = np.random.rand(100, 2)
         src = Curve(array)
         target = Scatter(array)
-        x_end = 0.8
+        y_start = 0.8
         y_end = 0.9
-        RangeToolLink(src, target, axes=['x', 'y'], axes_end={'x': x_end, 'y': y_end})
+        RangeToolLink(src, target, axes=['x', 'y'], boundsy=(y_start, y_end))
         layout = target + src
         plot = bokeh_renderer.get_plot(layout)
         tgt_plot = plot.subplots[(0, 0)].subplots['main']
-        self.assertEqual(tgt_plot.handles['x_range'].end, x_end)
+        self.assertEqual(tgt_plot.handles['y_range'].start, y_start)
         self.assertEqual(tgt_plot.handles['y_range'].end, y_end)
 
     def test_data_link_dynamicmap_table(self):

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -40,6 +40,34 @@ class TestLinkCallbacks(TestBokehPlot):
         self.assertEqual(range_tool.x_range, tgt_plot.handles['x_range'])
         self.assertEqual(range_tool.y_range, tgt_plot.handles['y_range'])
 
+    def test_range_tool_link_callback_start_arg(self):
+        from bokeh.models import RangeTool
+        array = np.random.rand(100, 2)
+        src = Curve(array)
+        target = Scatter(array)
+        x_start = 0.2
+        y_start = 0.3
+        RangeToolLink(src, target, axes=['x', 'y'], axes_start={'x': x_start, 'y': y_start})
+        layout = target + src
+        plot = bokeh_renderer.get_plot(layout)
+        tgt_plot = plot.subplots[(0, 0)].subplots['main']
+        self.assertEqual(tgt_plot.handles['x_range'].start, x_start)
+        self.assertEqual(tgt_plot.handles['y_range'].start, y_start)
+
+    def test_range_tool_link_callback_end_arg(self):
+        from bokeh.models import RangeTool
+        array = np.random.rand(100, 2)
+        src = Curve(array)
+        target = Scatter(array)
+        x_end = 0.8
+        y_end = 0.9
+        RangeToolLink(src, target, axes=['x', 'y'], axes_end={'x': x_end, 'y': y_end})
+        layout = target + src
+        plot = bokeh_renderer.get_plot(layout)
+        tgt_plot = plot.subplots[(0, 0)].subplots['main']
+        self.assertEqual(tgt_plot.handles['x_range'].end, x_end)
+        self.assertEqual(tgt_plot.handles['y_range'].end, y_end)
+
     def test_data_link_dynamicmap_table(self):
         dmap = DynamicMap(lambda X: Points([(0, X)]), kdims='X').redim.range(X=(-1, 1))
         table = Table([(-1,)], vdims='y')

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -27,6 +27,7 @@ class TestLinkCallbacks(TestBokehPlot):
         self.assertIs(range_tool.y_range, None)
 
     def test_range_tool_link_callback_both_axes(self):
+        from bokeh.models import RangeTool
         array = np.random.rand(100, 2)
         src = Curve(array)
         target = Scatter(array)
@@ -53,7 +54,6 @@ class TestLinkCallbacks(TestBokehPlot):
         self.assertEqual(tgt_plot.handles['y_range'].start, y_start)
 
     def test_range_tool_link_callback_end_arg(self):
-        from bokeh.models import RangeTool
         array = np.random.rand(100, 2)
         src = Curve(array)
         target = Scatter(array)


### PR DESCRIPTION
fixes #5437

Allows users to specify a start and end to the axes ranges in the call to RangeToolLink. Previously, this required a hook (#5437).

**update:** changed args and logic to boundsx/y rather than axes_start/end

```python
import pandas as pd
import holoviews as hv
from holoviews import opts
from holoviews.plotting.links import RangeToolLink

hv.extension('bokeh')
from bokeh.sampledata.stocks import AAPL

aapl_df = pd.DataFrame(AAPL['close'], columns=['close'], index=pd.to_datetime(AAPL['date']))
aapl_df.index.name = 'Date'

aapl_curve = hv.Curve(aapl_df, 'Date', ('close', 'Price ($)'))

tgt = aapl_curve.relabel('AAPL close price').opts(width=800, labelled=['y'], toolbar='disable')

src = aapl_curve.opts(width=800, height=100, yaxis=None, default_tools=[])

RangeToolLink(src, tgt, axes=['x', 'y'], boundsx= (pd.to_datetime('2006'), pd.to_datetime('2010')), boundsy=(None, 400))

layout = (tgt + src).cols(1)
layout.opts(opts.Layout(shared_axes=False, merge_tools=False))
```

<img width="813" alt="image" src="https://github.com/holoviz/holoviews/assets/6613202/15678192-25fd-4702-bd8b-c9cc17daaf86">