### PR TITLE
Allow pixel_ratio to go below 1

### DIFF
--- a/holoviews/operation/resample.py
+++ b/holoviews/operation/resample.py
@@ -50,7 +50,8 @@ class ResampleOperation1D(LinkableOperation):
     height = param.Integer(default=400, doc="""
        The height of the output image in pixels.""")
 
-    pixel_ratio = param.Number(default=1, bounds=(1,None), doc="""
+    pixel_ratio = param.Number(default=1, bounds=(0,None),
+                               inclusive_bounds=(False,False), doc="""
        Pixel ratio applied to the height and width. Useful for higher
        resolution screens where the PlotSize stream reports 'nominal'
        dimensions in pixels that do not match the physical pixels. For


### PR DESCRIPTION
For some reason `datashade`/`rasterize` `pixel_ratio` was constrained to increasing the resolution, but it should also be useful for _reducing_ the resolution:

```python
import holoviews as hv, numpy as np
from holoviews.operation.datashader import datashade, rasterize, dynspread
hv.extension("bokeh")

p = hv.Points(np.random.multivariate_normal((0,0), [[0.1, 0.1], [0.1, 1.0]], (300,)))
dynspread(rasterize(p, pixel_ratio=2)) + dynspread(rasterize(p, pixel_ratio=0.25))
```
<img width="664" alt="image" src="https://github.com/holoviz/holoviews/assets/1695496/8815d477-f656-4c65-9fa4-e040db1505e5">

Now checks that the ratio is above zero, rather than 1 or larger:
<img width="1017" alt="image" src="https://github.com/holoviz/holoviews/assets/1695496/10f88502-079c-4708-9f4b-0df5cc27c69e">
