### PR TITLE
Use contourpy for contour calculations

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -645,25 +645,26 @@ class contours(Operation):
             for lower_level, upper_level in zip(levels[:-1], levels[1:]):
                 filled = cont_gen.filled(lower_level, upper_level)
                 # Only have to consider last index 0 as we are using contourpy without chunking
-                points = filled[0][0]
+                if (points := filled[0][0]) is None:
+                    continue
+
                 exteriors = []
                 interiors = []
-                if points is not None:
-                    if any(data_is_datetime[0:2]):
-                        points = points_to_datetime(points)
+                if any(data_is_datetime[0:2]):
+                    points = points_to_datetime(points)
 
-                    offsets = filled[1][0]
-                    outer_offsets = filled[2][0]
+                offsets = filled[1][0]
+                outer_offsets = filled[2][0]
 
-                    # Loop through exterior polygon boundaries.
-                    for jstart, jend in zip(outer_offsets[:-1], outer_offsets[1:]):
-                        if exteriors:
-                            exteriors.append(empty)
-                        exteriors.append(points[offsets[jstart]:offsets[jstart + 1]])
+                # Loop through exterior polygon boundaries.
+                for jstart, jend in zip(outer_offsets[:-1], outer_offsets[1:]):
+                    if exteriors:
+                        exteriors.append(empty)
+                    exteriors.append(points[offsets[jstart]:offsets[jstart + 1]])
 
