### PR TITLE
Ensure PlotSize stream works with undefined width/height

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1429,8 +1429,8 @@ class PlotSize(LinkedStream):
        Scale factor to scale width and height values reported by the stream""")
 
     def transform(self):
-        return {'width':  int(self.width * self.scale),
-                'height': int(self.height * self.scale)}
+        return {'width':  int(self.width * self.scale) if self.width else None,
+                'height': int(self.height * self.scale) if self.height else None}
 
 
 class SelectMode(LinkedStream):


### PR DESCRIPTION
Certain operations (such as `downsample1D`) only require having a set width which means that the height scaling currently errors.