### PR TITLE
Remove all use of OrderedDict

### DIFF
--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -84,7 +84,7 @@ __version__ = str(param.version.Version(fpath=__file__, archive_commit="$Format:
 from . import util                                       # noqa (API import)
 from .core import archive, config                        # noqa (API import)
 from .core.boundingregion import BoundingBox             # noqa (API import)
-from .core.dimension import OrderedDict, Dimension       # noqa (API import)
+from .core.dimension import Dimension                    # noqa (API import)
 from .core.element import Element, Collator              # noqa (API import)
 from .core.layout import (Layout, NdLayout, Empty,       # noqa (API import)
                           AdjointLayout)

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -76,7 +76,7 @@ class annotate(param.ParameterizedFunction):
     vertex_style = param.Dict(default={'nonselection_alpha': 0.5}, doc="""
         Options to apply to vertices during drawing and editing.""")
 
-    _annotator_types = dict()
+    _annotator_types = {}
 
     @property
     def annotated(self):

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -76,7 +76,7 @@ class annotate(param.ParameterizedFunction):
     vertex_style = param.Dict(default={'nonselection_alpha': 0.5}, doc="""
         Options to apply to vertices during drawing and editing.""")
 
-    _annotator_types = OrderedDict()
+    _annotator_types = dict()
 
     @property
     def annotated(self):

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -1,6 +1,5 @@
 import sys
 
-from collections import OrderedDict
 from inspect import getmro
 
 import param

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -435,7 +435,7 @@ class Redim(metaclass=AccessorPipelineMeta):
         def dynamic_redim(obj, **dynkwargs):
             return obj.redim(specs, **dimensions)
         dmap = Dynamic(obj, streams=obj.streams, operation=dynamic_redim)
-        dmap.data = OrderedDict(self._filter_cache(redimmed, kdims))
+        dmap.data = dict(self._filter_cache(redimmed, kdims))
         with util.disable_constant(dmap):
             dmap.kdims = kdims
             dmap.vdims = vdims
@@ -597,7 +597,7 @@ class Opts(metaclass=AccessorPipelineMeta):
 
     def _holomap_opts(self, *args, clone=None, **kwargs):
         apply_groups, _, _ = util.deprecated_opts_signature(args, kwargs)
-        data = OrderedDict([(k, v.opts(*args, **kwargs))
+        data = dict([(k, v.opts(*args, **kwargs))
                              for k, v in self._obj.data.items()])
 
         # By default do not clone in .opts method
@@ -623,7 +623,7 @@ class Opts(metaclass=AccessorPipelineMeta):
                 obj.callback = self._obj.callback
                 self._obj.callback = dmap.callback
             dmap = self._obj
-            dmap.data = OrderedDict([(k, v.opts(*args, **kwargs))
+            dmap.data = dict([(k, v.opts(*args, **kwargs))
                                      for k, v in self._obj.data.items()])
         return dmap
 

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -4,7 +4,6 @@ Module for accessor objects for viewable HoloViews objects.
 import copy
 import sys
 
-from collections import OrderedDict
 from functools import wraps
 from types import FunctionType
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -15,7 +15,7 @@ from ..dimension import (
     Dimension, Dimensioned, LabelledData, dimension_name, process_dimensions
 )
 from ..element import Element
-from ..ndmapping import OrderedDict, MultiDimensionalMapping
+from ..ndmapping import MultiDimensionalMapping
 from ..spaces import HoloMap, DynamicMap
 from .. import util as core_util
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -1019,11 +1019,11 @@ argument to specify a selection specification""")
         """
         drop = kwargs.pop('drop', False)
         keep_index = kwargs.pop('keep_index', True)
-        transforms = OrderedDict()
+        transforms = dict()
         for s, transform in list(args)+list(kwargs.items()):
             transforms[core_util.wrap_tuple(s)] = transform
 
-        new_data = OrderedDict()
+        new_data = dict()
         for signature, transform in transforms.items():
             applied = transform.apply(
                 self, compute=False, keep_index=keep_index
@@ -1046,10 +1046,10 @@ argument to specify a selection specification""")
         if drop:
             kdims = [ds.get_dimension(d) for d in new_data if d in ds.kdims]
             vdims = [ds.get_dimension(d) or d for d in new_data if d not in ds.kdims]
-            data = OrderedDict([(dimension_name(d), values) for d, values in new_data.items()])
+            data = dict([(dimension_name(d), values) for d, values in new_data.items()])
             return ds.clone(data, kdims=kdims, vdims=vdims)
         else:
-            new_data = OrderedDict([(dimension_name(d), values) for d, values in new_data.items()])
+            new_data = dict([(dimension_name(d), values) for d, values in new_data.items()])
             data = ds.interface.assign(ds, new_data)
             data, drop = data if isinstance(data, tuple) else (data, [])
             kdims = [kd for kd in self.kdims if kd.name not in drop]
@@ -1149,7 +1149,7 @@ argument to specify a selection specification""")
             dimensions = self.dimensions()
         else:
             dimensions = [self.get_dimension(d, strict=True) for d in dimensions]
-        return OrderedDict([(d.name, self.dimension_values(d)) for d in dimensions])
+        return dict([(d.name, self.dimension_values(d)) for d in dimensions])
 
 
     @property

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -1019,11 +1019,11 @@ argument to specify a selection specification""")
         """
         drop = kwargs.pop('drop', False)
         keep_index = kwargs.pop('keep_index', True)
-        transforms = dict()
+        transforms = {}
         for s, transform in list(args)+list(kwargs.items()):
             transforms[core_util.wrap_tuple(s)] = transform
 
-        new_data = dict()
+        new_data = {}
         for signature, transform in transforms.items():
             applied = transform.apply(
                 self, compute=False, keep_index=keep_index

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -310,7 +310,7 @@ class DaskInterface(PandasInterface):
         if np.isscalar(rows):
             rows = [rows]
 
-        data = dict()
+        data = {}
         for c in cols:
             data[c] = dataset.data[c].compute().iloc[rows].values
         if scalar:

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -310,7 +310,7 @@ class DaskInterface(PandasInterface):
         if np.isscalar(rows):
             rows = [rows]
 
-        data = OrderedDict()
+        data = dict()
         for c in cols:
             data[c] = dataset.data[c].compute().iloc[rows].values
         if scalar:

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -6,7 +6,7 @@ import pandas as pd
 from .. import util
 from ..dimension import Dimension
 from ..element import Element
-from ..ndmapping import NdMapping, item_check, OrderedDict, sorted_context
+from ..ndmapping import NdMapping, item_check, sorted_context
 from .interface import Interface
 from .pandas import PandasInterface
 

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -18,7 +18,7 @@ class DictInterface(Interface):
     are collections representing the values in that column.
     """
 
-    types = (dict, OrderedDict)
+    types = (dict,)
 
     datatype = 'dictionary'
 
@@ -52,7 +52,7 @@ class DictInterface(Interface):
                     data = np.atleast_2d(data).T
             data = {k: data[:,i] for i,k in enumerate(dimensions)}
         elif isinstance(data, list) and data == []:
-            data = OrderedDict([(d, []) for d in dimensions])
+            data = dict([(d, []) for d in dimensions])
         elif isinstance(data, list) and isscalar(data[0]):
             if eltype._auto_indexable_1d:
                 data = {dimensions[0]: np.arange(len(data)), dimensions[1]: data}
@@ -109,10 +109,10 @@ class DictInterface(Interface):
 
         if not cls.expanded([vs for d, vs in unpacked if d in dimensions and not isscalar(vs)]):
             raise ValueError('DictInterface expects data to be of uniform shape.')
-        if isinstance(data, OrderedDict):
+        if isinstance(data, dict):
             data.update(unpacked)
         else:
-            data = OrderedDict(unpacked)
+            data = dict(unpacked)
 
         return data, {'kdims':kdims, 'vdims':vdims}, {}
 
@@ -189,7 +189,7 @@ class DictInterface(Interface):
         dim = dimension_name(dimension)
         data = list(dataset.data.items())
         data.insert(dim_pos, (dim, values))
-        return OrderedDict(data)
+        return dict(data)
 
     @classmethod
     def redim(cls, dataset, dimensions):
@@ -201,7 +201,7 @@ class DictInterface(Interface):
             elif k in all_dims:
                 k = dataset.get_dimension(k).name
             renamed.append((k, v))
-        return OrderedDict(renamed)
+        return dict(renamed)
 
 
     @classmethod
@@ -215,12 +215,12 @@ class DictInterface(Interface):
 
         template = datasets[0][1]
         dims = dimensions+template.dimensions()
-        return OrderedDict([(d.name, np.concatenate(columns[d.name])) for d in dims])
+        return dict([(d.name, np.concatenate(columns[d.name])) for d in dims])
 
 
     @classmethod
     def mask(cls, dataset, mask, mask_value=np.nan):
-        masked = OrderedDict(dataset.data)
+        masked = dict(dataset.data)
         for vd in dataset.vdims:
             new_array = np.copy(dataset.data[vd.name])
             new_array[mask] = mask_value
@@ -236,7 +236,7 @@ class DictInterface(Interface):
         else:
             arrays = [dataset.dimension_values(d) for d in by]
             sorting = util.arglexsort(arrays)
-        return OrderedDict([(d, v if isscalar(v) else (v[sorting][::-1] if reverse else v[sorting]))
+        return dict([(d, v if isscalar(v) else (v[sorting][::-1] if reverse else v[sorting]))
                             for d, v in dataset.data.items()])
 
 
@@ -266,7 +266,7 @@ class DictInterface(Interface):
 
     @classmethod
     def assign(cls, dataset, new_data):
-        data = OrderedDict(dataset.data)
+        data = dict(dataset.data)
         data.update(new_data)
         return data
 
@@ -274,7 +274,7 @@ class DictInterface(Interface):
     @classmethod
     def reindex(cls, dataset, kdims, vdims):
         dimensions = [dataset.get_dimension(d).name for d in kdims+vdims]
-        return OrderedDict([(d, dataset.dimension_values(d))
+        return dict([(d, dataset.dimension_values(d))
                             for d in dimensions])
 
 
@@ -302,7 +302,7 @@ class DictInterface(Interface):
         grouped_data = []
         for unique_key in util.unique_iterator(keys):
             mask = cls.select_mask(dataset, dict(zip(dimensions, unique_key)))
-            group_data = OrderedDict((d.name, dataset.data[d.name] if isscalar(dataset.data[d.name])
+            group_data = dict((d.name, dataset.data[d.name] if isscalar(dataset.data[d.name])
                                        else dataset.data[d.name][mask])
                                       for d in kdims+vdims)
             group_data = group_type(group_data, **group_kwargs)
@@ -325,7 +325,7 @@ class DictInterface(Interface):
             return {d.name: np.array([], dtype=cls.dtype(dataset, d))
                     for d in dimensions}
         indexed = cls.indexed(dataset, selection)
-        data = OrderedDict()
+        data = dict()
         for k, v in dataset.data.items():
             if k not in dimensions or isscalar(v):
                 data[k] = v
@@ -355,8 +355,8 @@ class DictInterface(Interface):
     def aggregate(cls, dataset, kdims, function, **kwargs):
         kdims = [dataset.get_dimension(d, strict=True).name for d in kdims]
         vdims = dataset.dimensions('value', label='name')
-        groups = cls.groupby(dataset, kdims, list, OrderedDict)
-        aggregated = OrderedDict([(k, []) for k in kdims+vdims])
+        groups = cls.groupby(dataset, kdims, list, dict)
+        aggregated = dict([(k, []) for k in kdims+vdims])
 
         dropped = []
         for key, group in groups:
@@ -394,7 +394,7 @@ class DictInterface(Interface):
         if isscalar(rows):
             rows = [rows]
 
-        new_data = OrderedDict()
+        new_data = dict()
         for d, values in dataset.data.items():
             if d in cols:
                 if isscalar(values):

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -325,7 +325,7 @@ class DictInterface(Interface):
             return {d.name: np.array([], dtype=cls.dtype(dataset, d))
                     for d in dimensions}
         indexed = cls.indexed(dataset, selection)
-        data = dict()
+        data = {}
         for k, v in dataset.data.items():
             if k not in dimensions or isscalar(v):
                 data[k] = v
@@ -394,7 +394,7 @@ class DictInterface(Interface):
         if isscalar(rows):
             rows = [rows]
 
-        new_data = dict()
+        new_data = {}
         for d, values in dataset.data.items():
             if d in cols:
                 if isscalar(values):

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 import numpy as np
 

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 import numpy as np
 

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -28,7 +28,7 @@ class GridInterface(DictInterface):
     longitudes can specify the position of NxM temperature samples.
     """
 
-    types = (dict, OrderedDict)
+    types = (dict,)
 
     datatype = 'grid'
 
@@ -59,9 +59,9 @@ class GridInterface(DictInterface):
                 data = {d: v for d, v in zip(dimensions, data)}
         elif (isinstance(data, list) and data == []):
             if len(kdims) == 1:
-                data = OrderedDict([(d, []) for d in dimensions])
+                data = dict([(d, []) for d in dimensions])
             else:
-                data = OrderedDict([(d.name, np.array([])) for d in kdims])
+                data = dict([(d.name, np.array([])) for d in kdims])
                 if len(vdims) == 1:
                     data[vdims[0].name] = np.zeros((0, 0))
                 else:
@@ -72,11 +72,11 @@ class GridInterface(DictInterface):
         elif isinstance(data, np.ndarray):
             if data.shape == (0, 0) and len(vdims) == 1:
                 array = data
-                data = OrderedDict([(d.name, np.array([])) for d in kdims])
+                data = dict([(d.name, np.array([])) for d in kdims])
                 data[vdims[0].name] = array
             elif data.shape == (0, 0, len(vdims)):
                 array = data
-                data = OrderedDict([(d.name, np.array([])) for d in kdims])
+                data = dict([(d.name, np.array([])) for d in kdims])
                 data[vdim_tuple] = array
             else:
                 if data.ndim == 1:
@@ -621,7 +621,7 @@ class GridInterface(DictInterface):
     def mask(cls, dataset, mask, mask_val=np.nan):
         mask = cls.canonicalize(dataset, mask)
         packed = cls.packed(dataset)
-        masked = OrderedDict(dataset.data)
+        masked = dict(dataset.data)
         if packed:
             masked = dataset.data[packed].copy()
             try:
@@ -804,7 +804,7 @@ class GridInterface(DictInterface):
 
     @classmethod
     def assign(cls, dataset, new_data):
-        data = OrderedDict(dataset.data)
+        data = dict(dataset.data)
         for k, v in new_data.items():
             if k in dataset.kdims:
                 coords = cls.coords(dataset, k)

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from packaging.version import Version
 
 import numpy as np

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -107,7 +107,7 @@ class PandasInterface(Interface, PandasAPI):
             columns = list(util.unique_iterator([dimension_name(d) for d in kdims+vdims]))
 
             if isinstance(data, dict) and all(c in data for c in columns):
-                data = OrderedDict((d, data[d]) for d in columns)
+                data = dict((d, data[d]) for d in columns)
             elif isinstance(data, list) and len(data) == 0:
                 data = {c: np.array([]) for c in columns}
             elif isinstance(data, (list, dict)) and data in ([], {}):
@@ -122,7 +122,7 @@ class PandasInterface(Interface, PandasAPI):
                                     "values.")
                 column_data = zip(*((util.wrap_tuple(k)+util.wrap_tuple(v))
                                     for k, v in column_data))
-                data = OrderedDict(((c, col) for c, col in zip(columns, column_data)))
+                data = dict(((c, col) for c, col in zip(columns, column_data)))
             elif isinstance(data, np.ndarray):
                 if data.ndim == 1:
                     if eltype._auto_indexable_1d and len(kdims)+len(vdims)>1:

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -158,7 +158,7 @@ class XArrayInterface(GridInterface):
                     for d, values in data.items()}
             coord_dims = [data[kd.name].ndim for kd in kdims]
             dims = tuple('dim_%d' % i for i in range(max(coord_dims)))[::-1]
-            coords = dict()
+            coords = {}
             for kd in kdims:
                 coord_vals = data[kd.name]
                 if coord_vals.ndim > 1:
@@ -671,7 +671,7 @@ class XArrayInterface(GridInterface):
         prev_coords = set.intersection(*[
             set(var.coords) for var in data.data_vars.values()
         ])
-        coords = dict()
+        coords = {}
         for k, v in new_data.items():
             if k not in dataset.kdims:
                 continue
@@ -686,7 +686,7 @@ class XArrayInterface(GridInterface):
             data = data.assign_coords(**coords)
 
         dims = tuple(kd.name for kd in dataset.kdims[::-1])
-        vars = dict()
+        vars = {}
         for k, v in new_data.items():
             if k in dataset.kdims:
                 continue

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -1,7 +1,6 @@
 import sys
 import types
 
-from collections import OrderedDict
 
 import numpy as np
 import pandas as pd

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -158,7 +158,7 @@ class XArrayInterface(GridInterface):
                     for d, values in data.items()}
             coord_dims = [data[kd.name].ndim for kd in kdims]
             dims = tuple('dim_%d' % i for i in range(max(coord_dims)))[::-1]
-            coords = OrderedDict()
+            coords = dict()
             for kd in kdims:
                 coord_vals = data[kd.name]
                 if coord_vals.ndim > 1:
@@ -599,7 +599,7 @@ class XArrayInterface(GridInterface):
 
         # Restore constant dimensions
         indexed = cls.indexed(dataset, selection)
-        dropped = OrderedDict((d.name, np.atleast_1d(data[d.name]))
+        dropped = dict((d.name, np.atleast_1d(data[d.name]))
                    for d in dataset.kdims
                    if not data[d.name].data.shape)
         if dropped and not indexed:
@@ -671,7 +671,7 @@ class XArrayInterface(GridInterface):
         prev_coords = set.intersection(*[
             set(var.coords) for var in data.data_vars.values()
         ])
-        coords = OrderedDict()
+        coords = dict()
         for k, v in new_data.items():
             if k not in dataset.kdims:
                 continue
@@ -686,7 +686,7 @@ class XArrayInterface(GridInterface):
             data = data.assign_coords(**coords)
 
         dims = tuple(kd.name for kd in dataset.kdims[::-1])
-        vars = OrderedDict()
+        vars = dict()
         for k, v in new_data.items():
             if k in dataset.kdims:
                 continue

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -804,7 +804,7 @@ class Dimensioned(LabelledData):
     by the value dimensions and ending with the deep dimensions.
     """
 
-    cdims = param.Dict(default=dict(), doc="""
+    cdims = param.Dict(default={}, doc="""
        The constant dimensions defined as a dictionary of Dimension:value
        pairs providing additional dimension information about the object.
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -22,7 +22,7 @@ from .accessors import Opts, Apply, Redim
 from .options import Store, Options, cleanup_custom_options
 from .pprint import PrettyPrinter
 from .tree import AttrTree
-from .util import OrderedDict, bytes_to_unicode
+from .util import bytes_to_unicode
 
 # Alias parameter support for pickle loading
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -804,7 +804,7 @@ class Dimensioned(LabelledData):
     by the value dimensions and ending with the deep dimensions.
     """
 
-    cdims = param.Dict(default=OrderedDict(), doc="""
+    cdims = param.Dict(default=dict(), doc="""
        The constant dimensions defined as a dictionary of Dimension:value
        pairs providing additional dimension information about the object.
 
@@ -842,7 +842,7 @@ class Dimensioned(LabelledData):
         super().__init__(data, **params)
         self.ndims = len(self.kdims)
         cdims = [(d.name, val) for d, val in self.cdims.items()]
-        self._cached_constants = OrderedDict(cdims)
+        self._cached_constants = dict(cdims)
         self._settings = None
 
         # Instantiate accessors

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from .dimension import Dimensioned, ViewableElement, asdim
 from .layout import Composable, Layout, NdLayout
-from .ndmapping import OrderedDict, NdMapping
+from .ndmapping import NdMapping
 from .overlay import Overlayable, NdOverlay, CompositeOverlay
 from .spaces import HoloMap, GridSpace
 from .tree import AttrTree

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -212,7 +212,7 @@ class Element(ViewableElement, Composable, Overlayable):
         else:
             dimensions = [self.get_dimension(d, strict=True).name for d in dimensions]
         column_names = dimensions
-        dim_vals = OrderedDict([(dim, self.dimension_values(dim)) for dim in column_names])
+        dim_vals = dict([(dim, self.dimension_values(dim)) for dim in column_names])
         df = pd.DataFrame(dim_vals)
         if multi_index:
             df = df.set_index([d for d in dimensions if d in self.kdims])

--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -32,7 +32,7 @@ from param.parameterized import bothmethod
 from .dimension import LabelledData
 from .element import Collator, Element
 from .overlay import Overlay, Layout
-from .ndmapping import OrderedDict, NdMapping, UniformNdMapping
+from .ndmapping import NdMapping, UniformNdMapping
 from .options import Store
 from .util import unique_iterator, group_sanitizer, label_sanitizer
 

--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -621,7 +621,7 @@ class FileArchive(Archive):
     def __init__(self, **params):
         super().__init__(**params)
         #  Items with key: (basename,ext) and value: (data, info)
-        self._files = dict()
+        self._files = {}
         self._validate_formatters()
 
 
@@ -832,7 +832,7 @@ class FileArchive(Archive):
         elif self.archive_format == 'tar':
             self._tar_archive(export_name, files, root)
         if self.flush_archive:
-            self._files = dict()
+            self._files = {}
 
     def _format(self, formatter, info):
         filtered = {k:v for k,v in info.items()

--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -621,7 +621,7 @@ class FileArchive(Archive):
     def __init__(self, **params):
         super().__init__(**params)
         #  Items with key: (basename,ext) and value: (data, info)
-        self._files = OrderedDict()
+        self._files = dict()
         self._validate_formatters()
 
 
@@ -832,7 +832,7 @@ class FileArchive(Archive):
         elif self.archive_format == 'tar':
             self._tar_archive(export_name, files, root)
         if self.flush_archive:
-            self._files = OrderedDict()
+            self._files = dict()
 
     def _format(self, formatter, info):
         filtered = {k:v for k,v in info.items()

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -106,7 +106,7 @@ class AdjointLayout(Layoutable, Dimensioned):
         elif isinstance(data, list):
             data = dict(zip(self.layout_order, data))
         else:
-            data = OrderedDict()
+            data = dict()
 
         super().__init__(data, **params)
 

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -9,7 +9,7 @@ import param
 import numpy as np
 
 from .dimension import Dimension, Dimensioned, ViewableElement, ViewableTree
-from .ndmapping import OrderedDict, NdMapping, UniformNdMapping
+from .ndmapping import NdMapping, UniformNdMapping
 from . import traversal
 
 

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -106,7 +106,7 @@ class AdjointLayout(Layoutable, Dimensioned):
         elif isinstance(data, list):
             data = dict(zip(self.layout_order, data))
         else:
-            data = dict()
+            data = {}
 
         super().__init__(data, **params)
 

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -103,7 +103,7 @@ class MultiDimensionalMapping(Dimensioned):
             params = dict(util.get_param_values(initial_items), **dict(params))
         if kdims is not None:
             params['kdims'] = kdims
-        super().__init__(dict(), **dict(params))
+        super().__init__({}, **dict(params))
 
         self._next_ind = 0
         self._check_key_type = True
@@ -343,7 +343,7 @@ class MultiDimensionalMapping(Dimensioned):
             raise ValueError("Added dimension values must be same length"
                                 "as existing keys.")
 
-        items = dict()
+        items = {}
         for dval, (key, val) in zip(dim_val, self.data.items()):
             if vdim:
                 new_val = list(val)

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -4,7 +4,6 @@ map types. The former class only allows indexing whereas the latter
 also enables slicing over multiple dimension ranges.
 """
 
-from collections import OrderedDict
 from itertools import cycle
 from operator import itemgetter
 import numpy as np

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -103,7 +103,7 @@ class MultiDimensionalMapping(Dimensioned):
             params = dict(util.get_param_values(initial_items), **dict(params))
         if kdims is not None:
             params['kdims'] = kdims
-        super().__init__(OrderedDict(), **dict(params))
+        super().__init__(dict(), **dict(params))
 
         self._next_ind = 0
         self._check_key_type = True
@@ -116,12 +116,12 @@ class MultiDimensionalMapping(Dimensioned):
                 initial_items = initial_items.items()
             elif isinstance(initial_items, MultiDimensionalMapping):
                 initial_items = initial_items.data.items()
-            self.data = OrderedDict((k if isinstance(k, tuple) else (k,), v)
+            self.data = dict((k if isinstance(k, tuple) else (k,), v)
                                     for k, v in initial_items)
             if self.sort:
                 self._resort()
         elif initial_items is not None:
-            self.update(OrderedDict(initial_items))
+            self.update(dict(initial_items))
 
 
     def _item_check(self, dim_vals, data):
@@ -172,7 +172,7 @@ class MultiDimensionalMapping(Dimensioned):
 
         # Updates nested data structures rather than simply overriding them.
         if (update and (dim_vals in self.data)
-            and isinstance(self.data[dim_vals], (MultiDimensionalMapping, OrderedDict))):
+            and isinstance(self.data[dim_vals], (MultiDimensionalMapping, dict))):
             self.data[dim_vals].update(data)
         else:
             self.data[dim_vals] = data
@@ -246,7 +246,7 @@ class MultiDimensionalMapping(Dimensioned):
 
 
     def _resort(self):
-        self.data = OrderedDict(dimension_sort(self.data, self.kdims, self.vdims,
+        self.data = dict(dimension_sort(self.data, self.kdims, self.vdims,
                                                range(self.ndims)))
 
 
@@ -343,7 +343,7 @@ class MultiDimensionalMapping(Dimensioned):
             raise ValueError("Added dimension values must be same length"
                                 "as existing keys.")
 
-        items = OrderedDict()
+        items = dict()
         for dval, (key, val) in zip(dim_val, self.data.items()):
             if vdim:
                 new_val = list(val)
@@ -429,7 +429,7 @@ class MultiDimensionalMapping(Dimensioned):
         indices = [self.get_dimension_index(el) for el in kdims]
 
         keys = [tuple(k[i] for i in indices) for k in self.data.keys()]
-        reindexed_items = OrderedDict(
+        reindexed_items = dict(
             (k, v) for (k, v) in zip(keys, self.data.values()))
         reduced_dims = {d.name for d in self.kdims}.difference(kdims)
         dimensions = [self.get_dimension(d) for d in kdims
@@ -850,7 +850,7 @@ class UniformNdMapping(NdMapping):
         for key, group in groups.items():
             last = group.values()[-1]
             if isinstance(last, UniformNdMapping):
-                group_data = OrderedDict([
+                group_data = dict([
                     (k, v.collapse()) for k, v in group.items()
                 ])
                 group = group.clone(group_data)
@@ -861,7 +861,7 @@ class UniformNdMapping(NdMapping):
                     group_data = group.type(agg)
             elif issubclass(group.type, CompositeOverlay) and hasattr(self, '_split_overlays'):
                 keys, maps = self._split_overlays()
-                group_data = group.type(OrderedDict([
+                group_data = group.type(dict([
                     (key, ndmap.collapse(function=function, spreadfn=spreadfn, **kwargs))
                     for key, ndmap in zip(keys, maps)
                 ]))

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -46,7 +46,7 @@ import param
 from .accessors import Opts # noqa (clean up in 2.0)
 from .tree import AttrTree
 from .util import (
-    OrderedDict, group_sanitizer, label_sanitizer, sanitize_identifier
+    group_sanitizer, label_sanitizer, sanitize_identifier
 )
 from .pprint import InfoPrinter
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -479,7 +479,7 @@ class Options:
         if invalid_kws and self.warn_on_skip:
             self.param.warning(f"Invalid options {invalid_kws!r}, valid options are: {allowed_keywords!s}")
 
-        self.kwargs = OrderedDict([(k,kwargs[k]) for k in sorted(kwargs.keys()) if k not in invalid_kws])
+        self.kwargs = dict([(k,kwargs[k]) for k in sorted(kwargs.keys()) if k not in invalid_kws])
         self._options = []
         self._max_cycles = max_cycles
 
@@ -1127,7 +1127,7 @@ class Store:
     object.
     """
 
-    renderers = OrderedDict() # The set of available Renderers across all backends.
+    renderers = dict() # The set of available Renderers across all backends.
 
     # A mapping from ViewableElement types to their corresponding plot
     # types grouped by the backend. Set using the register method.

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1127,7 +1127,7 @@ class Store:
     object.
     """
 
-    renderers = dict() # The set of available Renderers across all backends.
+    renderers = {} # The set of available Renderers across all backends.
 
     # A mapping from ViewableElement types to their corresponding plot
     # types grouped by the backend. Set using the register method.

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -7,7 +7,6 @@ Also supplies ViewMap which is the primary multi-dimensional Map type
 for indexing, slicing and animating collections of Views.
 """
 
-from collections import OrderedDict
 from functools import reduce
 import numpy as np
 

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -98,7 +98,7 @@ class CompositeOverlay(ViewableElement, Composable):
             dimension = [dim.name for dim in self.values()[main_layer_int_index].kdims]
         # Compute histogram for each dimension and each element in OverLay
         hists_per_dim = {
-            dim: OrderedDict([  # All histograms for a given dimension
+            dim: dict([  # All histograms for a given dimension
                 (
                     elem_key, elem.hist(
                         adjoin=False, dimension=dim, bin_range=bin_range,

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -138,7 +138,7 @@ class HoloMap(Layoutable, UniformNdMapping, Overlayable):
         Returns:
             Returns the cloned object with the options applied
         """
-        data = OrderedDict([(k, v.options(*args, **kwargs))
+        data = dict([(k, v.options(*args, **kwargs))
                              for k, v in self.data.items()])
         return self.clone(data)
 
@@ -147,7 +147,7 @@ class HoloMap(Layoutable, UniformNdMapping, Overlayable):
         if not issubclass(self.type, CompositeOverlay):
             return None, self.clone()
 
-        item_maps = OrderedDict()
+        item_maps = dict()
         for k, overlay in self.data.items():
             for key, el in overlay.items():
                 if key not in item_maps:
@@ -1061,7 +1061,7 @@ class DynamicMap(HoloMap):
 
     def reset(self):
         "Clear the DynamicMap cache"
-        self.data = OrderedDict()
+        self.data = dict()
         return self
 
 
@@ -1376,7 +1376,7 @@ class DynamicMap(HoloMap):
                                    f'layers of the {otype} do not change.')
                 return items[match][1]
             dmap = Dynamic(self, streams=self.streams, operation=split_overlay_callback)
-            dmap.data = OrderedDict([(list(self.data.keys())[-1], self.last.data[key])])
+            dmap.data = dict([(list(self.data.keys())[-1], self.last.data[key])])
             dmaps.append(dmap)
         return keys, dmaps
 
@@ -1804,8 +1804,8 @@ class GridSpace(Layoutable, UniformNdMapping):
         keys = super().keys()
         if self.ndims == 1 or not full_grid:
             return keys
-        dim1_keys = list(OrderedDict.fromkeys(k[0] for k in keys))
-        dim2_keys = list(OrderedDict.fromkeys(k[1] for k in keys))
+        dim1_keys = list(dict.fromkeys(k[0] for k in keys))
+        dim2_keys = list(dict.fromkeys(k[1] for k in keys))
         return [(d1, d2) for d1 in dim1_keys for d2 in dim2_keys]
 
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -13,7 +13,7 @@ import param
 
 from . import traversal, util
 from .accessors import Opts, Redim
-from .dimension import OrderedDict, Dimension, ViewableElement
+from .dimension import Dimension, ViewableElement
 from .layout import Layout, AdjointLayout, NdLayout, Empty, Layoutable
 from .ndmapping import UniformNdMapping, NdMapping, item_check
 from .overlay import Overlay, CompositeOverlay, NdOverlay, Overlayable

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -147,7 +147,7 @@ class HoloMap(Layoutable, UniformNdMapping, Overlayable):
         if not issubclass(self.type, CompositeOverlay):
             return None, self.clone()
 
-        item_maps = dict()
+        item_maps = {}
         for k, overlay in self.data.items():
             for key, el in overlay.items():
                 if key not in item_maps:
@@ -1061,7 +1061,7 @@ class DynamicMap(HoloMap):
 
     def reset(self):
         "Clear the DynamicMap cache"
-        self.data = dict()
+        self.data = {}
         return self
 
 

--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -59,7 +59,7 @@ class AttrTree:
 
         fixed_error = 'No attribute %r in this AttrTree, and none can be added because fixed=True'
         self.__dict__['_fixed_error'] = fixed_error
-        self.__dict__['data'] = dict()
+        self.__dict__['data'] = {}
         items = items.items() if isinstance(items, dict) else items
         # Python 3
         items = list(items) if items else items

--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -59,8 +59,8 @@ class AttrTree:
 
         fixed_error = 'No attribute %r in this AttrTree, and none can be added because fixed=True'
         self.__dict__['_fixed_error'] = fixed_error
-        self.__dict__['data'] = OrderedDict()
-        items = items.items() if isinstance(items, OrderedDict) else items
+        self.__dict__['data'] = dict()
+        items = items.items() if isinstance(items, dict) else items
         # Python 3
         items = list(items) if items else items
         items = [] if not items else items
@@ -157,7 +157,7 @@ class AttrTree:
             else:
                 items = [(key, v) for key, v in self.data.items()
                          if not all(k==p for k, p in zip(key, path))]
-                self.data = OrderedDict(items)
+                self.data = dict(items)
         else:
             self.data[path] = val
         if self.parent is not None:

--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 
 from . import util
 from .pprint import PrettyPrinter

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -14,7 +14,7 @@ import string
 import unicodedata
 import datetime as dt
 
-from collections import defaultdict, OrderedDict, namedtuple
+from collections import defaultdict, namedtuple
 from contextlib import contextmanager
 from packaging.version import Version
 from functools import partial

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1929,7 +1929,7 @@ class ndmapping_groupby(param.ParameterizedFunction):
             warnings.filterwarnings(
                 'ignore', category=FutureWarning, message="Creating a Groupby object with a length-1"
             )
-            groups = ((wrap_tuple(k), group_type(OrderedDict(unpack_group(group, getter)), **kwargs))
+            groups = ((wrap_tuple(k), group_type(dict(unpack_group(group, getter)), **kwargs))
                     for k, group in df.groupby(level=[d.name for d in dimensions], sort=sort))
 
         if sort:

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -27,7 +27,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 from . import *    # noqa (All Elements need to support comparison)
 from ..core import (Element, Empty, AdjointLayout, Overlay, Dimension,
                     HoloMap, Dimensioned, Layout, NdLayout, NdOverlay,
-                    GridSpace, DynamicMap, GridMatrix, OrderedDict)
+                    GridSpace, DynamicMap, GridMatrix)
 from ..core.options import Options, Cycle
 from ..core.util import (cast_array_to_int64, datetime_types, dt_to_int,
                          is_float)

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -112,7 +112,6 @@ class Comparison(ComparisonInterface):
 
         # Dictionary comparisons
         cls.equality_type_funcs[dict] =         cls.compare_dictionaries
-        cls.equality_type_funcs[OrderedDict] =  cls.compare_dictionaries
 
         # Numpy array comparison
         cls.equality_type_funcs[np.ndarray]          = cls.compare_arrays

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -479,5 +479,5 @@ class Bounds(BaseShape):
         super().__init__(lbrt=lbrt, **params)
         (l,b,r,t) = self.lbrt
         xdim, ydim = self.kdims
-        self.data = [OrderedDict([(xdim.name, np.array([l, l, r, r, l])),
+        self.data = [dict([(xdim.name, np.array([l, l, r, r, l])),
                                   (ydim.name, np.array([b, t, t, b, b]))])]

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -11,7 +11,6 @@ import param
 from ..core import Dataset
 from ..core.data import MultiInterface
 from ..core.dimension import Dimension
-from ..core.util import OrderedDict
 from .geom import Geometry
 from .selection import SelectionPolyExpr
 

--- a/holoviews/element/stats.py
+++ b/holoviews/element/stats.py
@@ -4,7 +4,7 @@ import numpy as np
 from ..core.dimension import Dimension, process_dimensions
 from ..core.data import Dataset
 from ..core.element import Element, Element2D
-from ..core.util import get_param_values, unique_iterator, OrderedDict
+from ..core.util import get_param_values, unique_iterator
 from .selection import Selection1DExpr, Selection2DExpr
 
 

--- a/holoviews/element/stats.py
+++ b/holoviews/element/stats.py
@@ -154,7 +154,7 @@ class StatisticsElement(Dataset, Element2D):
             raise ValueError('{} element does not hold data for value '
                              'dimensions. Could not return data for {} '
                              'dimension(s).'.format(type(self).__name__, ', '.join([d.name for d in vdims])))
-        return OrderedDict([(d.name, self.dimension_values(d)) for d in dimensions])
+        return dict([(d.name, self.dimension_values(d)) for d in dimensions])
 
 
 class Bivariate(Selection2DExpr, StatisticsElement):

--- a/holoviews/element/tabular.py
+++ b/holoviews/element/tabular.py
@@ -12,10 +12,9 @@ from .selection import SelectionIndexExpr
 class ItemTable(Element):
     """
     A tabular element type to allow convenient visualization of either
-    a standard Python dictionary, an OrderedDict or a list of tuples
-    (i.e. input suitable for an OrderedDict constructor). If an
-    OrderedDict is used, the headings will be kept in the correct
-    order. Tables store heterogeneous data with different labels.
+    a standard Python dictionary or a list of tuples
+    (i.e. input suitable for an dict constructor).
+    Tables store heterogeneous data with different labels.
 
     Dimension objects are also accepted as keys, allowing dimensional
     information (e.g. type and units) to be associated per heading.
@@ -44,12 +43,12 @@ class ItemTable(Element):
         if isinstance(data, dict):
             pass
         elif isinstance(data, list):
-            data = OrderedDict(data)
+            data = dict(data)
         else:
-            data = OrderedDict(list(data)) # Python 3
+            data = dict(list(data))
         if "vdims" not in params:
             params['vdims'] = list(data.keys())
-        str_keys = OrderedDict((dimension_name(k), v) for (k,v) in data.items())
+        str_keys = dict((dimension_name(k), v) for (k,v) in data.items())
         super().__init__(str_keys, **params)
 
     def __getitem__(self, heading):
@@ -71,10 +70,10 @@ class ItemTable(Element):
 
     def sample(self, samples=[]):
         if callable(samples):
-            sampled_data = OrderedDict(item for item in self.data.items()
+            sampled_data = dict(item for item in self.data.items()
                                        if samples(item))
         else:
-            sampled_data = OrderedDict((s, self.data.get(s, np.NaN)) for s in samples)
+            sampled_data = dict((s, self.data.get(s, np.NaN)) for s in samples)
         return self.clone(sampled_data)
 
 

--- a/holoviews/element/tabular.py
+++ b/holoviews/element/tabular.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 
 import numpy as np
 

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -138,7 +138,7 @@ class categorical_aggregate2d(Operation):
         # Determine global orderings of y-values using topological sort
         grouped = obj.groupby(xdim, container_type=dict,
                               group_type=Dataset).values()
-        orderings = dict()
+        orderings = {}
         sort = True
         for group in grouped:
             vals = group.dimension_values(ydim, False)

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -136,9 +136,9 @@ class categorical_aggregate2d(Operation):
             return xcoords, np.sort(ycoords)
 
         # Determine global orderings of y-values using topological sort
-        grouped = obj.groupby(xdim, container_type=OrderedDict,
+        grouped = obj.groupby(xdim, container_type=dict,
                               group_type=Dataset).values()
-        orderings = OrderedDict()
+        orderings = dict()
         sort = True
         for group in grouped:
             vals = group.dimension_values(ydim, False)

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -4,7 +4,7 @@ import param
 import numpy as np
 import pandas as pd
 
-from ..core import Dataset, OrderedDict
+from ..core import Dataset
 from ..core.boundingregion import BoundingBox
 from ..core.data import default_datatype, PandasInterface
 from ..core.operation import Operation

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1200,7 +1200,7 @@ class shade(LinkableOperation):
         Cast uint32 xarray DataArray to 4 uint8 channels.
         """
         new_array = img.values.view(dtype=np.uint8).reshape(img.shape + (4,))
-        coords = OrderedDict(list(img.coords.items())+[('band', [0, 1, 2, 3])])
+        coords = dict(list(img.coords.items())+[('band', [0, 1, 2, 3])])
         return xr.DataArray(new_array, coords=coords, dims=img.dims+('band',))
 
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1,6 +1,5 @@
 import warnings
 
-from collections import OrderedDict
 from collections.abc import Callable, Iterable
 from functools import partial
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -308,7 +308,7 @@ class Callback:
             return
 
         # Get unique event types in the queue
-        events = list(OrderedDict([(event.event_name, event)
+        events = list(dict([(event.event_name, event)
                                    for event, dt in self._queue]).values())
         self._queue = []
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -2,7 +2,7 @@ import asyncio
 import base64
 import time
 
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 
 import numpy as np
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -12,7 +12,7 @@ from bokeh.transform import jitter
 from ...core.data import Dataset
 from ...core.dimension import dimension_name
 from ...core.util import (
-    OrderedDict, dimension_sanitizer, isfinite
+    dimension_sanitizer, isfinite
 )
 from ...operation import interpolate_curve
 from ...util.transform import dim

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -909,7 +909,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
             grouped = {0: element}
         else:
             grouped = element.groupby(group_dim, group_type=Dataset,
-                                      container_type=OrderedDict,
+                                      container_type=dict,
                                       datatype=['dataframe', 'dictionary'])
 
         y0, y1 = ranges.get(ydim.name, {'combined': (None, None)})['combined']

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -762,7 +762,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         Returns a dictionary of axis properties depending
         on the specified axis.
         """
-        # need to copy dictionary by calling {} on it
+        # need to copy dictionary by calling dict() on it
         axis_props = dict(theme_attr_json(self.renderer.theme, 'Axis'))
 
         if ((axis == 'x' and self.xaxis in ['bottom-bare', 'top-bare', 'bare']) or

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -762,7 +762,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         Returns a dictionary of axis properties depending
         on the specified axis.
         """
-        # need to copy dictionary by calling dict() on it
+        # need to copy dictionary by calling {} on it
         axis_props = dict(theme_attr_json(self.renderer.theme, 'Axis'))
 
         if ((axis == 'x' and self.xaxis in ['bottom-bare', 'top-bare', 'bare']) or

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -12,7 +12,7 @@ from bokeh.models.layouts import Tabs
 
 from ...selection import NoOpSelectionDisplay
 from ...core import (
-    OrderedDict, Store, AdjointLayout, NdLayout, Layout, Empty,
+    Store, AdjointLayout, NdLayout, Layout, Empty,
     GridSpace, HoloMap, Element
 )
 from ...core.options import SkipRendering

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -495,7 +495,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
         else:
             width, height = self.plot_size, self.plot_size
 
-        subplots = dict()
+        subplots = {}
         frame_ranges = self.compute_ranges(layout, None, ranges)
         keys = self.keys[:1] if self.dynamic else self.keys
         frame_ranges = dict([(key, self.compute_ranges(layout, key, frame_ranges))

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -495,10 +495,10 @@ class GridPlot(CompositePlot, GenericCompositePlot):
         else:
             width, height = self.plot_size, self.plot_size
 
-        subplots = OrderedDict()
+        subplots = dict()
         frame_ranges = self.compute_ranges(layout, None, ranges)
         keys = self.keys[:1] if self.dynamic else self.keys
-        frame_ranges = OrderedDict([(key, self.compute_ranges(layout, key, frame_ranges))
+        frame_ranges = dict([(key, self.compute_ranges(layout, key, frame_ranges))
                                     for key in keys])
         collapsed_layout = layout.clone(shared_data=False, id=layout.id)
         for i, coord in enumerate(layout.keys(full_grid=True)):
@@ -727,7 +727,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         collapsed_layout = layout.clone(shared_data=False, id=layout.id)
         frame_ranges = self.compute_ranges(layout, None, None)
         keys = self.keys[:1] if self.dynamic else self.keys
-        frame_ranges = OrderedDict([(key, self.compute_ranges(layout, key, frame_ranges))
+        frame_ranges = dict([(key, self.compute_ranges(layout, key, frame_ranges))
                                     for key in keys])
         layout_items = layout.grid_items()
         layout_dimensions = layout.kdims if isinstance(layout, NdLayout) else None
@@ -750,7 +750,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             # to create the correct subaxes for all plots in the layout
             layout_key, _ = layout_items.get((r, c), (None, None))
             if isinstance(layout, NdLayout) and layout_key:
-                layout_dimensions = OrderedDict(zip(layout_dimensions, layout_key))
+                layout_dimensions = dict(zip(layout_dimensions, layout_key))
 
             # Generate the axes and create the subplots with the appropriate
             # axis objects, handling any Empty objects.

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -1159,7 +1159,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             elif element.label and handle:
                 legend_data.append((handle, labels.get(element.label, element.label)))
         all_handles, all_labels = list(zip(*legend_data)) if legend_data else ([], [])
-        data = OrderedDict()
+        data = dict()
         used_labels = []
         for handle, label in zip(all_handles, all_labels):
             # Ensure that artists with multiple handles are supported

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -1159,7 +1159,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             elif element.label and handle:
                 legend_data.append((handle, labels.get(element.label, element.label)))
         all_handles, all_labels = list(zip(*legend_data)) if legend_data else ([], [])
-        data = dict()
+        data = {}
         used_labels = []
         for handle, label in zip(all_handles, all_labels):
             # Ensure that artists with multiple handles are supported

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -13,7 +13,7 @@ from matplotlib.image import AxesImage
 from packaging.version import Version
 
 from ...core import util
-from ...core import (OrderedDict, NdOverlay, DynamicMap, Dataset,
+from ...core import (NdOverlay, DynamicMap, Dataset,
                      CompositeOverlay, Element3D, Element)
 from ...core.options import abbreviated_exception, Keywords
 from ...element import Graph, Path

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -390,10 +390,10 @@ class GridPlot(CompositePlot):
         axiswise = all(norm_opts.get('axiswise', []))
         if not ranges:
             self.handles['fig'].set_size_inches(self.fig_inches)
-        subplots, subaxes = OrderedDict(), OrderedDict()
+        subplots, subaxes = dict(), dict()
         frame_ranges = self.compute_ranges(layout, None, ranges)
         keys = self.keys[:1] if self.dynamic else self.keys
-        frame_ranges = OrderedDict([(key, self.compute_ranges(layout, key, frame_ranges))
+        frame_ranges = dict([(key, self.compute_ranges(layout, key, frame_ranges))
                                     for key in keys])
         collapsed_layout = layout.clone(shared_data=False, id=layout.id)
         r, c = (0, 0)
@@ -910,7 +910,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
         collapsed_layout = layout.clone(shared_data=False, id=layout.id)
         frame_ranges = self.compute_ranges(layout, None, None)
         keys = self.keys[:1] if self.dynamic else self.keys
-        frame_ranges = OrderedDict([(key, self.compute_ranges(layout, key, frame_ranges))
+        frame_ranges = dict([(key, self.compute_ranges(layout, key, frame_ranges))
                                     for key in keys])
         layout_subplots, layout_axes = {}, {}
         for r, c in self.coords:
@@ -938,7 +938,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
 
             layout_key, _ = layout_items.get((r, c), (None, None))
             if isinstance(layout, NdLayout) and layout_key:
-                layout_dimensions = OrderedDict(zip(layout_dimensions, layout_key))
+                layout_dimensions = dict(zip(layout_dimensions, layout_key))
 
             # Generate the axes and create the subplots with the appropriate
             # axis objects, handling any Empty objects.

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -390,7 +390,7 @@ class GridPlot(CompositePlot):
         axiswise = all(norm_opts.get('axiswise', []))
         if not ranges:
             self.handles['fig'].set_size_inches(self.fig_inches)
-        subplots, subaxes = dict(), dict()
+        subplots, subaxes = {}, {}
         frame_ranges = self.compute_ranges(layout, None, ranges)
         keys = self.keys[:1] if self.dynamic else self.keys
         frame_ranges = dict([(key, self.compute_ranges(layout, key, frame_ranges))

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -10,7 +10,7 @@ from matplotlib import pyplot as plt
 from matplotlib import gridspec, animation, rcParams
 from matplotlib.font_manager import font_scalings
 
-from ...core import (OrderedDict, HoloMap, AdjointLayout, NdLayout,
+from ...core import (HoloMap, AdjointLayout, NdLayout,
                      GridSpace, Element, CompositeOverlay, Empty,
                      Collator, GridMatrix, Layout)
 from ...core.options import Store, SkipRendering

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1921,7 +1921,7 @@ class GenericOverlayPlot(GenericElementPlot):
         if subplot.overlay_dims:
             odim_key = util.wrap_tuple(spec[-1])
             new_dims = zip(subplot.overlay_dims, odim_key)
-            subplot.overlay_dims = util.dict(new_dims)
+            subplot.overlay_dims = dict(new_dims)
 
     def _get_subplot_extents(self, overlay, ranges, range_type, dimension=None):
         """

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -292,7 +292,7 @@ class PlotSelector:
         the appropriate key to index plot_classes dictionary.
         """
         self.selector = selector
-        self.plot_classes = OrderedDict(plot_classes)
+        self.plot_classes = dict(plot_classes)
         interface = self._define_interface(self.plot_classes.values(), allow_mismatch)
         self.style_opts, self.plot_options = interface
 
@@ -571,7 +571,7 @@ class DimensionedPlot(Plot):
         prev_frame = getattr(self, 'prev_frame', None)
         all_table = all(isinstance(el, Table) for el in obj.traverse(lambda x: x, [Element]))
         if obj is None or not self.normalize or all_table:
-            return OrderedDict()
+            return dict()
         # Get inherited ranges
         ranges = self.ranges if ranges is None else {k: dict(v) for k, v in ranges.items()}
 
@@ -725,7 +725,7 @@ class DimensionedPlot(Plot):
                     categorical_dims.append(el_dim)
 
         prev_ranges = ranges.get(group, {})
-        group_ranges = OrderedDict()
+        group_ranges = dict()
         for el in elements:
             if isinstance(el, (Empty, Table)): continue
             opts = cls.lookup_options(el, 'style')
@@ -867,7 +867,7 @@ class DimensionedPlot(Plot):
                                                            combined=g=='hard')
         else:
             # Override global range
-            ranges[group] = OrderedDict(dim_ranges)
+            ranges[group] = dict(dim_ranges)
 
     @classmethod
     def _traverse_options(cls, obj, opt_type, opts, specs=None, keyfn=None, defaults=True):
@@ -895,7 +895,7 @@ class DimensionedPlot(Plot):
 
         # Traverse object and accumulate options by key
         traversed = obj.traverse(lookup, specs)
-        options = OrderedDict()
+        options = dict()
         default_opts = defaultdict(lambda: defaultdict(list))
         for key, opts in traversed:
             defaults = opts.pop('defaults', {})
@@ -1730,11 +1730,11 @@ class GenericOverlayPlot(GenericElementPlot):
         if keys and ranges and dimensions and not defaultdim:
             dim_inds = [dimensions.index(d) for d in holomap.kdims]
             sliced_keys = [tuple(k[i] for i in dim_inds) for k in keys]
-            frame_ranges = OrderedDict([(slckey, self.compute_ranges(holomap, key, ranges[key]))
+            frame_ranges = dict([(slckey, self.compute_ranges(holomap, key, ranges[key]))
                                         for key, slckey in zip(keys, sliced_keys) if slckey in holomap.data.keys()])
         else:
             mapwise_ranges = self.compute_ranges(holomap, None, None)
-            frame_ranges = OrderedDict([(key, self.compute_ranges(holomap, key, mapwise_ranges))
+            frame_ranges = dict([(key, self.compute_ranges(holomap, key, mapwise_ranges))
                                         for key in holomap.data.keys()])
         ranges = frame_ranges.values()
 
@@ -1769,7 +1769,7 @@ class GenericOverlayPlot(GenericElementPlot):
         for m in vmaps:
             self.map_lengths[group_fn(m)[:length]] += 1
 
-        subplots = OrderedDict()
+        subplots = dict()
         for (key, vmap, streams) in zip(keys, vmaps, dmap_streams):
             subplot = self._create_subplot(key, vmap, streams, ranges)
             if subplot is None:
@@ -1798,7 +1798,7 @@ class GenericOverlayPlot(GenericElementPlot):
         else:
             if not isinstance(key, tuple): key = (key,)
             style_key = group_fn(obj) + key
-            opts['overlay_dims'] = OrderedDict(zip(self.hmap.last.kdims, key))
+            opts['overlay_dims'] = dict(zip(self.hmap.last.kdims, key))
 
         if self.batched:
             vtype = type(obj.last.last)
@@ -1921,7 +1921,7 @@ class GenericOverlayPlot(GenericElementPlot):
         if subplot.overlay_dims:
             odim_key = util.wrap_tuple(spec[-1])
             new_dims = zip(subplot.overlay_dims, odim_key)
-            subplot.overlay_dims = util.OrderedDict(new_dims)
+            subplot.overlay_dims = util.dict(new_dims)
 
     def _get_subplot_extents(self, overlay, ranges, range_type, dimension=None):
         """

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -7,7 +7,7 @@ import uuid
 import warnings
 
 from ast import literal_eval
-from collections import Counter, defaultdict, OrderedDict
+from collections import Counter, defaultdict
 from functools import partial
 from itertools import groupby, product
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -571,7 +571,7 @@ class DimensionedPlot(Plot):
         prev_frame = getattr(self, 'prev_frame', None)
         all_table = all(isinstance(el, Table) for el in obj.traverse(lambda x: x, [Element]))
         if obj is None or not self.normalize or all_table:
-            return dict()
+            return {}
         # Get inherited ranges
         ranges = self.ranges if ranges is None else {k: dict(v) for k, v in ranges.items()}
 
@@ -725,7 +725,7 @@ class DimensionedPlot(Plot):
                     categorical_dims.append(el_dim)
 
         prev_ranges = ranges.get(group, {})
-        group_ranges = dict()
+        group_ranges = {}
         for el in elements:
             if isinstance(el, (Empty, Table)): continue
             opts = cls.lookup_options(el, 'style')
@@ -895,7 +895,7 @@ class DimensionedPlot(Plot):
 
         # Traverse object and accumulate options by key
         traversed = obj.traverse(lookup, specs)
-        options = dict()
+        options = {}
         default_opts = defaultdict(lambda: defaultdict(list))
         for key, opts in traversed:
             defaults = opts.pop('defaults', {})
@@ -1769,7 +1769,7 @@ class GenericOverlayPlot(GenericElementPlot):
         for m in vmaps:
             self.map_lengths[group_fn(m)[:length]] += 1
 
-        subplots = dict()
+        subplots = {}
         for (key, vmap, streams) in zip(keys, vmaps, dmap_streams):
             subplot = self._create_subplot(key, vmap, streams, ranges)
             if subplot is None:

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -1,7 +1,7 @@
 # standard library imports
 import uuid
 import copy
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 import pickle
 import base64
 

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -147,7 +147,7 @@ def to_function_spec(hvobj):
 
     # Build mapping from kdims to values/range
     dimensions_dict = {d.name: d for d in hvobj.dimensions()}
-    kdims = dict()
+    kdims = {}
     for k in kdims_list:
         dim = dimensions_dict[k.name]
         label = dim.label or dim.name
@@ -341,7 +341,7 @@ def to_dash(
     plots = []
     graph_ids = []
     initial_fig_dicts = []
-    all_kdims = dict()
+    all_kdims = {}
     kdims_per_fig = []
 
     # Initialize stream mappings
@@ -426,7 +426,7 @@ def to_dash(
     #    breadth-first order so all inputs to a triple are guaranteed to be earlier
     #    in the list. History streams will input and output their own id, which is
     #    fine.
-    stream_callbacks = dict()
+    stream_callbacks = {}
     for fn_spec in fig_to_fn_stream.values():
         populate_stream_callback_graph(stream_callbacks, fn_spec.streams)
 

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -147,7 +147,7 @@ def to_function_spec(hvobj):
 
     # Build mapping from kdims to values/range
     dimensions_dict = {d.name: d for d in hvobj.dimensions()}
-    kdims = OrderedDict()
+    kdims = dict()
     for k in kdims_list:
         dim = dimensions_dict[k.name]
         label = dim.label or dim.name
@@ -227,13 +227,13 @@ def build_history_callback(history_stream):
 
 def populate_stream_callback_graph(stream_callbacks, streams):
     """
-    Populate the stream_callbacks OrderedDict with StreamCallback instances
+    Populate the stream_callbacks dict with StreamCallback instances
     associated with all of the History and Derived streams in input stream list.
 
     Input streams to any History or Derived streams are processed recursively
 
     Args:
-        stream_callbacks:  OrderedDict from id(stream) to StreamCallbacks the should
+        stream_callbacks:  dict from id(stream) to StreamCallbacks the should
             be populated. Order will be a breadth-first traversal of the provided
             streams list, and any input streams that these depend on.
 
@@ -341,7 +341,7 @@ def to_dash(
     plots = []
     graph_ids = []
     initial_fig_dicts = []
-    all_kdims = OrderedDict()
+    all_kdims = dict()
     kdims_per_fig = []
 
     # Initialize stream mappings
@@ -426,7 +426,7 @@ def to_dash(
     #    breadth-first order so all inputs to a triple are guaranteed to be earlier
     #    in the list. History streams will input and output their own id, which is
     #    fine.
-    stream_callbacks = OrderedDict()
+    stream_callbacks = dict()
     for fn_spec in fig_to_fn_stream.values():
         populate_stream_callback_graph(stream_callbacks, fn_spec.streams)
 

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -302,7 +302,7 @@ class GridPlot(PlotlyPlot, GenericCompositePlot):
 
 
     def _create_subplots(self, layout, ranges):
-        subplots = dict()
+        subplots = {}
         frame_ranges = self.compute_ranges(layout, None, ranges)
         frame_ranges = dict([(key, self.compute_ranges(layout, key, frame_ranges))
                                     for key in self.keys])

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -80,7 +80,7 @@ class LayoutPlot(PlotlyPlot, GenericLayoutPlot):
         layout_count = 0
         collapsed_layout = layout.clone(shared_data=False, id=layout.id)
         frame_ranges = self.compute_ranges(layout, None, None)
-        frame_ranges = OrderedDict([(key, self.compute_ranges(layout, key, frame_ranges))
+        frame_ranges = dict([(key, self.compute_ranges(layout, key, frame_ranges))
                                     for key in self.keys])
         layout_items = layout.grid_items()
         layout_dimensions = layout.kdims if isinstance(layout, NdLayout) else None
@@ -103,7 +103,7 @@ class LayoutPlot(PlotlyPlot, GenericLayoutPlot):
             # to create the correct subaxes for all plots in the layout
             layout_key, _ = layout_items.get((r, c), (None, None))
             if isinstance(layout, NdLayout) and layout_key:
-                layout_dimensions = OrderedDict(zip(layout_dimensions, layout_key))
+                layout_dimensions = dict(zip(layout_dimensions, layout_key))
 
             # Generate the axes and create the subplots with the appropriate
             # axis objects, handling any Empty objects.
@@ -302,9 +302,9 @@ class GridPlot(PlotlyPlot, GenericCompositePlot):
 
 
     def _create_subplots(self, layout, ranges):
-        subplots = OrderedDict()
+        subplots = dict()
         frame_ranges = self.compute_ranges(layout, None, ranges)
-        frame_ranges = OrderedDict([(key, self.compute_ranges(layout, key, frame_ranges))
+        frame_ranges = dict([(key, self.compute_ranges(layout, key, frame_ranges))
                                     for key in self.keys])
         collapsed_layout = layout.clone(shared_data=False, id=layout.id)
         for coord in layout.keys(full_grid=True):

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -1,7 +1,7 @@
 import param
 
 from holoviews.plotting.util import attach_streams
-from ...core import (OrderedDict, NdLayout, AdjointLayout, Empty,
+from ...core import (NdLayout, AdjointLayout, Empty,
                      HoloMap, GridSpace, GridMatrix)
 from ...element import Histogram
 from ...core.options import Store

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -6,7 +6,6 @@ import param
 from param.parameterized import bothmethod
 
 from .core.data import Dataset
-from .core.dimension import OrderedDict
 from .core.element import Element, Layout
 from .core.options import CallbackError, Store
 from .core.overlay import NdOverlay, Overlay

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -196,7 +196,7 @@ class _base_link_selections(param.ParameterizedFunction):
                 )
             return hvobj
         elif isinstance(hvobj, (Layout, Overlay, NdOverlay, GridSpace, AdjointLayout)):
-            data = OrderedDict([(k, self._selection_transform(v, operations))
+            data = dict([(k, self._selection_transform(v, operations))
                                  for k, v in hvobj.items()])
             if isinstance(hvobj, NdOverlay):
                 def compose(*args, **kwargs):

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -13,7 +13,6 @@ from holoviews.element import Scatter, Curve
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.util.transform import dim
 
-from collections import OrderedDict
 
 import pandas as pd
 

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -488,11 +488,11 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_odict_init(self):
-        dataset = Dataset(OrderedDict(zip(self.xs, self.ys)), kdims=['A'], vdims=['B'])
+        dataset = Dataset(dict(zip(self.xs, self.ys)), kdims=['A'], vdims=['B'])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_odict_init_alias(self):
-        dataset = Dataset(OrderedDict(zip(self.xs, self.ys)),
+        dataset = Dataset(dict(zip(self.xs, self.ys)),
                           kdims=[('a', 'A')], vdims=[('b', 'B')])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 

--- a/holoviews/tests/core/data/test_binneddatasets.py
+++ b/holoviews/tests/core/data/test_binneddatasets.py
@@ -10,7 +10,6 @@ from holoviews.core.dimension import Dimension
 from holoviews.core.spaces import HoloMap
 from holoviews.core.data import Dataset
 from holoviews.core.data.interface import DataError
-from holoviews.core.util import OrderedDict
 from holoviews.element import Histogram, QuadMesh
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.util.transform import dim

--- a/holoviews/tests/core/data/test_binneddatasets.py
+++ b/holoviews/tests/core/data/test_binneddatasets.py
@@ -190,7 +190,7 @@ class Irregular2DBinsTest(ComparisonTestCase):
             import xarray as xr
         except ImportError:
             raise SkipTest("Test requires xarray")
-        coords = OrderedDict([('lat', (('y', 'x'), self.ys)),
+        coords = dict([('lat', (('y', 'x'), self.ys)),
                               ('lon', (('y', 'x'), self.xs))])
         da = xr.DataArray(self.zs, dims=['y', 'x'],
                           coords=coords, name='z')

--- a/holoviews/tests/core/data/test_dictinterface.py
+++ b/holoviews/tests/core/data/test_dictinterface.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import numpy as np
 
 from holoviews.core.data import Dataset
@@ -13,7 +11,7 @@ class DictDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
     """
 
     datatype = 'dictionary'
-    data_type = (OrderedDict,)
+    data_type = (dict,)
 
     __test__ = True
 

--- a/holoviews/tests/core/data/test_gridinterface.py
+++ b/holoviews/tests/core/data/test_gridinterface.py
@@ -345,7 +345,7 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 
 class GridInterfaceTests(BaseGridInterfaceTests):
     datatype = 'grid'
-    data_type = (OrderedDict, dict)
+    data_type = (dict,)
     element = Dataset
 
     __test__ = True
@@ -528,7 +528,7 @@ class DaskGridInterfaceTests(GridInterfaceTests):
 class ImageElement_GridInterfaceTests(BaseImageElementInterfaceTests):
 
     datatype = 'grid'
-    data_type = OrderedDict
+    data_type = dict
 
     __test__ = True
 
@@ -685,7 +685,7 @@ class ImageElement_GridInterfaceTests(BaseImageElementInterfaceTests):
 class RGBElement_GridInterfaceTests(BaseRGBElementInterfaceTests):
 
     datatype = 'grid'
-    data_type = OrderedDict
+    data_type = dict
 
     __test__ = True
 
@@ -697,7 +697,7 @@ class RGBElement_GridInterfaceTests(BaseRGBElementInterfaceTests):
 class RGBElement_PackedGridInterfaceTests(BaseRGBElementInterfaceTests):
 
     datatype = 'grid'
-    data_type = OrderedDict
+    data_type = dict
 
     __test__ = True
 
@@ -708,7 +708,7 @@ class RGBElement_PackedGridInterfaceTests(BaseRGBElementInterfaceTests):
 class HSVElement_GridInterfaceTests(BaseHSVElementInterfaceTests):
 
     datatype = 'grid'
-    data_type = OrderedDict
+    data_type = dict
 
     __test__ = True
 

--- a/holoviews/tests/core/data/test_gridinterface.py
+++ b/holoviews/tests/core/data/test_gridinterface.py
@@ -1,6 +1,5 @@
 import datetime as dt
 
-from collections import OrderedDict
 from itertools import product
 from unittest import SkipTest
 

--- a/holoviews/tests/core/data/test_xarrayinterface.py
+++ b/holoviews/tests/core/data/test_xarrayinterface.py
@@ -39,7 +39,7 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         y = np.arange(2, 12, 2) * multiplier
         da = xr.DataArray(
             data=[np.arange(100).reshape(5, 20)],
-            coords=OrderedDict([('band', [1]), ('x', x), ('y', y)]),
+            coords=dict([('band', [1]), ('x', x), ('y', y)]),
             dims=['band', 'y','x'],
             attrs={'transform': (3, 0, 2, 0, -2, -2)})
         xs, ys = (np.tile(x[:, np.newaxis], len(y)).T,
@@ -63,7 +63,7 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
                                 'reference_time': pd.Timestamp('2014-09-05')})
 
     def test_ignore_dependent_dimensions_if_not_specified(self):
-        coords = OrderedDict([('time', [0, 1]), ('lat', [0, 1]), ('lon', [0, 1])])
+        coords = dict([('time', [0, 1]), ('lat', [0, 1]), ('lon', [0, 1])])
         da = xr.DataArray(np.arange(8).reshape((2, 2, 2)),
                           coords, ['time', 'lat', 'lon']).assign_coords(
                               lat1=xr.DataArray([2,3], dims=['lat']))
@@ -155,7 +155,7 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
 
     def test_xarray_coord_ordering(self):
         data = np.zeros((3,4,5))
-        coords = OrderedDict([('b', range(3)), ('c', range(4)), ('a', range(5))])
+        coords = dict([('b', range(3)), ('c', range(4)), ('a', range(5))])
         darray = xr.DataArray(data, coords=coords, dims=['b', 'c', 'a'])
         dataset = xr.Dataset({'value': darray}, coords=coords)
         ds = Dataset(dataset)

--- a/holoviews/tests/core/data/test_xarrayinterface.py
+++ b/holoviews/tests/core/data/test_xarrayinterface.py
@@ -1,6 +1,5 @@
 import datetime as dt
 
-from collections import OrderedDict
 from unittest import SkipTest
 
 import numpy as np

--- a/holoviews/tests/core/test_dimensions.py
+++ b/holoviews/tests/core/test_dimensions.py
@@ -36,7 +36,7 @@ class DimensionNameLabelTest(LoggingComparisonTestCase):
 
     def test_dimension_dict_empty(self):
         with self.assertRaisesRegex(ValueError, 'must contain a "name" key'):
-            Dimension(dict())
+            Dimension({})
 
     def test_dimension_dict_label(self):
         with self.assertRaisesRegex(ValueError, 'must contain a "name" key'):

--- a/holoviews/tests/core/test_ndmapping.py
+++ b/holoviews/tests/core/test_ndmapping.py
@@ -41,7 +41,7 @@ class NdIndexableMappingTest(ComparisonTestCase):
     def setUp(self):
         self.init_items_1D_list = [(1, 'a'), (5, 'b')]
         self.init_item_list = [((1, 2.0), 'a'), ((5, 3.0), 'b')]
-        self.init_item_odict = OrderedDict([((1, 2.0), 'a'), ((5, 3.0), 'b')])
+        self.init_item_odict = dict([((1, 2.0), 'a'), ((5, 3.0), 'b')])
         self.dimension_labels = ['intdim', 'floatdim']
         self.dim1 = Dimension('intdim', type=int)
         self.dim2 = Dimension('floatdim', type=float)

--- a/holoviews/tests/core/test_ndmapping.py
+++ b/holoviews/tests/core/test_ndmapping.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 
 import numpy as np
 

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -741,10 +741,10 @@ class TestOptionTreeFind(ComparisonTestCase):
                          dict(kw2='value2'))
 
     def test_optiontree_find_mismatch3(self):
-        self.assertEqual(self.options.find('Baz').options('group').options, dict())
+        self.assertEqual(self.options.find('Baz').options('group').options, {})
 
     def test_optiontree_find_mismatch4(self):
-        self.assertEqual(self.options.find('Baz.Baz').options('group').options, dict())
+        self.assertEqual(self.options.find('Baz.Baz').options('group').options, {})
 
 
 

--- a/holoviews/tests/core/test_utils.py
+++ b/holoviews/tests/core/test_utils.py
@@ -6,7 +6,6 @@ import math
 import unittest
 
 from itertools import product
-from collections import OrderedDict
 
 import numpy as np
 import pandas as pd

--- a/holoviews/tests/core/test_utils.py
+++ b/holoviews/tests/core/test_utils.py
@@ -50,13 +50,13 @@ class TestDeepHash(ComparisonTestCase):
         self.assertNotEqual(deephash({1:'a',2:'b'}), deephash({2:'b', 1:'c'}))
 
     def test_deephash_odict_equality_v1(self):
-        odict1 = OrderedDict([(1,'a'), (2,'b')])
-        odict2 = OrderedDict([(1,'a'), (2,'b')])
+        odict1 = dict([(1,'a'), (2,'b')])
+        odict2 = dict([(1,'a'), (2,'b')])
         self.assertEqual(deephash(odict1), deephash(odict2))
 
     def test_deephash_odict_equality_v2(self):
-        odict1 = OrderedDict([(1,'a'), (2,'b')])
-        odict2 = OrderedDict([(1,'a'), (2,'c')])
+        odict1 = dict([(1,'a'), (2,'b')])
+        odict2 = dict([(1,'a'), (2,'c')])
         self.assertNotEqual(deephash(odict1), deephash(odict2))
 
     def test_deephash_numpy_equality(self):
@@ -130,22 +130,22 @@ class TestDeepHash(ComparisonTestCase):
         obj1 = [datetime.datetime(1,2,3), {1,2,3},
                 pd.DataFrame({'a':[1,2],'b':[3,4]}),
                 np.array([1,2,3]), {'a':'b', '1':True},
-                OrderedDict([(1,'a'),(2,'b')]), np.int64(34)]
+                dict([(1,'a'),(2,'b')]), np.int64(34)]
         obj2 = [datetime.datetime(1,2,3), {1,2,3},
                 pd.DataFrame({'a':[1,2],'b':[3,4]}),
                 np.array([1,2,3]), {'a':'b', '1':True},
-                OrderedDict([(1,'a'),(2,'b')]), np.int64(34)]
+                dict([(1,'a'),(2,'b')]), np.int64(34)]
         self.assertEqual(deephash(obj1), deephash(obj2))
 
     def test_deephash_nested_mixed_inequality(self):
         obj1 = [datetime.datetime(1,2,3), {1,2,3},
                 pd.DataFrame({'a':[1,2],'b':[3,4]}),
                 np.array([1,2,3]), {'a':'b', '2':True},
-                OrderedDict([(1,'a'),(2,'b')]), np.int64(34)]
+                dict([(1,'a'),(2,'b')]), np.int64(34)]
         obj2 = [datetime.datetime(1,2,3), {1,2,3},
                 pd.DataFrame({'a':[1,2],'b':[3,4]}),
                 np.array([1,2,3]), {'a':'b', '1':True},
-                OrderedDict([(1,'a'),(2,'b')]), np.int64(34)]
+                dict([(1,'a'),(2,'b')]), np.int64(34)]
         self.assertNotEqual(deephash(obj1), deephash(obj2))
 
 

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -922,7 +922,7 @@ class TestColorbarPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(colorbar.major_label_text_font_size, '22px')
 
     def test_explicit_categorical_cmap_on_integer_data(self):
-        explicit_mapping = OrderedDict([(0, 'blue'), (1, 'red'), (2, 'green'), (3, 'purple')])
+        explicit_mapping = dict([(0, 'blue'), (1, 'red'), (2, 'green'), (3, 'purple')])
         points = Scatter(([0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]), vdims=['y', 'Category']).opts(
             color_index='Category', cmap=explicit_mapping
         )

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -1,7 +1,6 @@
 import datetime as dt
 
 from unittest import SkipTest
-from collections import OrderedDict
 
 import numpy as np
 import pytest

--- a/holoviews/tests/plotting/bokeh/test_renderer.py
+++ b/holoviews/tests/plotting/bokeh/test_renderer.py
@@ -120,7 +120,7 @@ class BokehRendererTest(ComparisonTestCase):
         widgets = obj.layout.select(DiscreteSlider)
         self.assertEqual(len(widgets), 1)
         slider = widgets[0]
-        self.assertEqual(slider.options, OrderedDict([(str(i), i) for i in range(5)]))
+        self.assertEqual(slider.options, dict([(str(i), i) for i in range(5)]))
 
     def test_render_holomap_embedded(self):
         hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})

--- a/holoviews/tests/plotting/bokeh/test_renderer.py
+++ b/holoviews/tests/plotting/bokeh/test_renderer.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from io import BytesIO
 from unittest import SkipTest
 

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -3,7 +3,6 @@ Test cases for rendering exporters
 """
 import subprocess
 
-from collections import OrderedDict
 from unittest import SkipTest
 
 import numpy as np

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -105,7 +105,7 @@ class MPLRendererTest(ComparisonTestCase):
         widgets = obj.layout.select(DiscreteSlider)
         self.assertEqual(len(widgets), 1)
         slider = widgets[0]
-        self.assertEqual(slider.options, OrderedDict([(str(i), i) for i in range(5)]))
+        self.assertEqual(slider.options, dict([(str(i), i) for i in range(5)]))
 
     def test_render_holomap_embedded(self):
         hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})

--- a/holoviews/tests/plotting/plotly/test_renderer.py
+++ b/holoviews/tests/plotting/plotly/test_renderer.py
@@ -1,7 +1,6 @@
 """
 Test cases for rendering exporters
 """
-from collections import OrderedDict
 
 import panel as pn
 import param

--- a/holoviews/tests/plotting/plotly/test_renderer.py
+++ b/holoviews/tests/plotting/plotly/test_renderer.py
@@ -51,7 +51,7 @@ class PlotlyRendererTest(ComparisonTestCase):
         widgets = obj.layout.select(DiscreteSlider)
         self.assertEqual(len(widgets), 1)
         slider = widgets[0]
-        self.assertEqual(slider.options, OrderedDict([(str(i), i) for i in range(5)]))
+        self.assertEqual(slider.options, dict([(str(i), i) for i in range(5)]))
 
     def test_render_holomap_embedded(self):
         hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})

--- a/holoviews/tests/util/test_transform.py
+++ b/holoviews/tests/util/test_transform.py
@@ -77,7 +77,7 @@ class TestDimTransforms(ComparisonTestCase):
         array = np.arange(100).reshape(5, 20)
         darray = xr.DataArray(
             data=array,
-            coords=OrderedDict([('x', x), ('y', y)]),
+            coords=dict([('x', x), ('y', y)]),
             dims=['y','x']
         )
         self.dataset_xarray = Dataset(darray, vdims=['z'])
@@ -85,7 +85,7 @@ class TestDimTransforms(ComparisonTestCase):
             dask_array = da.from_array(array)
             dask_da = xr.DataArray(
                 data=dask_array,
-                coords=OrderedDict([('x', x), ('y', y)]),
+                coords=dict([('x', x), ('y', y)]),
                 dims=['y','x']
             )
             self.dataset_xarray_dask = Dataset(dask_da, vdims=['z'])

--- a/holoviews/tests/util/test_transform.py
+++ b/holoviews/tests/util/test_transform.py
@@ -6,7 +6,6 @@ import warnings
 
 import holoviews as hv
 
-from collections import OrderedDict
 from unittest import skipIf
 
 import numpy as np

--- a/holoviews/tests/util/test_utils.py
+++ b/holoviews/tests/util/test_utils.py
@@ -2,7 +2,6 @@
 Unit tests of the helper functions in utils
 """
 from unittest import SkipTest
-from collections import OrderedDict
 
 from holoviews import notebook_extension
 from holoviews.element.comparison import ComparisonTestCase

--- a/holoviews/tests/util/test_utils.py
+++ b/holoviews/tests/util/test_utils.py
@@ -34,14 +34,14 @@ class TestOutputUtil(ComparisonTestCase):
         Store.current_backend = 'matplotlib'
         Store.renderers['matplotlib'] = mpl.MPLRenderer.instance()
         Store.renderers['bokeh'] = bokeh.BokehRenderer.instance()
-        OutputSettings.options =  OrderedDict(OutputSettings.defaults.items())
+        OutputSettings.options =  dict(OutputSettings.defaults.items())
 
         super().setUp()
 
     def tearDown(self):
         Store.renderers['matplotlib'] = mpl.MPLRenderer.instance()
         Store.renderers['bokeh'] = bokeh.BokehRenderer.instance()
-        OutputSettings.options =  OrderedDict(OutputSettings.defaults.items())
+        OutputSettings.options =  dict(OutputSettings.defaults.items())
         for renderer in Store.renderers.values():
             renderer.comm_manager = CommManager
         super().tearDown()

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -18,7 +18,7 @@ from ..core import (
 from ..core.options import Keywords, Options, options_policy
 from ..core.operation import Operation
 from ..core.overlay import Overlay
-from ..core.util import merge_options_to_dict, OrderedDict
+from ..core.util import merge_options_to_dict
 from ..core.operation import OperationCallable
 from ..core import util
 from ..operation.element import function

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -896,7 +896,7 @@ class Dynamic(param.ParameterizedFunction):
             dmap = map_obj.clone(callback=callback, shared_data=self.p.shared_data,
                                  streams=streams)
             if self.p.shared_data:
-                dmap.data = OrderedDict([(k, callback.callable(*k))
+                dmap.data = dict([(k, callback.callable(*k))
                                           for k, v in dmap.data])
         else:
             dmap = self._make_dynamic(map_obj, callback, streams)

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -1,4 +1,4 @@
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from ..core import Store
 
 

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -9,8 +9,8 @@ class KeywordSettings:
     """
     # Dictionary from keywords to allowed bounds/values
     allowed = {}
-    defaults = OrderedDict([])  # Default keyword values.
-    options =  OrderedDict(defaults.items()) # Current options
+    defaults = dict([])  # Default keyword values.
+    options =  dict(defaults.items()) # Current options
 
     # Callables accepting (value, keyword, allowed) for custom exceptions
     custom_exceptions = {}
@@ -156,7 +156,7 @@ class OutputSettings(KeywordSettings):
                                             'max-width', 'min-width', 'max-height',
                                             'min-height', 'outline', 'float']}}
 
-    defaults = OrderedDict([('backend'      , None),
+    defaults = dict([('backend'      , None),
                             ('center'       , True),
                             ('fig'          , None),
                             ('holomap'      , None),
@@ -178,7 +178,7 @@ class OutputSettings(KeywordSettings):
     render_params = ['fig', 'holomap', 'size', 'fps', 'dpi', 'css',
                      'widget_mode', 'mode', 'widget_location', 'center']
 
-    options = OrderedDict()
+    options = dict()
     _backend_options = defaultdict(dict)
 
     # Used to disable info output in testing
@@ -293,7 +293,7 @@ class OutputSettings(KeywordSettings):
             if line is not None:
                 # Parse line
                 line = line.split('#')[0].strip()
-                kwargs = cls.extract_keywords(line, OrderedDict())
+                kwargs = cls.extract_keywords(line, dict())
 
             options = cls.get_options(kwargs, {}, warnfn)
 

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -178,7 +178,7 @@ class OutputSettings(KeywordSettings):
     render_params = ['fig', 'holomap', 'size', 'fps', 'dpi', 'css',
                      'widget_mode', 'mode', 'widget_location', 'center']
 
-    options = dict()
+    options = {}
     _backend_options = defaultdict(dict)
 
     # Used to disable info output in testing
@@ -293,7 +293,7 @@ class OutputSettings(KeywordSettings):
             if line is not None:
                 # Parse line
                 line = line.split('#')[0].strip()
-                kwargs = cls.extract_keywords(line, dict())
+                kwargs = cls.extract_keywords(line, {})
 
             options = cls.get_options(kwargs, {}, warnfn)
 


### PR DESCRIPTION
`OrderedDict` is no longer required as `dict` has been in insertion order since Python 3.7.