-                        # Loop over the (jend-jstart-1) interior boundaries.
-                        interior = [points[offsets[j]:offsets[j + 1]] for j in range(jstart+1, jend)]
-                        interiors.append(interior)
+                    # Loop over the (jend-jstart-1) interior boundaries.
+                    interior = [points[offsets[j]:offsets[j + 1]] for j in range(jstart+1, jend)]
+                    interiors.append(interior)
                 level = (lower_level + upper_level) / 2
                 geom = {
                     element.vdims[0].name:
@@ -677,16 +678,17 @@ class contours(Operation):
             for level in levels:
                 lines = cont_gen.lines(level)
                 # Only have to consider last index 0 as we are using contourpy without chunking
-                points = lines[0][0]
-                if points is not None:
-                    if any(data_is_datetime[0:2]):
-                        points = points_to_datetime(points)
+                if (points := lines[0][0]) is None:
+                    continue
 
-                    offsets = lines[1][0]
-                    if offsets is not None and len(offsets) > 2:
-                        # Casting offsets to int64 to avoid possible numpy UFuncOutputCastingError
-                        offsets = offsets[1:-1].astype(np.int64)
-                        points = np.insert(points, offsets, np.nan, axis=0)
+                if any(data_is_datetime[0:2]):
+                    points = points_to_datetime(points)
+
+                offsets = lines[1][0]
+                if offsets is not None and len(offsets) > 2:
+                    # Casting offsets to int64 to avoid possible numpy UFuncOutputCastingError
+                    offsets = offsets[1:-1].astype(np.int64)
+                    points = np.insert(points, offsets, np.nan, axis=0)
                 geom = {
                     element.vdims[0].name:
                     num2date(level) if data_is_datetime[2] else level,

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -561,7 +561,7 @@ class contours(Operation):
 
     def _process(self, element, key=None):
         try:
-            from contourpy import contour_generator, FillType, LineType
+            from contourpy import FillType, LineType, contour_generator
         except ImportError:
             raise ImportError("contours operation requires contourpy.")
 
@@ -588,7 +588,7 @@ class contours(Operation):
                                    "for filled contour calculations.")
 
             try:
-                from matplotlib.dates import num2date, date2num
+                from matplotlib.dates import date2num, num2date
             except ImportError:
                 raise ImportError("contours operation using datetimes requires matplotlib.") from None
 

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -596,6 +596,7 @@ class contours(Operation):
                 contours = contour_type([], [xdim, ydim], vdims)
                 return (element * contours) if self.p.overlaid else contours
             else:
+                # The +1 is consistent with Matplotlib's use of MaxNLocator for contours.
                 locator = MaxNLocator(levels + 1)
                 levels = locator.tick_values(zmin, zmax)
         else:

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -573,6 +573,9 @@ class contours(Operation):
         # if any data is a datetime, transform to matplotlib's numerical format
         data_is_datetime = tuple(isdatetime(arr) for k, arr in enumerate(data))
         if any(data_is_datetime):
+            if any(data_is_datetime[:2]) and self.p.filled:
+                raise RuntimeError("Datetime spatial coordinates are not supported "
+                                   "for filled contour calculations.")
             data = tuple(
                 date2num(d) if is_datetime else d
                 for d, is_datetime in zip(data, data_is_datetime)

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -546,11 +546,6 @@ class contours(Operation):
 
     def _process(self, element, key=None):
         try:
-            from matplotlib.dates import num2date, date2num
-        except ImportError:
-            raise ImportError("contours operation requires matplotlib.")
-
-        try:
             from contourpy import contour_generator, FillType, LineType
         except ImportError:
             raise ImportError("contours operation requires contourpy.")
@@ -576,6 +571,11 @@ class contours(Operation):
             if any(data_is_datetime[:2]) and self.p.filled:
                 raise RuntimeError("Datetime spatial coordinates are not supported "
                                    "for filled contour calculations.")
+            try:
+                from matplotlib.dates import num2date, date2num
+            except ImportError:
+                raise ImportError("contours operation using datetimes requires matplotlib.")
+
             data = tuple(
                 date2num(d) if is_datetime else d
                 for d, is_datetime in zip(data, data_is_datetime)

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -545,13 +545,15 @@ class contours(Operation):
 
     def _process(self, element, key=None):
         try:
-            from matplotlib.contour import QuadContourSet
-            from matplotlib.axes import Axes
-            from matplotlib.figure import Figure
             from matplotlib.dates import num2date, date2num
+            from matplotlib.ticker import MaxNLocator
         except ImportError:
             raise ImportError("contours operation requires matplotlib.")
-        extent = element.range(0) + element.range(1)[::-1]
+
+        try:
+            from contourpy import contour_generator, FillType, LineType
+        except ImportError:
+            raise ImportError("contours operation requires contourpy.")
 
         xs = element.dimension_values(0, True, flat=False)
         ys = element.dimension_values(1, True, flat=False)
@@ -583,61 +585,99 @@ class contours(Operation):
             contour_type = Contours
         vdims = element.vdims[:1]
 
-        kwargs = {}
         levels = self.p.levels
         zmin, zmax = element.range(2)
-        if isinstance(self.p.levels, int):
+        if isinstance(levels, int):
             if zmin == zmax:
                 contours = contour_type([], [xdim, ydim], vdims)
                 return (element * contours) if self.p.overlaid else contours
-            data += (levels,)
+            else:
+                locator = MaxNLocator(levels)
+                levels = locator.tick_values(zmin, zmax)
         else:
-            kwargs = {'levels': levels}
+            levels = np.array(levels)
 
-        fig = Figure()
-        ax = Axes(fig, [0, 0, 1, 1])
-        contour_set = QuadContourSet(ax, *data, filled=self.p.filled,
-                                     extent=extent, **kwargs)
-        levels = np.array(contour_set.get_array())
+        if data_is_datetime[2]:
+            levels = date2num(levels)
+            # Should check isdatetime(levels) too?
+
         crange = levels.min(), levels.max()
         if self.p.filled:
-            levels = levels[:-1] + np.diff(levels)/2.
             vdims = [vdims[0].clone(range=crange)]
 
+        cont_gen = contour_generator(
+            *data,
+            line_type=LineType.ChunkCombinedOffset,
+            fill_type=FillType.ChunkCombinedOffsetOffset,
+        )
+
+        def points_to_datetime(points):
+            # transform x/y coordinates back to datetimes
+            xs, ys = np.split(points, 2, axis=1)
+            if data_is_datetime[0]:
+                xs = np.array(num2date(xs))
+            if data_is_datetime[1]:
+                ys = np.array(num2date(ys))
+            return np.concatenate((xs, ys), axis=1)
+
         paths = []
-        empty = np.array([[np.nan, np.nan]])
-        for level, cset in zip(levels, contour_set.collections):
-            exteriors = []
-            interiors = []
-            for geom in cset.get_paths():
-                interior = []
-                polys = geom.to_polygons(closed_only=False)
-                for ncp, cp in enumerate(polys):
-                    if any(data_is_datetime[0:2]):
-                        # transform x/y coordinates back to datetimes
-                        xs, ys = np.split(cp, 2, axis=1)
-                        if data_is_datetime[0]:
-                            xs = np.array(num2date(xs))
-                        if data_is_datetime[1]:
-                            ys = np.array(num2date(ys))
-                        cp = np.concatenate((xs, ys), axis=1)
-                    if ncp == 0:
-                        exteriors.append(cp)
+        if self.p.filled:
+            empty = np.array([[np.nan, np.nan]])
+            for lower_level, upper_level in zip(levels[:-1], levels[1:]):
+                filled = cont_gen.filled(lower_level, upper_level)
+                # Only have to consider last index 0 as we are using contourpy without chunking
+                if (points := filled[0][0]) is None:
+                    continue
+
+                if any(data_is_datetime[0:2]):
+                    points = points_to_datetime(points)
+
+                offsets = filled[1][0]
+                outer_offsets = filled[2][0]
+                exteriors = []
+                interiors = []
+                for i in range(len(outer_offsets)-1):  # Loop through exterior boundaries
+                    jstart = outer_offsets[i]  # Start boundary index
+                    jend = outer_offsets[i+1]  # End boundary index
+                    if exteriors:
                         exteriors.append(empty)
-                    else:
-                        interior.append(cp)
-                if len(polys):
+                    exteriors.append(points[offsets[jstart]:offsets[jstart + 1]])
+
+                    # Loop over the (jend-jstart-1) interior boundaries,
+                    interior = [points[offsets[j]:offsets[j + 1]] for j in range(jstart+1, jend)]
                     interiors.append(interior)
-            if not exteriors:
-                continue
-            geom = {
-                element.vdims[0].name:
-                num2date(level) if data_is_datetime[2] else level,
-                (xdim, ydim): np.concatenate(exteriors[:-1])
-            }
-            if self.p.filled and interiors:
-                geom['holes'] = interiors
-            paths.append(geom)
+                level = (lower_level + upper_level) / 2
+                geom = {
+                    element.vdims[0].name:
+                    num2date(level) if data_is_datetime[2] else level,
+                    (xdim, ydim): np.concatenate(exteriors) if exteriors else [],
+                }
+                if interiors:
+                    geom['holes'] = interiors
+                paths.append(geom)
+        else:
+            for level in levels:
+                lines = cont_gen.lines(level)
+                # Only have to consider last index 0 as we are using contourpy without chunking
+                if (points := lines[0][0]) is None:
+                    continue
+
+                if any(data_is_datetime[0:2]):
+                    points = points_to_datetime(points)
+
+                offsets = lines[1][0]
+                if len(offsets) > 2:
+                    # Casting offsets to int64 to avoid possible numpy UFuncOutputCastingError
+                    offsets = offsets[1:-1].astype(np.int64)
+                    nan_separated_points = np.insert(points, offsets, np.nan, axis=0)
+                else:
+                    nan_separated_points = points
+                geom = {
+                    element.vdims[0].name:
+                    num2date(level) if data_is_datetime[2] else level,
+                    (xdim, ydim): nan_separated_points,
+                }
+                paths.append(geom)
         contours = contour_type(paths, label=element.label, kdims=element.kdims, vdims=vdims)
         if self.p.overlaid:
             contours = element * contours

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -571,6 +571,7 @@ class contours(Operation):
             if any(data_is_datetime[:2]) and self.p.filled:
                 raise RuntimeError("Datetime spatial coordinates are not supported "
                                    "for filled contour calculations.")
+
             try:
                 from matplotlib.dates import num2date, date2num
             except ImportError:
@@ -602,7 +603,6 @@ class contours(Operation):
 
         if data_is_datetime[2]:
             levels = date2num(levels)
-            # Should check isdatetime(levels) too?
 
         crange = levels.min(), levels.max()
         if self.p.filled:
@@ -639,14 +639,14 @@ class contours(Operation):
                 outer_offsets = filled[2][0]
                 exteriors = []
                 interiors = []
-                for i in range(len(outer_offsets)-1):  # Loop through exterior boundaries
-                    jstart = outer_offsets[i]  # Start boundary index
-                    jend = outer_offsets[i+1]  # End boundary index
+
+                # Loop through exterior polygon boundaries.
+                for jstart, jend in zip(outer_offsets[:-1], outer_offsets[1:]):
                     if exteriors:
                         exteriors.append(empty)
                     exteriors.append(points[offsets[jstart]:offsets[jstart + 1]])
 
-                    # Loop over the (jend-jstart-1) interior boundaries,
+                    # Loop over the (jend-jstart-1) interior boundaries.
                     interior = [points[offsets[j]:offsets[j + 1]] for j in range(jstart+1, jend)]
                     interiors.append(interior)
                 level = (lower_level + upper_level) / 2

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -575,7 +575,7 @@ class contours(Operation):
             try:
                 from matplotlib.dates import num2date, date2num
             except ImportError:
-                raise ImportError("contours operation using datetimes requires matplotlib.")
+                raise ImportError("contours operation using datetimes requires matplotlib.") from None
 
             data = tuple(
                 date2num(d) if is_datetime else d

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -596,7 +596,7 @@ class contours(Operation):
                 contours = contour_type([], [xdim, ydim], vdims)
                 return (element * contours) if self.p.overlaid else contours
             else:
-                locator = MaxNLocator(levels)
+                locator = MaxNLocator(levels + 1)
                 levels = locator.tick_values(zmin, zmax)
         else:
             levels = np.array(levels)

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -23,6 +23,7 @@ from ..element.raster import Image, RGB
 from ..element.path import Contours, Polygons
 from ..element.util import categorical_aggregate2d # noqa (API import)
 from ..streams import RangeXY
+from ..util.locator import MaxNLocator
 
 column_interfaces = [ArrayInterface, DictInterface, PandasInterface]
 
@@ -546,7 +547,6 @@ class contours(Operation):
     def _process(self, element, key=None):
         try:
             from matplotlib.dates import num2date, date2num
-            from matplotlib.ticker import MaxNLocator
         except ImportError:
             raise ImportError("contours operation requires matplotlib.")
 

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -277,12 +277,11 @@ class OperationTests(ComparisonTestCase):
         self.assertEqual(op_contours, polys)
 
     def test_image_contours_filled_auto_levels(self):
-        z = np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]])
+        z = np.array([[0, 1, 0], [3, 4, 5], [6, 7, 8]])
         img = Image(z)
         for nlevels in range(3, 20):
             op_contours = contours(img, filled=True, levels=nlevels)
             levels = [item['z'] for item in op_contours.data]
-            print(nlevels, len(levels), levels)
             assert len(levels) <= nlevels + 1
             delta = 0.5*(levels[1] - levels[0])
             assert np.min(levels) <= z.min() + delta
@@ -293,7 +292,7 @@ class OperationTests(ComparisonTestCase):
         y = np.array([6, 7])
         z = np.array([[0, 2, 0], [0, 2, 0]])
         img = Image((x, y, z))
-        msg = 'Datetime spatial coordinates are not supported for filled contour calculations.'
+        msg = r'Datetime spatial coordinates are not supported for filled contour calculations.'
         with pytest.raises(RuntimeError, match=msg):
             _ = contours(img, filled=True, levels=[0.5, 1.5])
 

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -107,10 +107,12 @@ class OperationTests(ComparisonTestCase):
         z = np.array([[0, 1], [1, 2]])
         img = Image((x, y, z))
         op_contours = contours(img, levels=[0.5])
-        contour = Contours([[(dt.datetime(2023, 9, 1), 14.5, 0.5),
-                             (dt.datetime(2023, 9, 1, 12), 14.0, 0.5)]],
-                            vdims=img.vdims)
-        self.assertEqual(op_contours, contour)
+        expected_x = np.array([dt.datetime(2023, 9, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2023, 9, 1, 12, tzinfo=dt.timezone.utc)],
+                              dtype=object)
+        np.testing.assert_array_equal(op_contours.dimension_values('x'), expected_x)
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('y'), [14.5, 14.0])
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('z'), [0.5, 0.5])
 
     def test_image_contours_y_datetime(self):
         x = [14, 15]
