### PR TITLE
Don't emit a warning when data has timezone in it

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -359,8 +359,7 @@ class PandasInterface(Interface, PandasAPI):
         if keep_index:
             return data
         if data.dtype.kind == 'M' and getattr(data.dtype, 'tz', None):
-            dts = [dt.replace(tzinfo=None) for dt in data.dt.to_pydatetime()]
-            data = np.array(dts, dtype=data.dtype.base)
+            data = data.dt.tz_localize(None)
         if not expanded:
             return pd.unique(data)
         return data.values if hasattr(data, 'values') else data

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -171,3 +171,10 @@ class PandasInterfaceTests(BasePandasInterfaceTests):
     data_type = pd.DataFrame
 
     __test__ = True
+
+    def test_data_with_tz(self):
+        dates = pd.date_range("2018-01-01", periods=3, freq="H")
+        dates_tz = dates.tz_localize("UTC")
+        df = pd.DataFrame({"dates": dates_tz})
+        data = Dataset(df).dimension_values("dates")
+        np.testing.assert_equal(dates, data)


### PR DESCRIPTION
Saw this warning in a hvplot notebook:

``` 
/home/shh/Repos/holoviz/holoviews/holoviews/core/data/pandas.py:364: FutureWarning: The behavior of DatetimeProperties.to_pydatetime is deprecated, in a future version this will return a Series containing python datetime objects instead of an ndarray. To retain the old behavior, call `np.array` on the result
  dts = [dt.replace(tzinfo=None) for dt in data.dt.to_pydatetime()]
```

This means that our test did not go down this code path. The fix was simple as I simply used a pandas built-in approach of removing timezone. This also has the advantage that we are not rounding our data to microseconds and also using a vectorized approach. 

Added a small test to go down the code path.