### PR TITLE
Fix `histogram` operation on Ibis data

### DIFF
--- a/holoviews/core/data/ibis.py
+++ b/holoviews/core/data/ibis.py
@@ -23,6 +23,11 @@ def ibis4():
     return ibis_version() >= Version("4.0")
 
 
+@lru_cache
+def ibis5():
+    return ibis_version() >= Version("5.0")
+
+
 class IbisInterface(Interface):
 
     types = ()
@@ -163,8 +168,8 @@ class IbisInterface(Interface):
         else:
             # sort_by will be removed in Ibis 5.0
             hist_bins = binned.value_counts().sort_by('bucket').execute()
-
-        for b, v in zip(hist_bins['bucket'], hist_bins['count']):
+        metric_name = 'bucket_count' if ibis5() else 'count'
+        for b, v in zip(hist_bins['bucket'], hist_bins[metric_name]):
             if np.isnan(b):
                 continue
             hist[int(b)] = v

--- a/holoviews/core/data/ibis.py
+++ b/holoviews/core/data/ibis.py
@@ -177,7 +177,7 @@ class IbisInterface(Interface):
             raise NotImplementedError("Weighted histograms currently "
                                       "not implemented for IbisInterface.")
         if density:
-            hist = hist/expr.count().execute()
+            hist = hist/expr.count().execute()/np.diff(bins)
         return hist, bins
 
     @classmethod

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -737,10 +737,16 @@ class histogram(Operation):
 
         # Mask data
         if is_ibis_expr(data):
+            from ..core.data.ibis import ibis5
+
             mask = data.notnull()
             if self.p.nonzero:
                 mask = mask & (data != 0)
-            data = data.to_projection()
+            if ibis5():
+                data = data.as_table()
+            else:
+                # to_projection removed in ibis 5.0.0
+                data = data.to_projection()
             data = data[mask]
             no_data = not len(data.head(1).execute())
             data = data[dim.name]

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -32,8 +32,12 @@ except Exception:
 
 @pytest.fixture
 def ibis_sqlite_backend():
-    import ibis
-    old = ibis.get_backend()
-    ibis.set_backend('sqlite')
-    yield
-    ibis.set_backend(old)
+    try:
+        import ibis
+    except ImportError:
+        yield None
+    else:
+        old = ibis.get_backend()
+        ibis.set_backend('sqlite')
+        yield
+        ibis.set_backend(old)

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -1,3 +1,5 @@
+import pytest
+
 from panel.tests.conftest import server_cleanup, port, pytest_addoption, pytest_configure, optional_markers  # noqa
 
 
@@ -26,3 +28,12 @@ try:
     dask.config.set({"dataframe.convert-string": False})
 except Exception:
     pass
+
+
+@pytest.fixture
+def ibis_sqlite_backend():
+    import ibis
+    old = ibis.get_backend()
+    ibis.set_backend('sqlite')
+    yield
+    ibis.set_backend(old)

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -37,7 +37,6 @@ def ibis_sqlite_backend():
     except ImportError:
         yield None
     else:
-        old = ibis.get_backend()
         ibis.set_backend('sqlite')
         yield
-        ibis.set_backend(old)
+        ibis.set_backend(None)

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -209,6 +209,17 @@ class OperationTests(ComparisonTestCase):
                          vdims=('x_frequency', 'Frequency'))
         self.assertEqual(op_hist, hist)
 
+    def test_dataset_histogram_explicit_bins_ibis(self):
+        df = pd.DataFrame(dict(x=np.arange(10)))
+        t = ibis.memtable(df, name='t')
+        ds = Dataset(t, vdims='x')
+        op_hist = histogram(ds, bins=[0, 1, 3], normed=False)
+
+        hist = Histogram(([0, 1, 3], [1, 3]),
+                         vdims=('x_count', 'Count'))
+        self.assertEqual(op_hist, hist)
+
+
     def test_points_histogram_bin_range(self):
         points = Points([float(i) for i in range(10)])
         op_hist = histogram(points, num_bins=3, bin_range=(0, 3), normed=True)

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -14,8 +14,6 @@ try:
     import ibis
 except ImportError:
     ibis = None
-else:
-    ibis.set_backend("sqlite")
 
 from holoviews import (HoloMap, NdOverlay, NdLayout, GridSpace, Image,
                        Contours, Polygons, Points, Histogram, Curve, Area,
@@ -188,6 +186,7 @@ class OperationTests(ComparisonTestCase):
         self.assertEqual(op_hist, hist)
 
     @ibis_skip
+    @pytest.mark.usefixtures('ibis_sqlite_backend')
     def test_dataset_histogram_ibis(self):
         df = pd.DataFrame(dict(x=np.arange(10)))
         t = ibis.memtable(df, name='t')
@@ -199,6 +198,7 @@ class OperationTests(ComparisonTestCase):
         self.assertEqual(op_hist, hist)
 
     @ibis_skip
+    @pytest.mark.usefixtures('ibis_sqlite_backend')
     def test_dataset_cumulative_histogram_ibis(self):
         df = pd.DataFrame(dict(x=np.arange(10)))
         t = ibis.memtable(df, name='t')

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -12,10 +12,10 @@ except ImportError:
 
 try:
     import ibis
-    from ibis import sqlite
 except ImportError:
-    ibis = sqlite = None
-
+    ibis = None
+else:
+    ibis.set_backend("sqlite")
 
 from holoviews import (HoloMap, NdOverlay, NdLayout, GridSpace, Image,
                        Contours, Polygons, Points, Histogram, Curve, Area,

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -209,6 +209,8 @@ class OperationTests(ComparisonTestCase):
                          vdims=('x_frequency', 'Frequency'))
         self.assertEqual(op_hist, hist)
 
+    @ibis_skip
+    @pytest.mark.usefixtures('ibis_sqlite_backend')
     def test_dataset_histogram_explicit_bins_ibis(self):
         df = pd.DataFrame(dict(x=np.arange(10)))
         t = ibis.memtable(df, name='t')


### PR DESCRIPTION
While working on https://github.com/holoviz/hvplot/pull/997 I realized that (perhaps unsurprisingly) some Ibis code paths were broken or not working as expected. I fixed some bugs related to API changes in ibis after version 5.0 and a bug in the histogram computation when `density=True`.