@@ -118,18 +120,39 @@ class OperationTests(ComparisonTestCase):
         z = np.array([[0, 1], [1, 2]])
         img = Image((x, y, z))
         op_contours = contours(img, levels=[0.5])
-        contour = Contours([[(14.0, dt.datetime(2023, 9, 1, 12), 0.5),
-                             (14.5, dt.datetime(2023, 9, 1), 0.5)]],
-                            vdims=img.vdims)
-        self.assertEqual(op_contours, contour)
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('x'), [14.0, 14.5])
+        expected_y = np.array([dt.datetime(2023, 9, 1, 12, tzinfo=dt.timezone.utc),
+                               dt.datetime(2023, 9, 1, tzinfo=dt.timezone.utc)],
+                              dtype=object)
+        np.testing.assert_array_equal(op_contours.dimension_values('y'), expected_y)
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('z'), [0.5, 0.5])
+
+    def test_image_contours_xy_datetime(self):
+        x = np.array(['2023-09-01', '2023-09-02'], dtype='datetime64')
+        y = np.array(['2023-10-07', '2023-10-08'], dtype='datetime64')
+        z = np.array([[0, 1], [1, 2]])
+        img = Image((x, y, z))
+        op_contours = contours(img, levels=[0.5])
+        expected_x = np.array([dt.datetime(2023, 9, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2023, 9, 1, 12, tzinfo=dt.timezone.utc)],
+                              dtype=object)
+        np.testing.assert_array_equal(op_contours.dimension_values('x'), expected_x)
+        expected_y = np.array([dt.datetime(2023, 10, 7, 12, tzinfo=dt.timezone.utc),
+                               dt.datetime(2023, 10, 7, tzinfo=dt.timezone.utc)],
+                              dtype=object)
+        np.testing.assert_array_equal(op_contours.dimension_values('y'), expected_y)
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('z'), [0.5, 0.5])
 
     def test_image_contours_z_datetime(self):
         z = np.array([['2023-09-10', '2023-09-10'], ['2023-09-10', '2023-09-12']], dtype='datetime64')
         img = Image(z)
         op_contours = contours(img, levels=[np.datetime64('2023-09-11')])
-        contour = Contours([[(0.25, 0, 0.5), (0.0, -0.25, 0.5)]],
-                            vdims=img.vdims)
-        self.assertEqual(op_contours, contour)
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('x'), [0.25, 0.0])
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('y'), [0.0, -0.25])
+        expected_z = np.array([dt.datetime(2023, 9, 11, tzinfo=dt.timezone.utc),
+                               dt.datetime(2023, 9, 11, tzinfo=dt.timezone.utc)],
+                              dtype=object)
+        np.testing.assert_array_equal(op_contours.dimension_values('z'), expected_z)
 
     def test_qmesh_contours(self):
         qmesh = QuadMesh(([0, 1, 2], [1, 2, 3], np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]])))
@@ -182,6 +205,11 @@ class OperationTests(ComparisonTestCase):
         op_contours = contours(img, filled=True, levels=[20.0, 23.0])
         polys = Polygons(None, vdims=img.vdims[0].clone(range=(20.0, 23.0)))
         self.assertEqual(op_contours, polys)
+
+
+
+    # dates on x, y, and xy ...
+
 
 
 

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -107,7 +107,7 @@ class OperationTests(ComparisonTestCase):
         img = Image(np.array([[0, 1, 0], [0, 1, 0]]))
         # Contour level outside of data limits
         op_contours = contours(img, levels=[23.0])
-        contour = Contours([[]], vdims=img.vdims)
+        contour = Contours([], vdims=img.vdims)
         self.assertEqual(op_contours, contour)
 
     def test_image_contours_auto_levels(self):
@@ -118,7 +118,7 @@ class OperationTests(ComparisonTestCase):
             levels = [item['z'] for item in op_contours.data]
             assert len(levels) <= nlevels + 2
             assert np.min(levels) <= z.min()
