### PR TITLE
Matplotlib pin

### DIFF
--- a/examples/user_guide/Customizing_Plots.ipynb
+++ b/examples/user_guide/Customizing_Plots.ipynb
@@ -650,7 +650,6 @@
     "Tick formatting works very differently in different backends, however the ``xformatter`` and ``yformatter`` options try to minimize these differences. Tick formatters may be defined in one of three formats:\n",
     "\n",
     "* A classic format string such as ``'%d'``, ``'%.3f'`` or ``'%d'`` which may also contain other characters (``'$%.2f'``)\n",
-    "* A function which will be compiled to JS using pscript (if installed) when using bokeh\n",
     "* A ``bokeh.models.TickFormatter`` in bokeh and a ``matplotlib.ticker.Formatter`` instance in matplotlib\n",
     "\n",
     "Here is a small example demonstrating how to use the string format and function approaches:"
@@ -662,10 +661,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def formatter(value):\n",
-    "    return str(value) + ' days'\n",
-    "\n",
-    "curve.relabel('Tick formatters').opts(xformatter=formatter, yformatter='$%.2f', width=500)"
+    "curve.relabel('Tick formatters').opts(xformatter='%.0f days', yformatter='$%.2f', width=500)"
    ]
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extras_require['tests_core'] = [
     'pytest-cov',
     'pytest-xdist',
     'flaky',
-    'matplotlib >=3',
+    'matplotlib >=3, <3.8',  # 3.8 breaks tests
     'nbconvert',
     'bokeh',
     'pillow',

--- a/tox.ini
+++ b/tox.ini
@@ -13,17 +13,17 @@ commands = python -c "import holoviews as hv; print(hv.__version__)"
 [_unit_core]
 description = Run unit tests with coverage but no optional test dependency
 deps = .[tests_core]
-commands = pytest holoviews --cov=./holoviews -vv
+commands = pytest holoviews --cov=./holoviews -v
 
 [_unit]
 description = Run unit tests with coverage and all the optional test dependencies
 deps = .[tests]
-commands = pytest holoviews --cov=./holoviews -vv
+commands = pytest holoviews --cov=./holoviews -v
 
 [_unit_gpu]
 description = Run unit tests with coverage and all the optional test dependencies
 deps = .[tests_gpu]
-commands = pytest holoviews --cov=./holoviews -vv
+commands = pytest holoviews --cov=./holoviews -v
 
 [_ui]
 description = Run UI tests
@@ -34,7 +34,6 @@ commands = pytest holoviews --cov=./holoviews --cov-report=xml --ui --browser ch
 description = Test that default examples run
 deps = .[examples_tests]
 commands = pytest -n auto --dist loadscope --nbval-lax examples
-# --force-flaky --max-runs=5
 
 [_all_recommended]
 description = Run all recommended tests


### PR DESCRIPTION
With the release of matplotlib 3.8, the following tests are failing [see here](https://github.com/holoviz/holoviews/actions/runs/6230968917/job/16911806806).

``` python
FAILED holoviews/tests/operation/test_operation.py::OperationTests::test_image_contours - AssertionError: Contours not almost equal to 6 decimals
FAILED holoviews/tests/operation/test_operation.py::OperationTests::test_image_contours_filled - AssertionError: Dimension parameter 'range' mismatched: (2.25, 2.25) != (2,...
FAILED holoviews/tests/operation/test_operation.py::OperationTests::test_qmesh_contours - AssertionError: Contours not almost equal to 6 decimals
FAILED holoviews/tests/operation/test_operation.py::OperationTests::test_qmesh_curvilinear_contours - AssertionError: Contours not almost equal to 6 decimals
FAILED holoviews/tests/operation/test_operation.py::OperationTests::test_qmesh_curvilinear_edges_contours - AssertionError: Contours not almost equal to 6 decimals
FAILED holoviews/tests/operation/test_statsoperations.py::KDEOperationTests::test_bivariate_kde_contours_filled - AssertionError: 9 != 10
FAILED holoviews/tests/plotting/matplotlib/test_heatmapplot.py::TestHeatMapPlot::test_heatmap_invert_axes - AssertionError: Arrays not almost equal to 6 decimals
FAILED holoviews/tests/plotting/matplotlib/test_heatmapplot.py::TestHeatMapPlot::test_heatmap_invert_xaxis - AssertionError: Arrays not almost equal to 6 decimals
FAILED holoviews/tests/plotting/matplotlib/test_heatmapplot.py::TestHeatMapPlot::test_heatmap_invert_yaxis - AssertionError: Arrays not almost equal to 6 decimals
FAILED holoviews/tests/plotting/matplotlib/test_quadmeshplot.py::TestQuadMeshPlot::test_quadmesh_invert_axes - AssertionError: Arrays not almost equal to 6 decimals
FAILED holoviews/tests/plotting/matplotlib/test_quadmeshplot.py::TestQuadMeshPlot::test_quadmesh_nodata - AssertionError: Arrays not almost equal to 6 decimals
FAILED holoviews/tests/plotting/matplotlib/test_quadmeshplot.py::TestQuadMeshPlot::test_quadmesh_nodata_uint - AssertionError: Arrays not almost equal to 6 decimals
```

Also adding the following warning:
``` python
holoviews/tests/operation/test_operation.py::OperationTests::test_image_contours
holoviews/tests/operation/test_operation.py::OperationTests::test_image_contours_filled
holoviews/tests/operation/test_operation.py::OperationTests::test_qmesh_contours
holoviews/tests/operation/test_operation.py::OperationTests::test_qmesh_curvilinear_contours
holoviews/tests/operation/test_operation.py::OperationTests::test_qmesh_curvilinear_edges_contours
  /home/runner/work/holoviews/holoviews/holoviews/operation/element.py:609: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
    for level, cset in zip(levels, contour_set.collections):
```

I will try to fix these tests later this week. But for now I will just pin.