### PR TITLE
Improve Legend support for Layout and add documentation

### DIFF
--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -489,7 +489,53 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The other ``muted_`` options can be used to define other aspects of the Histogram style when it is unselected."
+    "The other ``muted_`` options can be used to define other aspects of the Histogram style when it is unselected.\n",
+    "\n",
+    "If you have multiple plots in a ``Layout`` with the same legend label, muting one of them will automatically mute all of them. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overlay1 = hv.Curve([0, 0], label=\"A\") * hv.Curve([1, 1], label=\"B\")\n",
+    "overlay2 = hv.Curve([2, 2], label=\"A\") * hv.Curve([3, 3], label=\"B\")\n",
+    "layout = overlay1 + overlay2\n",
+    "layout                                                           "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to turn off this behavior, use ``.opts(sync_legends=False)``"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layout.opts(sync_legends=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to control the number of legend shown in the ``Layout`` or the position of them ``show_legends`` and ``legend_position`` can be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layout.opts(sync_legends=True, show_legends=0, legend_position=\"top_left\")"
    ]
   },
   {
@@ -914,5 +960,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -31,7 +31,7 @@ from ..util import attach_streams, displayable, collate
 from .links import LinkCallback
 from .util import (
     bokeh3, filter_toolboxes, make_axis, sync_legends, update_shared_sources, empty_plot,
-    decode_bytes, theme_attr_json, cds_column_replace, get_default, merge_tools,
+    decode_bytes, theme_attr_json, cds_column_replace, get_default, merge_tools, select_legends
 )
 
 if bokeh3:
@@ -690,6 +690,21 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
     sync_legends = param.Boolean(default=True, doc="""
         Whether to sync the legend when muted/unmuted based on the name""")
 
+    show_legends = param.ClassSelector(default=True, class_=(list, int, bool), doc="""
+        Whether to show the legend for a particular subplot by index. If True all legends
+        will be shown. If False no legends will be shown.""")
+
+    legend_position = param.ObjectSelector(objects=["top_right",
+                                                    "top_left",
+                                                    "bottom_left",
+                                                    "bottom_right",
+                                                    'right', 'left',
+                                                    'top', 'bottom'],
+                                                    default="right",
+                                                    doc="""
+        Allows selecting between a number of predefined legend position
+        options.""")
+
     tabs = param.Boolean(default=False, doc="""
         Whether to display overlaid plots in separate panes""")
 
@@ -699,6 +714,10 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         if self.top_level:
             self.traverse(lambda x: attach_streams(self, x.hmap, 2),
                           [GenericElementPlot])
+
+    @param.depends('show_legends', 'legend_position', watch=True, on_init=True)
+    def _update_show_legend(self):
+        select_legends(self.layout, self.show_legends, self.legend_position)
 
     def _init_layout(self, layout):
         # Situate all the Layouts in the grid and compute the gridspec

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -700,7 +700,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                                                     "bottom_right",
                                                     'right', 'left',
                                                     'top', 'bottom'],
-                                                    default="right",
+                                                    default="top_right",
                                                     doc="""
         Allows selecting between a number of predefined legend position
         options.""")

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -690,7 +690,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
     sync_legends = param.Boolean(default=True, doc="""
         Whether to sync the legend when muted/unmuted based on the name""")
 
-    show_legends = param.ClassSelector(default=True, class_=(list, int, bool), doc="""
+    show_legends = param.ClassSelector(default=None, class_=(list, int, bool), doc="""
         Whether to show the legend for a particular subplot by index. If True all legends
         will be shown. If False no legends will be shown.""")
 
@@ -703,7 +703,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                                                     default="top_right",
                                                     doc="""
         Allows selecting between a number of predefined legend position
-        options.""")
+        options. Will only be applied if show_legend is not None.""")
 
     tabs = param.Boolean(default=False, doc="""
         Whether to display overlaid plots in separate panes""")
@@ -717,7 +717,8 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
 
     @param.depends('show_legends', 'legend_position', watch=True, on_init=True)
     def _update_show_legend(self):
