### PR TITLE
Avoid setting `batched` before the class is initialized

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1164,7 +1164,6 @@ class GenericElementPlot(DimensionedPlot):
         self.zorder = zorder
         self.cyclic_index = cyclic_index
         self.overlaid = overlaid
-        self.batched = batched
         self.overlay_dims = overlay_dims
 
         if not isinstance(element, (HoloMap, DynamicMap)):
@@ -1179,7 +1178,7 @@ class GenericElementPlot(DimensionedPlot):
             self.stream_sources = compute_overlayable_zorders(self.hmap)
 
         plot_element = self.hmap.last
-        if self.batched and not isinstance(self, GenericOverlayPlot):
+        if batched and not isinstance(self, GenericOverlayPlot):
             plot_element = plot_element.last
 
         dynamic = isinstance(element, DynamicMap) and not element.unbounded
@@ -1203,6 +1202,7 @@ class GenericElementPlot(DimensionedPlot):
                 self.param.warning(self._deprecations[p])
         super().__init__(keys=keys, dimensions=dimensions,
                          dynamic=dynamic, **applied_params)
+        self.batched = batched
         self.streams = get_nested_streams(self.hmap) if streams is None else streams
 
         # Attach streams if not overlaid and not a batched ElementPlot


### PR DESCRIPTION
@Hoxbro feel free to reject this PR since it's not a fix per say.

What used to happen is showed in the example below, where the `batched` Parameter of `GenericOverlayPlot` was set (`self.batched = batched`) before `Parameterized.__init__` was called. Setting a Parameter value before a Parameterized class is initialized (at the Param sense) has been supported somehow in Param for a long time.  https://github.com/holoviz/param/pull/766 broke that support temporarily, while https://github.com/holoviz/param/pull/790 is an attempt at restoring it before Param 2.0 is released. Breaking that support temporarily allowed me to spot that this `batched` case was the only occurrence of a Parameter value being set early across a few code bases (Panel, Lumen, HoloViews). Because of that, and because it feels to me like an anti-pattern, I was tempted to open this PR to avoid this, 

```
class GenericElementPlot(param.Parameterized):

    ....

    def __init__(self, batched=False, **params):
        self.batched = batched
        super().__init__(**params)

class GenericOverlayPlot(GenericElementPlot):

    ...

    batched = param.Boolean()

    def __init__(self, batched=True, **params):
        super().__init__(batched=batched, **params)

# When GenericOverlayPlot is instantiated `batched` is set before `Parameterized.__init__` is called.
GenericOverlayPlot()
```