### PR TITLE
Account for overlaid elements when using subcoordinates_y

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -488,7 +488,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     # This sum() is equal to n+1, n being the number of elements contained
                     # in the overlay with subcoordinate_y=True, as the traversal goes through
                     # the root overlay that has subcoordinate_y=True too since it's propagated.
-                    v0, v1 = 0-offset, sum(self.traverse(lambda p: p.subcoordinate_y))-2+offset
+                    subcoords = self.traverse(lambda p: p.subcoordinate_y)
+                    start = next(i for i, s in enumerate(subcoords[1:]) if s)
+                    end = start + sum(s for s in subcoords[(1 + start):]) - 1
+                    v0, v1 = start-offset, end+offset
                 else:
                     v0, v1 = 0, 1
             else:
@@ -575,8 +578,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             axpos0, axpos1 = 'left', 'right'
 
         ax_specs, yaxes, dimensions = {}, {}, {}
-        subcoordinate_axes = 0
-        for el, sp in zip(element, self.subplots.values()):
+        for i, (el, sp) in enumerate(zip(element, self.subplots.values())):
             ax_dims = sp._get_axis_dims(el)[:2]
             if sp.invert_axes:
                 ax_dims[::-1]
@@ -588,7 +590,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 if opts.get('subcoordinate_y') is None:
                     continue
                 ax_name = el.label
-                subcoordinate_axes += 1
+                subcoordinate_axes = i
             else:
                 ax_name = yd.name
             dimensions[ax_name] = yd
@@ -605,7 +607,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     'axis_label_text_font_size': sp._fontsize('ylabel').get('fontsize'),
                     'major_label_text_font_size': sp._fontsize('yticks').get('fontsize')
                 },
-                'subcoordinate_y': subcoordinate_axes-1 if self._subcoord_overlaid else None
+                'subcoordinate_y': subcoordinate_axes if self._subcoord_overlaid else None
             }
 
         for ydim, info in yaxes.items():

--- a/holoviews/tests/plotting/bokeh/test_subcoordy.py
+++ b/holoviews/tests/plotting/bokeh/test_subcoordy.py
@@ -76,6 +76,20 @@ class TestSubcoordinateY(TestBokehPlot):
         with_span = overlay * VSpan(1, 2)
         bokeh_renderer.get_plot(with_span)
 
+    def test_underlaid_ytick_alignment(self):
+        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        with_span = VSpan(1, 2) * overlay
+        plot = bokeh_renderer.get_plot(with_span)
+        # the yticks are aligned with their subcoordinate_y axis
+        assert plot.state.yaxis.ticker.ticks == [0, 1]
+
+    def test_overlaid_ytick_alignment(self):
+        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        with_span = overlay * VSpan(1, 2)
+        plot = bokeh_renderer.get_plot(with_span)
+        # the yticks are aligned with their subcoordinate_y axis
+        assert plot.state.yaxis.ticker.ticks == [0, 1]
+
     def test_custom_ylabel(self):
         overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         overlay.opts(ylabel='Y label')


### PR DESCRIPTION
Fixes #5913 

``` python
import holoviews as hv
import numpy as np
import panel as pn

np.random.seed(100)
hv.extension("bokeh")

fn = lambda channel: hv.Curve(
    (np.arange(10), np.random.rand(10), channel), "Time", "Channel", label=channel
).opts(subcoordinate_y=True)
subcoord = hv.Overlay([fn(n) for n in "ABCD"], kdims="Channel")
annotation = hv.VSpan(1, 1.5)

pn.panel(annotation * subcoord).servable()
pn.panel(subcoord * annotation).servable()
pn.panel(subcoord).servable()
pn.panel(annotation * subcoord + subcoord * annotation).servable()


```

![image](https://github.com/holoviz/holoviews/assets/19758978/c841ed13-31a2-4048-adde-57da20a6f8f5)

# TODO:
- [x] Add tests