-            assert np.max(levels) >= z.max()
+            assert np.max(levels) < z.max()
 
     def test_image_contours_no_range(self):
         img = Image(np.zeros((2, 2)))
@@ -293,7 +293,7 @@ class OperationTests(ComparisonTestCase):
         img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
         # Contour level outside of data limits
         op_contours = contours(img, filled=True, levels=[20.0, 23.0])
-        polys = Polygons([[]], vdims=img.vdims[0].clone(range=(20.0, 23.0)))
+        polys = Polygons([], vdims=img.vdims[0].clone(range=(20.0, 23.0)))
         self.assertEqual(op_contours, polys)
 
     def test_image_contours_filled_auto_levels(self):

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -192,12 +192,16 @@ class OperationTests(ComparisonTestCase):
         self.assertEqual(op_contours, contour)
 
     def test_image_contours_filled(self):
-        img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
-        op_contours = contours(img, filled=True, levels=[2, 2.5])
-        data = [[(-0.333333, 0.111111, 2.25), (-0.333333, 0.055556, 2.25), (0., 0.166667, 2.25),
-                 (0.333333, 0.166667, 2.25), (0.333333, 0.2, 2.25), (0., 0.222222, 2.25), (-0.333333, 0.111111, 2.25)]]
-        polys = Polygons(data, vdims=img.vdims[0].clone(range=(2, 2.5)))
+        img = Image(np.array([[0, 0, 0], [0, 1, 0.], [0, 0, 0]]))
+        # Single polygon with hole
+        op_contours = contours(img, filled=True, levels=[0.25, 0.75])
+        data = [[(-0.25, 0.0, 0.5), (0.0, -0.25, 0.5), (0.25, 0.0, 0.5), (0.0, 0.25, 0.5),
+                  (-0.25, 0.0, 0.5)]]
+        polys = Polygons(data, vdims=img.vdims[0].clone(range=(0.25, 0.75)))
         self.assertEqual(op_contours, polys)
+        expected_holes = [[[np.array([[0.0, -0.08333333], [-0.08333333, 0.0], [0.0,  0.08333333],
+                                      [0.08333333, 0.0], [0.0, -0.08333333]])]]]
+        np.testing.assert_array_almost_equal(op_contours.holes(), expected_holes)
 
     def test_image_contours_filled_empty(self):
         img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
@@ -206,13 +210,14 @@ class OperationTests(ComparisonTestCase):
         polys = Polygons(None, vdims=img.vdims[0].clone(range=(20.0, 23.0)))
         self.assertEqual(op_contours, polys)
 
-
-
-    # dates on x, y, and xy ...
-
-
-
-
+    def test_image_contours_filled_xy_datetime(self):
+        x = np.array(['2023-09-01', '2023-09-02', '2023-09-03'], dtype='datetime64')
+        y = np.array(['2023-10-07', '2023-10-08', '2023-10-09'], dtype='datetime64')
+        z = np.array([[0, 0, 0], [0, 1, 0.], [0, 0, 0]])
+        img = Image((x, y, z))
+        msg = 'Datetime spatial coordinates are not supported for filled contour calculations.'
+        with pytest.raises(RuntimeError, match=msg):
+            _ = contours(img, filled=True, levels=[0.5, 2.0])
 
     def test_points_histogram(self):
         points = Points([float(i) for i in range(10)])

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -74,16 +74,17 @@ class OperationTests(ComparisonTestCase):
         self.assertEqual(op_img, img.clone(np.array([[3.162278, 3.162278], [3.162278, 3.162278]]), group='Gradient'))
 
     def test_image_contours(self):
-        img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
+        img = Image(np.array([[0, 1, 0], [0, 1, 0]]))
         op_contours = contours(img, levels=[0.5])
-        contour = Contours([[(-0.166667,  0.333333, 0.5), (-0.333333, 0.277778, 0.5),
-                             (np.nan, np.nan, 0.5), (0.333333, 0.3, 0.5),
-                             (0.166667, 0.333333, 0.5)]],
+        # Note multiple lines which are nan-separated.
+        contour = Contours([[(-0.166667, 0.25, 0.5), (-0.1666667, -0.25, 0.5),
+                             (np.nan, np.nan, 0.5), (0.1666667, -0.25, 0.5),
+                             (0.1666667, 0.25, 0.5)]],
                             vdims=img.vdims)
         self.assertEqual(op_contours, contour)
 
     def test_image_contours_empty(self):
-        img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
+        img = Image(np.array([[0, 1, 0], [0, 1, 0]]))
         # Contour level outside of data limits
         op_contours = contours(img, levels=[23.0])
         contour = Contours(None, vdims=img.vdims)
@@ -102,46 +103,81 @@ class OperationTests(ComparisonTestCase):
         self.assertEqual(op_contours, contour)
 
     def test_image_contours_x_datetime(self):
-        x = np.array(['2023-09-01', '2023-09-02'], dtype='datetime64')
+        x = np.array(['2023-09-01', '2023-09-03', '2023-09-05'], dtype='datetime64')
         y = [14, 15]
-        z = np.array([[0, 1], [1, 2]])
+        z = np.array([[0, 1, 0], [0, 1, 0]])
         img = Image((x, y, z))
         op_contours = contours(img, levels=[0.5])
-        expected_x = np.array([dt.datetime(2023, 9, 1, tzinfo=dt.timezone.utc),
-                               dt.datetime(2023, 9, 1, 12, tzinfo=dt.timezone.utc)],
-                              dtype=object)
-        np.testing.assert_array_equal(op_contours.dimension_values('x'), expected_x)
-        np.testing.assert_array_almost_equal(op_contours.dimension_values('y'), [14.5, 14.0])
-        np.testing.assert_array_almost_equal(op_contours.dimension_values('z'), [0.5, 0.5])
+        # Note multiple lines which are nan-separated.
+        tz = dt.timezone.utc
+        expected_x = np.array(
+            [dt.datetime(2023, 9, 2, tzinfo=tz), dt.datetime(2023, 9, 2, tzinfo=tz), np.nan,
+             dt.datetime(2023, 9, 4, tzinfo=tz), dt.datetime(2023, 9, 4, tzinfo=tz)],
+            dtype=object)
+
+        # Separately compare nans and datetimes
+        x = op_contours.dimension_values('x')
+        mask = np.array([True, True, False, True, True])  # Mask ignoring nans
+        np.testing.assert_array_equal(x[mask], expected_x[mask])
+        np.testing.assert_array_equal(x[~mask].astype(float), expected_x[~mask].astype(float))
+
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('y').astype(float),
+                                             [15, 14, np.nan, 14, 15])
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('z'), [0.5]*5)
 
     def test_image_contours_y_datetime(self):
-        x = [14, 15]
-        y = np.array(['2023-09-01', '2023-09-02'], dtype='datetime64')
-        z = np.array([[0, 1], [1, 2]])
+        x = [14, 15, 16]
+        y = np.array(['2023-09-01', '2023-09-03'], dtype='datetime64')
+        z = np.array([[0, 1, 0], [0, 1, 0]])
         img = Image((x, y, z))
         op_contours = contours(img, levels=[0.5])
