### PR TITLE
Update to compatibility with latest param.rx API

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -547,7 +547,7 @@ class Callable(param.Parameterized):
         kwarg_hash = kwargs.pop('_memoization_hash_', ())
         (self.args, self.kwargs) = (args, kwargs)
         if hasattr(self.callable, 'rx'):
-            return self.callable.rx.resolve()
+            return self.callable.rx.value
         if not args and not kwargs and not any(kwarg_hash): return self.callable()
         inputs = [i for i in self.inputs if isinstance(i, DynamicMap)]
         streams = []


### PR DESCRIPTION
param2.0.0rc6 changed the API for getting the current value of an rx object to `.rx.value`