### PR TITLE
Vectorized VLines, HLines, VSpans and HSpans elements

### DIFF
--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,6 +1,7 @@
 import platform
 import sys
 
+import bokeh
 import pandas as pd
 from packaging.version import Version
 
@@ -37,4 +38,14 @@ if sys.version_info[:2] == (3, 8) and platform.system() == "Linux":
     collect_ignore_glob += [
         "gallery/demos/*/bachelors_degrees_by_gender.ipynb",
         "gallery/demos/*/topographic_hillshading.ipynb",
+    ]
+
+
+# First available in Bokeh 3.2.0
+if Version(bokeh.__version__) < Version("3.2.0"):
+    collect_ignore_glob += [
+        "reference/elements/bokeh/HLines.ipynb",
+        "reference/elements/bokeh/HSpans.ipynb",
+        "reference/elements/bokeh/VLines.ipynb",
+        "reference/elements/bokeh/VSpans.ipynb",
     ]

--- a/examples/reference/elements/bokeh/HLines.ipynb
+++ b/examples/reference/elements/bokeh/HLines.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: HLine Element\n",
+    "\n",
+    "**Dependencies**: Bokeh 3.2\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/HLines.ipynb), [Bokeh](../bokeh/HLines.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "\n",
+    "hv.extension('bokeh')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``HLines`` element is a type of annotation that can mark multiple lines along the y-axis. It accepts a list of y-coordinates and will draw a horizontal line at each location. This has the advantage over [``HLine``](./HLine.ipynb) of being able to draw multiple lines at once and also being able to get hover information for each of the line."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ys = np.random.normal(size=10)\n",
+    "hv.HLines(ys).opts(tools=['hover'], color='red', line_width=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.HLines).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/elements/bokeh/HSpans.ipynb
+++ b/examples/reference/elements/bokeh/HSpans.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: HLine Element\n",
+    "\n",
+    "**Dependencies**: Bokeh 3.2\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/HSpans.ipynb), [Bokeh](../bokeh/HSpans.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "\n",
+    "hv.extension('bokeh')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``HSpans`` element is a type of annotation that can mark multiple spans along the y-axis. It accepts a list of start and end y-coordinates and will draw horizontal spans. This has the advantage over [``HSpan``](./HSpan.ipynb) of being able to draw multiple spans at once and also being able to get hover information for each of the span."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_start = np.arange(10)\n",
+    "y_end = y_start + np.random.random(size=10) / 2\n",
+    "hv.HSpans((y_start, y_end)).opts(tools=['hover'], color='red')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.HSpans).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/elements/bokeh/VLines.ipynb
+++ b/examples/reference/elements/bokeh/VLines.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: HLine Element\n",
+    "\n",
+    "**Dependencies**: Bokeh 3.2\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/VLines.ipynb), [Bokeh](../bokeh/VLines.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "\n",
+    "hv.extension('bokeh')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``VLines`` element is a type of annotation that can mark multiple lines along the x-axis. It accepts a list of x-coordinates and will draw a vertical line at each location. This has the advantage over [``VLine``](./VLine.ipynb) of being able to draw multiple lines at once and also being able to get hover information for each of the line."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.random.normal(size=10)\n",
+    "hv.VLines(xs).opts(tools=['hover'], color='red', line_width=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.VLines).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/elements/bokeh/VSpans.ipynb
+++ b/examples/reference/elements/bokeh/VSpans.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: HLine Element\n",
+    "\n",
+    "**Dependencies**: Bokeh 3.2\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/VSpans.ipynb), [Bokeh](../bokeh/VSpans.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "\n",
+    "hv.extension('bokeh')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``VSpans`` element is a type of annotation that can mark multiple spans along the x-axis. It accepts a list of start and end x-coordinates and will draw vertical spans at each location. This has the advantage over [``VSpan``](./VSpan.ipynb) of being able to draw multiple spans at once and also being able to get hover information for each of the span."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_start = np.arange(10)\n",
+    "x_end = x_start + np.random.random(size=10) / 2\n",
+    "hv.VSpans((x_start, x_end)).opts(tools=['hover'], color='red')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.VSpans).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/elements/matplotlib/HLines.ipynb
+++ b/examples/reference/elements/matplotlib/HLines.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: HLine Element\n",
+    "\n",
+    "**Dependencies**: Matplotlib\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/HLines.ipynb), [Bokeh](../bokeh/HLines.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "\n",
+    "hv.extension('matplotlib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``HLines`` element is a type of annotation that can mark multiple lines along the y-axis. It accepts a list of y-coordinates and will draw a horizontal line at each location. This has the advantage over [``HLine``](./HLine.ipynb) of being able to draw multiple lines at once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ys = np.random.normal(size=10)\n",
+    "hv.HLines(ys).opts(color='red')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.HLines).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/elements/matplotlib/HSpans.ipynb
+++ b/examples/reference/elements/matplotlib/HSpans.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: HLine Element\n",
+    "\n",
+    "**Dependencies**: Matplotlib\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/HSpans.ipynb), [Bokeh](../bokeh/HSpans.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "\n",
+    "hv.extension('matplotlib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``HSpans`` element is a type of annotation that can mark multiple spans along the y-axis. It accepts a list of start and end y-coordinates and will draw horizontal spans. This has the advantage over [``HSpan``](./HSpan.ipynb) of being able to draw multiple spans at once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_start = np.arange(10)\n",
+    "y_end = y_start + np.random.random(size=10) / 2\n",
+    "hv.HSpans((y_start, y_end)).opts(color='red')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.HSpans).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/elements/matplotlib/VLines.ipynb
+++ b/examples/reference/elements/matplotlib/VLines.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: HLine Element\n",
+    "\n",
+    "**Dependencies**: Matplotlib\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/VLines.ipynb), [Bokeh](../bokeh/VLines.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "\n",
+    "hv.extension('matplotlib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``VLines`` element is a type of annotation that can mark multiple lines along the x-axis. It accepts a list of x-coordinates and will draw a vertical line at each location. This has the advantage over [``VLine``](./VLine.ipynb) of being able to draw multiple lines at once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.random.normal(size=10)\n",
+    "hv.VLines(xs).opts(color='red', linewidth=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.VLines).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/elements/matplotlib/VSpans.ipynb
+++ b/examples/reference/elements/matplotlib/VSpans.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **Title**: HLine Element\n",
+    "\n",
+    "**Dependencies**: Matplotlib\n",
+    "\n",
+    "**Backends**: [Matplotlib](../matplotlib/VSpans.ipynb), [Bokeh](../bokeh/VSpans.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "\n",
+    "hv.extension('matplotlib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``VSpans`` element is a type of annotation that can mark multiple spans along the x-axis. It accepts a list of start and end x-coordinates and will draw vertical spans at each location. This has the advantage over [``VSpan``](./VSpan.ipynb) of being able to draw multiple spans at once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_start = np.arange(10)\n",
+    "x_end = x_start + np.random.random(size=10) / 2\n",
+    "hv.VSpans((x_start, x_end)).opts(color='red')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For full documentation and the available style and plot options, use ``hv.help(hv.VSpans).``"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -39,8 +39,8 @@ class HLines(VectorizedAnnotation):
 
 class HSpans(VectorizedAnnotation):
 
