### PR TITLE
Fix bug where extents contained None and would error for {V,H}Spans

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -4,6 +4,7 @@ from html import escape
 
 import param
 import numpy as np
+import pandas as pd
 
 from bokeh.models import BoxAnnotation, Span, Arrow, Slope
 from panel.models import HTML
@@ -68,9 +69,11 @@ class _SyntheticAnnotationPlot(ColorbarPlot):
         elif isinstance(element, VLines):
             extents = extents[0], np.nan, extents[2], np.nan
         elif isinstance(element, HSpans):
-            extents = np.nan, min(extents[:2]), np.nan, max(extents[2:])
+            extents = pd.array(extents)
+            extents = np.nan, extents[:2].min(), np.nan, extents[2:].max()
         elif isinstance(element, VSpans):
-            extents = min(extents[:2]), np.nan, max(extents[2:]), np.nan
+            extents = pd.array(extents)
+            extents = extents[:2].min(), np.nan, extents[2:].max(), np.nan
         return extents
 
 class HLinesAnnotationPlot(_SyntheticAnnotationPlot):

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -1,7 +1,7 @@
 import param
 import numpy as np
 import matplotlib as mpl
-
+import pandas as pd
 from matplotlib import patches
 from matplotlib.lines import Line2D
 
@@ -312,9 +312,11 @@ class _SyntheticAnnotationPlot(AnnotationPlot):
         elif isinstance(element, VLines):
             extents = extents[0], np.nan, extents[2], np.nan
         elif isinstance(element, HSpans):
-            extents = np.nan, min(extents[:2]), np.nan, max(extents[2:])
+            extents = pd.array(extents)
+            extents = np.nan, extents[:2].min(), np.nan, extents[2:].max()
         elif isinstance(element, VSpans):
-            extents = min(extents[:2]), np.nan, max(extents[2:]), np.nan
+            extents = pd.array(extents)
+            extents = extents[:2].min(), np.nan, extents[2:].max(), np.nan
         return extents
 
     def initialize_plot(self, ranges=None):

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -547,6 +547,18 @@ class TestHVSpansPlot(TestBokehPlot):
         assert (source.data["other0"] == [0, 3, 5.5]).all()
         assert (source.data["other1"] == [1, 4, 6.5]).all()
 
+    def test_dynamicmap_overlay_vspans(self):
+        el = hv.VSpans(data=[[1, 3], [2, 4]])
+        dmap = hv.DynamicMap(lambda: hv.Overlay([el]))
+
+        plot_el = bokeh_renderer.get_plot(el)
+        plot_dmap = bokeh_renderer.get_plot(dmap)
+
+        assert plot_el.handles["x_range"].start == plot_dmap.handles["x_range"].start
+        assert plot_el.handles["x_range"].end == plot_dmap.handles["x_range"].end
+        assert plot_el.handles["y_range"].start == plot_dmap.handles["y_range"].start
+        assert plot_el.handles["y_range"].end == plot_dmap.handles["y_range"].end
+
     def test_vspans_hspans_overlay(self):
         hspans = HSpans(
             {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
@@ -588,3 +600,15 @@ class TestHVSpansPlot(TestBokehPlot):
         data = plot.handles["glyph_renderer"].data_source.data
         np.testing.assert_allclose(data["alpha"], [0, 0.5, 1])
         assert data["line_dash"] == ["dashed", "solid", "solid"]
+
+    def test_dynamicmap_overlay_hspans(self):
+        el = hv.HSpans(data=[[1, 3], [2, 4]])
+        dmap = hv.DynamicMap(lambda: hv.Overlay([el]))
+
+        plot_el = bokeh_renderer.get_plot(el)
+        plot_dmap = bokeh_renderer.get_plot(dmap)
+
+        assert plot_el.handles["x_range"].start == plot_dmap.handles["x_range"].start
+        assert plot_el.handles["x_range"].end == plot_dmap.handles["x_range"].end
+        assert plot_el.handles["y_range"].start == plot_dmap.handles["y_range"].start
+        assert plot_el.handles["y_range"].end == plot_dmap.handles["y_range"].end

--- a/holoviews/tests/plotting/matplotlib/test_annotationplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_annotationplot.py
@@ -1,4 +1,5 @@
 import numpy as np
+import holoviews as hv
 from holoviews.element import HLines, VLines, HSpans, VSpans
 
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -191,6 +192,21 @@ class TestHVSpansPlot(TestMPLPlot):
             assert np.allclose(source.xy[:, 1], [0, 1, 1, 0, 0])
             assert np.allclose(source.xy[:, 0], [v0, v0, v1, v1, v0])
 
+    def test_dynamicmap_overlay_hspans(self):
+        el = HSpans(data=[[1, 3], [2, 4]])
+        dmap = hv.DynamicMap(lambda: hv.Overlay([el]))
+
+        plot_el = mpl_renderer.get_plot(el)
+        plot_dmap = mpl_renderer.get_plot(dmap)
+
+        xlim_el = plot_el.handles["fig"].axes[0].get_xlim()
+        ylim_el = plot_el.handles["fig"].axes[0].get_ylim()
+        xlim_dmap = plot_dmap.handles["fig"].axes[0].get_xlim()
+        ylim_dmap = plot_dmap.handles["fig"].axes[0].get_ylim()
+
+        assert np.allclose(xlim_el, xlim_dmap)
+        assert np.allclose(ylim_el, ylim_dmap)
+
     def test_hspans_nondefault_kdim(self):
         hspans = HSpans(
             {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
@@ -299,3 +315,18 @@ class TestHVSpansPlot(TestMPLPlot):
         for source, v0, v1 in zip(sources[3:6], vspans.data["x0"], vspans.data["x1"]):
             assert np.allclose(source.xy[:, 1], [0, 1, 1, 0, 0])
             assert np.allclose(source.xy[:, 0], [v0, v0, v1, v1, v0])
+
+    def test_dynamicmap_overlay_vspans(self):
+        el = VSpans(data=[[1, 3], [2, 4]])
+        dmap = hv.DynamicMap(lambda: hv.Overlay([el]))
+
+        plot_el = mpl_renderer.get_plot(el)
+        plot_dmap = mpl_renderer.get_plot(dmap)
+
+        xlim_el = plot_el.handles["fig"].axes[0].get_xlim()
+        ylim_el = plot_el.handles["fig"].axes[0].get_ylim()
+        xlim_dmap = plot_dmap.handles["fig"].axes[0].get_xlim()
+        ylim_dmap = plot_dmap.handles["fig"].axes[0].get_ylim()
+
+        assert np.allclose(xlim_el, xlim_dmap)
+        assert np.allclose(ylim_el, ylim_dmap)


### PR DESCRIPTION
This would fail `hv.DynamicMap(lambda: hv.Overlay([hv.VSpans(data=[[1, 3], [2, 4]])]))`