### PR TITLE
Fix overlaying labels with sankey

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -421,7 +421,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             specs = ((dim.name, dim.label, dim.unit),)
         else:
             if isinstance(self, OverlayPlot):
-                l, b, r, t = self.get_extents(range_el, ranges, range_type=dim or "combined")
+                l, b, r, t = self.get_extents(range_el, ranges, dimension=dim)
             else:
                 l, b, r, t = self.get_extents(range_el, ranges)
             if self.invert_axes:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -421,7 +421,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             specs = ((dim.name, dim.label, dim.unit),)
         else:
             if isinstance(self, OverlayPlot):
-                l, b, r, t = self.get_extents(range_el, ranges, dim)
+                l, b, r, t = self.get_extents(range_el, ranges, range_type=dim or "combined")
             else:
                 l, b, r, t = self.get_extents(range_el, ranges)
             if self.invert_axes:


### PR DESCRIPTION
Not sure if this fixes the root of the problem or is simply a bandaid, but fixes https://github.com/holoviz/holoviews/issues/5863

```python
import holoviews as hv
from holoviews import opts, dim
hv.extension('bokeh')
import numpy as np


nodes = ["PhD", "Career Outside Science",  "Early Career Researcher", "Research Staff",
         "Permanent Research Staff",  "Professor",  "Non-Academic Research"]
nodes = hv.Dataset(enumerate(nodes), 'index', 'label')
edges = [
    (0, 1, 53), (0, 2, 47), (2, 6, 17), (2, 3, 30), (3, 1, 22.5), (3, 4, 3.5), (3, 6, 4.), (4, 5, 0.45)   
]

value_dim = hv.Dimension('Percentage', unit='%')
careers = hv.Sankey((edges, nodes), ['From', 'To'], vdims=value_dim)
labels = hv.Labels(([0, 1, 2, 3], [6, 6, 6, 6], ["A", "B", "C", "D"]), kdims=["From", "To"])

labels * careers
```