### PR TITLE
Use select in apply_when

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -159,7 +159,7 @@ class apply_when(param.ParameterizedFunction):
     def _apply(self, element, x_range, y_range, invert=False):
         selected = element
         if x_range is not None and y_range is not None:
-            selected = element[x_range, y_range]
+            selected = element.select(x_range=x_range, y_range=y_range)
         condition = self.predicate(selected)
         if (not invert and condition) or (invert and not condition):
             return selected


### PR DESCRIPTION
`select` method is more robust than indexing. With this new change, I don't get the traceback below.


From https://holoviews.org/user_guide/Indexing_and_Selecting_Data.html
"""
select | e.select(y=5.5),e.select(y=(3,5.5)) | More verbose notation covering all supported slice and index operations by dimension name.
"""

```python
import xarray as xr
import hvplot.xarray
ds = xr.tutorial.open_dataset("air_temperature")

ds.hvplot.quadmesh("lon", "lat", rasterize=True, aggregation_threshold=1000)
```

Without:
```
WARNING:param.dynamic_operation: Callable raised "IndexError('index 0 is out of bounds for axis 0 with size 0')".
Invoked as dynamic_operation(numpy.datetime64('2013-01-01T00:00:00.000000000'), height=228, scale=1.0, width=531, x_range=(277.5928609589502, 278.1414798212634), y_range=(49.20858986965831, 49.46737235188152))
WARNING:param.dynamic_mul: Callable raised "IndexError('index 0 is out of bounds for axis 0 with size 0')".
Invoked as dynamic_mul(numpy.datetime64('2013-01-01T00:00:00.000000000'))
WARNING:param.dynamic_operation: Callable raised "IndexError('index 0 is out of bounds for axis 0 with size 0')".
Invoked as dynamic_operation(numpy.datetime64('2013-01-01T00:00:00.000000000'))
WARNING:param.dynamic_operation: Callable raised "IndexError('index 0 is out of bounds for axis 0 with size 0')".
Invoked as dynamic_operation(numpy.datetime64('2013-01-01T00:00:00.000000000'))
Traceback (most recent call last):
  File "/Users/ahuang/repos/holoviews/holoviews/plotting/util.py", line 279, in get_plot_frame
    return map_obj[key]
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 1212, in __getitem__
    val = self._execute_callback(*tuple_key)
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 979, in _execute_callback
    retval = self.callback(*args, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 579, in __call__
    ret = self.callable(*args, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/util/__init__.py", line 1025, in dynamic_operation
    key, obj = resolve(key, kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/util/__init__.py", line 1014, in resolve
    return key, map_obj[key]
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 1212, in __getitem__
    val = self._execute_callback(*tuple_key)
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 979, in _execute_callback
    retval = self.callback(*args, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 579, in __call__
    ret = self.callable(*args, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/util/__init__.py", line 1025, in dynamic_operation
    key, obj = resolve(key, kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/util/__init__.py", line 1014, in resolve
    return key, map_obj[key]
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 1212, in __getitem__
    val = self._execute_callback(*tuple_key)
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 979, in _execute_callback
    retval = self.callback(*args, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 579, in __call__
    ret = self.callable(*args, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 199, in dynamic_mul
    self_el = self.select(HoloMap, **key_map) if self.kdims else self[()]
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 1259, in select
    selection = super().select(selection_specs=selection_specs, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/core/dimension.py", line 1110, in select
    selection = self.get(tuple(select), None)
  File "/Users/ahuang/repos/holoviews/holoviews/core/ndmapping.py", line 538, in get
    return self[key]
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 1212, in __getitem__
    val = self._execute_callback(*tuple_key)
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 979, in _execute_callback
    retval = self.callback(*args, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/core/spaces.py", line 579, in __call__
    ret = self.callable(*args, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/util/__init__.py", line 1026, in dynamic_operation
    return apply(obj, *key, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/util/__init__.py", line 1018, in apply
    processed = self._process(element, key, kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/util/__init__.py", line 1000, in _process
    return self.p.operation.process_element(element, key, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/core/operation.py", line 194, in process_element
    return self._apply(element, key)
  File "/Users/ahuang/repos/holoviews/holoviews/core/operation.py", line 141, in _apply
    ret = self._process(element, key)
  File "/Users/ahuang/repos/holoviews/holoviews/operation/datashader.py", line 1411, in _process
    element = element.map(op, predicate)
  File "/Users/ahuang/repos/holoviews/holoviews/core/data/__init__.py", line 197, in pipelined_fn
    result = method_fn(*args, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/core/data/__init__.py", line 1205, in map
    return super().map(*args, **kwargs)
  File "/Users/ahuang/repos/holoviews/holoviews/core/dimension.py", line 698, in map
    return map_fn(self) if applies else self
  File "/Users/ahuang/repos/holoviews/holoviews/core/operation.py", line 214, in __call__
    return self._apply(element)
  File "/Users/ahuang/repos/holoviews/holoviews/core/operation.py", line 141, in _apply
    ret = self._process(element, key)
  File "/Users/ahuang/repos/holoviews/holoviews/operation/datashader.py", line 1041, in _process
    agg = cvs.quadmesh(data[vdim], x.name, y.name, agg_fn)
  File "/Users/ahuang/miniconda3/envs/hvplot/lib/python3.10/site-packages/datashader/core.py", line 818, in quadmesh
    yarr, np.linspace(yarr[0], yarr[-1], len(yarr))
  File "/Users/ahuang/miniconda3/envs/hvplot/lib/python3.10/site-packages/xarray/core/dataarray.py", line 823, in __getitem__
    return self.isel(indexers=self._item_key_to_dict(key))
  File "/Users/ahuang/miniconda3/envs/hvplot/lib/python3.10/site-packages/xarray/core/dataarray.py", line 1421, in isel
    variable = self._variable.isel(indexers, missing_dims=missing_dims)
  File "/Users/ahuang/miniconda3/envs/hvplot/lib/python3.10/site-packages/xarray/core/variable.py", line 1378, in isel
    return self[key]
  File "/Users/ahuang/miniconda3/envs/hvplot/lib/python3.10/site-packages/xarray/core/variable.py", line 900, in __getitem__
    data = as_indexable(self._data)[indexer]
  File "/Users/ahuang/miniconda3/envs/hvplot/lib/python3.10/site-packages/xarray/core/indexing.py", line 1544, in __getitem__
    result = self.array[key]
  File "/Users/ahuang/miniconda3/envs/hvplot/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 5320, in __getitem__
    return getitem(key)
IndexError: index 0 is out of bounds for axis 0 with size 0
```