### PR TITLE
Prevent edge cases in XArrayInterface from crashing

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -144,7 +144,7 @@ class XArrayInterface(GridInterface):
                     packed = True
                 else:
                     data = {d: v for d, v in zip(dimensions, data)}
-            elif isinstance(data, list) and data == []:
+            elif isinstance(data, (list, np.ndarray)) and len(data) == 0:
                 dimensions = [d.name for d in kdims + vdims]
                 data = {d: np.array([]) for d in dimensions[:ndims]}
                 data.update({d: np.empty((0,) * ndims) for d in dimensions[ndims:]})

--- a/holoviews/core/sheetcoords.py
+++ b/holoviews/core/sheetcoords.py
@@ -515,13 +515,18 @@ class Slice(np.ndarray):
         t_m,l_m = scs.sheet2matrix(l,t)
         b_m,r_m = scs.sheet2matrix(r,b)
 
-        l_idx = int(np.ceil(l_m-0.5))
-        t_idx = int(np.ceil(t_m-0.5))
+        l_idx = np.ceil(l_m-0.5)
+        t_idx = np.ceil(t_m-0.5)
         # CBENHANCEMENT: Python 2.6's math.trunc()?
-        r_idx = int(np.floor(r_m+0.5))
-        b_idx = int(np.floor(b_m+0.5))
+        r_idx = np.floor(r_m+0.5)
+        b_idx = np.floor(b_m+0.5)
 
-        return t_idx,b_idx,l_idx,r_idx
+        # sometimes contains NaNs so just set them to 0
+        # rather than raising an exception
+        indices = np.array([t_idx, b_idx, l_idx, r_idx])
+        indices[np.isnan(indices)] = 0
+
+        return tuple(indices.astype(int))
 
 
     @staticmethod

--- a/holoviews/core/sheetcoords.py
+++ b/holoviews/core/sheetcoords.py
@@ -515,18 +515,12 @@ class Slice(np.ndarray):
         t_m,l_m = scs.sheet2matrix(l,t)
         b_m,r_m = scs.sheet2matrix(r,b)
 
-        l_idx = np.ceil(l_m-0.5)
-        t_idx = np.ceil(t_m-0.5)
-        # CBENHANCEMENT: Python 2.6's math.trunc()?
-        r_idx = np.floor(r_m+0.5)
-        b_idx = np.floor(b_m+0.5)
+        l_idx = int(np.ceil(l_m-0.5))
+        t_idx = int(np.ceil(t_m-0.5))
+        r_idx = int(np.floor(r_m+0.5))
+        b_idx = int(np.floor(b_m+0.5))
 
-        # sometimes contains NaNs so just set them to 0
-        # rather than raising an exception
-        indices = np.array([t_idx, b_idx, l_idx, r_idx])
-        indices[np.isnan(indices)] = 0
-
-        return tuple(indices.astype(int))
+        return t_idx,b_idx,l_idx,r_idx
 
 
     @staticmethod

--- a/holoviews/tests/core/data/test_xarrayinterface.py
+++ b/holoviews/tests/core/data/test_xarrayinterface.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     raise SkipTest("Could not import xarray, skipping XArrayInterface tests.")
 
-from holoviews.core.data import Dataset, concat
+from holoviews.core.data import Dataset, concat, XArrayInterface
 from holoviews.core.dimension import Dimension
 from holoviews.core.spaces import HoloMap
 from holoviews.element import Image, RGB, HSV, QuadMesh
@@ -257,6 +257,18 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         expected = array.copy()
         expected[mask] = np.nan
         self.assertEqual(masked_array, expected)
+
+    def test_from_empty_numpy(self):
+        """
+        Datashader sometimes pass an empty array to the interface
+        """
+        kdims = ["dim_0", "dim_1"]
+        vdims = ["dim_2"]
+        ds = XArrayInterface.init(Image, np.array([]), kdims, vdims)
+        assert isinstance(ds[0], xr.Dataset)
+        assert ds[0][vdims[0]].size == 0
+        assert ds[1]["kdims"] == kdims
+        assert ds[1]["vdims"] == vdims
 
     # Disabled tests for NotImplemented methods
     def test_dataset_array_init_hm(self):


### PR DESCRIPTION
Closes https://github.com/holoviz/geoviews/issues/663 and https://github.com/holoviz/holoviews/issues/4910

The examples in the issues above no longer crashes. I suspect datashade was peddling numpy arrays into XArrayInterface, but there was no handling for that so this PR implements that.

Also, there was NaNs in the bounds and casting to int raised an exception; this simply sets NaNs to 0s to prevent it from crashing.
