### PR TITLE
Drop requirement for NdMapping to be defined with OrderedDict

### DIFF
--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -104,10 +104,6 @@ class MultiDimensionalMapping(Dimensioned):
         if kdims is not None:
             params['kdims'] = kdims
         super().__init__(OrderedDict(), **dict(params))
-        if type(initial_items) is dict and not self.sort:
-            raise ValueError('If sort=False the data must define a fixed '
-                             'ordering, please supply a list of items or '
-                             'an OrderedDict, not a regular dictionary.')
 
         self._next_ind = 0
         self._check_key_type = True

--- a/holoviews/element/tabular.py
+++ b/holoviews/element/tabular.py
@@ -41,10 +41,8 @@ class ItemTable(Element):
     def __init__(self, data, **params):
         if data is None:
             data = []
-        if type(data) == dict:
-            raise ValueError("ItemTable cannot accept a standard Python  dictionary "
-                             "as a well-defined item ordering is required.")
-        elif isinstance(data, dict): pass
+        if isinstance(data, dict):
+            pass
         elif isinstance(data, list):
             data = OrderedDict(data)
         else:


### PR DESCRIPTION
Since Python dict is now ordered the limitation around requiring an NdMapping input dict to be an `OrderedDict` is no longer necessary.