### PR TITLE
Add 'norm' in init_artists in holoviews/plotting/mpl/raster.py,

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -592,8 +592,8 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         plot_method = self._plot_methods.get('batched' if self.batched else 'single')
         plot_fn = getattr(ax, plot_method)
         if 'norm' in plot_kwargs: # vmin/vmax should now be exclusively in norm
-             plot_kwargs.pop('vmin', None)
-             plot_kwargs.pop('vmax', None)
+            plot_kwargs.pop('vmin', None)
+            plot_kwargs.pop('vmax', None)
         with warnings.catch_warnings():
             # scatter have a default cmap and with an empty array will emit this warning
             warnings.filterwarnings('ignore', "No data for colormapping provided via 'c'")

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -191,8 +191,8 @@ class QuadMeshPlot(ColorbarPlot):
         artist = ax.pcolormesh(*plot_args, **plot_kwargs)
         colorbar = self.handles.get('cbar')
         if 'norm' in plot_kwargs: # vmin/vmax should now be exclusively in norm
-             plot_kwargs.pop('vmin', None)
-             plot_kwargs.pop('vmax', None)
+            plot_kwargs.pop('vmin', None)
+            plot_kwargs.pop('vmax', None)
         if colorbar and mpl_version < Version('3.1'):
             colorbar.set_norm(artist.norm)
             if hasattr(colorbar, 'set_array'):

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -190,6 +190,9 @@ class QuadMeshPlot(ColorbarPlot):
         locs = plot_kwargs.pop('locs', None)
         artist = ax.pcolormesh(*plot_args, **plot_kwargs)
         colorbar = self.handles.get('cbar')
+        if 'norm' in plot_kwargs: # vmin/vmax should now be exclusively in norm
+             plot_kwargs.pop('vmin', None)
+             plot_kwargs.pop('vmax', None)
         if colorbar and mpl_version < Version('3.1'):
             colorbar.set_norm(artist.norm)
             if hasattr(colorbar, 'set_array'):


### PR DESCRIPTION
Added handling of 'norm' kwarg to init_artists in the same way is already present in /holoviews/plotting/mpl/element.py, in order to pass norm when plotting a quadmesh with matplotlib backend. This allows to pass a custom norm and colormap to be able to plot a colobar with discrete, uneven intervals correctly. Related to #5966 