### PR TITLE
Fixing URLs to bokeh project

### DIFF
--- a/examples/gallery/demos/bokeh/legend_example.ipynb
+++ b/examples/gallery/demos/bokeh/legend_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/legend.html\n",
+    "URL: https://docs.bokeh.org/en/latest/docs/examples/basic/annotations/legend.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",

--- a/examples/gallery/demos/matplotlib/legend_example.ipynb
+++ b/examples/gallery/demos/matplotlib/legend_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/legend.html\n",
+    "URL: https://docs.bokeh.org/en/latest/docs/examples/basic/annotations/legend.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",


### PR DESCRIPTION
Noticed that the link to Bokeh examples don't work. I think this is the new and correct URL.