### PR TITLE
Fix `Path.datatype` parameter type

### DIFF
--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -56,7 +56,7 @@ class Path(SelectionPolyExpr, Geometry):
 
     group = param.String(default="Path", constant=True)
 
-    datatype = param.ObjectSelector(default=[
+    datatype = param.List(default=[
         'multitabular', 'spatialpandas', 'dask_spatialpandas']
     )
 


### PR DESCRIPTION
From `ObjectSelector` to `List`, `List` being the type of `datatype` in the base class `Dataset`.