### PR TITLE
Handle parameter references from Param 2.0

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -547,6 +547,8 @@ class Callable(param.Parameterized):
         # Nothing to do for callbacks that accept no arguments
         kwarg_hash = kwargs.pop('_memoization_hash_', ())
         (self.args, self.kwargs) = (args, kwargs)
+        if hasattr(self.callable, 'rx'):
+            return self.callable.rx.resolve()
         if not args and not kwargs and not any(kwarg_hash): return self.callable()
         inputs = [i for i in self.inputs if isinstance(i, DynamicMap)]
         streams = []
@@ -773,7 +775,9 @@ class DynamicMap(HoloMap):
             streams = streams_list_from_dict(streams)
 
         # If callback is a parameterized method and watch is disabled add as stream
-        if (params.get('watch', True) and (util.is_param_method(callback, has_deps=True) or
+        if util.param_version > util.Version('2.0.0rc1') and param.parameterized.resolve_ref(callback):
+            streams.append(callback)
+        elif (params.get('watch', True) and (util.is_param_method(callback, has_deps=True) or
             (isinstance(callback, FunctionType) and hasattr(callback, '_dinfo')))):
             streams.append(callback)
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -459,8 +459,7 @@ class Callable(param.Parameterized):
     """
 
     callable = param.Callable(default=None, constant=True, doc="""
-         The callable function being wrapped.""",
-        **{'allow_refs': False} if util.param_version > util.Version('2.0.0rc1') else {})
+         The callable function being wrapped.""", **util.disallow_refs)
 
     inputs = param.List(default=[], constant=True, doc="""
          The list of inputs the callable function is wrapping. Used

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -459,7 +459,8 @@ class Callable(param.Parameterized):
     """
 
     callable = param.Callable(default=None, constant=True, doc="""
-         The callable function being wrapped.""")
+         The callable function being wrapped.""",
+        **{'allow_refs': False} if util.param_version > util.Version('2.0.0rc1') else {})
 
     inputs = param.List(default=[], constant=True, doc="""
          The list of inputs the callable function is wrapping. Used

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -43,6 +43,8 @@ masked_types = ()
 
 anonymous_dimension_label = '_'
 
+disallow_refs = {'allow_refs': False} if param_version > Version('2.0.0rc1') else {}
+
 # Argspec was removed in Python 3.11
 ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
 
@@ -1617,7 +1619,10 @@ def resolve_dependent_value(value):
         from panel.depends import param_value_if_widget
         from panel.widgets import RangeSlider
         range_widget = isinstance(value, RangeSlider)
-        value = param_value_if_widget(value)
+        if param_version > Version('2.0.0rc1'):
+            value = param.parameterized.resolve_value(value)
+        else:
+            value = param_value_if_widget(value)
 
     if is_param_method(value, has_deps=True):
         value = value()

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -681,7 +681,7 @@ class Params(Stream):
 
     parameterized = param.ClassSelector(class_=(param.Parameterized,
                                                 param.parameterized.ParameterizedMetaclass),
-                                        constant=True, allow_None=True, doc="""
+                                        constant=True, allow_refs=False, allow_None=True, doc="""
         Parameterized instance to watch for parameter changes.""")
 
     parameters = param.List(default=[], constant=True, doc="""

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -681,8 +681,9 @@ class Params(Stream):
 
     parameterized = param.ClassSelector(class_=(param.Parameterized,
                                                 param.parameterized.ParameterizedMetaclass),
-                                        constant=True, allow_refs=False, allow_None=True, doc="""
-        Parameterized instance to watch for parameter changes.""")
+                                        constant=True, allow_None=True, doc="""
+        Parameterized instance to watch for parameter changes.""",
+        **{'allow_refs': False} if util.param_version > util.Version('2.0.0rc1') else {})
 
     parameters = param.List(default=[], constant=True, doc="""
         Parameters on the parameterized to watch.""")

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -50,10 +50,10 @@ def streams_list_from_dict(streams):
     params = {}
     for k, v in streams.items():
         if 'panel' in sys.modules:
-            from panel.depends import param_value_if_widget
             if util.param_version > util.Version('2.0.0rc1'):
-                v = param.parameterized.resolve_value(v)
+                v = param.parameterized.transform_reference(v)
             else:
+                from panel.depends import param_value_if_widget
                 v = param_value_if_widget(v)
         if isinstance(v, param.Parameter) and v.owner is not None:
             params[k] = v
@@ -682,8 +682,7 @@ class Params(Stream):
     parameterized = param.ClassSelector(class_=(param.Parameterized,
                                                 param.parameterized.ParameterizedMetaclass),
                                         constant=True, allow_None=True, doc="""
-        Parameterized instance to watch for parameter changes.""",
-        **{'allow_refs': False} if util.param_version > util.Version('2.0.0rc1') else {})
+        Parameterized instance to watch for parameter changes.""", **util.disallow_refs)
 
     parameters = param.List(default=[], constant=True, doc="""
         Parameters on the parameterized to watch.""")

--- a/holoviews/tests/util/test_transform.py
+++ b/holoviews/tests/util/test_transform.py
@@ -481,7 +481,7 @@ class TestDimTransforms(ComparisonTestCase):
         with warnings.catch_warnings():
             # The kwargs is {'axis': None} and is already handled by the code.
             # This context manager can be removed, when it raises an TypeError instead of warning.
-            warnings.simplefilter("ignore", "Passing additional kwargs to Rolling.mean")
+            warnings.filterwarnings("ignore", "Passing additional kwargs to Rolling.mean")
             self.assert_apply(expr, self.linear_ints.rolling(1).mean())
 
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -885,7 +885,7 @@ class Dynamic(param.ParameterizedFunction):
         Whether the cloned DynamicMap will share the same cache.""")
 
     streams = param.ClassSelector(default=[], class_=(list, dict), doc="""
-        List of streams to attach to the returned DynamicMap""")
+        List of streams to attach to the returned DynamicMap""", **util.disallow_refs)
 
     def __call__(self, map_obj, **params):
         watch = params.pop('watch', True)


### PR DESCRIPTION
Avoids various warnings when working with Param 2.0