### PR TITLE
Explicitly clear Matplotlib figure to remove warning about auto-removal of overlapping axes

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -898,6 +898,10 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
                                     wspace=self.hspace,
                                     hspace=self.vspace)
 
+        # Explicitly clear current Matplotlib figure to avoid
+        # "Auto-removal of overlapping axes" warning.
+        plt.clf()
+
         # Situate all the Layouts in the grid and compute the gridspec
         # indices for all the axes required by each LayoutPlot.
         gidx = 0

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -898,9 +898,9 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
                                     wspace=self.hspace,
                                     hspace=self.vspace)
 
-        # Explicitly clear current Matplotlib figure to avoid
+        # Explicitly clear Matplotlib figures to avoid
         # "Auto-removal of overlapping axes" warning.
-        plt.clf()
+        self.handles['fig'].clf()
 
         # Situate all the Layouts in the grid and compute the gridspec
         # indices for all the axes required by each LayoutPlot.


### PR DESCRIPTION
Running the Matplotlib tests currently gives a `MatplotlibDeprecationWarning` as follows:

```
$ pytest -v holoviews/tests/plotting/matplotlib/test_renderer.py::MPLRendererTest::test_get_size_row_plot
<snip>                                                                                                                    
holoviews/tests/plotting/matplotlib/test_renderer.py::MPLRendererTest::test_get_size_row_plot PASSED                               [100%]

============================================================ warnings summary ============================================================
holoviews/tests/plotting/matplotlib/test_renderer.py::MPLRendererTest::test_get_size_row_plot
  /Users/iant/github/holoviews/holoviews/plotting/mpl/plot.py:958: MatplotlibDeprecationWarning: Auto-removal of overlapping axes is deprecated since 3.6 and will be removed two minor releases later; explicitly call ax.remove() as needed.
    subaxes = [plt.subplot(self.gs[ind], projection=proj)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 1 passed, 1 warning in 0.45s ======================================================
```

This PR explicitly clears the current Matplotlib figure using `plt.clf()`, which deletes all of its `axes` objects. The fix is added before the start of a loop that potentially calls `plt.subplot` multiple times as the clearing of the current figure only needs to occur the first time around.

With this fix all the Matplotlib tests pass locally without producing a warning. It does need to be checked by a HoloViews expert to confirm there won't be any unwanted side-effects.