### PR TITLE
Do not allow partial matches when updating OverlayPlot

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2054,7 +2054,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         return any(md['id'] == model.ref['id'] for models in stream_metadata
                    for md in models.values())
 
-
     @property
     def framewise(self):
         """
@@ -2989,10 +2988,8 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                 # If not batched get the Element matching the subplot
                 elif element is not None:
                     idx, spec, exact = self._match_subplot(k, subplot, items, element)
-                    if idx is not None:
+                    if idx is not None and exact:
                         _, el = items.pop(idx)
-                        if not exact:
-                            self._update_subplot(subplot, spec)
 
                 # Skip updates to subplots when its streams is not one of
                 # the streams that initiated the update

--- a/holoviews/tests/plotting/bokeh/test_overlayplot.py
+++ b/holoviews/tests/plotting/bokeh/test_overlayplot.py
@@ -308,10 +308,10 @@ class TestLegends(TestBokehPlot):
         self.assertEqual(legend_labels, [{'value': 'C'}, {'value': 'B'}])
         plot.update((1,))
         legend_labels = [property_to_dict(item.label) for item in plot.state.legend[0].items]
-        self.assertEqual(legend_labels, [{'value': 'D'}, {'value': 'B'}])
+        self.assertEqual(legend_labels, [{'value': 'B'}, {'value': 'D'}])
         plot.update((2,))
         legend_labels = [property_to_dict(item.label) for item in plot.state.legend[0].items]
-        self.assertEqual(legend_labels, [{'value': 'E'}, {'value': 'B'}])
+        self.assertEqual(legend_labels, [{'value': 'B'}, {'value': 'E'}])
 
     def test_holomap_legend_updates_varying_lengths(self):
         hmap = HoloMap({i: Overlay([Curve([1, 2, j], label=chr(65+j)) for j in range(i)]) for i in range(1, 4)})
@@ -334,10 +334,10 @@ class TestLegends(TestBokehPlot):
         self.assertEqual(legend_labels, [{'value': 'C'}, {'value': 'B'}])
         plot.update((1,))
         legend_labels = [property_to_dict(item.label) for item in plot.state.legend[0].items]
-        self.assertEqual(legend_labels, [{'value': 'D'}, {'value': 'B'}])
+        self.assertEqual(legend_labels, [{'value': 'B'}, {'value': 'D'}])
         plot.update((2,))
         legend_labels = [property_to_dict(item.label) for item in plot.state.legend[0].items]
-        self.assertEqual(legend_labels, [{'value': 'E'}, {'value': 'B'}])
+        self.assertEqual(legend_labels, [{'value': 'B'}, {'value': 'E'}])
 
     def test_dynamicmap_legend_updates_add_dynamic_plots(self):
         hmap = HoloMap({i: Overlay([Curve([1, 2, j], label=chr(65+j)) for j in range(i)]) for i in range(1, 4)})

--- a/holoviews/tests/plotting/bokeh/test_overlayplot.py
+++ b/holoviews/tests/plotting/bokeh/test_overlayplot.py
@@ -3,7 +3,6 @@ import panel as pn
 from bokeh.models import FactorRange, FixedTicker, HoverTool, Range1d, Span
 
 from holoviews.core import DynamicMap, HoloMap, NdOverlay, Overlay
-from holoviews.core.options import Cycle
 from holoviews.element import (
     Bars,
     Box,

--- a/holoviews/tests/plotting/bokeh/test_overlayplot.py
+++ b/holoviews/tests/plotting/bokeh/test_overlayplot.py
@@ -301,21 +301,6 @@ class TestLegends(TestBokehPlot):
         legend_labels = [l.label['value'] for l in plot.state.legend[0].items]
         self.assertEqual(legend_labels, ['A Curve', 'B Curve'])
 
-    def test_dynamic_subplot_remapping(self):
-        # Checks that a plot is appropriately updated when reused
-        def cb(X):
-            return NdOverlay({i: Curve(np.arange(10)+i) for i in range(X-2, X)})
-        dmap = DynamicMap(cb, kdims=['X']).redim.range(X=(1, 10))
-        plot = bokeh_renderer.get_plot(dmap)
-        plot.update((3,))
-        legend_labels = [property_to_dict(item.label) for item in plot.state.legend[0].items]
-        self.assertEqual(legend_labels, [{'value': '1'}, {'value': '2'}])
-        colors = Cycle().values
-        for i, (subplot, color) in enumerate(zip(plot.subplots.values(), colors[3:])):
-            self.assertEqual(subplot.handles['glyph'].line_color, color)
-            self.assertEqual(subplot.cyclic_index, i+3)
-            self.assertEqual(list(subplot.overlay_dims.values()), [i+1])
-
     def test_holomap_legend_updates(self):
         hmap = HoloMap({i: Curve([1, 2, 3], label=chr(65+i+2)) * Curve([1, 2, 3], label='B')
                         for i in range(3)})
@@ -324,10 +309,10 @@ class TestLegends(TestBokehPlot):
         self.assertEqual(legend_labels, [{'value': 'C'}, {'value': 'B'}])
         plot.update((1,))
         legend_labels = [property_to_dict(item.label) for item in plot.state.legend[0].items]
-        self.assertEqual(legend_labels, [{'value': 'B'}, {'value': 'D'}])
+        self.assertEqual(legend_labels, [{'value': 'D'}, {'value': 'B'}])
         plot.update((2,))
         legend_labels = [property_to_dict(item.label) for item in plot.state.legend[0].items]
-        self.assertEqual(legend_labels, [{'value': 'B'}, {'value': 'E'}])
+        self.assertEqual(legend_labels, [{'value': 'E'}, {'value': 'B'}])
 
     def test_holomap_legend_updates_varying_lengths(self):
         hmap = HoloMap({i: Overlay([Curve([1, 2, j], label=chr(65+j)) for j in range(i)]) for i in range(1, 4)})


### PR DESCRIPTION
For the longest time OverlayPlots tried to be smart and remappped dynamically created elements to subplots as long as they partially matched the plot spec. A plot spec consists of `(<element-type>, <group>, <label>, <ndoverlay-dims>)`. Remapping plots like this can be more efficient but may also cause significant issues because a plot created for one element may have a bunch of state that is not correct for the new element. In theory all this state could be updated but we never did a good job at this, resulting in a variety of issues, e.g. subplots would end up assigning the wrong colors, legend order or a variety of other incorrect properties to a glyph/renderer.

Fixes:

```python
import holoviews as hv
import pandas as pd
import panel as pn

hv.extension("bokeh")

color_dim = hv.dim("category").categorize(
    categories={"B": "red", "A": "blue", "C": "green"}, default="grey"
)
data = pd.DataFrame(
    {"x": range(5), "y": range(5), "category": ["A", "B", "A", "C", "B"]}
)


def inner(value):
    el = hv.Dataset(data).to(hv.Points, kdims=["x", "y"], groupby="category")
    if value:
        el = el.get(value)
    el.opts(color=color_dim, show_legend=False, xlim=(-1, 6), ylim=(-1, 6))
    return el.overlay()


w1 = pn.widgets.MultiSelect(value=["A"], options=list("ABC"))
pn.Row(w1, hv.DynamicMap(inner, streams=[w1.param.value])).servable()
```