### PR TITLE
support python3-only systems

### DIFF
--- a/holoviews/tests/util/test_init.py
+++ b/holoviews/tests/util/test_init.py
@@ -14,6 +14,6 @@ def test_no_blocklist_imports():
         print(", ".join(mods), end="")
         """
 
-    output = check_output(['python', '-c', dedent(check)])
+    output = check_output(['python3', '-c', dedent(check)])
 
     assert output == b""

--- a/holoviews/tests/util/test_init.py
+++ b/holoviews/tests/util/test_init.py
@@ -1,5 +1,6 @@
 from textwrap import dedent
 from subprocess import check_output
+from shutil import which
 
 
 def test_no_blocklist_imports():
@@ -14,6 +15,6 @@ def test_no_blocklist_imports():
         print(", ".join(mods), end="")
         """
 
-    output = check_output(['python3', '-c', dedent(check)])
+    output = check_output([('python' if which('python') else 'python3'), '-c', dedent(check)])
 
     assert output == b""


### PR DESCRIPTION
Python 2 has been dead for some time and some rolling distros (like openSUSE Tumbleweed) don't have the `python` binary anymore. I think that checking for the `python3` binary is more inclusive and doesn't change the nature of the test.