### PR TITLE
Enforce labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+changelog:
+  categories:
+    - title: New features
+      labels:
+        - "type: feature"
+    - title: Enhancements
+      labels:
+        - "type: enhancement"
+    - title: Bug fixes
+      labels:
+        - "type: bug"
+    - title: Compatibility
+      labels:
+        - "type: compatibility"
+    - title: Documentation
+      labels:
+        - "type: doc"
+    - title: Maintenance
+      labels:
+        - "type: maintenance"
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,17 @@
+name: labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    name: Pull Request Labels
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: "type: bug, type: enhancement, type: feature, type: docs, type: maintenance, type: compatibility"


### PR DESCRIPTION
It is always taking longer than it should for me to sort the changelog. This is an attempt to reduce the time needed by tagging a PR with one of the following labels: `type: bug`, `type: enhancement`, `type: feature`, `type: docs`, `type: maintenance`, `type: compatibility`, and then have the automatic changelog generator sort them for me.