-        np.testing.assert_array_almost_equal(op_contours.dimension_values('x'), [14.0, 14.5])
-        expected_y = np.array([dt.datetime(2023, 9, 1, 12, tzinfo=dt.timezone.utc),
-                               dt.datetime(2023, 9, 1, tzinfo=dt.timezone.utc)],
-                              dtype=object)
-        np.testing.assert_array_equal(op_contours.dimension_values('y'), expected_y)
-        np.testing.assert_array_almost_equal(op_contours.dimension_values('z'), [0.5, 0.5])
+        # Note multiple lines which are nan-separated.
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('x').astype(float),
+                                             [14.5, 14.5, np.nan, 15.5, 15.5])
+
+        tz = dt.timezone.utc
+        expected_y = np.array(
+            [dt.datetime(2023, 9, 3, tzinfo=tz), dt.datetime(2023, 9, 1, tzinfo=tz), np.nan,
+             dt.datetime(2023, 9, 1, tzinfo=tz), dt.datetime(2023, 9, 3, tzinfo=tz)],
+            dtype=object)
+
+        # Separately compare nans and datetimes
+        y = op_contours.dimension_values('y')
+        mask = np.array([True, True, False, True, True])  # Mask ignoring nans
+        np.testing.assert_array_equal(y[mask], expected_y[mask])
+        np.testing.assert_array_equal(y[~mask].astype(float), expected_y[~mask].astype(float))
+
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('z'), [0.5]*5)
 
     def test_image_contours_xy_datetime(self):
-        x = np.array(['2023-09-01', '2023-09-02'], dtype='datetime64')
+        x = np.array(['2023-09-01', '2023-09-03', '2023-09-05'], dtype='datetime64')
         y = np.array(['2023-10-07', '2023-10-08'], dtype='datetime64')
-        z = np.array([[0, 1], [1, 2]])
+        z = np.array([[0, 1, 0], [0, 1, 0]])
         img = Image((x, y, z))
         op_contours = contours(img, levels=[0.5])
-        expected_x = np.array([dt.datetime(2023, 9, 1, tzinfo=dt.timezone.utc),
-                               dt.datetime(2023, 9, 1, 12, tzinfo=dt.timezone.utc)],
-                              dtype=object)
-        np.testing.assert_array_equal(op_contours.dimension_values('x'), expected_x)
-        expected_y = np.array([dt.datetime(2023, 10, 7, 12, tzinfo=dt.timezone.utc),
-                               dt.datetime(2023, 10, 7, tzinfo=dt.timezone.utc)],
-                              dtype=object)
-        np.testing.assert_array_equal(op_contours.dimension_values('y'), expected_y)
-        np.testing.assert_array_almost_equal(op_contours.dimension_values('z'), [0.5, 0.5])
+        # Note multiple lines which are nan-separated.
+
+        tz = dt.timezone.utc
+        expected_x = np.array(
+            [dt.datetime(2023, 9, 2, tzinfo=tz), dt.datetime(2023, 9, 2, tzinfo=tz), np.nan,
+             dt.datetime(2023, 9, 4, tzinfo=tz), dt.datetime(2023, 9, 4, tzinfo=tz)],
+            dtype=object)
+        expected_y = np.array(
+            [dt.datetime(2023, 10, 8, tzinfo=tz), dt.datetime(2023, 10, 7, tzinfo=tz), np.nan,
+             dt.datetime(2023, 10, 7, tzinfo=tz), dt.datetime(2023, 10, 8, tzinfo=tz)],
+            dtype=object)
+
+        # Separately compare nans and datetimes
+        x = op_contours.dimension_values('x')
+        mask = np.array([True, True, False, True, True])  # Mask ignoring nans
+        np.testing.assert_array_equal(x[mask], expected_x[mask])
+        np.testing.assert_array_equal(x[~mask].astype(float), expected_x[~mask].astype(float))
+
+        y = op_contours.dimension_values('y')
+        np.testing.assert_array_equal(y[mask], expected_y[mask])
+        np.testing.assert_array_equal(y[~mask].astype(float), expected_y[~mask].astype(float))
+
+        np.testing.assert_array_almost_equal(op_contours.dimension_values('z'), [0.5]*5)
 
     def test_image_contours_z_datetime(self):
         z = np.array([['2023-09-10', '2023-09-10'], ['2023-09-10', '2023-09-12']], dtype='datetime64')
@@ -149,9 +185,9 @@ class OperationTests(ComparisonTestCase):
         op_contours = contours(img, levels=[np.datetime64('2023-09-11')])
         np.testing.assert_array_almost_equal(op_contours.dimension_values('x'), [0.25, 0.0])
         np.testing.assert_array_almost_equal(op_contours.dimension_values('y'), [0.0, -0.25])
-        expected_z = np.array([dt.datetime(2023, 9, 11, tzinfo=dt.timezone.utc),
-                               dt.datetime(2023, 9, 11, tzinfo=dt.timezone.utc)],
-                              dtype=object)
+        expected_z = np.array([
+            dt.datetime(2023, 9, 11, 0, 0, tzinfo=dt.timezone.utc),
+            dt.datetime(2023, 9, 11, 0, 0, tzinfo=dt.timezone.utc)], dtype=object)
         np.testing.assert_array_equal(op_contours.dimension_values('z'), expected_z)
 
     def test_qmesh_contours(self):
@@ -192,6 +228,16 @@ class OperationTests(ComparisonTestCase):
         self.assertEqual(op_contours, contour)
 
     def test_image_contours_filled(self):
+        img = Image(np.array([[0, 2, 0], [0, 2, 0]]))
+        # Two polygons (nan-separated) without holes
+        op_contours = contours(img, filled=True, levels=[0.5, 1.5])
+        data = [[(-0.25, -0.25, 1), (-0.08333333, -0.25, 1), (-0.08333333, 0.25, 1),
+                 (-0.25, 0.25, 1), (-0.25, -0.25, 1), (np.nan, np.nan, 1), (0.08333333, -0.25, 1),
+                 (0.25, -0.25, 1), (0.25, 0.25, 1), (0.08333333, 0.25, 1), (0.08333333, -0.25, 1)]]
+        polys = Polygons(data, vdims=img.vdims[0].clone(range=(0.5, 1.5)))
+        self.assertEqual(op_contours, polys)
+
+    def test_image_contours_filled_with_hole(self):
         img = Image(np.array([[0, 0, 0], [0, 1, 0.], [0, 0, 0]]))
         # Single polygon with hole
         op_contours = contours(img, filled=True, levels=[0.25, 0.75])
@@ -203,6 +249,22 @@ class OperationTests(ComparisonTestCase):
                                       [0.08333333, 0.0], [0.0, -0.08333333]])]]]
         np.testing.assert_array_almost_equal(op_contours.holes(), expected_holes)
 
