### PR TITLE
Actually enable Mathjax with enable_mathjax

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -186,7 +186,7 @@ class notebook_extension(extension):
         same_cell_execution = getattr(self, '_repeat_execution_in_cell', False)
         for r in [r for r in resources if r != 'holoviews']:
             Store.renderers[r].load_nb(inline=p.inline)
-        Renderer.load_nb(inline=p.inline, reloading=same_cell_execution, enable_mathjax=self.enable_mathjax)
+        Renderer.load_nb(inline=p.inline, reloading=same_cell_execution, enable_mathjax=p.enable_mathjax)
 
         if hasattr(ip, 'kernel') and not loaded:
             Renderer.comm_manager.get_client_comm(notebook_extension._process_comm_msg,

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -715,6 +715,9 @@ class extension(_pyviz_extension):
 
         import panel as pn
 
+        if params.get("enable_mathjax", False) and selected_backend == "bokeh":
+            pn.extension("mathjax")
+
         if pn.config.comms == "default":
             if "google.colab" in sys.modules:
                 pn.config.comms = "colab"
@@ -724,10 +727,6 @@ class extension(_pyviz_extension):
                 pn.config.comms = "vscode"
                 self._ignore_bokeh_warnings()
                 return
-
-        if params.get("enable_mathjax", False) and selected_backend == "bokeh":
-            pn.extension("mathjax")
-
 
     @classmethod
     def register_backend_callback(cls, backend, callback):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -725,7 +725,7 @@ class extension(_pyviz_extension):
                 self._ignore_bokeh_warnings()
                 return
 
-        if params.get("enable_mathjax", True) and selected_backend == "bokeh":
+        if params.get("enable_mathjax", False) and selected_backend == "bokeh":
             pn.extension("mathjax")
 
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -725,6 +725,10 @@ class extension(_pyviz_extension):
                 self._ignore_bokeh_warnings()
                 return
 
+        if params.get("enable_mathjax", True) and selected_backend == "bokeh":
+            pn.extension("mathjax")
+
+
     @classmethod
     def register_backend_callback(cls, backend, callback):
         """Registers a hook which is run when a backend is loaded"""


### PR DESCRIPTION
This should now enable Mathjax without both in a notebook and when running `panel serve`.

``` python
import holoviews as hv
import panel as pn

hv.extension("bokeh", enable_mathjax=True)

a = hv.Rectangles([[0, 0, 1, 1]]).opts(title=r"$$\alpha \beta$$", xlabel="$$y$$")

pn.panel(a).servable()
```

Should fix the problem described in https://github.com/holoviz/holoviews/issues/5740#issuecomment-1705372739