### PR TITLE
Try/except get_extents without dimension and add kwargs to all get_extents

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -421,7 +421,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             specs = ((dim.name, dim.label, dim.unit),)
         else:
             if isinstance(self, OverlayPlot):
-                l, b, r, t = self.get_extents(range_el, ranges, dimension=dim)
+                try:
+                    l, b, r, t = self.get_extents(range_el, ranges, dimension=dim)
+                except TypeError:
+                    # GeoViews ProjectionPlot.get_extents() does not support dimension
+                    # before 1.10.2
+                    l, b, r, t = self.get_extents(range_el, ranges)
             else:
                 l, b, r, t = self.get_extents(range_el, ranges)
             if self.invert_axes:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -420,14 +420,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             axis_label = str(dim)
             specs = ((dim.name, dim.label, dim.unit),)
         else:
-            if isinstance(self, OverlayPlot):
-                try:
-                    l, b, r, t = self.get_extents(range_el, ranges, dimension=dim)
-                except TypeError:
-                    # GeoViews ProjectionPlot.get_extents() does not support dimension
-                    # before 1.10.2
-                    l, b, r, t = self.get_extents(range_el, ranges)
-            else:
+            try:
+                l, b, r, t = self.get_extents(range_el, ranges, dimension=dim)
+            except TypeError:
+                # Backward compatibility for e.g. GeoViews=<1.10.1 since dimension
+                # is a newly added keyword argument in HoloViews 1.17
                 l, b, r, t = self.get_extents(range_el, ranges)
             if self.invert_axes:
                 l, b, r, t = b, l, t, r
@@ -988,9 +985,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 range_dim = None
             try:
                 l, b, r, t = self.get_extents(element, ranges, dimension=range_dim)
-            except Exception:
+            except TypeError:
                 # Backward compatibility for e.g. GeoViews=<1.10.1 since dimension
-                # is a newly added keyword argument
+                # is a newly added keyword argument in HoloViews 1.17
                 l, b, r, t = self.get_extents(element, ranges)
             if self.invert_axes:
                 l, b, r, t = b, l, t, r

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -276,7 +276,7 @@ class SpreadPlot(AreaPlot):
         pos_error = element.dimension_values(pos_idx)
         return (xs, mean-neg_error, mean+pos_error), style, {}
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         return ChartPlot.get_extents(self, element, ranges, range_type)
 
 
@@ -390,7 +390,7 @@ class HistogramPlot(ColorbarPlot):
             labels = [dim.pprint_value(v) for v in xvals]
         return [xvals, labels]
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         ydim = element.get_dimension(1)
         s0, s1 = ranges[ydim.name]['soft']
         s0 = min(s0, 0) if isfinite(s0) else 0

--- a/holoviews/plotting/mpl/heatmap.py
+++ b/holoviews/plotting/mpl/heatmap.py
@@ -298,7 +298,7 @@ class RadialHeatMapPlot(ColorbarPlot):
         return ticks
 
 
-    def get_extents(self, view, ranges, range_type='combined'):
+    def get_extents(self, view, ranges, range_type='combined', **kwargs):
         if range_type == 'hard':
             return (np.nan,)*4
         return (0, 0, np.pi*2, self.max_radius+self.radius_outer)

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -37,7 +37,7 @@ class RasterBasePlot(ElementPlot):
 
     _plot_methods = dict(single='imshow')
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         extents = super().get_extents(element, ranges, range_type)
         if self.situate_axes or range_type not in ('combined', 'data'):
             return extents
@@ -294,7 +294,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
     def _finalize_artist(self, key):
         pass
 
-    def get_extents(self, view, ranges, range_type='combined'):
+    def get_extents(self, view, ranges, range_type='combined', **kwargs):
         if range_type == 'hard':
             return (np.nan,)*4
         width, height, _, _, _, _ = self.border_extents

--- a/holoviews/plotting/mpl/sankey.py
+++ b/holoviews/plotting/mpl/sankey.py
@@ -47,7 +47,7 @@ class SankeyPlot(GraphPlot):
 
     style_opts = GraphPlot.style_opts + ['label_text_font_size']
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         """
         A Chord plot is always drawn on a unit circle.
         """

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1407,7 +1407,7 @@ class GenericElementPlot(DimensionedPlot):
 
         return (x0, y0, x1, y1)
 
-    def get_extents(self, element, ranges, range_type='combined', dimension=None, xdim=None, ydim=None, zdim=None):
+    def get_extents(self, element, ranges, range_type='combined', dimension=None, xdim=None, ydim=None, zdim=None, **kwargs):
         """
         Gets the extents for the axes from the current Element. The globally
         computed ranges can optionally override the extents.

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -214,7 +214,7 @@ class BarPlot(BarsMixin, ElementPlot):
             xdims = element.kdims[0]
         return (xdims, element.vdims[0])
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         x0, y0, x1, y1 = BarsMixin.get_extents(self, element, ranges, range_type)
         if range_type not in ('data', 'combined'):
             return x0, y0, x1, y1

--- a/holoviews/plotting/plotly/tiles.py
+++ b/holoviews/plotting/plotly/tiles.py
@@ -53,7 +53,7 @@ class TilePlot(ElementPlot):
 
         return opts
 
-    def get_extents(self, element, ranges, range_type='combined'):
+    def get_extents(self, element, ranges, range_type='combined', **kwargs):
         extents = super().get_extents(element, ranges, range_type)
         if (not self.overlaid and all(e is None or not np.isfinite(e) for e in extents)
             and range_type in ('combined', 'data')):


### PR DESCRIPTION
Handle all cases where `get_extents` does not support `dimension`. Furthermore, all `get_extents` now have `**kwargs`.  