### PR TITLE
Fix regression on Bounds stream

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -727,7 +727,7 @@ class BoundsCallback(Callback):
     models = ['plot']
     on_events = ['selectiongeometry']
 
-    skip_events = [lambda event: event.geometry['type'] != 'quad',
+    skip_events = [lambda event: event.geometry['type'] != 'rect',
                    lambda event: not event.final]
 
     def _process_msg(self, msg):

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -25,7 +25,7 @@ def test_box_select(page, port):
 
     serve(pn_scatter, port=port, threaded=True, show=False)
 
-    time.sleep(1)
+    time.sleep(0.5)
 
     page.goto(f"http://localhost:{port}")
 
@@ -41,6 +41,6 @@ def test_box_select(page, port):
     page.mouse.move(bbox['x']+150, bbox['y']+150, steps=5)
     page.mouse.up()
 
-    time.sleep(0.2)
+    time.sleep(0.5)
 
     assert bounds.bounds == (0.32844036697247725, 1.8285714285714285, 0.8788990825688077, 2.3183673469387758)

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -78,6 +78,8 @@ def test_lasso_select(page, port):
     page.mouse.move(bbox['x']+50, bbox['y']+150, steps=5)
     page.mouse.up()
 
+    time.sleep(1)
+
     expected_array = np.array([
         [ 3.28440367e-01,  2.31836735e+00],
         [ 5.48623853e-01,  2.12244898e+00],
@@ -91,7 +93,7 @@ def test_lasso_select(page, port):
         [-2.00000000e-01,  1.82857143e+00],
         [-2.00000000e-01,  1.82857143e+00]
     ])
-    wait_until(lambda: np.testing.assert_almost_equal(lasso.geometry, expected_array), page)
+    np.testing.assert_almost_equal(lasso.geometry, expected_array)
 
 
 def test_rangexy(page, port):

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -1,0 +1,46 @@
+import time
+
+import pytest
+
+try:
+    from playwright.sync_api import expect
+except ImportError:
+    pytestmark = pytest.mark.skip('playwright not available')
+
+pytestmark = pytest.mark.ui
+
+from holoviews import Scatter
+from holoviews.streams import BoundsXY
+from holoviews.plotting.bokeh import BokehRenderer
+from panel.pane.holoviews import HoloViews
+from panel.io.server import serve
+
+
+def test_box_select(page, port):
+    hv_scatter = Scatter([1, 2, 3]).opts(tools=['box_select'], active_tools=['box_select'])
+
+    bounds = BoundsXY(source=hv_scatter)
+
+    pn_scatter = HoloViews(hv_scatter, renderer=BokehRenderer)
+
+    serve(pn_scatter, port=port, threaded=True, show=False)
+
+    time.sleep(1)
+
+    page.goto(f"http://localhost:{port}")
+
+    hv_plot = page.locator('.bk-events')
+
+    expect(hv_plot).to_have_count(1)
+
+    bbox = hv_plot.bounding_box()
+    hv_plot.click()
+
+    page.mouse.move(bbox['x']+100, bbox['y']+100)
+    page.mouse.down()
+    page.mouse.move(bbox['x']+150, bbox['y']+150, steps=5)
+    page.mouse.up()
+
+    time.sleep(0.2)
+
+    assert bounds.bounds == (0.32844036697247725, 1.8285714285714285, 0.8788990825688077, 2.3183673469387758)

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -14,10 +14,13 @@ from holoviews.streams import BoundsXY
 from holoviews.plotting.bokeh import BokehRenderer
 from panel.pane.holoviews import HoloViews
 from panel.io.server import serve
+from panel.tests.util import wait_until
 
 
 def test_box_select(page, port):
-    hv_scatter = Scatter([1, 2, 3]).opts(tools=['box_select'], active_tools=['box_select'])
+    hv_scatter = Scatter([1, 2, 3]).opts(
+        backend='bokeh', tools=['box_select'], active_tools=['box_select']
+    )
 
     bounds = BoundsXY(source=hv_scatter)
 
@@ -41,6 +44,5 @@ def test_box_select(page, port):
     page.mouse.move(bbox['x']+150, bbox['y']+150, steps=5)
     page.mouse.up()
 
-    time.sleep(0.5)
-
-    assert bounds.bounds == (0.32844036697247725, 1.8285714285714285, 0.8788990825688077, 2.3183673469387758)
+    EXPECTED_BOUNDS = (0.32844036697247725, 1.8285714285714285, 0.8788990825688077, 2.3183673469387758)
+    wait_until(lambda: bounds.bounds == EXPECTED_BOUNDS, page)

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -1,5 +1,6 @@
 import time
 
+import numpy as np
 import pytest
 
 try:
@@ -10,7 +11,7 @@ except ImportError:
 pytestmark = pytest.mark.ui
 
 from holoviews import Scatter
-from holoviews.streams import BoundsXY, RangeXY
+from holoviews.streams import BoundsXY, Lasso, RangeXY
 from holoviews.plotting.bokeh import BokehRenderer
 from panel.pane.holoviews import HoloViews
 from panel.io.server import serve
@@ -44,8 +45,53 @@ def test_box_select(page, port):
     page.mouse.move(bbox['x']+150, bbox['y']+150, steps=5)
     page.mouse.up()
 
-    EXPECTED_BOUNDS = (0.32844036697247725, 1.8285714285714285, 0.8788990825688077, 2.3183673469387758)
-    wait_until(lambda: bounds.bounds == EXPECTED_BOUNDS, page)
+    expected_bounds = (0.32844036697247725, 1.8285714285714285, 0.8788990825688077, 2.3183673469387758)
+    wait_until(lambda: bounds.bounds == expected_bounds, page)
+
+
+
+def test_lasso_select(page, port):
+    hv_scatter = Scatter([1, 2, 3]).opts(
+        backend='bokeh', tools=['lasso_select'], active_tools=['lasso_select']
+    )
+
+    lasso = Lasso(source=hv_scatter)
+
+    pn_scatter = HoloViews(hv_scatter, renderer=BokehRenderer)
+
+    serve(pn_scatter, port=port, threaded=True, show=False)
+
+    time.sleep(0.5)
+
+    page.goto(f"http://localhost:{port}")
+
+    hv_plot = page.locator('.bk-events')
+
+    expect(hv_plot).to_have_count(1)
+
+    bbox = hv_plot.bounding_box()
+    hv_plot.click()
+
+    page.mouse.move(bbox['x']+100, bbox['y']+100)
+    page.mouse.down()
+    page.mouse.move(bbox['x']+150, bbox['y']+150, steps=5)
+    page.mouse.move(bbox['x']+50, bbox['y']+150, steps=5)
+    page.mouse.up()
+
+    expected_array = np.array([
+        [ 3.28440367e-01,  2.31836735e+00],
+        [ 5.48623853e-01,  2.12244898e+00],
+        [ 6.58715596e-01,  2.02448980e+00],
+        [ 7.68807339e-01,  1.92653061e+00],
+        [ 8.78899083e-01,  1.82857143e+00],
+        [ 6.58715596e-01,  1.82857143e+00],
+        [ 4.38532110e-01,  1.82857143e+00],
+        [ 2.18348624e-01,  1.82857143e+00],
+        [-1.83486239e-03,  1.82857143e+00],
+        [-2.00000000e-01,  1.82857143e+00],
+        [-2.00000000e-01,  1.82857143e+00]
+    ])
+    wait_until(lambda: np.testing.assert_almost_equal(lasso.geometry, expected_array), page)
 
 
 def test_rangexy(page, port):
@@ -73,6 +119,6 @@ def test_rangexy(page, port):
     page.mouse.move(bbox['x']+150, bbox['y']+150, steps=5)
     page.mouse.up()
 
-    EXPECTED_XRANGE = (0.32844036697247725, 0.8788990825688077)
-    EXPECTED_YRANGE = (1.8285714285714285, 2.3183673469387758)
-    wait_until(lambda: rangexy.x_range == EXPECTED_XRANGE and rangexy.y_range == EXPECTED_YRANGE, page)
+    expected_xrange = (0.32844036697247725, 0.8788990825688077)
+    expected_yrange = (1.8285714285714285, 2.3183673469387758)
+    wait_until(lambda: rangexy.x_range == expected_xrange and rangexy.y_range == expected_yrange, page)


### PR DESCRIPTION
Fixes regression introduced in https://github.com/holoviz/holoviews/pull/5760

The box-select geometry is and always has been called 'rect' so updating it to 'quad' was wrong.