### PR TITLE
Support RangeXY streams on multi-axes

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -400,7 +400,6 @@ class Callback:
 
         # Hash the plot handle with Callback type allowing multiple
         # callbacks on one handle to be merged
-        handle_ids = [id(h) for h in cb_handles]
         hash_ids = [id(h) for h in hash_handles]
         cb_hash = tuple(hash_ids)+(id(type(self)),)
         if cb_hash in self._callbacks:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1350,14 +1350,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if 'legend_field' in properties and 'legend_label' in properties:
             del properties['legend_label']
 
-        axis_dims = self._get_axis_dims(self.current_frame)[:2]
-        if self.invert_axes:
-            axis_dims[0], axis_dims[1] = axis_dims[::-1]
-        xdim, ydim = axis_dims
-        if xdim.name in plot.extra_x_ranges:
-            properties['x_range_name'] = xdim.name
-        if ydim.name in plot.extra_y_ranges:
-            properties['y_range_name'] = ydim.name
+        if self.handles['x_range'].name in plot.extra_x_ranges:
+            properties['x_range_name'] = self.handles['y_range'].name
+        if self.handles['y_range'].name in plot.extra_y_ranges:
+            properties['y_range_name'] = self.handles['y_range'].name
 
         if "name" not in properties:
             properties["name"] = properties.get("legend_label") or properties.get("legend_field")

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1692,6 +1692,29 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         with abbreviated_exception():
             self._update_glyph(renderer, properties, mapping, glyph, source, source.data)
 
