### PR TITLE
Ibis: update deprecated call to `order_by`

### DIFF
--- a/holoviews/core/data/ibis.py
+++ b/holoviews/core/data/ibis.py
@@ -191,7 +191,9 @@ class IbisInterface(Interface):
     @classmethod
     def sort(cls, dataset, by=[], reverse=False):
         if ibis4():
-            return dataset.data.order_by([(dataset.get_dimension(x).name, not reverse) for x in by])
+            import ibis
+            ikey = getattr(ibis, 'desc' if reverse else 'asc')
+            return dataset.data.order_by([ikey(dataset.get_dimension(x).name) for x in by])
         else:
             # sort_by will be removed in Ibis 5.0
             return dataset.data.sort_by([(dataset.get_dimension(x).name, not reverse) for x in by])


### PR DESCRIPTION
This PR takes care of this warning:

```
holoviews/tests/core/data/test_ibisinterface.py: 16 warnings
  /Users/mliquet/miniconda3/envs/hv39/lib/python3.9/site-packages/ibis/expr/types/relations.py:1268: FutureWarning: `table.order_by((key, True)) and table.order_by((key, False)) syntax` is deprecated as of v6.0, removed in v7.0; Use ibis.desc(key) or ibis.asc(key) instead
```