### PR TITLE
Cycle through text_color when overlaying Labels

### DIFF
--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -204,7 +204,7 @@ options.Slope = Options('style', color=Cycle(), line_width=3, alpha=1)
 options.VSpan = Options('style', color=Cycle(), alpha=0.5)
 options.HSpan = Options('style', color=Cycle(), alpha=0.5)
 options.Arrow = Options('style', arrow_size=10)
-options.Labels = Options('style', text_align='center', text_baseline='middle')
+options.Labels = Options('style', text_color=Cycle(), text_align='center', text_baseline='middle')
 
 # Graphs
 options.Graph = Options(

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -270,7 +270,7 @@ options.Slope = Options('style', color=Cycle())
 options.VSpan = Options('style', alpha=0.5, facecolor=Cycle())
 options.HSpan = Options('style', alpha=0.5, facecolor=Cycle())
 options.Spline = Options('style', edgecolor=Cycle())
-options.Labels = Options('style', text_color=Cycle())
+options.Labels = Options('style', color=Cycle())
 
 options.Arrow = Options('style', color='k', linewidth=2, textsize=13)
 # Paths

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -270,6 +270,7 @@ options.Slope = Options('style', color=Cycle())
 options.VSpan = Options('style', alpha=0.5, facecolor=Cycle())
 options.HSpan = Options('style', alpha=0.5, facecolor=Cycle())
 options.Spline = Options('style', edgecolor=Cycle())
+options.Labels = Options('style', text_color=Cycle())
 
 options.Arrow = Options('style', color='k', linewidth=2, textsize=13)
 # Paths

--- a/holoviews/plotting/plotly/__init__.py
+++ b/holoviews/plotting/plotly/__init__.py
@@ -135,6 +135,7 @@ options.Scatter3D = Options('style', color=Cycle(), size=6)
 # Annotations
 options.VSpan = Options('style', fillcolor=Cycle(), opacity=0.5)
 options.HSpan = Options('style', fillcolor=Cycle(), opacity=0.5)
+options.Labels = Options('style', color=Cycle())
 
 # Shapes
 options.Rectangles = Options('style', line_color=dflt_shape_line_color)

--- a/holoviews/tests/plotting/bokeh/test_labels.py
+++ b/holoviews/tests/plotting/bokeh/test_labels.py
@@ -194,6 +194,6 @@ class TestLabelsPlot(TestBokehPlot):
             {i: Labels([
                 (0, 0 + i, "Label 1"),
                 (1, 1 + i, "Label 2")
-            ]) for i in range(0, 3)}
+            ]) for i in range(3)}
         ).overlay()
         assert isinstance(hm[0].opts["text_color"], Cycle)

--- a/holoviews/tests/plotting/bokeh/test_labels.py
+++ b/holoviews/tests/plotting/bokeh/test_labels.py
@@ -2,7 +2,9 @@ import numpy as np
 
 from holoviews.core.dimension import Dimension
 from holoviews.element import Labels
+from holoviews.core.spaces import HoloMap
 from holoviews.plotting.bokeh.util import property_to_dict
+from holoviews.core.options import Cycle
 
 from bokeh.models import LinearColorMapper, CategoricalColorMapper
 
@@ -186,3 +188,12 @@ class TestLabelsPlot(TestBokehPlot):
             "color_index.\n"
         )
         self.assertEqual(log_msg, warning)
+
+    def test_labels_text_color_cycle(self):
+        hm = HoloMap(
+            {i: Labels([
+                (0, 0 + i, "Label 1"),
+                (1, 1 + i, "Label 2")
+            ]) for i in range(0, 3)}
+        ).overlay()
+        assert isinstance(hm[0].opts["text_color"], Cycle)

--- a/holoviews/tests/plotting/matplotlib/test_labels.py
+++ b/holoviews/tests/plotting/matplotlib/test_labels.py
@@ -178,6 +178,6 @@ class TestLabelsPlot(TestMPLPlot):
             {i: Labels([
                 (0, 0 + i, "Label 1"),
                 (1, 1 + i, "Label 2")
-            ]) for i in range(0, 3)}
+            ]) for i in range(3)}
         ).overlay()
         assert isinstance(hm[0].opts["color"], Cycle)

--- a/holoviews/tests/plotting/matplotlib/test_labels.py
+++ b/holoviews/tests/plotting/matplotlib/test_labels.py
@@ -180,4 +180,4 @@ class TestLabelsPlot(TestMPLPlot):
                 (1, 1 + i, "Label 2")
             ]) for i in range(0, 3)}
         ).overlay()
