### PR TITLE
Handle rasterized output which is ImageStack

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1288,15 +1288,15 @@ class shade(LinkableOperation):
 
         # Compute shading options depending on whether
         # it is a categorical or regular aggregate
-        if element.ndims > 2:
-            kdims = element.kdims[1:]
+        if element.ndims > 2 or isinstance(element, ImageStack):
+            kdims = element.kdims if isinstance(element, ImageStack) else element.kdims[1:]
             categories = array.shape[-1]
             if not self.p.color_key:
                 pass
             elif isinstance(self.p.color_key, dict):
                 shade_opts['color_key'] = self.p.color_key
             elif isinstance(self.p.color_key, Iterable):
-                shade_opts['color_key'] = [c for i, c in
+                shade_opts['color_key'] = [c for _, c in
                                            zip(range(categories), self.p.color_key)]
             else:
                 colors = [self.p.color_key(s) for s in np.linspace(0, 1, categories)]

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1,6 +1,7 @@
 import datetime as dt
 from unittest import SkipTest, skipIf
 
+import colorcet as cc
 import numpy as np
 import pandas as pd
 import pytest
@@ -1530,3 +1531,17 @@ def test_uint64_dtype():
     curve = Curve(df)
     with pytest.raises(TypeError, match="Dtype of uint64 for column A is not supported."):
         rasterize(curve, dynamic=False, height=10, width=10)
+
+
+def test_imagestack_datashader_color_key():
+    d = np.arange(23)
+    df = pd.DataFrame({"x": d, "y": d, "language": list(map(str, d))})
+    points = Points(df, ["x", "y"], ["language"])
+
+    # This will run rasterize which outputs an ImageStack
+    op = datashade(
+        points,
+        aggregator=ds.by("language", ds.count()),
+        color_key=cc.glasbey_light,
+    )
+    render(op)  # should not error out


### PR DESCRIPTION
Because rasterize now can output an `ImageStack`, we need to also allow it to accept `color_key` 