-        select_legends(self.layout, self.show_legends, self.legend_position)
+        if self.show_legends is not None:
+            select_legends(self.layout, self.show_legends, self.legend_position)
 
     def _init_layout(self, layout):
         # Situate all the Layouts in the grid and compute the gridspec

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -468,14 +468,17 @@ def select_legends(holoviews_layout, figure_index=None, legend_position="top_rig
     ----------
     holoviews_layout : Holoviews Layout
         Holoviews Layout with legends.
-    figure_index : list[int] | int | None
+    figure_index : list[int] | bool | int | None
         Index of the figures which legends to show.
         If None is chosen, only the first figures legend is shown
+        If True is chosen, all legends are shown.
     legend_position : str
         Position of the legend(s).
     """
     if figure_index is None:
         figure_index = [0]
+    elif isinstance(figure_index, bool):
+        figure_index = range(len(holoviews_layout)) if figure_index else []
     elif isinstance(figure_index, int):
         figure_index = [figure_index]
     if not isinstance(holoviews_layout, Layout):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -33,7 +33,7 @@ from packaging.version import Version
 
 from ...core.layout import Layout
 from ...core.ndmapping import NdMapping
-from ...core.overlay import Overlay
+from ...core.overlay import Overlay, NdOverlay
 from ...core.util import (
     arraylike_types, callable_name, cftime_types,
     cftime_to_timestamp, isnumeric, pd, unique_array
@@ -485,6 +485,8 @@ def select_legends(holoviews_layout, figure_index=None, legend_position="top_rig
         holoviews_layout = [holoviews_layout]
 
     for i, plot in enumerate(holoviews_layout):
+        if not isinstance(plot, (NdOverlay, Overlay)):
+            continue
         if i in figure_index:
             plot.opts(show_legend=True, legend_position=legend_position)
         else:

--- a/holoviews/tests/plotting/bokeh/test_utils.py
+++ b/holoviews/tests/plotting/bokeh/test_utils.py
@@ -1,6 +1,9 @@
+import pytest
+
+import holoviews as hv
 from holoviews.core import Store
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.plotting.bokeh.util import filter_batched_data, glyph_order
+from holoviews.plotting.bokeh.util import filter_batched_data, glyph_order, select_legends
 from holoviews.plotting.bokeh.styles import expand_batched_style
 
 bokeh_renderer = Store.renderers['bokeh']
@@ -74,3 +77,28 @@ class TestBokehUtilsInstantiation(ComparisonTestCase):
         order = glyph_order(['scatter_1', 'patch_1', 'rect_1'],
                             ['scatter', 'patch'])
         self.assertEqual(order, ['scatter_1', 'patch_1', 'rect_1'])
+
+
+@pytest.mark.parametrize(
+    "figure_index,expected",
+    [
+        (0, [True, False]),
+        (1, [False, True]),
+        ([0], [True, False]),
+        ([1], [False, True]),
+        ([0, 1], [True, True]),
+        (True, [True, True]),
+        (False, [False, False]),
+        (None, [True, False]),
+    ],
+    ids=["int0", "int1", "list0", "list1", "list01", "True", "False", "None"],
+)
+def test_select_legends_figure_index(figure_index, expected):
+    overlays = [
+        hv.Curve([0, 0]) * hv.Curve([1, 1]),
+        hv.Curve([2, 2]) * hv.Curve([3, 3]),
+    ]
+    layout = hv.Layout(overlays)
+    select_legends(layout, figure_index)
+    output = [ol.opts["show_legend"] for ol in overlays]
+    assert expected == output


### PR DESCRIPTION
closes #5833

This PR I want to implement the following:

- [x] Add `show_legends` and `legend_position` to `.opts` for a Layout Plot. (Note that `show_legends` is plural)
- [x] Add documentation for `sync_legends` and `show_legends` in a Layout plot.
- [x] Add unit test for  `util.select_legends`.
- [ ] Maybe rename `util.select_legends` to `util.show_legends`.

Example of show_legends:
![image](https://github.com/holoviz/holoviews/assets/19758978/545ca3e8-a63f-4f56-92b7-b8f914dbb1f7)


``` python
import holoviews as hv
import hvplot.pandas
import numpy as np
import pandas as pd

df = pd.DataFrame(np.arange(10)[:, None] * np.array([1, 2, 3]), columns=list("ABC"))
plot = (df.hvplot() + df.hvplot() + df.hvplot() + df.hvplot()).cols(2)
plot.opts(sync_legends=True, show_legends=0, legend_position="top_left")
```