### PR TITLE
Compability updates with xarray 2023.12

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -178,12 +178,18 @@ class XArrayInterface(GridInterface):
                     arrays[vdim.name] = arr
                 data = xr.Dataset(arrays)
         else:
+            # Started to warn in xarray 2023.12.0:
+            # The return type of `Dataset.dims` will be changed to return a
+            # set of dimension names in future, in order to be more consistent
+            # with `DataArray.dims`. To access a mapping from dimension names to
+            # lengths, please use `Dataset.sizes`.
+            data_info =  data.sizes if hasattr(data, "sizes") else data.dims
             if not data.coords:
-                data = data.assign_coords(**{k: range(v) for k, v in data.dims.items()})
+                data = data.assign_coords(**{k: range(v) for k, v in data_info.items()})
             if vdims is None:
                 vdims = list(data.data_vars)
             if kdims is None:
-                xrdims = list(data.dims)
+                xrdims = list(data_info)
                 xrcoords = list(data.coords)
                 kdims = [name for name in data.indexes.keys()
                          if isinstance(data[name].data, np.ndarray)]
@@ -636,7 +642,7 @@ class XArrayInterface(GridInterface):
     def dframe(cls, dataset, dimensions):
         import xarray as xr
         if cls.packed(dataset):
-            bands = {vd.name: dataset.data[..., i].drop('band')
+            bands = {vd.name: dataset.data[..., i].drop_vars('band')
                      for i, vd in enumerate(dataset.vdims)}
             data = xr.Dataset(bands)
         else:

--- a/holoviews/tests/core/data/test_xarrayinterface.py
+++ b/holoviews/tests/core/data/test_xarrayinterface.py
@@ -249,8 +249,16 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
             coords=dict(chain=range(d.shape[0]), value=range(d.shape[1])))
         ds = Dataset(da)
         t = ds.select(chain=0)
-        self.assertEqual(t.data.dims , dict(chain=1,value=8))
-        self.assertEqual(t.data.stuff.shape , (1,8))
+        if hasattr(t.data, "sizes"):
+            # Started to warn in xarray 2023.12.0:
+            # The return type of `Dataset.dims` will be changed to return a
+            # set of dimension names in future, in order to be more consistent
+            # with `DataArray.dims`. To access a mapping from dimension names to
+            # lengths, please use `Dataset.sizes`.
+            assert t.data.sizes == dict(chain=1, value=8)
+        else:
+            assert t.data.dims == dict(chain=1, value=8)
+        assert t.data.stuff.shape == (1, 8)
 
     def test_mask_2d_array_transposed(self):
         array = np.random.rand(4, 3)


### PR DESCRIPTION
I started to see some deprecation warnings in the test suite. This PR will remove those warnings by following its instructions. 