-        assert isinstance(hm[0].opts["text_color"], Cycle)
+        assert isinstance(hm[0].opts["color"], Cycle)

--- a/holoviews/tests/plotting/matplotlib/test_labels.py
+++ b/holoviews/tests/plotting/matplotlib/test_labels.py
@@ -3,6 +3,7 @@ import numpy as np
 from holoviews.core.dimension import Dimension
 from holoviews.core.spaces import HoloMap
 from holoviews.element import Labels
+from holoviews.core.options import Cycle
 from holoviews.plotting.util import rgb2hex
 
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -171,3 +172,12 @@ class TestLabelsPlot(TestMPLPlot):
         artist = plot.handles['artist']
         self.assertEqual([a.get_rotation() for a in artist],
                          [30, 120, 60])
+
+    def test_labels_text_color_cycle(self):
+        hm = HoloMap(
+            {i: Labels([
+                (0, 0 + i, "Label 1"),
+                (1, 1 + i, "Label 2")
+            ]) for i in range(0, 3)}
+        ).overlay()
+        assert isinstance(hm[0].opts["text_color"], Cycle)

--- a/holoviews/tests/plotting/plotly/test_labelplot.py
+++ b/holoviews/tests/plotting/plotly/test_labelplot.py
@@ -140,6 +140,6 @@ class TestMapboxLabelsPlot(TestPlotlyPlot):
             {i: Labels([
                 (0, 0 + i, "Label 1"),
                 (1, 1 + i, "Label 2")
-            ]) for i in range(0, 3)}
+            ]) for i in range(3)}
         ).overlay()
         assert isinstance(hm[0].opts["color"], Cycle)

--- a/holoviews/tests/plotting/plotly/test_labelplot.py
+++ b/holoviews/tests/plotting/plotly/test_labelplot.py
@@ -142,4 +142,4 @@ class TestMapboxLabelsPlot(TestPlotlyPlot):
                 (1, 1 + i, "Label 2")
             ]) for i in range(0, 3)}
         ).overlay()
-        assert isinstance(hm[0].opts["text_color"], Cycle)
+        assert isinstance(hm[0].opts["color"], Cycle)

--- a/holoviews/tests/plotting/plotly/test_labelplot.py
+++ b/holoviews/tests/plotting/plotly/test_labelplot.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from holoviews.element import Labels, Tiles
+from holoviews.core.options import Cycle
+from holoviews.core.spaces import HoloMap
 
 from .test_plot import TestPlotlyPlot
 
@@ -132,3 +134,12 @@ class TestMapboxLabelsPlot(TestPlotlyPlot):
         element = Tiles("") * Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(visible=False)
         state = self._get_plot_state(element)
         self.assertEqual(state['data'][1]['visible'], False)
+
+    def test_labels_text_color_cycle(self):
+        hm = HoloMap(
+            {i: Labels([
+                (0, 0 + i, "Label 1"),
+                (1, 1 + i, "Label 2")
+            ]) for i in range(0, 3)}
+        ).overlay()
+        assert isinstance(hm[0].opts["text_color"], Cycle)


### PR DESCRIPTION
Closes https://github.com/holoviz/holoviews/issues/5887

So it's easy to create legends directly in the plot.
![image](https://github.com/holoviz/holoviews/assets/15331990/2eb2c597-374d-49da-b3ef-098df02f68be)

And if they need the labels to be black, it's still easy:
`hv.Labels().opts(text_color="black")`
```python
import pandas as pd
import holoviews as hv

df = pd.DataFrame(
    {
        "City": ["Buenos Aires", "Brasilia", "Santiago", "Bogota", "Caracas"],
        "Country": ["Argentina", "Brazil", "Chile", "Colombia", "Venezuela"],
        "Latitude": [-34.58, -15.78, -33.45, 4.60, 10.48],
        "Longitude": [-58.66, -47.91, -70.66, -74.08, -66.86],
    }
)
hv.Dataset(df).to.labels(["Latitude", "Longitude"], ["City"]).overlay().opts("Labels", text_color="black")
```
<img width="799" alt="image" src="https://github.com/holoviz/holoviews/assets/15331990/3354812e-c360-45ba-b671-9af96dcc31e1">
<img width="977" alt="image" src="https://github.com/holoviz/holoviews/assets/15331990/4a379c7f-71fc-4c9b-8280-ccc43d437b42">


Or just use `hv.Text()`
