### PR TITLE
Remove warnings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -134,8 +134,8 @@ jobs:
           files: ./coverage.xml
           flags: ui-tests
           fail_ci_if_error: false # optional (default = false)
-  core_test:
-    name: Core test on ${{ matrix.python-version }}, ${{ matrix.os }}
+  core_tests:
+    name: Core tests on ${{ matrix.python-version }}, ${{ matrix.os }}
     needs: [pre_commit]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -148,7 +148,7 @@ jobs:
       run:
         shell: bash -el {0}
     env:
-      DESC: "Python ${{ matrix.python-version }} tests"
+      DESC: "Python ${{ matrix.python-version }} core tests"
       PYTHON_VERSION: ${{ matrix.python-version }}
       SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
       DISPLAY: ":99.0"

--- a/holoviews/core/data/ibis.py
+++ b/holoviews/core/data/ibis.py
@@ -194,7 +194,7 @@ class IbisInterface(Interface):
             import ibis
             order = ibis.desc if reverse else ibis.asc
             return dataset.data.order_by([order(dataset.get_dimension(x).name) for x in by])
-        if ibis4():
+        elif ibis4():
             # Tuple syntax will be removed in Ibis 7.0:
             # https://github.com/ibis-project/ibis/pull/6082
             return dataset.data.order_by([(dataset.get_dimension(x).name, not reverse) for x in by])

--- a/holoviews/core/data/ibis.py
+++ b/holoviews/core/data/ibis.py
@@ -25,7 +25,7 @@ def ibis4():
 
 @lru_cache
 def ibis6():
-    return ibis_version() >= Version("7.0")
+    return ibis_version() >= Version("6.0")
 
 
 class IbisInterface(Interface):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -36,7 +36,7 @@ class PandasInterface(Interface, PandasAPI):
     def dimension_type(cls, dataset, dim):
         name = dataset.get_dimension(dim, strict=True).name
         idx = list(dataset.data.columns).index(name)
-        return dataset.data.dtypes[idx].type
+        return dataset.data.dtypes.iloc[idx].type
 
     @classmethod
     def init(cls, eltype, data, kdims, vdims):
@@ -257,7 +257,10 @@ class PandasInterface(Interface, PandasAPI):
             # pandas uses ddof=1 for std and var
             fn = lambda x: function(x, ddof=0)
         else:
-            fn = function
+            # To avoid pandas warning about using DataFrameGroupBy.function
+            # introduced in Pandas 2.1
+            # MRE: pd.DataFrame([0, 1]).groupby(0).aggregate(np.mean)
+            fn = lambda x: function(x)
         if len(dimensions):
             # The reason to use `numeric_cols` is to prepare for when pandas will not
             # automatically drop columns that are not numerical for numerical

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -266,7 +266,7 @@ class PandasInterface(Interface, PandasAPI):
             # automatically drop columns that are not numerical for numerical
             # functions, e.g., `np.mean`.
             # pandas started warning about this in v1.5.0