+    def _find_axes(self, plot, element):
+        """
+        Looks up the axes and plot ranges given the plot and an element.
+        """
+        axis_dims = self._get_axis_dims(element)[:2]
+        if self.invert_axes:
+            axis_dims[0], axis_dims[1] = axis_dims[::-1]
+        x, y = axis_dims
+        if x.name in plot.extra_x_ranges:
+            x_range = plot.extra_x_ranges[x.name]
+            xaxes = [xaxis for xaxis in plot.xaxis if xaxis.x_range_name == x.name]
+            x_axis = (xaxes if xaxes else plot.xaxis)[0]
+        else:
+            x_range = plot.x_range
+            x_axis = plot.xaxis[0]
+        if y.name in plot.extra_y_ranges:
+            y_range = plot.extra_y_ranges[y.name]
+            yaxes = [yaxis for yaxis in plot.yaxis if yaxis.y_range_name == y.name]
+            y_axis = (yaxes if yaxes else plot.yaxis)[0]
+        else:
+            y_range = plot.y_range
+            y_axis = plot.yaxis[0]
+        return (x_axis, y_axis), (x_range, y_range)
 
     def initialize_plot(self, ranges=None, plot=None, plots=None, source=None):
         """
@@ -1714,10 +1737,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             plot = self._init_plot(key, style_element, ranges=ranges, plots=plots)
             self._init_axes(plot)
         else:
-            self.handles['xaxis'] = plot.xaxis[0]
-            self.handles['x_range'] = plot.x_range
-            self.handles['yaxis'] = plot.yaxis[0]
-            self.handles['y_range'] = plot.y_range
+            axes, plot_ranges = self._find_axes(plot, element)
+            self.handles['xaxis'], self.handles['yaxis'] = axes
+            self.handles['x_range'], self.handles['y_range'] = plot_ranges
         self.handles['plot'] = plot
 
         if self.autorange:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1696,14 +1696,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if self.invert_axes:
             axis_dims[0], axis_dims[1] = axis_dims[::-1]
         x, y = axis_dims
-        if x.name in plot.extra_x_ranges:
+        if isinstance(x, Dimension) and x.name in plot.extra_x_ranges:
             x_range = plot.extra_x_ranges[x.name]
             xaxes = [xaxis for xaxis in plot.xaxis if xaxis.x_range_name == x.name]
             x_axis = (xaxes if xaxes else plot.xaxis)[0]
         else:
             x_range = plot.x_range
             x_axis = plot.xaxis[0]
-        if y.name in plot.extra_y_ranges:
+        if isinstance(y, Dimension) and y.name in plot.extra_y_ranges:
             y_range = plot.extra_y_ranges[y.name]
             yaxes = [yaxis for yaxis in plot.yaxis if yaxis.y_range_name == y.name]
             y_axis = (yaxes if yaxes else plot.yaxis)[0]

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1350,27 +1350,22 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if 'legend_field' in properties and 'legend_label' in properties:
             del properties['legend_label']
 
-        # ALERT: This only handles XYGlyph types right now
-        # and note guard against Field (unhashable) when using FactorRanges
-        mapping = property_to_dict(mapping)
-        if 'x' in mapping:
-            x = mapping['x']
-            if plot.extra_x_ranges and (x in plot.extra_x_ranges):
-                properties['x_range_name'] = mapping['x']
-        if 'y' in mapping:
-            y = mapping['y']
-            if plot.extra_y_ranges and (y in plot.extra_y_ranges):
-                properties['y_range_name'] = mapping['y']
+        axis_dims = self._get_axis_dims(self.current_frame)[:2]
+        if self.invert_axes:
+            axis_dims[0], axis_dims[1] = axis_dims[::-1]
+        xdim, ydim = axis_dims
+        if xdim.name in plot.extra_x_ranges:
+            properties['x_range_name'] = xdim.name
+        if ydim.name in plot.extra_y_ranges:
+            properties['y_range_name'] = ydim.name
 
         if "name" not in properties:
             properties["name"] = properties.get("legend_label") or properties.get("legend_field")
         renderer = getattr(plot, plot_method)(**dict(properties, **mapping))
         return renderer, renderer.glyph
 
-
     def _element_transform(self, transform, element, ranges):
         return transform.apply(element, ranges=ranges, flat=True)
-
 
     def _apply_transforms(self, element, data, ranges, style, group=None):
         new_style = dict(style)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -939,8 +939,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             factors = self._get_dimension_factors(element, ranges, axis_dim)
             extra_scale = self.handles[f'extra_{multi_dim}_scales'][axis_dim] # Assumes scales and ranges zip
             log = isinstance(extra_scale, LogScale)
-            range_update = ((not (self.model_changed(extra_y_range) or self.model_changed(plot))
-                             and self.framewise))
+            range_update = (not (self.model_changed(extra_y_range) or self.model_changed(plot))
+                            and self.framewise)
             if self.drawn and not range_update:
                 continue
             self._update_range(

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -927,6 +927,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     def _update_ranges(self, element, ranges):
         x_range = self.handles['x_range']
         y_range = self.handles['y_range']
+        plot = self.handles['plot']
 
         self._update_main_ranges(element, x_range, y_range, ranges)
 
@@ -938,6 +939,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             factors = self._get_dimension_factors(element, ranges, axis_dim)
             extra_scale = self.handles[f'extra_{multi_dim}_scales'][axis_dim] # Assumes scales and ranges zip
             log = isinstance(extra_scale, LogScale)
+            range_update = ((not (self.model_changed(extra_y_range) or self.model_changed(plot))
+                             and self.framewise))
+            if self.drawn and not range_update:
+                continue
             self._update_range(
                 extra_y_range, b, t, factors,
                 extra_y_range.tags[1]['invert_yaxis'] if extra_y_range.tags else False,

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -82,18 +82,6 @@ class RasterPlot(ColorbarPlot):
         if self.hmap.type == Raster:
             self.invert_yaxis = not self.invert_yaxis
 
-    def _init_glyph(self, plot, mapping, properties):
-        renderer, glyph = super()._init_glyph(plot, mapping, properties)
-        axis_dims = self._get_axis_dims(self.current_frame)[:2]
-        if self.invert_axes:
-            axis_dims[0], axis_dims[1] = axis_dims[::-1]
-        xdim, ydim = axis_dims
-        if xdim.name in plot.extra_x_ranges:
-            renderer.x_range_name = xdim.name
-        if ydim.name in plot.extra_y_ranges:
-            renderer.y_range_name = ydim.name
-        return renderer, glyph
-
     def get_data(self, element, ranges, style):
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
         val_dim = element.vdims[0]

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -82,6 +82,18 @@ class RasterPlot(ColorbarPlot):
         if self.hmap.type == Raster:
             self.invert_yaxis = not self.invert_yaxis
 
+    def _init_glyph(self, plot, mapping, properties):
+        renderer, glyph = super()._init_glyph(plot, mapping, properties)
+        axis_dims = self._get_axis_dims(self.current_frame)[:2]
+        if self.invert_axes:
+            axis_dims[0], axis_dims[1] = axis_dims[::-1]
+        xdim, ydim = axis_dims
+        if xdim.name in plot.extra_x_ranges:
+            renderer.x_range_name = xdim.name
+        if ydim.name in plot.extra_y_ranges:
+            renderer.y_range_name = ydim.name
+        return renderer, glyph
+
     def get_data(self, element, ranges, style):
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
         val_dim = element.vdims[0]

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1699,7 +1699,7 @@ class GenericOverlayPlot(GenericElementPlot):
 
         if ('multi_y' in self.param) and self.multi_y:
             for s in self.streams:
-                intersection =  set(s.param) & {'y', 'y_selection', 'y_range', 'bounds', 'boundsy'}
+                intersection =  set(s.param) & {'y', 'y_selection', 'bounds', 'boundsy'}
                 if intersection:
                     self.param.warning(f'{type(s).__name__} stream parameters'
                                        f' {list(intersection)} not yet supported with multi_y=True')

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -445,3 +445,23 @@ def test_msg_with_base64_array():
 
     data_expected = np.array([10.0, 20.0, 30.0, 40.0])
     assert np.equal(data_expected, data_after).all()
+
+
+def test_rangexy_multi_yaxes():
+    c1 = Curve(np.arange(100).cumsum(), vdims='y')
+    c2 = Curve(-np.arange(100).cumsum(), vdims='y2')
+    r1 = RangeXY(source=c1)
+    r2 = RangeXY(source=c2)
+
+    overlay = (c1 * c2).opts(backend='bokeh', multi_y=True)
+    plot = bokeh_server_renderer.get_plot(overlay)
+
+    p1, p2 = plot.subplots.values()
+
+    assert plot.state.y_range is p1.handles['y_range']
+    assert 'y2' in plot.state.extra_y_ranges
+    assert plot.state.extra_y_ranges['y2'] is p2.handles['y_range']
+
+    # Ensure both callbacks are attached
+    assert p1.callbacks[0].plot is p1
+    assert p2.callbacks[0].plot is p2

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -450,8 +450,8 @@ def test_msg_with_base64_array():
 def test_rangexy_multi_yaxes():
     c1 = Curve(np.arange(100).cumsum(), vdims='y')
     c2 = Curve(-np.arange(100).cumsum(), vdims='y2')
-    r1 = RangeXY(source=c1)
-    r2 = RangeXY(source=c2)
+    RangeXY(source=c1)
+    RangeXY(source=c2)
 
     overlay = (c1 * c2).opts(backend='bokeh', multi_y=True)
     plot = bokeh_server_renderer.get_plot(overlay)


### PR DESCRIPTION
This PR does four things:

- Generalize the logic for populating `Plot.handles` with the correct x/y-range and x/y-axis 
- Generalize the logic for mapping the correct axes/ranges to the GlyphRenderer
- Fix Linked Stream Callback hashing to ensure that plots with different axes don't reuse the same callback
- Look up RangeXY data on ranges rather than use event data   
 

- [x] Add tests