### PR TITLE
Improve support for NdOverlay and Overlay in downsample1d

### DIFF
--- a/holoviews/operation/downsample.py
+++ b/holoviews/operation/downsample.py
@@ -35,7 +35,7 @@ import numpy as np
 import param
 
 from .resample import ResampleOperation1D
-from ..core.overlay import NdOverlay, Overlay
+from ..core import NdOverlay, Overlay, Store
 from ..element.chart import Area
 
 
@@ -169,7 +169,7 @@ class downsample1d(ResampleOperation1D):
     def _process(self, element, key=None):
         if isinstance(element, (Overlay, NdOverlay)):
             _process = partial(self._process, key=key)
-            _opts = element.opts.get().kwargs
+            _opts = element.opts.get().kwargs if Store._options else {}
             if isinstance(element, Overlay):
                 elements = [v.map(_process) for v in element]
                 return Overlay(elements).opts(**_opts)

--- a/holoviews/operation/downsample.py
+++ b/holoviews/operation/downsample.py
@@ -29,11 +29,13 @@ SOFTWARE.
 """
 
 import math
+from functools import partial
 
 import numpy as np
 import param
 
 from .resample import ResampleOperation1D
+from ..core.overlay import NdOverlay, Overlay
 from ..element.chart import Area
 
 
@@ -165,6 +167,16 @@ class downsample1d(ResampleOperation1D):
     algorithm = param.Selector(default='lttb', objects=['lttb', 'nth'])
 
     def _process(self, element, key=None):
+        if isinstance(element, (Overlay, NdOverlay)):
+            _process = partial(self._process, key=key)
+            _opts = element.opts.get().kwargs
+            if isinstance(element, Overlay):
+                elements = [v.map(_process) for v in element]
+                return Overlay(elements).opts(**_opts)
+            else:
+                elements = {k: v.map(_process) for k, v in element.items()}
+                return NdOverlay(elements).opts(**_opts)
+
         if self.p.x_range:
             element = element[slice(*self.p.x_range)]
         if len(element) <= self.p.width:

--- a/holoviews/operation/downsample.py
+++ b/holoviews/operation/downsample.py
@@ -35,7 +35,7 @@ import numpy as np
 import param
 
 from .resample import ResampleOperation1D
-from ..core import NdOverlay, Overlay, Store
+from ..core import NdOverlay, Overlay
 from ..element.chart import Area
 
 
@@ -169,13 +169,11 @@ class downsample1d(ResampleOperation1D):
     def _process(self, element, key=None):
         if isinstance(element, (Overlay, NdOverlay)):
             _process = partial(self._process, key=key)
-            _opts = element.opts.get().kwargs if Store._options else {}
             if isinstance(element, Overlay):
                 elements = [v.map(_process) for v in element]
-                return Overlay(elements).opts(**_opts)
             else:
                 elements = {k: v.map(_process) for k, v in element.items()}
-                return NdOverlay(elements).opts(**_opts)
+            return element.clone(elements)
 
         if self.p.x_range:
             element = element[slice(*self.p.x_range)]

--- a/holoviews/tests/operation/test_downsample.py
+++ b/holoviews/tests/operation/test_downsample.py
@@ -1,0 +1,20 @@
+import pytest
+
+import holoviews as hv
+from holoviews.operation.downsample import downsample1d
+
+
+@pytest.mark.parametrize("plottype", ["overlay", "ndoverlay"])
+def test_downsample1d_multi(plottype):
+    N = 1000
+    assert N > downsample1d.width
+
+    if plottype == "overlay":
+        figure = hv.Overlay([hv.Curve(range(N)), hv.Curve(range(N))])
+    elif plottype == "ndoverlay":
+        figure = hv.NdOverlay({"A": hv.Curve(range(N)), "B": hv.Curve(range(N))})
+
+    figure_values = downsample1d(figure, dynamic=False).data.values()
+    for n in figure_values:
+        for value in n.data.values():
+            assert value.size == downsample1d.width


### PR DESCRIPTION
Before the following code will always return the non-downsampled ndoverlay/overlay. 

``` python
        if len(element) <= self.p.width:
            return element
```