### PR TITLE
Allow and handle non-parameters in rasterize.instance()

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1375,21 +1375,25 @@ class rasterize(AggregationOperation):
     ]
 
     __instance_params = set()
+    __instance_kwargs = {}
 
     @bothmethod
     def instance(self_or_cls, **params):
-        inst = super().instance(**params)
-        inst.__instance_params = set(params)
+        kwargs = set(params) - set(self_or_cls.param)
+        inst_params = {k: v for k, v in params.items() if k in self_or_cls.param}
+        inst = super().instance(**inst_params)
+        inst.__instance_params = set(inst_params)
+        inst.__instance_kwargs = {k: v for k, v in params.items() if k in kwargs}
         return inst
 
     def _process(self, element, key=None):
         # Potentially needs traverse to find element types first?
         all_allowed_kws = set()
         all_supplied_kws = set()
-        instance_params = {
-            k: getattr(self, k) for k in self.__instance_params
-            if hasattr(self, k)
-        }
+        instance_params = dict(
+            self.__instance_kwargs,
+            **{k: getattr(self, k) for k in self.__instance_params}
+        )
         for predicate, transform in self._transforms:
             merged_param_values = dict(instance_params, **self.p)
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1388,6 +1388,7 @@ class rasterize(AggregationOperation):
         all_supplied_kws = set()
         instance_params = {
             k: getattr(self, k) for k in self.__instance_params
+            if hasattr(self, k)
         }
         for predicate, transform in self._transforms:
             merged_param_values = dict(instance_params, **self.p)

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -9,8 +9,9 @@ import pytest
 from holoviews import (
     Dimension, Curve, Points, Image, Dataset, RGB, Path, Graph, TriMesh,
     QuadMesh, NdOverlay, Contours, Spikes, Spread, Area, Rectangles,
-    Segments, Polygons, Nodes
+    Segments, Polygons, Nodes, DynamicMap, Overlay
 )
+from holoviews.util import render
 from holoviews.streams import Tap
 from holoviews.element.comparison import ComparisonTestCase
 from numpy import nan
@@ -1182,7 +1183,11 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         output = apply_when(
             curve, operation=custom_rasterize, predicate=lambda x: len(x) > 1000
         )
-        assert isinstance(output, Image)
+        render(output, "bokeh")
+        assert isinstance(output, DynamicMap)
+        overlay = output.items()[0][1]
+        assert isinstance(overlay, Overlay)
+        assert len(overlay) == 2
 
 class DatashaderSpreadTests(ComparisonTestCase):
 

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1174,14 +1174,15 @@ class DatashaderRasterizeTests(ComparisonTestCase):
     def test_rasterize_apply_when_instance_with_line_width(self):
         df = pd.DataFrame(
             np.random.multivariate_normal(
-            (0, 0), [[0.1, 0.1], [0.1, 1.0]], (500000,))
+            (0, 0), [[0.1, 0.1], [0.1, 1.0]], (100,))
         )
         df.columns = ["a", "b"]
 
         curve = Curve(df, kdims=["a"], vdims=["b"])
+        # line_width is not a parameter
         custom_rasterize = rasterize.instance(line_width=2)
         output = apply_when(
-            curve, operation=custom_rasterize, predicate=lambda x: len(x) > 1000
+            curve, operation=custom_rasterize, predicate=lambda x: len(x) > 10
         )
         render(output, "bokeh")
         assert isinstance(output, DynamicMap)

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1181,6 +1181,7 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         curve = Curve(df, kdims=["a"], vdims=["b"])
         # line_width is not a parameter
         custom_rasterize = rasterize.instance(line_width=2)
+        assert {'line_width': 2} == custom_rasterize._rasterize__instance_kwargs
         output = apply_when(
             curve, operation=custom_rasterize, predicate=lambda x: len(x) > 10
         )

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -14,6 +14,7 @@ from holoviews import (
 from holoviews.streams import Tap
 from holoviews.element.comparison import ComparisonTestCase
 from numpy import nan
+from holoviews.operation import apply_when
 from packaging.version import Version
 
 try:
@@ -1168,6 +1169,20 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         img = rasterize(Image(da), expand=True, **rast_input)
         output = img.data["z"].to_numpy()
         assert np.isnan(output).any()
+
+    def test_rasterize_apply_when_instance_with_line_width(self):
+        df = pd.DataFrame(
+            np.random.multivariate_normal(
+            (0, 0), [[0.1, 0.1], [0.1, 1.0]], (500000,))
+        )
+        df.columns = ["a", "b"]
+
+        curve = Curve(df, kdims=["a"], vdims=["b"])
+        custom_rasterize = rasterize.instance(line_width=2)
+        output = apply_when(
+            curve, operation=custom_rasterize, predicate=lambda x: len(x) > 1000
+        )
+        assert isinstance(output, Image)
 
 class DatashaderSpreadTests(ComparisonTestCase):
 


### PR DESCRIPTION
I don't fully understand this...

If I use HoloViews alone / try to reproduce with HoloViews:
```python
import numpy as np
import pandas as pd
import holoviews as hv
hv.extension("bokeh")
from holoviews.operation.datashader import rasterize

df = pd.DataFrame(
    np.random.multivariate_normal((0, 0), [[0.1, 0.1], [0.1, 1.0]], (500000,))
)
df.columns = ["a", "b"]

curve = hv.Curve(df, kdims=["a"], vdims=["b"]).opts("Curve", line_width=1)
hv.operation.apply_when(curve, operation=rasterize, predicate=lambda x: len(x) > 1000)
```
It runs fine...


However, if I use hvplot with this [PR](https://github.com/holoviz/hvplot/pull/1103/files):
```python
import numpy as np
import pandas as pd
import hvplot.pandas

df = pd.DataFrame(
    np.random.multivariate_normal((0, 0), [[0.1, 0.1], [0.1, 1.0]], (500000,))
)
df.columns = ["a", "b"]
df.hvplot("a", "b", rasterize=True, aggregation_threshold=1000)
```

I get the following traceback:
```
File [~/repos/holoviews/holoviews/operation/datashader.py:1389](https://file+.vscode-resource.vscode-cdn.net/Users/ahuang/repos/sketches/~/repos/holoviews/holoviews/operation/datashader.py:1389), in rasterize._process(self, element, key)
   1387 all_allowed_kws = set()
   1388 all_supplied_kws = set()
-> 1389 instance_params = {
   1390     k: getattr(self, k) for k in self.__instance_params
   1391 }
   1392 for predicate, transform in self._transforms:
   1393     merged_param_values = dict(instance_params, **self.p)

File [~/repos/holoviews/holoviews/operation/datashader.py:1390](https://file+.vscode-resource.vscode-cdn.net/Users/ahuang/repos/sketches/~/repos/holoviews/holoviews/operation/datashader.py:1390), in (.0)
   1387 all_allowed_kws = set()
   1388 all_supplied_kws = set()
   1389 instance_params = {
-> 1390     k: getattr(self, k) for k in self.__instance_params
   1391 }
   1392 for predicate, transform in self._transforms:
   1393     merged_param_values = dict(instance_params, **self.p)

AttributeError: 'rasterize' object has no attribute 'line_width'
```