### PR TITLE
Small improvements to `hv.ImageStack`

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -530,6 +530,15 @@ class ImageStack(Image):
     _vdim_reductions = {1: Image}
 
     def __init__(self, data, kdims=None, vdims=None, **params):
+        if isinstance(data, np.ndarray) and data.ndim == 3:
+            x = np.arange(data.shape[0])
+            y = np.arange(data.shape[1])
+            data = (x, y, *(data[:, :, n] for n in range(data.shape[2])))
+        elif (
+            isinstance(data, tuple) and len(data) == 3
+            and isinstance(data[2], np.ndarray) and data[2].ndim == 3
+        ):
+            data = (data[0], data[1], *(data[2][:, :,n] for n in range(data[2].shape[2])))
         if vdims is None:
             if isinstance(data, tuple):
                 vdims = [Dimension(f"level_{i}") for i in range(len(data[2:]))]

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -11,7 +11,7 @@ from .chart import PointPlot
 from .element import ColorbarPlot, LegendPlot
 from .selection import BokehOverlaySelectionDisplay
 from .styles import base_properties, fill_properties, line_properties, mpl_to_bokeh
-from .util import colormesh
+from .util import bokeh33, colormesh
 
 
 class RasterPlot(ColorbarPlot):
@@ -287,11 +287,16 @@ class ImageStackPlot(RasterPlot):
         return (data, mapping, style)
 
     def _hover_opts(self, element):
-        xdim, ydim = element.kdims
-        # TODO: Bokeh 3.3 not yet released; it has support for multi hover
+        # Bokeh 3.3 has simple support for multi hover in a tuple.
         # https://github.com/bokeh/bokeh/pull/13193
         # https://github.com/bokeh/bokeh/pull/13366
-        return [(xdim.pprint_label, '$x'), (ydim.pprint_label, '$y')], {}
+        if bokeh33:
+            xdim, ydim = element.kdims
+            vdim = ", ".join([d.pprint_label for d in element.vdims])
+            return [(xdim.pprint_label, '$x'), (ydim.pprint_label, '$y'), (vdim, '@image')], {}
+        else:
+            xdim, ydim = element.kdims
+            return [(xdim.pprint_label, '$x'), (ydim.pprint_label, '$y')], {}
 
 
 class HSVPlot(RGBPlot):

--- a/holoviews/tests/plotting/bokeh/test_rasterplot.py
+++ b/holoviews/tests/plotting/bokeh/test_rasterplot.py
@@ -321,3 +321,43 @@ class TestRasterPlot(TestBokehPlot):
         assert source.data["y"][0] == -0.5
         assert source.data["dw"][0] == 3
         assert source.data["dh"][0] == 3
+
+    def test_image_stack_array(self):
+        a = np.array([[np.nan, np.nan, 1], [np.nan] * 3, [np.nan] * 3])
+        b = np.array([[np.nan] * 3, [1, 1, np.nan], [np.nan] * 3])
+        c = np.array([[np.nan] * 3, [np.nan] * 3, [1, 1, 1]])
+
+        data = np.dstack((a, b, c))
+
+        img_stack = ImageStack(data, kdims=["x", "y"], vdims=["a", "b", "c"])
+        plot = bokeh_renderer.get_plot(img_stack)
+        source = plot.handles["source"]
+        np.testing.assert_equal(source.data["image"][0][0], a.T)
+        np.testing.assert_equal(source.data["image"][0][1], b.T)
+        np.testing.assert_equal(source.data["image"][0][2], c.T)
+        assert source.data["x"][0] == -0.5
+        assert source.data["y"][0] == -0.5
+        assert source.data["dw"][0] == 3
+        assert source.data["dh"][0] == 3
+        assert isinstance(plot, ImageStackPlot)
+
+    def test_image_stack_tuple_single_3darray(self):
+        x = np.arange(0, 3)
+        y = np.arange(5, 8)
+        a = np.array([[np.nan, np.nan, 1], [np.nan] * 3, [np.nan] * 3])
+        b = np.array([[np.nan] * 3, [1, 1, np.nan], [np.nan] * 3])
+        c = np.array([[np.nan] * 3, [np.nan] * 3, [1, 1, 1]])
+
+        data = (x, y, np.dstack((a, b, c)))
+
+        img_stack = ImageStack(data, kdims=["x", "y"], vdims=["a", "b", "c"])
+        plot = bokeh_renderer.get_plot(img_stack)
+        source = plot.handles["source"]
+        np.testing.assert_equal(source.data["image"][0][0], a.T)
+        np.testing.assert_equal(source.data["image"][0][1], b.T)
+        np.testing.assert_equal(source.data["image"][0][2], c.T)
+        assert source.data["x"][0] == -0.5
+        assert source.data["y"][0] == 4.5
+        assert source.data["dw"][0] == 3
+        assert source.data["dh"][0] == 3
+        assert isinstance(plot, ImageStackPlot)


### PR DESCRIPTION
- Adding simple `HoverTool` support if Bokeh 3.3 is installed
- Allow more inputs type to `ImageStack`:

``` python
import numpy as np
import panel as pn

import holoviews as hv

hv.extension("bokeh")

data = np.asarray(
    [
        [[0, 1, 2], [1, 1, 2], [0, 1, 2]],
        [[1, 0, 1], [2, 2, 2], [3, 3, 3]],
        [[0, 1, 4], [7, 1, 3], [3, 5, 1]],
    ]
)
# And:
# data = (range(5, 8), range(10, 13), data) 

colors = ["red", "blue", "green"]
hv.ImageStack(data).opts(
    width=800, height=800, cmap=colors, num_colors=100, tools=["hover"]
)

```
