### PR TITLE
Allow to link to an `Overlay`

### DIFF
--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -289,7 +289,7 @@ class Overlay(ViewableTree, CompositeOverlay, Layoutable, Overlayable):
 
     def clone(self, data=None, shared_data=True, new_type=None, link=True,
               *args, **overrides):
-        if link:
+        if data is None and link:
             overrides['plot_id'] = self._plot_id
         return super().clone(data, shared_data=shared_data, new_type=new_type, link=link, *args, **overrides)
 

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -287,6 +287,12 @@ class Overlay(ViewableTree, CompositeOverlay, Layoutable, Overlayable):
     def shape(self):
         raise NotImplementedError
 
+    def clone(self, data=None, shared_data=True, new_type=None, link=True,
+              *args, **overrides):
+        if link:
+            overrides['plot_id'] = self._plot_id
+        return super().clone(data, shared_data=shared_data, new_type=new_type, link=link, *args, **overrides)
+
 
 class NdOverlay(Overlayable, UniformNdMapping, CompositeOverlay):
     """

--- a/holoviews/plotting/bokeh/links.py
+++ b/holoviews/plotting/bokeh/links.py
@@ -85,7 +85,7 @@ class LinkCallback:
         Traverses the supplied plot and searches for any Links on
         the plotted objects.
         """
-        plot_fn = lambda x: isinstance(x, GenericElementPlot) and not isinstance(x, GenericOverlayPlot)
+        plot_fn = lambda x: isinstance(x, (GenericElementPlot, GenericOverlayPlot))
         plots = root_plot.traverse(lambda x: x, [plot_fn])
         potentials = [cls.find_link(plot) for plot in plots]
         source_links = [p for p in potentials if p is not None]

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -331,9 +331,9 @@ class BokehPlot(DimensionedPlot, CallbackPlot):
             cb = Link._callbacks['bokeh'][type(link)]
             if src_plot is None or (link._requires_target and tgt_plot is None):
                 continue
+            # The link callback (`cb`) is instantiated (with side-effects).
             callbacks.append(cb(self.root, link, src_plot, tgt_plot))
         return callbacks
-
 
 
 class CompositePlot(BokehPlot):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -994,7 +994,7 @@ class CallbackPlot:
             zorders = [self.zorder]
 
         if isinstance(self, GenericOverlayPlot) and not self.batched:
-            sources = []
+            sources = [self.hmap.last]
         elif not self.static or isinstance(self.hmap, DynamicMap):
             sources = [o for i, inputs in self.stream_sources.items()
                        for o in inputs if i in zorders]

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -26,6 +26,20 @@ class TestLinkCallbacks(TestBokehPlot):
         self.assertEqual(range_tool.x_range, tgt_plot.handles['x_range'])
         self.assertIs(range_tool.y_range, None)
 
+    def test_range_tool_link_callback_single_axis_overlay_target(self):
+        from bokeh.models import RangeTool
+        array = np.random.rand(100, 2)
+        src = Curve(array)
+        target = Scatter(array, label='a') * Scatter(array, label='b')
+        RangeToolLink(src, target)
+        layout = target + src
+        plot = bokeh_renderer.get_plot(layout)
+        tgt_plot = plot.subplots[(0, 0)].subplots['main']
+        src_plot = plot.subplots[(0, 1)].subplots['main']
+        range_tool = src_plot.state.select_one({'type': RangeTool})
+        self.assertEqual(range_tool.x_range, tgt_plot.handles['x_range'])
+        self.assertIs(range_tool.y_range, None)
+
     def test_range_tool_link_callback_both_axes(self):
         from bokeh.models import RangeTool
         array = np.random.rand(100, 2)

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from holoviews.core.spaces import DynamicMap
-from holoviews.element import Curve, Polygons, Table, Scatter, Path, Points
+from holoviews.element import Curve, Image, Polygons, Table, Scatter, Path, Points
 from holoviews.plotting.links import (Link, RangeToolLink, DataLink)
 
 from bokeh.models import ColumnDataSource
@@ -33,6 +33,20 @@ class TestLinkCallbacks(TestBokehPlot):
         target = Scatter(array, label='a') * Scatter(array, label='b')
         RangeToolLink(src, target)
         layout = target + src
+        plot = bokeh_renderer.get_plot(layout)
+        tgt_plot = plot.subplots[(0, 0)].subplots['main']
+        src_plot = plot.subplots[(0, 1)].subplots['main']
+        range_tool = src_plot.state.select_one({'type': RangeTool})
+        self.assertEqual(range_tool.x_range, tgt_plot.handles['x_range'])
+        self.assertIs(range_tool.y_range, None)
+
+    def test_range_tool_link_callback_single_axis_overlay_target_image_source(self):
+        from bokeh.models import RangeTool
+        data = np.random.rand(50, 50)
+        target = Curve(data) * Curve(data)
+        source = Image(np.random.rand(50, 50), bounds=(0, 0, 1, 1))
+        RangeToolLink(source, target)
+        layout = target + source
         plot = bokeh_renderer.get_plot(layout)
         tgt_plot = plot.subplots[(0, 0)].subplots['main']
         src_plot = plot.subplots[(0, 1)].subplots['main']


### PR DESCRIPTION
Partly extracted from https://github.com/holoviz/holoviews/pull/5840

The goal of this PR is to allow linking (with a `RangeToolLink`) to an `Overlay`, the example in mind being a minimap targeting a plot with subcoordinates (subcoordinates being implemented as an `Overlay`).

Overriding `.clone` at the `Overlay` level is done to be more specific instead of what was done in https://github.com/holoviz/holoviews/pull/5840 at the `LabelledData` level.

Overriding `clone` is only required to get `test_range_tool_link_callback_single_axis_overlay_target_image_source` to pass, i.e. `test_range_tool_link_callback_single_axis_overlay_target` runs fine without it. While the two tests look very much alike, the former uses an `Image` as a source. I saw that there's a [`Compositor` registered for the `Image` element](https://github.com/holoviz/holoviews/blob/14869550861111538584840503f237113a403726/holoviews/plotting/__init__.py#L16), which makes the code run through a pretty hairy path when creating a simple `Image` (`.map`, `.collapse_element`) and leads to the creation of internal/intermediate overlays.

I would be happy to:

- have someone more knowledgeable in the `Compositor` logic explain what is going on there :)
- add more tests to:
  - cover the breadth of the envisioned feature; so far I've only tested the `RangeToolLink` to a simple overlay of curves, with either an `Image` or a `Curve` as source.
  - maybe cover what those changes (that still feel a little hacky to, because I feel I'm just playing with a house of cards!) could break

As for documenting these changes, I haven't found any place to update where links were described as limited to elements. There are two gallery examples that demonstrate how to use the `RangeToolLink`, it seems to me it wouldn't improve them so much to show how to link to an overlay. My suggestion instead would be to show that this can be done adding an EEG example to the gallery (in or after https://github.com/holoviz/holoviews/pull/5840).