-            if fn in [np.size]:
+            if function in [np.size]:
                 # np.size actually works with non-numerical columns
                 numeric_cols = [
                     c for c in reindexed.columns if c not in cols

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -257,10 +257,7 @@ class PandasInterface(Interface, PandasAPI):
             # pandas uses ddof=1 for std and var
             fn = lambda x: function(x, ddof=0)
         else:
-            # To avoid pandas warning about using DataFrameGroupBy.function
-            # introduced in Pandas 2.1
-            # MRE: pd.DataFrame([0, 1]).groupby(0).aggregate(np.mean)
-            fn = lambda x: function(x)
+            fn = util._PANDAS_FUNC_LOOKUP.get(function, function)
         if len(dimensions):
             # The reason to use `numeric_cols` is to prepare for when pandas will not
             # automatically drop columns that are not numerical for numerical

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -1,6 +1,5 @@
 import sys
 import types
-import warnings
 
 from collections import OrderedDict
 
@@ -173,17 +172,7 @@ class XArrayInterface(GridInterface):
                 for vdim in vdims:
                     arr = data[vdim.name]
                     if not isinstance(arr, xr.DataArray):
-                        with warnings.catch_warnings():
-                            # xarray emit a warning when datetime/timedelta is not nanosecond,
-                            # and then convert it to nanosecond precision. The full warning is:
-                            #   Converting non-nanosecond precision {case} values to nanosecond precision.
-                            #   This behavior can eventually be relaxed in xarray, as it is an artifact from
-                            #   pandas which is now beginning to support non-nanosecond precision values.
-                            #   This warning is caused by passing non-nanosecond np.datetime64 or
-                            #   np.timedelta64 values to the DataArray or Variable constructor; it can be
-                            #   silenced by converting the values to nanosecond precision ahead of time.
-                            warnings.filterwarnings("ignore", "Converting non-nanosecond precision")
-                            arr = xr.DataArray(arr, coords=coords, **xr_kwargs)
+                        arr = xr.DataArray(arr, coords=coords, **xr_kwargs)
                     arrays[vdim.name] = arr
                 data = xr.Dataset(arrays)
         else:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1,3 +1,4 @@
+import builtins
 import sys
 import warnings
 import operator
@@ -86,6 +87,40 @@ try:
 except ImportError:
     cftime_types = ()
 _STANDARD_CALENDARS = {'standard', 'gregorian', 'proleptic_gregorian'}
+
+
+# To avoid pandas warning about using DataFrameGroupBy.function
+# introduced in Pandas 2.1.
+# MRE: pd.DataFrame([0, 1]).groupby(0).aggregate(np.mean)
+# Copied from here:
+# https://github.com/pandas-dev/pandas/blob/723feb984e6516e3e1798d3c4440c844b12ea18f/pandas/core/common.py#L592
+_PANDAS_FUNC_LOOKUP = {
+    builtins.sum: "sum",
+    builtins.max: "max",
+    builtins.min: "min",
+    np.all: "all",
+    np.any: "any",
+    np.sum: "sum",
+    np.nansum: "sum",
+    np.mean: "mean",
+    np.nanmean: "mean",
+    np.prod: "prod",
+    np.nanprod: "prod",
+    np.std: "std",
+    np.nanstd: "std",
+    np.var: "var",
+    np.nanvar: "var",
+    np.median: "median",
+    np.nanmedian: "median",
+    np.max: "max",
+    np.nanmax: "max",
+    np.min: "min",
+    np.nanmin: "min",
+    np.cumprod: "cumprod",
+    np.nancumprod: "cumprod",
+    np.cumsum: "cumsum",
+    np.nancumsum: "cumsum",
+}
 
 
 class VersionError(Exception):

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -251,6 +251,11 @@ class Area(Curve):
         vdims = [[el.vdims[0], baseline_name] for el in areas]
         baseline = None
         stacked = areas.clone(shared_data=False)
+        if len(levels) == 1:
+            # Pandas 2.1 gives the following FutureWarning:
+            #   Creating a Groupby object with a length-1 list-like level parameter
+            #   will yield indexes as tuples in a future version.
+            levels = levels[0]
         for (key, sdf), element_vdims in zip(df.groupby(level=levels, sort=False), vdims):
             vdim = element_vdims[0]
             sdf = sdf.droplevel(levels).reindex(index=df.index.unique(-1), fill_value=0)

--- a/holoviews/operation/timeseries.py
+++ b/holoviews/operation/timeseries.py
@@ -5,7 +5,7 @@ from packaging.version import Version
 
 from ..core import Operation, Element
 from ..core.data import PandasInterface
-from ..core.util import pandas_version
+from ..core.util import pandas_version, _PANDAS_FUNC_LOOKUP
 from ..element import Scatter
 
 
@@ -89,7 +89,8 @@ class resample(Operation):
         resample_kwargs = {'rule': self.p.rule, 'label': self.p.label,
                            'closed': self.p.closed}
         df = df.set_index(xdim).resample(**resample_kwargs)
-        return element.clone(df.apply(self.p.function).reset_index())
+        fn = _PANDAS_FUNC_LOOKUP.get(self.p.function, self.p.function)
+        return element.clone(df.apply(fn).reset_index())
 
     def _process(self, element, key=None):
         return element.map(self._process_layer, Element)

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -380,7 +380,7 @@ class HomogeneousColumnTests:
 
     def test_dataset_get_dframe_by_dimension(self):
         df = self.dataset_hm.dframe(['x'])
-        self.assertEqual(df, pd.DataFrame({'x': self.xs}, dtype=df.dtypes[0]))
+        self.assertEqual(df, pd.DataFrame({'x': self.xs}, dtype=df.dtypes.iloc[0]))
 
     def test_dataset_transform_replace_hm(self):
         transformed = self.dataset_hm.transform(y=dim('y')*2)

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -1089,6 +1089,14 @@ class TestCrossBackendOptionPickling(TestCrossBackendOptions):
 
     cleanup = ['test_raw_pickle.pkl', 'test_pickle_mpl_bokeh.pkl']
 
+    def setUp(self):
+        super().setUp()
+        self.raw = Image(np.random.rand(10,10))
+        Store.current_backend = 'matplotlib'
+        StoreOptions.set_options(self.raw, style={'Image':{'cmap':'Blues'}})
+        Store.current_backend = 'bokeh'
+        StoreOptions.set_options(self.raw, style={'Image':{'cmap':'Purple'}})
+
     def tearDown(self):
         super().tearDown()
         for f in self.cleanup:
@@ -1102,12 +1110,13 @@ class TestCrossBackendOptionPickling(TestCrossBackendOptions):
         Test usual pickle saving and loading (no style information preserved)
         """
         fname= 'test_raw_pickle.pkl'
-        raw = super().test_mpl_bokeh_mpl()
-        pickle.dump(raw, open(fname,'wb'))
+        with open(fname,'wb') as handle:
+            pickle.dump(self.raw, handle)
         self.clear_options()
-        img = pickle.load(open(fname,'rb'))
+        with open(fname,'rb') as handle:
+            img = pickle.load(handle)
         # Data should match
-        self.assertEqual(raw, img)
+        self.assertEqual(self.raw, img)
         # But the styles will be lost without using Store.load/Store.dump
         pickle.current_backend = 'matplotlib'
         mpl_opts = Store.lookup_options('matplotlib', img, 'style').options
@@ -1122,12 +1131,13 @@ class TestCrossBackendOptionPickling(TestCrossBackendOptions):
         Test pickle saving and loading with Store (style information preserved)
         """
         fname = 'test_pickle_mpl_bokeh.pkl'
-        raw = super().test_mpl_bokeh_mpl()
-        Store.dump(raw, open(fname,'wb'))
+        with open(fname,'wb') as handle:
+            Store.dump(self.raw, handle)
         self.clear_options()
-        img = Store.load(open(fname,'rb'))
+        with open(fname,'rb') as handle:
+            img = Store.load(handle)
         # Data should match
-        self.assertEqual(raw, img)
+        self.assertEqual(self.raw, img)
         # Check it is still blue in matplotlib...
         Store.current_backend = 'matplotlib'
         mpl_opts = Store.lookup_options('matplotlib', img, 'style').options

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -813,8 +813,6 @@ class TestCrossBackendOptions(ComparisonTestCase):
         Store.current_backend = 'bokeh'
         bokeh_opts = Store.lookup_options('bokeh', img, 'style').options
         self.assertEqual(bokeh_opts, {'cmap':'Purple'})
-        return img
-
 
     def test_mpl_bokeh_offset_mpl(self):
         img = Image(np.random.rand(10,10))
@@ -841,7 +839,6 @@ class TestCrossBackendOptions(ComparisonTestCase):
         Store.current_backend = 'bokeh'
         bokeh_opts = Store.lookup_options('bokeh', img, 'style').options
         self.assertEqual(bokeh_opts, {'cmap':'Purple'})
-        return img
 
     def test_builder_backend_switch_signature(self):
         Store.options(val=self.store_mpl, backend='matplotlib')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,15 @@ filterwarnings = [
     "ignore: Deprecated API features detected:DeprecationWarning:ibis.backends.base.sql.alchemy",  # https://github.com/ibis-project/ibis/issues/5048
     # 2023-03: Already handling the nested sequence
     "ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning:holoviews.core.data.spatialpandas",
-    # 2023-08: Dash needs to update their code to use the comm module
-    "ignore:The `.+?` class has been deprecated:DeprecationWarning:dash._jupyter:",
-    # 2023-08: See https://github.com/bokeh/bokeh/issues/13324
+    # 2023-09: Dash needs to update their code to use the comm module and pkg_resources
+    "ignore:The `.+?` class has been deprecated:DeprecationWarning:dash._jupyter",
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning:dash.dash",
+    # 2023-09: See https://github.com/bokeh/bokeh/issues/13324
     "ignore:log_path has been deprecated, please use log_output:DeprecationWarning:bokeh.io.webdriver",
+    # 2023-09: Not a relevant warning for HoloViews
+    "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
+    # 2023-09: See https://github.com/matplotlib/matplotlib/issues/25244
+    "ignore:Deprecated call to `pkg_resources.declare_namespace('mpl_toolkits')`;DeprecationWarning",
 ]
 
 [tool.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ filterwarnings = [
     "ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning:holoviews.core.data.spatialpandas",
     # 2023-08: Dash needs to update their code to use the comm module
     "ignore:The `.+?` class has been deprecated:DeprecationWarning:dash._jupyter:",
+    # 2023-08: See https://github.com/bokeh/bokeh/issues/13324
+    "ignore:log_path has been deprecated, please use log_output:DeprecationWarning:bokeh.io.webdriver",
 ]
 
 [tool.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ filterwarnings = [
     # 2023-09: Not a relevant warning for HoloViews
     "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
     # 2023-09: See https://github.com/matplotlib/matplotlib/issues/25244
-    "ignore:Deprecated call to `pkg_resources.declare_namespace('mpl_toolkits')`;DeprecationWarning",
+    "ignore:Deprecated call to `pkg_resources.+?'mpl_toolkits:DeprecationWarning",
+    "ignore:Deprecated call to `pkg_resources.+?'sphinxcontrib:DeprecationWarning",
 ]
 
 [tool.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ filterwarnings = [
     # 2023-01: Sqlalchemy 2.0 warning:
     "ignore: Deprecated API features detected:DeprecationWarning:ibis.backends.base.sql.alchemy",  # https://github.com/ibis-project/ibis/issues/5048
     # 2023-03: Already handling the nested sequence
-    "ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning:holoviews.core.data.spatialpandas"
+    "ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning:holoviews.core.data.spatialpandas",
+    # 2023-08: Dash needs to update their code to use the comm module
+    "ignore:The `.+?` class has been deprecated:DeprecationWarning:dash._jupyter:",
 ]
 
 [tool.coverage]


### PR DESCRIPTION
Removing warnings from the CI. The goal is to have warnings raise an error in the CI. 

Gridplot warning will be handled in: https://github.com/holoviz/holoviews/pull/5873

xarray warnings will be handled in another PR, as I'm not sure about what to do with them right now: 
``` python-traceback
UserWarning: rename 'x' to 'x' does not create an index anymore. Try using swap_dims instead or use set_index after rename to create an indexed coordinate.
UserWarning: Converting non-nanosecond precision datetime values to nanosecond precision. This behavior can eventually be relaxed in xarray, as it is an artifact from pandas which is now beginning to support non-nanosecond precision values. This warning is caused by passing non-nanosecond np.datetime64 or np.timedelta64 values to the DataArray or Variable constructor; it can be silenced by converting the values to nanosecond precision ahead of time.