### PR TITLE
Disable Dask's conversion of strings in test 

### DIFF
--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -17,3 +17,12 @@ def pytest_collection_modifyitems(config, items):
 
     config.hook.pytest_deselected(items=skipped)
     items[:] = selected
+
+
+try:
+    # From Dask 2023.7,1 they now automatic convert strings
+    # https://docs.dask.org/en/stable/changelog.html#v2023-7-1
+    import dask
+    dask.config.set({"dataframe.convert-string": False})
+except Exception:
+    pass

--- a/holoviews/tests/core/data/__init__.py
+++ b/holoviews/tests/core/data/__init__.py
@@ -1,7 +1,0 @@
-try:
-    # From Dask 2023.7,1 they now automatic convert strings
-    # https://docs.dask.org/en/stable/changelog.html#v2023-7-1
-    import dask
-    dask.config.set({"dataframe.convert-string": False})
-except Exception:
-    pass

--- a/holoviews/tests/core/data/__init__.py
+++ b/holoviews/tests/core/data/__init__.py
@@ -1,0 +1,7 @@
+try:
+    # From Dask 2023.7,1 they now automatic convert strings
+    # https://docs.dask.org/en/stable/changelog.html#v2023-7-1
+    import dask
+    dask.config.set({"dataframe.convert-string": False})
+except Exception:
+    pass


### PR DESCRIPTION
Ref: https://docs.dask.org/en/stable/changelog.html#v2023-7-1

In the future, we should look into how our library handles the pyarrow backend in pandas.  This should be done with `pd.options.mode.string_storage = "pyarrow"` [ref](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.StringDtype.html).

But this seems like a bigger undertaking and for now this make our test go green again.