+    def test_image_contours_filled_multi_holes(self):
+        img = Image(np.array([[0, 0, 0, 0, 0], [0, 1, 0, 1, 0], [0, 0, 0, 0, 0]]))
+        # Single polygon with two holes
+        op_contours = contours(img, filled=True, levels=[-0.5, 0.5])
+        data = [[(-0.4, -0.3333333, 0), (-0.2, -0.3333333, 0), (0, -0.3333333, 0),
+                 (0.2, -0.3333333, 0), (0.4, -0.3333333, 0), (0.4, 0, 0), (0.4, 0.3333333, 0),
+                 (0.2, 0.3333333, 0), (0, 0.3333333, 0), (-0.2, 0.3333333, 0), (-0.4, 0.3333333, 0),
+                 (-0.4, 0, 0), (-0.4, -0.3333333, 0)]]
+        polys = Polygons(data, vdims=img.vdims[0].clone(range=(-0.5, 0.5)))
+        self.assertEqual(op_contours, polys)
+        expected_holes = [[[np.array([[-0.2, -0.16666667], [-0.3, 0], [-0.2, 0.16666667], [-0.1, 0],
+                                      [-0.2, -0.16666667]]),
+                            np.array([[0.2, -0.16666667], [0.1, 0], [0.2, 0.16666667], [0.3, 0],
+                                      [0.2, -0.16666667]])]]]
+        np.testing.assert_array_almost_equal(op_contours.holes(), expected_holes)
+
     def test_image_contours_filled_empty(self):
         img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
         # Contour level outside of data limits
@@ -210,14 +272,14 @@ class OperationTests(ComparisonTestCase):
         polys = Polygons(None, vdims=img.vdims[0].clone(range=(20.0, 23.0)))
         self.assertEqual(op_contours, polys)
 
-    def test_image_contours_filled_xy_datetime(self):
-        x = np.array(['2023-09-01', '2023-09-02', '2023-09-03'], dtype='datetime64')
-        y = np.array(['2023-10-07', '2023-10-08', '2023-10-09'], dtype='datetime64')
-        z = np.array([[0, 0, 0], [0, 1, 0.], [0, 0, 0]])
+    def test_image_contours_filled_x_datetime(self):
+        x = np.array(['2023-09-01', '2023-09-05', '2023-09-09'], dtype='datetime64')
+        y = np.array([6, 7])
+        z = np.array([[0, 2, 0], [0, 2, 0]])
         img = Image((x, y, z))
         msg = 'Datetime spatial coordinates are not supported for filled contour calculations.'
         with pytest.raises(RuntimeError, match=msg):
-            _ = contours(img, filled=True, levels=[0.5, 2.0])
+            _ = contours(img, filled=True, levels=[0.5, 1.5])
 
     def test_points_histogram(self):
         points = Points([float(i) for i in range(10)])

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -82,10 +82,53 @@ class OperationTests(ComparisonTestCase):
                             vdims=img.vdims)
         self.assertEqual(op_contours, contour)
 
+    def test_image_contours_empty(self):
+        img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
+        # Contour level outside of data limits
+        op_contours = contours(img, levels=[23.0])
+        contour = Contours(None, vdims=img.vdims)
+        self.assertEqual(op_contours, contour)
+
+    def test_image_contours_auto_levels(self):
+        img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
+        op_contours = contours(img)
+        levels = [item['z'] for item in op_contours.data]
+        self.assertEqual(levels, [0, 0.8, 1.6, 2.4, 3.2, 4, 4.8, 5.6, 6.4, 7.2])
+
     def test_image_contours_no_range(self):
         img = Image(np.zeros((2, 2)))
         op_contours = contours(img, levels=2)
         contour = Contours([], vdims=img.vdims)
+        self.assertEqual(op_contours, contour)
+
+    def test_image_contours_x_datetime(self):
+        x = np.array(['2023-09-01', '2023-09-02'], dtype='datetime64')
+        y = [14, 15]
+        z = np.array([[0, 1], [1, 2]])
+        img = Image((x, y, z))
+        op_contours = contours(img, levels=[0.5])
+        contour = Contours([[(dt.datetime(2023, 9, 1), 14.5, 0.5),
+                             (dt.datetime(2023, 9, 1, 12), 14.0, 0.5)]],
+                            vdims=img.vdims)
+        self.assertEqual(op_contours, contour)
+
+    def test_image_contours_y_datetime(self):
+        x = [14, 15]
+        y = np.array(['2023-09-01', '2023-09-02'], dtype='datetime64')
+        z = np.array([[0, 1], [1, 2]])
+        img = Image((x, y, z))
+        op_contours = contours(img, levels=[0.5])
+        contour = Contours([[(14.0, dt.datetime(2023, 9, 1, 12), 0.5),
+                             (14.5, dt.datetime(2023, 9, 1), 0.5)]],
+                            vdims=img.vdims)
+        self.assertEqual(op_contours, contour)
+
+    def test_image_contours_z_datetime(self):
+        z = np.array([['2023-09-10', '2023-09-10'], ['2023-09-10', '2023-09-12']], dtype='datetime64')
+        img = Image(z)
+        op_contours = contours(img, levels=[np.datetime64('2023-09-11')])
+        contour = Contours([[(0.25, 0, 0.5), (0.0, -0.25, 0.5)]],
+                            vdims=img.vdims)
         self.assertEqual(op_contours, contour)
 
     def test_qmesh_contours(self):
@@ -128,10 +171,20 @@ class OperationTests(ComparisonTestCase):
     def test_image_contours_filled(self):
         img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
         op_contours = contours(img, filled=True, levels=[2, 2.5])
-        data = [[(0., 0.166667, 2.25), (0.333333, 0.166667, 2.25), (0.333333, 0.2, 2.25), (0., 0.222222, 2.25),
-                 (-0.333333, 0.111111, 2.25), (-0.333333, 0.055556, 2.25), (0., 0.166667, 2.25)]]
+        data = [[(-0.333333, 0.111111, 2.25), (-0.333333, 0.055556, 2.25), (0., 0.166667, 2.25),
+                 (0.333333, 0.166667, 2.25), (0.333333, 0.2, 2.25), (0., 0.222222, 2.25), (-0.333333, 0.111111, 2.25)]]
         polys = Polygons(data, vdims=img.vdims[0].clone(range=(2, 2.5)))
         self.assertEqual(op_contours, polys)
+
+    def test_image_contours_filled_empty(self):
+        img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
+        # Contour level outside of data limits
+        op_contours = contours(img, filled=True, levels=[20.0, 23.0])
+        polys = Polygons(None, vdims=img.vdims[0].clone(range=(20.0, 23.0)))
+        self.assertEqual(op_contours, polys)
+
+
+
 
     def test_points_histogram(self):
         points = Points([float(i) for i in range(10)])

