### PR TITLE
Remove twitter from index page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,7 +9,7 @@
 .. raw:: html
 
   <div style="display: flex">
-    <div style="width: 70%">
+    <div style="width: 95%">
 
 HoloViews is an `open-source <https://github.com/holoviz/holoviews/blob/main/LICENSE.txt>`_ Python library designed to make data analysis and visualization seamless and simple.  With HoloViews, you can usually express what you want to do in very few lines of code, letting you focus on what you are trying to explore and convey, not on the process of plotting.
 
@@ -26,9 +26,6 @@ If you have any `issues <https://github.com/holoviz/holoviews/issues>`_ or wish 
 .. raw:: html
 
   </div>
-
-.. raw:: html
-  :file: latest_news.html
 
 .. raw:: html
 

--- a/doc/latest_news.html
+++ b/doc/latest_news.html
@@ -1,4 +1,0 @@
-<div style="float: right; width: 30%; margin-top: -4%;">
-  <a class="twitter-timeline" data-width="400" data-height="360" data-link-color="#902040" href="https://twitter.com/HoloViews">Tweets by HoloViews</a>
-  <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-</div>


### PR DESCRIPTION
Because of recent policy changes on Twitter, we can't show tweets without logging in.

How it looks right now:
![image](https://github.com/holoviz/holoviews/assets/19758978/18fd6c4b-4f6b-4238-b68a-1fd06fb13930)

With this PR
![image](https://github.com/holoviz/holoviews/assets/19758978/c2ec6800-b48f-41f6-a4ec-7de8e07ea451)