-    kdims = param.List(default=[Dimension('x1'), Dimension('x2'),
-                                Dimension('y1'), Dimension('y2')],
+    kdims = param.List(default=[Dimension('x0'), Dimension('x1'),
+                                Dimension('y0'), Dimension('y1')],
                        bounds=(4, 4))
 
     group = param.String(default='HSpans', constant=True)
@@ -49,8 +49,8 @@ class HSpans(VectorizedAnnotation):
 
 class VSpans(VectorizedAnnotation):
 
-    kdims = param.List(default=[Dimension('x1'), Dimension('x2'),
-                                Dimension('y1'), Dimension('y2')],
+    kdims = param.List(default=[Dimension('x0'), Dimension('x1'),
+                                Dimension('y0'), Dimension('y1')],
                        bounds=(4, 4))
 
     group = param.String(default='VSpans', constant=True)

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -39,22 +39,22 @@ class HLines(VectorizedAnnotation):
 
 class HSpans(VectorizedAnnotation):
 
-    kdims = param.List(default=[Dimension('x0'), Dimension('x1'),
-                                Dimension('y0'), Dimension('y1')],
+    kdims = param.List(default=[Dimension('x0'), Dimension('y0'),
+                                Dimension('x1'), Dimension('y1')],
                        bounds=(4, 4))
 
     group = param.String(default='HSpans', constant=True)
-    _synthetic_dimensions = [0,1]
+    _synthetic_dimensions = [0,2]
 
 
 class VSpans(VectorizedAnnotation):
 
-    kdims = param.List(default=[Dimension('x0'), Dimension('x1'),
-                                Dimension('y0'), Dimension('y1')],
+    kdims = param.List(default=[Dimension('x0'), Dimension('y0'),
+                                Dimension('x1'), Dimension('y1')],
                        bounds=(4, 4))
 
     group = param.String(default='VSpans', constant=True)
-    _synthetic_dimensions = [2,3]
+    _synthetic_dimensions = [1,3]
 
 
 

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -43,6 +43,42 @@ class HLines(VectorizedAnnotation):
         super().__init__(ds.data, kdims, **params)
 
 
+class HSpans(VectorizedAnnotation):
+
+    kdims = param.List(default=[Dimension('x1'), Dimension('x2'),
+                                Dimension('y1'), Dimension('y2')],
+                       bounds=(4, 4))
+
+    group = param.String(default='HSpans', constant=True)
+    _auto_indexable_1d = False
+
+    def __init__(self, data, **params):
+        synthetic_dimensions = [0,1]
+        kdims = params.pop('kdims', self.kdims)
+        real_kdims = [kd for i, kd in enumerate(kdims) if i not in synthetic_dimensions]
+        ds = Dataset(data, real_kdims, params.get('vdims', []))
+        for sd in synthetic_dimensions:
+            ds = ds.add_dimension(kdims[sd], sd, np.nan)
+        super().__init__(ds.data, kdims, **params)
+
+
+class VSpans(VectorizedAnnotation):
+
+    kdims = param.List(default=[Dimension('x1'), Dimension('x2'),
+                                Dimension('y1'), Dimension('y2')],
+                       bounds=(4, 4))
+
+    group = param.String(default='VSpans', constant=True)
+    _auto_indexable_1d = False
+
+    def __init__(self, data, **params):
+        synthetic_dimensions = [2,3]
+        kdims = params.pop('kdims', self.kdims)
+        real_kdims = [kd for i, kd in enumerate(kdims) if i not in synthetic_dimensions]
+        ds = Dataset(data, real_kdims, params.get('vdims', []))
+        for sd in synthetic_dimensions:
+            ds = ds.add_dimension(kdims[sd], sd, np.nan)
+        super().__init__(ds.data, kdims, **params)
 
 
 class Annotation(Element2D):

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -7,6 +7,44 @@ from ..core import Dimension, Element2D, Element
 from ..core.data import Dataset
 
 
+
+class VectorizedAnnotation(Dataset, Element2D):
+
+    kdims = param.List(default=[Dimension('x'), Dimension('y')],
+                       bounds=(2, 2))
+
+    _auto_indexable_1d = False
+
+class VLines(VectorizedAnnotation):
+
+    group = param.String(default='VLines', constant=True)
+
+    def __init__(self, data, **params):
+        synthetic_dimensions = [1]
+        kdims = params.pop('kdims', self.kdims)
+        real_kdims = [kd for i, kd in enumerate(kdims) if i not in synthetic_dimensions]
+        ds = Dataset(data, real_kdims, params.get('vdims', []))
+        for sd in synthetic_dimensions:
+            ds = ds.add_dimension(kdims[sd], sd, np.nan)
+        super().__init__(ds.data, kdims, **params)
+
+
+class HLines(VectorizedAnnotation):
+
+    group = param.String(default='HLines', constant=True)
+
+    def __init__(self, data, **params):
+        synthetic_dimensions = [0]
+        kdims = params.pop('kdims', self.kdims)
+        real_kdims = [kd for i, kd in enumerate(kdims) if i not in synthetic_dimensions]
+        ds = Dataset(data, real_kdims, params.get('vdims', []))
+        for sd in synthetic_dimensions:
+            ds = ds.add_dimension(kdims[sd], sd, np.nan)
+        super().__init__(ds.data, kdims, **params)
+
+
+
+
 class Annotation(Element2D):
     """
     An Annotation is a special type of element that is designed to be

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -14,33 +14,27 @@ class VectorizedAnnotation(Dataset, Element2D):
                        bounds=(2, 2))
 
     _auto_indexable_1d = False
+    _synthetic_dimensions = []
+
+    def __init__(self, data, **params):
+        kdims = params.pop('kdims', self.kdims)
+        real_kdims = [kd for i, kd in enumerate(kdims) if i not in self._synthetic_dimensions]
+        ds = Dataset(data, real_kdims, params.get('vdims', []))
+        for sd in self._synthetic_dimensions:
+            ds = ds.add_dimension(kdims[sd], sd, np.nan)
+        super().__init__(ds.data, kdims, **params)
 
 class VLines(VectorizedAnnotation):
 
     group = param.String(default='VLines', constant=True)
 
-    def __init__(self, data, **params):
-        synthetic_dimensions = [1]
-        kdims = params.pop('kdims', self.kdims)
-        real_kdims = [kd for i, kd in enumerate(kdims) if i not in synthetic_dimensions]
-        ds = Dataset(data, real_kdims, params.get('vdims', []))
-        for sd in synthetic_dimensions:
-            ds = ds.add_dimension(kdims[sd], sd, np.nan)
-        super().__init__(ds.data, kdims, **params)
+    _synthetic_dimensions = [1]
 
 
 class HLines(VectorizedAnnotation):
 
     group = param.String(default='HLines', constant=True)
-
-    def __init__(self, data, **params):
-        synthetic_dimensions = [0]
-        kdims = params.pop('kdims', self.kdims)
-        real_kdims = [kd for i, kd in enumerate(kdims) if i not in synthetic_dimensions]
-        ds = Dataset(data, real_kdims, params.get('vdims', []))
-        for sd in synthetic_dimensions:
-            ds = ds.add_dimension(kdims[sd], sd, np.nan)
-        super().__init__(ds.data, kdims, **params)
+    _synthetic_dimensions = [0]
 
 
 class HSpans(VectorizedAnnotation):
@@ -50,16 +44,7 @@ class HSpans(VectorizedAnnotation):
                        bounds=(4, 4))
 
     group = param.String(default='HSpans', constant=True)
-    _auto_indexable_1d = False
-
-    def __init__(self, data, **params):
-        synthetic_dimensions = [0,1]
-        kdims = params.pop('kdims', self.kdims)
-        real_kdims = [kd for i, kd in enumerate(kdims) if i not in synthetic_dimensions]
-        ds = Dataset(data, real_kdims, params.get('vdims', []))
-        for sd in synthetic_dimensions:
-            ds = ds.add_dimension(kdims[sd], sd, np.nan)
-        super().__init__(ds.data, kdims, **params)
+    _synthetic_dimensions = [0,1]
 
 
 class VSpans(VectorizedAnnotation):
@@ -69,16 +54,8 @@ class VSpans(VectorizedAnnotation):
                        bounds=(4, 4))
 
     group = param.String(default='VSpans', constant=True)
-    _auto_indexable_1d = False
+    _synthetic_dimensions = [2,3]
 
-    def __init__(self, data, **params):
-        synthetic_dimensions = [2,3]
-        kdims = params.pop('kdims', self.kdims)
-        real_kdims = [kd for i, kd in enumerate(kdims) if i not in synthetic_dimensions]
-        ds = Dataset(data, real_kdims, params.get('vdims', []))
-        for sd in synthetic_dimensions:
-            ds = ds.add_dimension(kdims[sd], sd, np.nan)
-        super().__init__(ds.data, kdims, **params)
 
 
 class Annotation(Element2D):

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -10,40 +10,13 @@ from ..core.data import Dataset
 
 class VectorizedAnnotation(Dataset, Element2D):
 
-
     _auto_indexable_1d = False
-
-    # def __init__(self, data, **params):
-    #     kdims = params.pop('kdims', self.kdims)
-    #     real_kdims = [kd for i, kd in enumerate(kdims) if i not in self._synthetic_dimensions]
-    #     ds = Dataset(data, real_kdims, params.get('vdims', []))
-    #     for sd in self._synthetic_dimensions:
-
-    #         ds = ds.add_dimension(kdims[sd], sd, np.nan)
-    #     super().__init__(ds.data, kdims, **params)
 
 
 class VLines(VectorizedAnnotation):
 
     kdims = param.List(default=[Dimension('x')], bounds=(1, 1))
     group = param.String(default='VLines', constant=True)
-
-
-    def __dimension_values(self, dimension, expanded=True, flat=True):
-        """Return the values along the requested dimension.
-
-        Args:
-            dimension: The dimension to return values for
-            expanded (bool, optional): Whether to expand values
-            flat (bool, optional): Whether to flatten array
-
-        Returns:
-            NumPy array of values along the requested dimension
-        """
-        index = self.get_dimension_index(dimension)
-        if index == 1 and len(self.kdims) == 1:
-            return self.data[str(self.kdims[0])]
-        return super().dimension_values(dimension)
 
 
 class HLines(VectorizedAnnotation):

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -10,51 +10,62 @@ from ..core.data import Dataset
 
 class VectorizedAnnotation(Dataset, Element2D):
 
-    kdims = param.List(default=[Dimension('x'), Dimension('y')],
-                       bounds=(2, 2))
 
     _auto_indexable_1d = False
-    _synthetic_dimensions = []
 
-    def __init__(self, data, **params):
-        kdims = params.pop('kdims', self.kdims)
-        real_kdims = [kd for i, kd in enumerate(kdims) if i not in self._synthetic_dimensions]
-        ds = Dataset(data, real_kdims, params.get('vdims', []))
-        for sd in self._synthetic_dimensions:
-            ds = ds.add_dimension(kdims[sd], sd, np.nan)
-        super().__init__(ds.data, kdims, **params)
+    # def __init__(self, data, **params):
+    #     kdims = params.pop('kdims', self.kdims)
+    #     real_kdims = [kd for i, kd in enumerate(kdims) if i not in self._synthetic_dimensions]
+    #     ds = Dataset(data, real_kdims, params.get('vdims', []))
+    #     for sd in self._synthetic_dimensions:
+
+    #         ds = ds.add_dimension(kdims[sd], sd, np.nan)
+    #     super().__init__(ds.data, kdims, **params)
+
 
 class VLines(VectorizedAnnotation):
 
+    kdims = param.List(default=[Dimension('x')], bounds=(1, 1))
     group = param.String(default='VLines', constant=True)
 
-    _synthetic_dimensions = [1]
+
+    def __dimension_values(self, dimension, expanded=True, flat=True):
+        """Return the values along the requested dimension.
+
+        Args:
+            dimension: The dimension to return values for
+            expanded (bool, optional): Whether to expand values
+            flat (bool, optional): Whether to flatten array
+
+        Returns:
+            NumPy array of values along the requested dimension
+        """
+        index = self.get_dimension_index(dimension)
+        if index == 1 and len(self.kdims) == 1:
+            return self.data[str(self.kdims[0])]
+        return super().dimension_values(dimension)
 
 
 class HLines(VectorizedAnnotation):
 
+    kdims = param.List(default=[Dimension('y')], bounds=(1, 1))
     group = param.String(default='HLines', constant=True)
-    _synthetic_dimensions = [0]
 
 
 class HSpans(VectorizedAnnotation):
 
-    kdims = param.List(default=[Dimension('x0'), Dimension('y0'),
-                                Dimension('x1'), Dimension('y1')],
-                       bounds=(4, 4))
+    kdims = param.List(default=[Dimension('y0'), Dimension('y1')],
+                       bounds=(2, 2))
 
     group = param.String(default='HSpans', constant=True)
-    _synthetic_dimensions = [0,2]
 
 
 class VSpans(VectorizedAnnotation):
 
-    kdims = param.List(default=[Dimension('x0'), Dimension('y0'),
-                                Dimension('x1'), Dimension('y1')],
-                       bounds=(4, 4))
+    kdims = param.List(default=[Dimension('x0'), Dimension('x1')],
+                       bounds=(2, 2))
 
     group = param.String(default='VSpans', constant=True)
-    _synthetic_dimensions = [1,3]
 
 
 

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -59,12 +59,6 @@ associations = {Overlay: OverlayPlot,
                 Layout: LayoutPlot,
                 NdLayout: LayoutPlot,
 
-                VLines: VLinesAnnotationPlot,
-                HLines: HLinesAnnotationPlot,
-
-                HSpans:HSpansAnnotationPlot,
-                VSpans:VSpansAnnotationPlot,
-
                 # Charts
                 Curve: CurvePlot,
                 Bars: BarPlot,
@@ -101,6 +95,10 @@ associations = {Overlay: OverlayPlot,
                 Segments: SegmentPlot,
 
                 # Annotations
+                VLines: VLinesAnnotationPlot,
+                HLines: HLinesAnnotationPlot,
+                HSpans: HSpansAnnotationPlot,
+                VSpans: VSpansAnnotationPlot,
                 HLine: LineAnnotationPlot,
                 VLine: LineAnnotationPlot,
                 HSpan: BoxAnnotationPlot,

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -14,11 +14,11 @@ from ...element import (Curve, Points, Scatter, Image, Raster, Path,
                         Table, ItemTable, Area, HSV, QuadMesh, VectorField,
                         Graph, Nodes, EdgePaths, Distribution, Bivariate,
                         TriMesh, Violin, Chord, Div, HexTiles, Labels, Sankey,
-                        Tiles, Segments, Slope, Rectangles)
+                        Tiles, Segments, Slope, Rectangles, VLines, HLines)
 from ...core.options import Options, Cycle, Palette
 
 from .annotation import (
-    TextPlot, LineAnnotationPlot, BoxAnnotationPlot, SplinePlot, ArrowPlot,
+    TextPlot, LineAnnotationPlot, VLinesAnnotationPlot, HLinesAnnotationPlot, BoxAnnotationPlot, SplinePlot, ArrowPlot,
     DivPlot, LabelsPlot, SlopePlot
 )
 from ..plot import PlotSelector
@@ -56,6 +56,9 @@ associations = {Overlay: OverlayPlot,
                 AdjointLayout: AdjointLayoutPlot,
                 Layout: LayoutPlot,
                 NdLayout: LayoutPlot,
+
+                VLines: VLinesAnnotationPlot,
+                HLines: HLinesAnnotationPlot,
 
                 # Charts
                 Curve: CurvePlot,

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -14,13 +14,15 @@ from ...element import (Curve, Points, Scatter, Image, Raster, Path,
                         Table, ItemTable, Area, HSV, QuadMesh, VectorField,
                         Graph, Nodes, EdgePaths, Distribution, Bivariate,
                         TriMesh, Violin, Chord, Div, HexTiles, Labels, Sankey,
-                        Tiles, Segments, Slope, Rectangles, VLines, HLines)
+                        Tiles, Segments, Slope, Rectangles, VLines, VSpans, HLines, HSpans)
 from ...core.options import Options, Cycle, Palette
 
 from .annotation import (
-    TextPlot, LineAnnotationPlot, VLinesAnnotationPlot, HLinesAnnotationPlot, BoxAnnotationPlot, SplinePlot, ArrowPlot,
+    TextPlot, LineAnnotationPlot, VLinesAnnotationPlot, VSpansAnnotationPlot,
+    HLinesAnnotationPlot, HSpansAnnotationPlot, BoxAnnotationPlot, SplinePlot, ArrowPlot,
     DivPlot, LabelsPlot, SlopePlot
 )
+
 from ..plot import PlotSelector
 from ..util import fire
 from .callbacks import Callback # noqa (API import)
@@ -59,6 +61,9 @@ associations = {Overlay: OverlayPlot,
 
                 VLines: VLinesAnnotationPlot,
                 HLines: HLinesAnnotationPlot,
+
+                HSpans:HSpansAnnotationPlot,
+                VSpans:VSpansAnnotationPlot,
 
                 # Charts
                 Curve: CurvePlot,

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -211,6 +211,10 @@ options.VSpan = Options('style', color=Cycle(), alpha=0.5)
 options.HSpan = Options('style', color=Cycle(), alpha=0.5)
 options.Arrow = Options('style', arrow_size=10)
 options.Labels = Options('style', text_align='center', text_baseline='middle')
+options.HLines = Options('style', color=Cycle(), line_width=3, alpha=1)
+options.VLines = Options('style', color=Cycle(), line_width=3, alpha=1)
+options.VSpans = Options('style', color=Cycle(), alpha=0.5)
+options.HSpans = Options('style', color=Cycle(), alpha=0.5)
 
 # Graphs
 options.Graph = Options(

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -44,7 +44,7 @@ class _SyntheticAnnotationPlot(ElementPlot):
         return super()._init_glyph(plot, mapping, properties)
 
     def get_data(self, element, ranges, style):
-        data = {str(k): v for k, v in element.data.items()}
+        data = {str(k): v for k, v in element.dataset.data.items()}
         default = self._element_default[self.invert_axes].kdims
         mapping = {str(d): str(k) for d, k in zip(default, element.kdims)}
         return data, mapping, style

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -11,7 +11,7 @@ from bokeh.models import TeeHead, NormalHead
 from bokeh.transform import dodge
 
 from ...core.util import datetime_types, dimension_sanitizer
-from ...element import HLine, VLine, VSpan
+from ...element import HLine, VLine, VSpan, VLines, HLines
 from ..plot import GenericElementPlot
 from .element import AnnotationPlot, ElementPlot, CompositeElementPlot, ColorbarPlot
 from .selection import BokehOverlaySelectionDisplay
@@ -22,6 +22,53 @@ from .util import date_to_integer
 arrow_start = {'<->': NormalHead, '<|-|>': NormalHead}
 arrow_end = {'->': NormalHead, '-[': TeeHead, '-|>': NormalHead,
                 '-': None}
+
+try:
+    from bokeh.models import HSpan, VSpan, HStrip, VStrip
+except:
+    raise Exception('Bokeh version check?')
+
+
+
+class HLinesAnnotationPlot(ElementPlot):
+    apply_ranges = param.Boolean(default=True, doc="""
+        Whether to include the annotation in axis range calculations.""")
+
+    style_opts = line_properties + ['level', 'visible']
+    _allow_implicit_categories = False
+    _plot_methods = dict(single='hspan')
+
+    def get_data(self, element, ranges, style):
+        data, mapping = {}, {}
+        loc = list(element.dimension_values(element.kdims[1])) # invert_axes?
+        if isinstance(loc, datetime_types):
+            loc = date_to_integer(loc)
+        data['y'] = loc
+
+        vdim_data = {str(name):element.dimension_values(name) for name in element.vdims}
+        data.update(vdim_data)
+        return (data, {'y':'y'}, style)
+
+
+class VLinesAnnotationPlot(ElementPlot):
+    apply_ranges = param.Boolean(default=True, doc="""
+        Whether to include the annotation in axis range calculations.""")
+
+    style_opts = line_properties + ['level', 'visible']
+    _allow_implicit_categories = False
+    _plot_methods = dict(single='vspan')
+
+    def get_data(self, element, ranges, style):
+        data, mapping = {}, {}
+        loc = list(element.dimension_values(element.kdims[0])) # invert_axes?
+        if isinstance(loc, datetime_types):
+            loc = date_to_integer(loc)
+        data['x'] = loc
+
+        vdim_data = {str(name):element.dimension_values(name) for name in element.vdims}
+        data.update(vdim_data)
+        return (data, {'x':'x'}, style)
+
 
 
 class TextPlot(ElementPlot, AnnotationPlot):

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -39,14 +39,20 @@ class _SyntheticAnnotationPlot(ElementPlot):
             raise ImportError(msg)
         super().__init__(element, **kwargs)
 
+    def _init_glyph(self, plot, mapping, properties):
+        self._plot_methods = {"single": self._methods[self.invert_axes]}
+        return super()._init_glyph(plot, mapping, properties)
+
     def get_data(self, element, ranges, style):
         data = {str(k): v for k, v in element.data.items()}
-        mapping = {str(d): str(k) for d, k in zip(element.param.kdims.default, element.kdims)}
+        default = self._element_default[self.invert_axes].kdims
+        mapping = {str(d): str(k) for d, k in zip(default, element.kdims)}
         return data, mapping, style
 
     def initialize_plot(self, ranges=None, plot=None, plots=None, source=None):
         figure = super().initialize_plot(ranges=ranges, plot=plot, plots=plots, source=source)
-        for ax, label in zip(figure.axis, "xy"):
+        labels = "yx" if self.invert_axes else "xy"
+        for ax, label in zip(figure.axis, labels):
             ax.axis_label = label
         return figure
 
@@ -64,26 +70,27 @@ class _SyntheticAnnotationPlot(ElementPlot):
 
 class HLinesAnnotationPlot(_SyntheticAnnotationPlot):
 
-    _plot_methods = dict(single='hspan')
-    _element_name = 'VLines'
+    # If invert_axes is False we use the first method,
+    # and if True the second as _plot_methods(single=...)
+    _methods = ('hspan', 'vspan')
+    _element_default = (HLines, VLines)
 
 
 class VLinesAnnotationPlot(_SyntheticAnnotationPlot):
 
-    _plot_methods = dict(single='vspan')
-    _element_name = 'HLines'
-
+    _methods = ('vspan', 'hspan')
+    _element_default = (VLines, HLines)
 
 class HSpansAnnotationPlot(_SyntheticAnnotationPlot):
 
-    _plot_methods = dict(single='hstrip')
-    _element_name = 'HSpans'
+    _methods = ('hstrip', 'vstrip')
+    _element_default = (HSpans, VSpans)
 
 
 class VSpansAnnotationPlot(_SyntheticAnnotationPlot):
 
-    _plot_methods = dict(single='vstrip')
-    _element_name = 'VSpans'
+    _methods = ('vstrip', 'hstrip')
+    _element_default = (VSpans, HSpans)
 
 
 class TextPlot(ElementPlot, AnnotationPlot):

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -34,7 +34,7 @@ class _SyntheticAnnotationPlot(ElementPlot):
 
     def __init__(self, element, **kwargs):
         if not bokeh32:
-            name = type(element.last).__name__
+            name = type(getattr(element, "last", element)).__name__
             msg = f'{name} element requires Bokeh >=3.2'
             raise ImportError(msg)
         super().__init__(element, **kwargs)

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -44,6 +44,12 @@ class _SyntheticAnnotationPlot(ElementPlot):
         mapping = {str(k): str(k) for k in element.kdims}
         return data, mapping, style
 
+    def initialize_plot(self, ranges=None, plot=None, plots=None, source=None):
+        figure = super().initialize_plot(ranges=ranges, plot=plot, plots=plots, source=source)
+        for ax, label in zip(figure.axis, "xy"):
+            ax.axis_label = label
+        return figure
+
     def get_extents(self, element, ranges=None, range_type='combined', **kwargs):
         extents = super().get_extents(element, ranges, range_type)
         if isinstance(element, HLines):

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -40,7 +40,7 @@ class _SyntheticAnnotationPlot(ElementPlot):
 
     def get_data(self, element, ranges, style):
         data = {}
-        indices = set(range(4)) - set(element._synthetic_dimensions)
+        indices = set(range(len(element.kdims))) - set(element._synthetic_dimensions)
         for index in indices:
             name = element.kdims[index]
             loc = list(element.dimension_values(name)) # invert_axes?

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -50,6 +50,13 @@ class _SyntheticAnnotationPlot(ElementPlot):
         data.update({str(name): element.dimension_values(name) for name in element.vdims})
         return data, mapping, style
 
+    def _hover_opts(self, element):
+        dims, opts = super()._hover_opts(element)
+        for sd in element._synthetic_dimensions:
+            name = element.kdims[sd]
+            if name in dims:
+                dims.remove(name)
+        return dims, opts
 
 class HLinesAnnotationPlot(_SyntheticAnnotationPlot):
 

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -13,7 +13,7 @@ from bokeh.transform import dodge
 from ...core.util import datetime_types, dimension_sanitizer
 from ...element import HLine, VLine, VSpan, HLines, VLines, HSpans, VSpans
 from ..plot import GenericElementPlot
-from .element import AnnotationPlot, ElementPlot, CompositeElementPlot, ColorbarPlot
+from .element import AnnotationPlot, ColorbarPlot, CompositeElementPlot, ElementPlot
 from .selection import BokehOverlaySelectionDisplay
 from .styles import base_properties, fill_properties, line_properties, text_properties
 from .plot import BokehPlot
@@ -24,7 +24,7 @@ arrow_end = {'->': NormalHead, '-[': TeeHead, '-|>': NormalHead,
                 '-': None}
 
 
-class _SyntheticAnnotationPlot(ElementPlot):
+class _SyntheticAnnotationPlot(ColorbarPlot):
 
     apply_ranges = param.Boolean(default=True, doc="""
         Whether to include the annotation in axis range calculations.""")
@@ -81,16 +81,19 @@ class VLinesAnnotationPlot(_SyntheticAnnotationPlot):
     _methods = ('vspan', 'hspan')
     _element_default = (VLines, HLines)
 
+
 class HSpansAnnotationPlot(_SyntheticAnnotationPlot):
 
     _methods = ('hstrip', 'vstrip')
     _element_default = (HSpans, VSpans)
+    style_opts = [*fill_properties, *line_properties, 'level', 'visible']
 
 
 class VSpansAnnotationPlot(_SyntheticAnnotationPlot):
 
     _methods = ('vstrip', 'hstrip')
     _element_default = (VSpans, HSpans)
+    style_opts = [*fill_properties, *line_properties, 'level', 'visible']
 
 
 class TextPlot(ElementPlot, AnnotationPlot):

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -41,7 +41,7 @@ class _SyntheticAnnotationPlot(ElementPlot):
 
     def get_data(self, element, ranges, style):
         data = {str(k): v for k, v in element.data.items()}
-        mapping = {str(k): str(k) for k in element.kdims}
+        mapping = {str(d): str(k) for d, k in zip(element.param.kdims.default, element.kdims)}
         return data, mapping, style
 
     def initialize_plot(self, ranges=None, plot=None, plots=None, source=None):

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -11,7 +11,7 @@ from bokeh.models import TeeHead, NormalHead
 from bokeh.transform import dodge
 
 from ...core.util import datetime_types, dimension_sanitizer
-from ...element import HLine, VLine, VSpan, HLines, VLines
+from ...element import HLine, VLine, VSpan, HLines, VLines, HSpans, VSpans
 from ..plot import GenericElementPlot
 from .element import AnnotationPlot, ElementPlot, CompositeElementPlot, ColorbarPlot
 from .selection import BokehOverlaySelectionDisplay
@@ -50,6 +50,10 @@ class _SyntheticAnnotationPlot(ElementPlot):
             extents = np.nan, extents[0], np.nan, extents[2]
         elif isinstance(element, VLines):
             extents = extents[0], np.nan, extents[2], np.nan
+        elif isinstance(element, HSpans):
+            extents = np.nan, min(extents[:2]), np.nan, max(extents[2:])
+        elif isinstance(element, VSpans):
+            extents = min(extents[:2]), np.nan, max(extents[2:]), np.nan
         return extents
 
 class HLinesAnnotationPlot(_SyntheticAnnotationPlot):

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -24,7 +24,7 @@ arrow_end = {'->': NormalHead, '-[': TeeHead, '-|>': NormalHead,
                 '-': None}
 
 
-class SyntheticAnnotationPlot(ElementPlot):
+class _SyntheticAnnotationPlot(ElementPlot):
 
     apply_ranges = param.Boolean(default=True, doc="""
         Whether to include the annotation in axis range calculations.""")
@@ -40,40 +40,39 @@ class SyntheticAnnotationPlot(ElementPlot):
 
     def get_data(self, element, ranges, style):
         data = {}
-        for name, index in self._data_dims.items():
-            loc = list(element.dimension_values(element.kdims[index])) # invert_axes?
-            data[name]= date_to_integer(loc) if isinstance(loc, datetime_types) else loc
+        indices = set(range(4)) - set(element._synthetic_dimensions)
+        for index in indices:
+            name = element.kdims[index]
+            loc = list(element.dimension_values(name)) # invert_axes?
+            data[str(name)] = date_to_integer(loc) if isinstance(loc, datetime_types) else loc
 
-        mapping = {k:k for k in self._data_dims}
-        data.update({str(name):element.dimension_values(name) for name in element.vdims})
-        return (data, mapping, style)
+        mapping = {k: k for k in data}
+        data.update({str(name): element.dimension_values(name) for name in element.vdims})
+        return data, mapping, style
 
-class HLinesAnnotationPlot(SyntheticAnnotationPlot):
 
-    _data_dims = {'y':1}
-    _element_name = 'VLines'
+class HLinesAnnotationPlot(_SyntheticAnnotationPlot):
+
     _plot_methods = dict(single='hspan')
+    _element_name = 'VLines'
 
 
-class VLinesAnnotationPlot(SyntheticAnnotationPlot):
+class VLinesAnnotationPlot(_SyntheticAnnotationPlot):
 
     _plot_methods = dict(single='vspan')
     _element_name = 'HLines'
-    _data_dims = {'x':0}
 
 
-class HSpansAnnotationPlot(SyntheticAnnotationPlot):
+class HSpansAnnotationPlot(_SyntheticAnnotationPlot):
 
     _plot_methods = dict(single='hstrip')
     _element_name = 'HSpans'
-    _data_dims = {'y0':2, 'y1':3}
 
 
-class VSpansAnnotationPlot(SyntheticAnnotationPlot):
+class VSpansAnnotationPlot(_SyntheticAnnotationPlot):
 
     _plot_methods = dict(single='vstrip')
-    _element_name = 'HSpans'
-    _data_dims = {'x0':0, 'x1':1}
+    _element_name = 'VSpans'
 
 
 class TextPlot(ElementPlot, AnnotationPlot):

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -24,115 +24,56 @@ arrow_end = {'->': NormalHead, '-[': TeeHead, '-|>': NormalHead,
                 '-': None}
 
 
-class HLinesAnnotationPlot(ElementPlot):
+class SyntheticAnnotationPlot(ElementPlot):
+
     apply_ranges = param.Boolean(default=True, doc="""
         Whether to include the annotation in axis range calculations.""")
 
     style_opts = line_properties + ['level', 'visible']
     _allow_implicit_categories = False
+    _element_name = ''
+
+    def __init__(self, element, **kwargs):
+        if not bokeh32:
+            raise ImportError(f'{self._element_name} element requires bokeh >=3.2')
+        super().__init__(element, **kwargs)
+
+    def get_data(self, element, ranges, style):
+        data = {}
+        for name, index in self._data_dims.items():
+            loc = list(element.dimension_values(element.kdims[index])) # invert_axes?
+            data[name]= date_to_integer(loc) if isinstance(loc, datetime_types) else loc
+
+        mapping = {k:k for k in self._data_dims}
+        data.update({str(name):element.dimension_values(name) for name in element.vdims})
+        return (data, mapping, style)
+
+class HLinesAnnotationPlot(SyntheticAnnotationPlot):
+
+    _data_dims = {'y':1}
+    _element_name = 'VLines'
     _plot_methods = dict(single='hspan')
 
-    def __init__(self, element, **kwargs):
-        if not bokeh32:
-            raise ImportError('HLines element requires bokeh >=3.2')
-        super().__init__(self, **kwargs)
 
-    def get_data(self, element, ranges, style):
-        data = {}
-        loc = list(element.dimension_values(element.kdims[1])) # invert_axes?
-        if isinstance(loc, datetime_types):
-            loc = date_to_integer(loc)
-        data['y'] = loc
+class VLinesAnnotationPlot(SyntheticAnnotationPlot):
 
-        vdim_data = {str(name):element.dimension_values(name) for name in element.vdims}
-        data.update(vdim_data)
-        return (data, {'y':'y'}, style)
-
-
-class VLinesAnnotationPlot(ElementPlot):
-    apply_ranges = param.Boolean(default=True, doc="""
-        Whether to include the annotation in axis range calculations.""")
-
-    style_opts = line_properties + ['level', 'visible']
-    _allow_implicit_categories = False
     _plot_methods = dict(single='vspan')
-
-    def __init__(self, element, **kwargs):
-        if not bokeh32:
-            raise ImportError('VLines element requires bokeh >=3.2')
-        super().__init__(self, **kwargs)
-
-    def get_data(self, element, ranges, style):
-        data = {}
-        loc = list(element.dimension_values(element.kdims[0])) # invert_axes?
-        if isinstance(loc, datetime_types):
-            loc = date_to_integer(loc)
-        data['x'] = loc
-
-        vdim_data = {str(name):element.dimension_values(name) for name in element.vdims}
-        data.update(vdim_data)
-        return (data, {'x':'x'}, style)
+    _element_name = 'HLines'
+    _data_dims = {'x':0}
 
 
-class HSpansAnnotationPlot(ElementPlot):
-    apply_ranges = param.Boolean(default=True, doc="""
-        Whether to include the annotation in axis range calculations.""")
+class HSpansAnnotationPlot(SyntheticAnnotationPlot):
 
-    style_opts = line_properties + ['level', 'visible']
-    _allow_implicit_categories = False
     _plot_methods = dict(single='hstrip')
-
-    def __init__(self, element, **kwargs):
-        if not bokeh32:
-            raise ImportError('HSpans element requires bokeh >=3.2')
-        super().__init__(self, **kwargs)
-
-    def get_data(self, element, ranges, style):
-        data = {}
-        loc0 = list(element.dimension_values(element.kdims[2])) # invert_axes?
-        if isinstance(loc0, datetime_types):
-            loc0 = date_to_integer(loc0)
-        data['y0'] = loc0
-
-        loc1 = list(element.dimension_values(element.kdims[3]))
-        if isinstance(loc1, datetime_types):
-            loc1 = date_to_integer(loc1)
-        data['y1'] = loc1
-
-        vdim_data = {str(name):element.dimension_values(name) for name in element.vdims}
-        data.update(vdim_data)
-        return (data, {'y0':'y0', 'y1':'y1'}, style)
+    _element_name = 'HSpans'
+    _data_dims = {'y0':2, 'y1':3}
 
 
+class VSpansAnnotationPlot(SyntheticAnnotationPlot):
 
-class VSpansAnnotationPlot(ElementPlot):
-    apply_ranges = param.Boolean(default=True, doc="""
-        Whether to include the annotation in axis range calculations.""")
-
-    style_opts = line_properties + ['level', 'visible']
-    _allow_implicit_categories = False
     _plot_methods = dict(single='vstrip')
-
-    def __init__(self, element, **kwargs):
-        if not bokeh32:
-            raise ImportError('VSpans element requires bokeh >=3.2')
-        super().__init__(self, **kwargs)
-
-    def get_data(self, element, ranges, style):
-        data = {}
-        loc0 = list(element.dimension_values(element.kdims[0])) # invert_axes?
-        if isinstance(loc0, datetime_types):
-            loc0 = date_to_integer(loc0)
-        data['x0'] = loc0
-
-        loc1 = list(element.dimension_values(element.kdims[1]))
-        if isinstance(loc1, datetime_types):
-            loc1 = date_to_integer(loc1)
-        data['x1'] = loc1
-
-        vdim_data = {str(name):element.dimension_values(name) for name in element.vdims}
-        data.update(vdim_data)
-        return (data, {'x0':'x0', 'x1':'x1'}, style)
+    _element_name = 'HSpans'
+    _data_dims = {'x0':0, 'x1':1}
 
 
 class TextPlot(ElementPlot, AnnotationPlot):

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -11,23 +11,17 @@ from bokeh.models import TeeHead, NormalHead
 from bokeh.transform import dodge
 
 from ...core.util import datetime_types, dimension_sanitizer
-from ...element import HLine, VLine, VSpan, VLines, HLines
+from ...element import HLine, VLine, VSpan
 from ..plot import GenericElementPlot
 from .element import AnnotationPlot, ElementPlot, CompositeElementPlot, ColorbarPlot
 from .selection import BokehOverlaySelectionDisplay
 from .styles import base_properties, fill_properties, line_properties, text_properties
 from .plot import BokehPlot
-from .util import date_to_integer
+from .util import date_to_integer, bokeh32
 
 arrow_start = {'<->': NormalHead, '<|-|>': NormalHead}
 arrow_end = {'->': NormalHead, '-[': TeeHead, '-|>': NormalHead,
                 '-': None}
-
-try:
-    from bokeh.models import HSpan, VSpan, HStrip, VStrip
-except:
-    raise Exception('Bokeh version check?')
-
 
 
 class HLinesAnnotationPlot(ElementPlot):
@@ -38,8 +32,13 @@ class HLinesAnnotationPlot(ElementPlot):
     _allow_implicit_categories = False
     _plot_methods = dict(single='hspan')
 
+    def __init__(self, element, **kwargs):
+        if not bokeh32:
+            raise ImportError('HLines element requires bokeh >=3.2')
+        super().__init__(self, **kwargs)
+
     def get_data(self, element, ranges, style):
-        data, mapping = {}, {}
+        data = {}
         loc = list(element.dimension_values(element.kdims[1])) # invert_axes?
         if isinstance(loc, datetime_types):
             loc = date_to_integer(loc)
@@ -58,8 +57,13 @@ class VLinesAnnotationPlot(ElementPlot):
     _allow_implicit_categories = False
     _plot_methods = dict(single='vspan')
 
+    def __init__(self, element, **kwargs):
+        if not bokeh32:
+            raise ImportError('VLines element requires bokeh >=3.2')
+        super().__init__(self, **kwargs)
+
     def get_data(self, element, ranges, style):
-        data, mapping = {}, {}
+        data = {}
         loc = list(element.dimension_values(element.kdims[0])) # invert_axes?
         if isinstance(loc, datetime_types):
             loc = date_to_integer(loc)
@@ -78,8 +82,13 @@ class HSpansAnnotationPlot(ElementPlot):
     _allow_implicit_categories = False
     _plot_methods = dict(single='hstrip')
 
+    def __init__(self, element, **kwargs):
+        if not bokeh32:
+            raise ImportError('HSpans element requires bokeh >=3.2')
+        super().__init__(self, **kwargs)
+
     def get_data(self, element, ranges, style):
-        data, mapping = {}, {}
+        data = {}
         loc0 = list(element.dimension_values(element.kdims[2])) # invert_axes?
         if isinstance(loc0, datetime_types):
             loc0 = date_to_integer(loc0)
@@ -104,8 +113,13 @@ class VSpansAnnotationPlot(ElementPlot):
     _allow_implicit_categories = False
     _plot_methods = dict(single='vstrip')
 
+    def __init__(self, element, **kwargs):
+        if not bokeh32:
+            raise ImportError('VSpans element requires bokeh >=3.2')
+        super().__init__(self, **kwargs)
+
     def get_data(self, element, ranges, style):
-        data, mapping = {}, {}
+        data = {}
         loc0 = list(element.dimension_values(element.kdims[0])) # invert_axes?
         if isinstance(loc0, datetime_types):
             loc0 = date_to_integer(loc0)

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -70,6 +70,56 @@ class VLinesAnnotationPlot(ElementPlot):
         return (data, {'x':'x'}, style)
 
 
+class HSpansAnnotationPlot(ElementPlot):
+    apply_ranges = param.Boolean(default=True, doc="""
+        Whether to include the annotation in axis range calculations.""")
+
+    style_opts = line_properties + ['level', 'visible']
+    _allow_implicit_categories = False
+    _plot_methods = dict(single='hstrip')
+
+    def get_data(self, element, ranges, style):
+        data, mapping = {}, {}
+        loc0 = list(element.dimension_values(element.kdims[2])) # invert_axes?
+        if isinstance(loc0, datetime_types):
+            loc0 = date_to_integer(loc0)
+        data['y0'] = loc0
+
+        loc1 = list(element.dimension_values(element.kdims[3]))
+        if isinstance(loc1, datetime_types):
+            loc1 = date_to_integer(loc1)
+        data['y1'] = loc1
+
+        vdim_data = {str(name):element.dimension_values(name) for name in element.vdims}
+        data.update(vdim_data)
+        return (data, {'y0':'y0', 'y1':'y1'}, style)
+
+
+
+class VSpansAnnotationPlot(ElementPlot):
+    apply_ranges = param.Boolean(default=True, doc="""
+        Whether to include the annotation in axis range calculations.""")
+
+    style_opts = line_properties + ['level', 'visible']
+    _allow_implicit_categories = False
+    _plot_methods = dict(single='vstrip')
+
+    def get_data(self, element, ranges, style):
+        data, mapping = {}, {}
+        loc0 = list(element.dimension_values(element.kdims[0])) # invert_axes?
+        if isinstance(loc0, datetime_types):
+            loc0 = date_to_integer(loc0)
+        data['x0'] = loc0
+
+        loc1 = list(element.dimension_values(element.kdims[1]))
+        if isinstance(loc1, datetime_types):
+            loc1 = date_to_integer(loc1)
+        data['x1'] = loc1
+
+        vdim_data = {str(name):element.dimension_values(name) for name in element.vdims}
+        data.update(vdim_data)
+        return (data, {'x0':'x0', 'x1':'x1'}, style)
+
 
 class TextPlot(ElementPlot, AnnotationPlot):
 

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -274,6 +274,10 @@ options.Slope = Options('style', color=Cycle())
 options.VSpan = Options('style', alpha=0.5, facecolor=Cycle())
 options.HSpan = Options('style', alpha=0.5, facecolor=Cycle())
 options.Spline = Options('style', edgecolor=Cycle())
+options.HLines = Options('style', color=Cycle())
+options.VLines = Options('style', color=Cycle())
+options.VSpans = Options('style', alpha=0.5, facecolor=Cycle())
+options.HSpans = Options('style', alpha=0.5, facecolor=Cycle())
 
 options.Arrow = Options('style', color='k', linewidth=2, textsize=13)
 # Paths

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -164,6 +164,10 @@ Store.register({Curve: CurvePlot,
                 Sankey: SankeyPlot,
 
                 # Annotation plots
+                VLines: VLinesAnnotationPlot,
+                HLines: HLinesAnnotationPlot,
+                HSpans: HSpansAnnotationPlot,
+                VSpans: VSpansAnnotationPlot,
                 VLine: VLinePlot,
                 HLine: HLinePlot,
                 VSpan: VSpanPlot,

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -296,9 +296,12 @@ class _SyntheticAnnotationPlot(AnnotationPlot):
                   'linewidth', 'linestyle', 'visible']
 
     def draw_annotation(self, axis, positions, opts):
-        size = len(self.hmap.last.kdims)
-        first_keys = list(positions)[:size]
-        values = zip(*[positions[n] for n in first_keys])
+        if isinstance(positions, np.ndarray):
+            values = positions
+        else:
+            size = len(self.hmap.last.kdims)
+            first_keys = list(positions)[:size]
+            values = zip(*[positions[n] for n in first_keys])
         fn = getattr(axis, self._methods[self.invert_axes])
         return [fn(*val, **opts) for val in values]
 

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -245,9 +245,8 @@ class TestHVLinesPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 5.5
 
         source = plot.handles["source"]
-        assert list(source.data) == ["y", "extra"]
+        assert list(source.data) == ["y"]
         assert (source.data["y"] == [0, 1, 2, 5.5]).all()
-        assert (source.data["extra"] == [-1, -2, -3, -44]).all()
 
     def test_hlines_plot_invert_axes(self):
         hlines = HLines(

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -228,7 +228,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 5.5
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["y", "extra"]
+        assert list(source.data) == ["y", "extra"]
         assert (source.data["y"] == [0, 1, 2, 5.5]).all()
         assert (source.data["extra"] == [-1, -2, -3, -44]).all()
 
@@ -247,7 +247,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 1
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["y", "extra"]
+        assert list(source.data) == ["y", "extra"]
         assert (source.data["y"] == [0, 1, 2, 5.5]).all()
         assert (source.data["extra"] == [-1, -2, -3, -44]).all()
 
@@ -266,7 +266,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 5.5
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["extra"]
+        assert list(source.data) == ["extra"]
         assert (source.data["extra"] == [0, 1, 2, 5.5]).all()
 
     def test_vlines_plot(self):
@@ -284,7 +284,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 1
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["x", "extra"]
+        assert list(source.data) == ["x", "extra"]
         assert (source.data["x"] == [0, 1, 2, 5.5]).all()
         assert (source.data["extra"] == [-1, -2, -3, -44]).all()
 
@@ -303,7 +303,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 5.5
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["x", "extra"]
+        assert list(source.data) == ["x", "extra"]
         assert (source.data["x"] == [0, 1, 2, 5.5]).all()
         assert (source.data["extra"] == [-1, -2, -3, -44]).all()
 
@@ -322,7 +322,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 1
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["extra"]
+        assert list(source.data) == ["extra"]
         assert (source.data["extra"] == [0, 1, 2, 5.5]).all()
 
     def test_vlines_hlines_overlay(self):
@@ -364,7 +364,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 6.5
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["y0", "y1", "extra"]
+        assert list(source.data) == ["y0", "y1", "extra"]
         assert (source.data["y0"] == [0, 3, 5.5]).all()
         assert (source.data["y1"] == [1, 4, 6.5]).all()
         assert (source.data["extra"] == [-1, -2, -3]).all()
@@ -384,7 +384,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 1
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["y0", "y1", "extra"]
+        assert list(source.data) == ["y0", "y1", "extra"]
         assert (source.data["y0"] == [0, 3, 5.5]).all()
         assert (source.data["y1"] == [1, 4, 6.5]).all()
         assert (source.data["extra"] == [-1, -2, -3]).all()
@@ -404,7 +404,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 6.5
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["other0", "other1"]
+        assert list(source.data) == ["other0", "other1"]
         assert (source.data["other0"] == [0, 3, 5.5]).all()
         assert (source.data["other1"] == [1, 4, 6.5]).all()
 
@@ -423,7 +423,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 1
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["x0", "x1", "extra"]
+        assert list(source.data) == ["x0", "x1", "extra"]
         assert (source.data["x0"] == [0, 3, 5.5]).all()
         assert (source.data["x1"] == [1, 4, 6.5]).all()
         assert (source.data["extra"] == [-1, -2, -3]).all()
@@ -443,7 +443,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 6.5
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["x0", "x1", "extra"]
+        assert list(source.data) == ["x0", "x1", "extra"]
         assert (source.data["x0"] == [0, 3, 5.5]).all()
         assert (source.data["x1"] == [1, 4, 6.5]).all()
         assert (source.data["extra"] == [-1, -2, -3]).all()
@@ -463,7 +463,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert plot.handles["y_range"].end == 1
 
         source = plot.handles["source"]
-        assert list(source.data.keys()) == ["other0", "other1"]
+        assert list(source.data) == ["other0", "other1"]
         assert (source.data["other0"] == [0, 3, 5.5]).all()
         assert (source.data["other1"] == [1, 4, 6.5]).all()
 

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -222,6 +222,25 @@ class TestHVLinesPlot(TestBokehPlot):
         assert (source.data["y"] == [0, 1, 2, 5.5]).all()
         assert (source.data["extra"] == [-1, -2, -3, -44]).all()
 
+    def test_hlines_plot_invert_axes(self):
+        hlines = HLines(
+            {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        ).opts(invert_axes=True)
+        plot = bokeh_renderer.get_plot(hlines)
+        assert isinstance(plot.handles["glyph"], BkVSpan)
+        assert plot.handles["xaxis"].axis_label == "y"
+        assert plot.handles["yaxis"].axis_label == "x"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 5.5
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 1
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["y", "extra"]
+        assert (source.data["y"] == [0, 1, 2, 5.5]).all()
+        assert (source.data["extra"] == [-1, -2, -3, -44]).all()
+
     def test_hlines_nondefault_kdim(self):
         hlines = HLines(
             {"extra": [0, 1, 2, 5.5]}, kdims=["extra"]
@@ -253,6 +272,25 @@ class TestHVLinesPlot(TestBokehPlot):
         assert plot.handles["x_range"].end == 5.5
         assert plot.handles["y_range"].start == 0
         assert plot.handles["y_range"].end == 1
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["x", "extra"]
+        assert (source.data["x"] == [0, 1, 2, 5.5]).all()
+        assert (source.data["extra"] == [-1, -2, -3, -44]).all()
+
+    def test_vlines_plot_invert_axes(self):
+        vlines = VLines(
+            {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        ).opts(invert_axes=True)
+        plot = bokeh_renderer.get_plot(vlines)
+        assert isinstance(plot.handles["glyph"], BkHSpan)
+        assert plot.handles["xaxis"].axis_label == "y"
+        assert plot.handles["yaxis"].axis_label == "x"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 1
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 5.5
 
         source = plot.handles["source"]
         assert list(source.data.keys()) == ["x", "extra"]
@@ -316,6 +354,26 @@ class TestHVSpansPlot(TestBokehPlot):
         assert (source.data["y1"] == [1, 4, 6.5]).all()
         assert (source.data["extra"] == [-1, -2, -3]).all()
 
+    def test_hspans_plot_invert_axes(self):
+        hspans = HSpans(
+            {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
+        ).opts(invert_axes=True)
+        plot = bokeh_renderer.get_plot(hspans)
+        assert isinstance(plot.handles["glyph"], BkVStrip)
+        assert plot.handles["xaxis"].axis_label == "y"
+        assert plot.handles["yaxis"].axis_label == "x"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 6.5
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 1
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["y0", "y1", "extra"]
+        assert (source.data["y0"] == [0, 3, 5.5]).all()
+        assert (source.data["y1"] == [1, 4, 6.5]).all()
+        assert (source.data["extra"] == [-1, -2, -3]).all()
+
     def test_hspans_nondefault_kdims(self):
         hspans = HSpans(
             {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
@@ -348,6 +406,26 @@ class TestHVSpansPlot(TestBokehPlot):
         assert plot.handles["x_range"].end == 6.5
         assert plot.handles["y_range"].start == 0
         assert plot.handles["y_range"].end == 1
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["x0", "x1", "extra"]
+        assert (source.data["x0"] == [0, 3, 5.5]).all()
+        assert (source.data["x1"] == [1, 4, 6.5]).all()
+        assert (source.data["extra"] == [-1, -2, -3]).all()
+
+    def test_vspans_plot_invert_axes(self):
+        vspans = VSpans(
+            {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
+        ).opts(invert_axes=True)
+        plot = bokeh_renderer.get_plot(vspans)
+        assert isinstance(plot.handles["glyph"], BkHStrip)
+        assert plot.handles["xaxis"].axis_label == "y"
+        assert plot.handles["yaxis"].axis_label == "x"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 1
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 6.5
 
         source = plot.handles["source"]
         assert list(source.data.keys()) == ["x0", "x1", "extra"]

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -1,13 +1,18 @@
+import unittest
+
 import numpy as np
 
-from bokeh.models import VSpan as BkVSpan, HSpan as BkHSpan, VStrip as BkVStrip, HStrip as BkHStrip
 
 from holoviews.element import (
     HLine, VLine, Text, Labels, Arrow, HSpan, VSpan, Slope,
     HLines, VLines, HSpans, VSpans,
 )
+from holoviews.plotting.bokeh.util import bokeh32
 
 from .test_plot import TestBokehPlot, bokeh_renderer
+
+if bokeh32:
+    from bokeh.models import VSpan as BkVSpan, HSpan as BkHSpan, VStrip as BkVStrip, HStrip as BkHStrip
 
 
 class TestHVLinePlot(TestBokehPlot):
@@ -203,6 +208,11 @@ class TestLabelsPlot(TestBokehPlot):
 
 class TestHVLinesPlot(TestBokehPlot):
 
+    def setUp(self):
+        if not bokeh32:
+            raise unittest.SkipTest("Bokeh 3.2 added H/VLines")
+        super().setUp()
+
     def test_hlines_plot(self):
         hlines = HLines(
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
@@ -333,6 +343,11 @@ class TestHVLinesPlot(TestBokehPlot):
 
 
 class TestHVSpansPlot(TestBokehPlot):
+
+    def setUp(self):
+        if not bokeh32:
+            raise unittest.SkipTest("Bokeh 3.2 added H/VSpans")
+        super().setUp()
 
     def test_hspans_plot(self):
         hspans = HSpans(

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -219,6 +219,23 @@ class TestHVLinesPlot(TestBokehPlot):
         assert (source.data["y"] == [0, 1, 2, 5.5]).all()
         assert (source.data["extra"] == [-1, -2, -3, -44]).all()
 
+    def test_hlines_nondefault_kdim(self):
+        hlines = HLines(
+            {"extra": [0, 1, 2, 5.5]}, kdims=["extra"]
+        )
+        plot = bokeh_renderer.get_plot(hlines)
+        assert plot.handles["xaxis"].axis_label == "x"
+        assert plot.handles["yaxis"].axis_label == "y"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 1
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 5.5
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["extra"]
+        assert (source.data["extra"] == [0, 1, 2, 5.5]).all()
+
     def test_vlines_plot(self):
         vlines = VLines(
             {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
@@ -236,6 +253,23 @@ class TestHVLinesPlot(TestBokehPlot):
         assert list(source.data.keys()) == ["x", "extra"]
         assert (source.data["x"] == [0, 1, 2, 5.5]).all()
         assert (source.data["extra"] == [-1, -2, -3, -44]).all()
+
+    def test_vlines_nondefault_kdim(self):
+        vlines = VLines(
+            {"extra": [0, 1, 2, 5.5]}, kdims=["extra"]
+        )
+        plot = bokeh_renderer.get_plot(vlines)
+        assert plot.handles["xaxis"].axis_label == "x"
+        assert plot.handles["yaxis"].axis_label == "y"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 5.5
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 1
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["extra"]
+        assert (source.data["extra"] == [0, 1, 2, 5.5]).all()
 
     def test_vlines_hlines_overlay(self):
         hlines = HLines(
@@ -275,6 +309,24 @@ class TestHVSpansPlot(TestBokehPlot):
         assert (source.data["y1"] == [1, 4, 6.5]).all()
         assert (source.data["extra"] == [-1, -2, -3]).all()
 
+    def test_hspans_nondefault_kdims(self):
+        hspans = HSpans(
+            {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
+        )
+        plot = bokeh_renderer.get_plot(hspans)
+        assert plot.handles["xaxis"].axis_label == "x"
+        assert plot.handles["yaxis"].axis_label == "y"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 1
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 6.5
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["other0", "other1"]
+        assert (source.data["other0"] == [0, 3, 5.5]).all()
+        assert (source.data["other1"] == [1, 4, 6.5]).all()
+
     def test_vspans_plot(self):
         vspans = VSpans(
             {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
@@ -293,6 +345,24 @@ class TestHVSpansPlot(TestBokehPlot):
         assert (source.data["x0"] == [0, 3, 5.5]).all()
         assert (source.data["x1"] == [1, 4, 6.5]).all()
         assert (source.data["extra"] == [-1, -2, -3]).all()
+
+    def test_vspans_nondefault_kdims(self):
+        vspans = VSpans(
+            {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
+        )
+        plot = bokeh_renderer.get_plot(vspans)
+        assert plot.handles["xaxis"].axis_label == "x"
+        assert plot.handles["yaxis"].axis_label == "y"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 6.5
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 1
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["other0", "other1"]
+        assert (source.data["other0"] == [0, 3, 5.5]).all()
+        assert (source.data["other1"] == [1, 4, 6.5]).all()
 
     def test_vspans_hspans_overlay(self):
         hspans = HSpans(

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from bokeh.models import VSpan as BkVSpan, HSpan as BkHSpan, VStrip as BkVStrip, HStrip as BkHStrip
+
 from holoviews.element import (
     HLine, VLine, Text, Labels, Arrow, HSpan, VSpan, Slope,
     HLines, VLines, HSpans, VSpans,
@@ -206,6 +208,7 @@ class TestHVLinesPlot(TestBokehPlot):
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(hlines)
+        assert isinstance(plot.handles["glyph"], BkHSpan)
         assert plot.handles["xaxis"].axis_label == "x"
         assert plot.handles["yaxis"].axis_label == "y"
 
@@ -224,6 +227,7 @@ class TestHVLinesPlot(TestBokehPlot):
             {"extra": [0, 1, 2, 5.5]}, kdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(hlines)
+        assert isinstance(plot.handles["glyph"], BkHSpan)
         assert plot.handles["xaxis"].axis_label == "x"
         assert plot.handles["yaxis"].axis_label == "y"
 
@@ -241,6 +245,7 @@ class TestHVLinesPlot(TestBokehPlot):
             {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(vlines)
+        assert isinstance(plot.handles["glyph"], BkVSpan)
         assert plot.handles["xaxis"].axis_label == "x"
         assert plot.handles["yaxis"].axis_label == "y"
 
@@ -259,6 +264,7 @@ class TestHVLinesPlot(TestBokehPlot):
             {"extra": [0, 1, 2, 5.5]}, kdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(vlines)
+        assert isinstance(plot.handles["glyph"], BkVSpan)
         assert plot.handles["xaxis"].axis_label == "x"
         assert plot.handles["yaxis"].axis_label == "y"
 
@@ -295,6 +301,7 @@ class TestHVSpansPlot(TestBokehPlot):
             {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(hspans)
+        assert isinstance(plot.handles["glyph"], BkHStrip)
         assert plot.handles["xaxis"].axis_label == "x"
         assert plot.handles["yaxis"].axis_label == "y"
 
@@ -314,6 +321,7 @@ class TestHVSpansPlot(TestBokehPlot):
             {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
         )
         plot = bokeh_renderer.get_plot(hspans)
+        assert isinstance(plot.handles["glyph"], BkHStrip)
         assert plot.handles["xaxis"].axis_label == "x"
         assert plot.handles["yaxis"].axis_label == "y"
 
@@ -332,6 +340,7 @@ class TestHVSpansPlot(TestBokehPlot):
             {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(vspans)
+        assert isinstance(plot.handles["glyph"], BkVStrip)
         assert plot.handles["xaxis"].axis_label == "x"
         assert plot.handles["yaxis"].axis_label == "y"
 
@@ -351,6 +360,7 @@ class TestHVSpansPlot(TestBokehPlot):
             {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
         )
         plot = bokeh_renderer.get_plot(vspans)
+        assert isinstance(plot.handles["glyph"], BkVStrip)
         assert plot.handles["xaxis"].axis_label == "x"
         assert plot.handles["yaxis"].axis_label == "y"
 

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from holoviews.element import (
-    HLine, VLine, Text, Labels, Arrow, HSpan, VSpan, Slope
+    HLine, VLine, Text, Labels, Arrow, HSpan, VSpan, Slope,
+    HLines, VLines, HSpans, VSpans,
 )
 
 from .test_plot import TestBokehPlot, bokeh_renderer
@@ -196,3 +197,115 @@ class TestLabelsPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(text)
         glyph = plot.handles['glyph']
         self.assertEqual(glyph.angle, np.pi/2.)
+
+
+class TestHVLinesPlot(TestBokehPlot):
+
+    def test_hlines_plot(self):
+        hlines = HLines(
+            {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        )
+        plot = bokeh_renderer.get_plot(hlines)
+        assert plot.handles["xaxis"].axis_label == "x"
+        assert plot.handles["yaxis"].axis_label == "y"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 1
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 5.5
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["y", "extra"]
+        assert (source.data["y"] == [0, 1, 2, 5.5]).all()
+        assert (source.data["extra"] == [-1, -2, -3, -44]).all()
+
+    def test_vlines_plot(self):
+        vlines = VLines(
+            {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        )
+        plot = bokeh_renderer.get_plot(vlines)
+        assert plot.handles["xaxis"].axis_label == "x"
+        assert plot.handles["yaxis"].axis_label == "y"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 5.5
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 1
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["x", "extra"]
+        assert (source.data["x"] == [0, 1, 2, 5.5]).all()
+        assert (source.data["extra"] == [-1, -2, -3, -44]).all()
+
+    def test_vlines_hlines_overlay(self):
+        hlines = HLines(
+            {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        )
+        vlines = VLines(
+            {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        )
+        plot = bokeh_renderer.get_plot(hlines * vlines)
+        assert plot.handles["xaxis"].axis_label == "x"
+        assert plot.handles["yaxis"].axis_label == "y"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 5.5
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 5.5
+
+
+class TestHVSpansPlot(TestBokehPlot):
+
+    def test_hspans_plot(self):
+        hspans = HSpans(
+            {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
+        )
+        plot = bokeh_renderer.get_plot(hspans)
+        assert plot.handles["xaxis"].axis_label == "x"
+        assert plot.handles["yaxis"].axis_label == "y"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 1
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 6.5
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["y0", "y1", "extra"]
+        assert (source.data["y0"] == [0, 3, 5.5]).all()
+        assert (source.data["y1"] == [1, 4, 6.5]).all()
+        assert (source.data["extra"] == [-1, -2, -3]).all()
+
+    def test_vspans_plot(self):
+        vspans = VSpans(
+            {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
+        )
+        plot = bokeh_renderer.get_plot(vspans)
+        assert plot.handles["xaxis"].axis_label == "x"
+        assert plot.handles["yaxis"].axis_label == "y"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 6.5
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 1
+
+        source = plot.handles["source"]
+        assert list(source.data.keys()) == ["x0", "x1", "extra"]
+        assert (source.data["x0"] == [0, 3, 5.5]).all()
+        assert (source.data["x1"] == [1, 4, 6.5]).all()
+        assert (source.data["extra"] == [-1, -2, -3]).all()
+
+    def test_vspans_hspans_overlay(self):
+        hspans = HSpans(
+            {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
+        )
+        vspans = VSpans(
+            {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
+        )
+        plot = bokeh_renderer.get_plot(hspans * vspans)
+        assert plot.handles["xaxis"].axis_label == "x"
+        assert plot.handles["yaxis"].axis_label == "y"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 6.5
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 6.5

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -232,6 +232,23 @@ class TestHVLinesPlot(TestBokehPlot):
         assert (source.data["y"] == [0, 1, 2, 5.5]).all()
         assert (source.data["extra"] == [-1, -2, -3, -44]).all()
 
+    def test_hlines_array(self):
+        hlines = HLines(np.array([0, 1, 2, 5.5]))
+        plot = bokeh_renderer.get_plot(hlines)
+        assert isinstance(plot.handles["glyph"], BkHSpan)
+        assert plot.handles["xaxis"].axis_label == "x"
+        assert plot.handles["yaxis"].axis_label == "y"
+
+        assert plot.handles["x_range"].start == 0
+        assert plot.handles["x_range"].end == 1
+        assert plot.handles["y_range"].start == 0
+        assert plot.handles["y_range"].end == 5.5
+
+        source = plot.handles["source"]
+        assert list(source.data) == ["y", "extra"]
+        assert (source.data["y"] == [0, 1, 2, 5.5]).all()
+        assert (source.data["extra"] == [-1, -2, -3, -44]).all()
+
     def test_hlines_plot_invert_axes(self):
         hlines = HLines(
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-
+import holoviews as hv
 from holoviews.element import (
     HLine, VLine, Text, Labels, Arrow, HSpan, VSpan, Slope,
     HLines, VLines, HSpans, VSpans,
@@ -357,6 +357,21 @@ class TestHVLinesPlot(TestBokehPlot):
         assert plot.handles["y_range"].start == 0
         assert plot.handles["y_range"].end == 5.5
 
+    def test_coloring_hline(self):
+        hlines = HLines({"y": [1, 2, 3]})
+        hlines = hlines.opts(
+            alpha=hv.dim("y").norm(),
+            line_color="red",
+            line_dash=hv.dim("y").bin([0, 1.5, 3], ["dashed", "solid"]),
+        )
+
+        plot = hv.renderer("bokeh").get_plot(hlines)
+        assert plot.handles["glyph"].line_color == "red"
+
+        data = plot.handles["glyph_renderer"].data_source.data
+        np.testing.assert_allclose(data["alpha"], [0, 0.5, 1])
+        assert data["line_dash"] == ["dashed", "solid", "solid"]
+
 
 class TestHVSpansPlot(TestBokehPlot):
 
@@ -498,3 +513,17 @@ class TestHVSpansPlot(TestBokehPlot):
         assert plot.handles["x_range"].end == 6.5
         assert plot.handles["y_range"].start == 0
         assert plot.handles["y_range"].end == 6.5
+
+    def test_coloring_hline(self):
+        hspans = HSpans({"y0": [1, 3, 5], "y1": [2, 4, 6]}).opts(
+            alpha=hv.dim("y0").norm(),
+            line_color="red",
+            line_dash=hv.dim("y1").bin([0, 3, 6], ["dashed", "solid"]),
+        )
+
+        plot = hv.renderer("bokeh").get_plot(hspans)
+        assert plot.handles["glyph"].line_color == "red"
+
+        data = plot.handles["glyph_renderer"].data_source.data
+        np.testing.assert_allclose(data["alpha"], [0, 0.5, 1])
+        assert data["line_dash"] == ["dashed", "solid", "solid"]

--- a/holoviews/tests/plotting/matplotlib/test_annotationplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_annotationplot.py
@@ -23,6 +23,22 @@ class TestHVLinesPlot(TestMPLPlot):
         for source, val in zip(sources, hlines.data["y"]):
             assert source.get_data() == ([0, 1], [val, val])
 
+    def test_hlines_array(self):
+        hlines = HLines(np.array([0, 1, 2, 5.5]))
+        plot = mpl_renderer.get_plot(hlines)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "x"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "y"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (-0.055, 0.055))
+        assert np.allclose(ylim, (0, 5.5))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 4
+        for source, val in zip(sources, hlines.data):
+            assert source.get_data() == ([0, 1], [val, val])
+
     def test_hlines_plot_invert_axes(self):
         hlines = HLines(
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]

--- a/holoviews/tests/plotting/matplotlib/test_annotationplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_annotationplot.py
@@ -1,0 +1,285 @@
+import numpy as np
+from holoviews.element import HLines, VLines, HSpans, VSpans
+
+from .test_plot import TestMPLPlot, mpl_renderer
+
+
+class TestHVLinesPlot(TestMPLPlot):
+    def test_hlines_plot(self):
+        hlines = HLines(
+            {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        )
+        plot = mpl_renderer.get_plot(hlines)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "x"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "y"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (-0.055, 0.055))
+        assert np.allclose(ylim, (0, 5.5))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 4
+        for source, val in zip(sources, hlines.data["y"]):
+            assert source.get_data() == ([0, 1], [val, val])
+
+    def test_hlines_plot_invert_axes(self):
+        hlines = HLines(
+            {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        ).opts(invert_axes=True)
+        plot = mpl_renderer.get_plot(hlines)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "y"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "x"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (0, 5.5))
+        assert np.allclose(ylim, (-0.055, 0.055))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 4
+        for source, val in zip(sources, hlines.data["y"]):
+            assert source.get_data() == ([val, val], [0, 1])
+
+    def test_hlines_nondefault_kdim(self):
+        hlines = HLines({"other": [0, 1, 2, 5.5]}, kdims=["other"])
+        plot = mpl_renderer.get_plot(hlines)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "x"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "y"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (-0.055, 0.055))
+        assert np.allclose(ylim, (0, 5.5))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 4
+        for source, val in zip(sources, hlines.data["other"]):
+            assert source.get_data() == ([0, 1], [val, val])
+
+    def test_vlines_plot(self):
+        vlines = VLines(
+            {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        )
+        plot = mpl_renderer.get_plot(vlines)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "x"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "y"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (0, 5.5))
+        assert np.allclose(ylim, (-0.055, 0.055))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 4
+        for source, val in zip(sources, vlines.data["x"]):
+            assert source.get_data() == ([val, val], [0, 1])
+
+    def test_vlines_plot_invert_axes(self):
+        vlines = VLines(
+            {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        ).opts(invert_axes=True)
+        plot = mpl_renderer.get_plot(vlines)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "y"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "x"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (-0.055, 0.055))
+        assert np.allclose(ylim, (0, 5.5))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 4
+        for source, val in zip(sources, vlines.data["x"]):
+            assert source.get_data() == ([0, 1], [val, val])
+
+    def test_vlines_nondefault_kdim(self):
+        vlines = VLines({"other": [0, 1, 2, 5.5]}, kdims=["other"])
+        plot = mpl_renderer.get_plot(vlines)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "x"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "y"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (0, 5.5))
+        assert np.allclose(ylim, (-0.055, 0.055))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 4
+        for source, val in zip(sources, vlines.data["other"]):
+            assert source.get_data() == ([val, val], [0, 1])
+
+    def test_vlines_hlines_overlay(self):
+        hlines = HLines(
+            {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        )
+        vlines = VLines(
+            {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
+        )
+
+        plot = mpl_renderer.get_plot(hlines * vlines)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "x"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "y"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (0, 5.5))
+        assert np.allclose(ylim, (0, 5.5))
+
+        sources = plot.handles["fig"].axes[0].get_children()
+        for source, val in zip(sources[:4], hlines.data["y"]):
+            assert source.get_data() == ([0, 1], [val, val])
+
+        for source, val in zip(sources[4:], vlines.data["x"]):
+            assert source.get_data() == ([val, val], [0, 1])
+
+
+class TestHVSpansPlot(TestMPLPlot):
+    def test_hspans_plot(self):
+        hspans = HSpans(
+            {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]},
+            vdims=["extra"],
+        )
+        plot = mpl_renderer.get_plot(hspans)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "x"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "y"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (-0.055, 0.055))
+        assert np.allclose(ylim, (0, 6.5))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 3
+        for source, v0, v1 in zip(sources, hspans.data["y0"], hspans.data["y1"]):
+            assert np.allclose(source.xy[:, 0], [0, 0, 1, 1, 0])
+            assert np.allclose(source.xy[:, 1], [v0, v1, v1, v0, v0])
+
+    def test_hspans_inverse_plot(self):
+        hspans = HSpans(
+            {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]},
+            vdims=["extra"],
+        ).opts(invert_axes=True)
+        plot = mpl_renderer.get_plot(hspans)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "y"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "x"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (0, 6.5))
+        assert np.allclose(ylim, (-0.055, 0.055))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 3
+        for source, v0, v1 in zip(sources, hspans.data["y0"], hspans.data["y1"]):
+            assert np.allclose(source.xy[:, 1], [0, 1, 1, 0, 0])
+            assert np.allclose(source.xy[:, 0], [v0, v0, v1, v1, v0])
+
+    def test_hspans_nondefault_kdim(self):
+        hspans = HSpans(
+            {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
+        )
+        plot = mpl_renderer.get_plot(hspans)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "x"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "y"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (-0.055, 0.055))
+        assert np.allclose(ylim, (0, 6.5))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 3
+        for source, v0, v1 in zip(
+            sources, hspans.data["other0"], hspans.data["other1"]
+        ):
+            assert np.allclose(source.xy[:, 0], [0, 0, 1, 1, 0])
+            assert np.allclose(source.xy[:, 1], [v0, v1, v1, v0, v0])
+
+    def test_vspans_plot(self):
+        vspans = VSpans(
+            {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]},
+            vdims=["extra"],
+        )
+        plot = mpl_renderer.get_plot(vspans)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "x"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "y"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (0, 6.5))
+        assert np.allclose(ylim, (-0.055, 0.055))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 3
+        for source, v0, v1 in zip(sources, vspans.data["x0"], vspans.data["x1"]):
+            assert np.allclose(source.xy[:, 1], [0, 1, 1, 0, 0])
+            assert np.allclose(source.xy[:, 0], [v0, v0, v1, v1, v0])
+
+    def test_vspans_inverse_plot(self):
+        vspans = VSpans(
+            {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]},
+            vdims=["extra"],
+        ).opts(invert_axes=True)
+        plot = mpl_renderer.get_plot(vspans)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "y"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "x"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (-0.055, 0.055))
+        assert np.allclose(ylim, (0, 6.5))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 3
+        for source, v0, v1 in zip(sources, vspans.data["x0"], vspans.data["x1"]):
+            assert np.allclose(source.xy[:, 0], [0, 0, 1, 1, 0])
+            assert np.allclose(source.xy[:, 1], [v0, v1, v1, v0, v0])
+
+    def test_vspans_nondefault_kdims(self):
+        vspans = VSpans(
+            {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
+        )
+        plot = mpl_renderer.get_plot(vspans)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "x"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "y"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (0, 6.5))
+        assert np.allclose(ylim, (-0.055, 0.055))
+
+        sources = plot.handles["annotations"]
+        assert len(sources) == 3
+        for source, v0, v1 in zip(
+            sources, vspans.data["other0"], vspans.data["other1"]
+        ):
+            assert np.allclose(source.xy[:, 1], [0, 1, 1, 0, 0])
+            assert np.allclose(source.xy[:, 0], [v0, v0, v1, v1, v0])
+
+    def test_vspans_hspans_overlay(self):
+        hspans = HSpans(
+            {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]},
+            vdims=["extra"],
+        )
+        vspans = VSpans(
+            {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]},
+            vdims=["extra"],
+        )
+        plot = mpl_renderer.get_plot(hspans * vspans)
+        assert plot.handles["fig"].axes[0].get_xlabel() == "x"
+        assert plot.handles["fig"].axes[0].get_ylabel() == "y"
+
+        xlim = plot.handles["fig"].axes[0].get_xlim()
+        ylim = plot.handles["fig"].axes[0].get_ylim()
+        assert np.allclose(xlim, (0, 6.5))
+        assert np.allclose(ylim, (0, 6.5))
+
+        sources = plot.handles["fig"].axes[0].get_children()
+        for source, v0, v1 in zip(sources[:3], hspans.data["y0"], hspans.data["y1"]):
+            assert np.allclose(source.xy[:, 0], [0, 0, 1, 1, 0])
+            assert np.allclose(source.xy[:, 1], [v0, v1, v1, v0, v0])
+
+        for source, v0, v1 in zip(sources[3:6], vspans.data["x0"], vspans.data["x1"]):
+            assert np.allclose(source.xy[:, 1], [0, 1, 1, 0, 0])
+            assert np.allclose(source.xy[:, 0], [v0, v0, v1, v1, v0])


### PR DESCRIPTION
New elements to use the new vectorized Bokeh glyphs.

`VLines` and `HLines`:

<img width="928" alt="image" src="https://github.com/holoviz/holoviews/assets/890576/8a95a098-7339-49e3-b5c2-7471a0bced2f">

`VSpans` and `HSpans`:

<img width="908" alt="image" src="https://github.com/holoviz/holoviews/assets/890576/4af13a74-4326-43ee-a973-bb1be18db42d">

WIP

- [x] Add unit tests
- [x] Implement `invert_axes`
- [x] Matplotlib support
- [x] <s>Decide on synthetic dimension approach</s> not using it
- [x] Fix default hover behavior
- [x] Docs