--- a/holoviews/tests/operation/test_statsoperations.py
+++ b/holoviews/tests/operation/test_statsoperations.py
@@ -61,7 +61,7 @@ class KDEOperationTests(ComparisonTestCase):
         kde = bivariate_kde(bivariate, n_samples=100, x_range=(0, 1),
                             y_range=(0, 1), contours=True, levels=10)
         self.assertIsInstance(kde, Contours)
-        self.assertEqual(len(kde.data), 9)
+        self.assertEqual(len(kde.data), 11)
 
     def test_bivariate_kde_contours_filled(self):
         np.random.seed(1)

--- a/holoviews/tests/operation/test_statsoperations.py
+++ b/holoviews/tests/operation/test_statsoperations.py
@@ -61,7 +61,7 @@ class KDEOperationTests(ComparisonTestCase):
         kde = bivariate_kde(bivariate, n_samples=100, x_range=(0, 1),
                             y_range=(0, 1), contours=True, levels=10)
         self.assertIsInstance(kde, Contours)
-        self.assertEqual(len(kde.data), 11)
+        self.assertEqual(len(kde.data), 9)
 
     def test_bivariate_kde_contours_filled(self):
         np.random.seed(1)

--- a/holoviews/tests/util/test_locator.py
+++ b/holoviews/tests/util/test_locator.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pytest
+
+from ...util.locator import MaxNLocator
+
+
+@pytest.mark.parametrize(
+    "n, vmin, vmax, expected",
+    [
+        (1, 20, 100, [0, 80, 160]),
+        (2, 20, 100, [0, 40, 80, 120]),
+        (3, 20, 100, [0, 30, 60, 90, 120]),
+        (4, 20, 100, [20, 40, 60, 80, 100]),
+        (5, 20, 100, [20, 40, 60, 80, 100]),
+        (6, 20, 100, [15, 30, 45, 60, 75, 90, 105]),
+        (7, 20, 100, [15, 30, 45, 60, 75, 90, 105]),
+        (8, 20, 100, [20, 30, 40, 50, 60, 70, 80, 90, 100]),
+        (9, 20, 100, [20, 30, 40, 50, 60, 70, 80, 90, 100]),
+        (10, 20, 100, [16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104]),
+        (1, 1e-4, 1e-3, [0, 1e-3]),
+        (2, 1e-4, 1e-3, [0, 5e-4, 1e-3]),
+        (3, 1e-4, 1e-3, [0, 3e-4, 6e-4, 9e-4, 1.2e-3]),
+        (4, 1e-4, 1e-3, [0, 2.5e-4, 5e-4, 7.5e-4, 1e-3]),
+        (5, 1e-4, 1e-3, [0, 2e-4, 4e-4, 6e-4, 8e-4, 1e-3]),
+        (6, 1e-4, 1e-3, [0, 1.5e-4, 3e-4, 4.5e-4, 6e-4, 7.5e-4, 9e-4, 1.05e-3]),
+        (7, 1e-4, 1e-3, [0, 1.5e-4, 3e-4, 4.5e-4, 6e-4, 7.5e-4, 9e-4, 1.05e-3]),
+        (8, 1e-4, 1e-3, [0, 1.5e-4, 3e-4, 4.5e-4, 6e-4, 7.5e-4, 9e-4, 1.05e-3]),
+        (9, 1e-4, 1e-3, [1e-4, 2e-4, 3e-4, 4e-4, 5e-4, 6e-4, 7e-4, 8e-4, 9e-4, 1e-3]),
+        (10, 1e-4, 1e-3, [1e-4, 2e-4, 3e-4, 4e-4, 5e-4, 6e-4, 7e-4, 8e-4, 9e-4, 1e-3]),
+        (2, -1e15, 1e15, [-1e15, 0, 1e15]),
+        (4, -1e15, 1e15, [-1e15, -5e14, 0, 5e14, 1e15]),
+        (8, -1e15, 1e15, [-1e15, -7.5e14, -5e14, -2.5e14, 0, 2.5e14, 5e14, 7.5e14, 1e15]),
+        (5, 0, 0.85e-50, [0, 2e-51, 4e-51, 6e-51, 8e-51, 1e-50]),
+        (5, -0.85e-50, 0, [-1e-50, -8e-51, -6e-51, -4e-51, -2e-51, 0]),
+        (5, 1.23, 1.23, [1.23]*5),
+    ],
+)
+def test_max_n_locator(n, vmin, vmax, expected):
+    locator = MaxNLocator(n)
+    ticks = locator.tick_values(vmin, vmax)
+    np.testing.assert_almost_equal(ticks, expected)
+
+    # Same results if swap vmin and vmax
+    ticks = locator.tick_values(vmax, vmin)
+    np.testing.assert_almost_equal(ticks, expected)
+
+
+@pytest.mark.parametrize("n", (0, -1, -2))
+def test_max_n_locator_invalid_n(n):
+    with pytest.raises(ValueError):
+        _ = MaxNLocator(n)

--- a/holoviews/util/locator.py
+++ b/holoviews/util/locator.py
@@ -1,6 +1,7 @@
 """
 Minimal set of functionality of Matplotlib's MaxNLocator to choose contour
 levels without having to have Matplotlib installed.
+Taken from Matplotlib 3.8.0.
 """
 import math
 import numpy as np

--- a/holoviews/util/locator.py
+++ b/holoviews/util/locator.py
@@ -1,0 +1,169 @@
+"""
+Minimal set of functionality of Matplotlib's MaxNLocator to choose contour
+levels without having to have Matplotlib installed.
+"""
+import math
+import numpy as np
+
+
+class _Edge_integer:
+    """
+    Helper for `.MaxNLocator`, `.MultipleLocator`, etc.
+
+    Take floating-point precision limitations into account when calculating
+    tick locations as integer multiples of a step.
+    """
+    def __init__(self, step, offset):
+        """
+        Parameters
+        ----------
+        step : float > 0
+            Interval between ticks.
+        offset : float
+            Offset subtracted from the data limits prior to calculating tick
+            locations.
+        """
+        if step <= 0:
+            raise ValueError("'step' must be positive")
+        self.step = step
+        self._offset = abs(offset)
+
+    def closeto(self, ms, edge):
+        # Allow more slop when the offset is large compared to the step.
+        if self._offset > 0:
+            digits = np.log10(self._offset / self.step)
+            tol = max(1e-10, 10 ** (digits - 12))
+            tol = min(0.4999, tol)
+        else:
+            tol = 1e-10
+        return abs(ms - edge) < tol
+
+    def le(self, x):
+        """Return the largest n: n*step <= x."""
+        d, m = divmod(x, self.step)
+        if self.closeto(m / self.step, 1):
+            return d + 1
+        return d
+
+    def ge(self, x):
+        """Return the smallest n: n*step >= x."""
+        d, m = divmod(x, self.step)
+        if self.closeto(m / self.step, 0):
+            return d
+        return d + 1
+
+
+def nonsingular(vmin, vmax, expander=0.001, tiny=1e-15, increasing=True):
+    """
+    Modify the endpoints of a range as needed to avoid singularities.
+
+    Parameters
+    ----------
+    vmin, vmax : float
+        The initial endpoints.
+    expander : float, default: 0.001
+        Fractional amount by which *vmin* and *vmax* are expanded if
+        the original interval is too small, based on *tiny*.
+    tiny : float, default: 1e-15
+        Threshold for the ratio of the interval to the maximum absolute
+        value of its endpoints.  If the interval is smaller than
+        this, it will be expanded.  This value should be around
+        1e-15 or larger; otherwise the interval will be approaching
+        the double precision resolution limit.
+    increasing : bool, default: True
+        If True, swap *vmin*, *vmax* if *vmin* > *vmax*.
+
+    Returns
+    -------
+    vmin, vmax : float
+        Endpoints, expanded and/or swapped if necessary.
+        If either input is inf or NaN, or if both inputs are 0 or very
+        close to zero, it returns -*expander*, *expander*.
+    """
+
+    if (not np.isfinite(vmin)) or (not np.isfinite(vmax)):
+        return -expander, expander
+
+    swapped = False
+    if vmax < vmin:
+        vmin, vmax = vmax, vmin
+        swapped = True
+
+    # Expand vmin, vmax to float: if they were integer types, they can wrap
+    # around in abs (abs(np.int8(-128)) == -128) and vmax - vmin can overflow.
+    vmin, vmax = map(float, [vmin, vmax])
+
+    maxabsvalue = max(abs(vmin), abs(vmax))
+    if maxabsvalue < (1e6 / tiny) * np.finfo(float).tiny:
+        vmin = -expander
+        vmax = expander
+
+    elif vmax - vmin <= maxabsvalue * tiny:
+        if vmax == 0 and vmin == 0:
+            vmin = -expander
+            vmax = expander
+        else:
+            vmin -= expander*abs(vmin)
+            vmax += expander*abs(vmax)
+
+    if swapped and not increasing:
+        vmin, vmax = vmax, vmin
+    return vmin, vmax
+
+
+def scale_range(vmin, vmax, n=1, threshold=100):
+    dv = abs(vmax - vmin)  # > 0 as nonsingular is called before.
+    meanv = (vmax + vmin) / 2
+    if abs(meanv) / dv < threshold:
+        offset = 0
+    else:
+        offset = math.copysign(10 ** (math.log10(abs(meanv)) // 1), meanv)
+    scale = 10 ** (math.log10(dv / n) // 1)
+    return scale, offset
+
+
+class MaxNLocator:
+    _extended_steps = np.array([
+        0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.8,
+        1., 1.5, 2., 2.5, 3., 4., 5., 6., 8., 10., 15.])
+    _min_n_ticks = 1
+
+    def __init__(self, nbins: int = 10):
+        self.nbins = nbins
+
+    def _raw_ticks(self, vmin, vmax):
+        scale, offset = scale_range(vmin, vmax, self.nbins)
+        _vmin = vmin - offset
+        _vmax = vmax - offset
+        steps = self._extended_steps * scale
+
+        raw_step = ((_vmax - _vmin) / self.nbins)
+        large_steps = steps >= raw_step
+
+        # Find index of smallest large step
+        istep = np.nonzero(large_steps)[0][0]
+
+        # Start at smallest of the steps greater than the raw step, and check
+        # if it provides enough ticks. If not, work backwards through
+        # smaller steps until one is found that provides enough ticks.
+        for step in steps[:istep+1][::-1]:
+            best_vmin = (_vmin // step) * step
+
+            # Find tick locations spanning the vmin-vmax range, taking into
+            # account degradation of precision when there is a large offset.
+            # The edge ticks beyond vmin and/or vmax are needed for the
+            # "round_numbers" autolimit mode.
+            edge = _Edge_integer(step, offset)
+            low = edge.le(_vmin - best_vmin)
+            high = edge.ge(_vmax - best_vmin)
+            ticks = np.arange(low, high + 1) * step + best_vmin
+            # Count only the ticks that will be displayed.
+            nticks = ((ticks <= _vmax) & (ticks >= _vmin)).sum()
+            if nticks >= self._min_n_ticks:
+                break
+        return ticks + offset
+
+    def tick_values(self, vmin, vmax):
+        vmin, vmax = nonsingular(vmin, vmax, expander=1e-13, tiny=1e-14)
+        locs = self._raw_ticks(vmin, vmax)
+        return locs

--- a/holoviews/util/locator.py
+++ b/holoviews/util/locator.py
@@ -129,6 +129,8 @@ class MaxNLocator:
     _min_n_ticks = 1
 
     def __init__(self, nbins: int = 10):
+        if nbins < 1:
+            raise ValueError("MaxNLocator nbins must be an integer greater than zero")
         self.nbins = nbins
 
     def _raw_ticks(self, vmin, vmax):

--- a/holoviews/util/locator.py
+++ b/holoviews/util/locator.py
@@ -4,6 +4,7 @@ levels without having to have Matplotlib installed.
 Taken from Matplotlib 3.8.0.
 """
 import math
+
 import numpy as np
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ extras_require['tests_core'] = [
     'pillow',
     'plotly >=4.0',
     'ipython >=5.4.0',
+    'contourpy',
 ]
 
 # Optional tests dependencies, i.e. one should be able


### PR DESCRIPTION
This is a WIP to use ContourPy for contour calculations. It was originally intended just to fix #5899, caused by a change within Matplotlib of how contour data is internally stored, but it is easier and better just to use ContourPy directly. This is faster and avoids unnecessary generation and manipulation of extra contour data such as Matplotlib `path` codes.

Notes:

1. ContourPy must be available of course, but it is a compulsory dependency of both Bokeh and Matplotlib.
2. Processing of the returned contour line and filled polygon data is performed separately as the data formats differ.
3. Matplotlib is still used for conversion of dates to and from numbers. It may be possible to replace these with NumPy or Pandas equivalents.
4. Matplotlib is also used for auto generation of required contour levels when the `levels` kwarg is an integer. This currently uses the `MaxNLocator` class. The required functionality could be directly vendored within HoloViews to completely remove the need for Matplotlib, e.g. if using the Bokeh backend.
5. There are issues using dates/times for `x`, `y`, and/or `z` arrays. There were no tests of these so have added some. Unfortunately some of these new tests such as `test_image_contours_x_datetime` pass regardless of the comparison `contour` in the `assertEqual`. I suspect that `assertEqual` silently ignores datetimes.
6. Datetime `z` data implies datetime `levels` too. To fully support this we may not be able to rely on `MaxNLocator` but might need to also use or implement some of Matplotlib's `DateLocator` functionality.