### PR TITLE
Override Curve's count aggregator default to `self_intersect=False`

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -444,6 +444,17 @@ class aggregate(LineAggregationOperation):
                 agg[col] = ((y.name, x.name), val)
         return agg
 
+class curve_aggregate(aggregate):
+    """
+    Optimized aggregation for Curve objects by setting the default
+    of the aggregator to self-intersect=False.
+    """
+    aggregator = param.ClassSelector(class_=(rd.Reduction, rd.summary, str),
+                                     default=rd.count(self_intersect=False), doc="""
+        Datashader reduction function used for aggregating the data.
+        The aggregator may also define a column to aggregate; if
+        no column is defined the first value dimension of the element
+        will be used. May also be defined as a string.""")
 
 class overlay_aggregate(aggregate):
     """
@@ -1457,7 +1468,7 @@ class rasterize(AggregationOperation):
                    (Graph, aggregate),
                    (Scatter, aggregate),
                    (Points, aggregate),
-                   (Curve, aggregate),
+                   (Curve, curve_aggregate),
                    (Path, aggregate),
                    (type(None), shade) # To handle parameters of datashade
     ]

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -447,7 +447,8 @@ class aggregate(LineAggregationOperation):
 class curve_aggregate(aggregate):
     """
     Optimized aggregation for Curve objects by setting the default
-    of the aggregator to self-intersect=False.
+    of the aggregator to self_intersect=False to be more consistent
+    with the appearance of non-aggregated curves.
     """
     aggregator = param.ClassSelector(class_=(rd.Reduction, rd.summary, str),
                                      default=rd.count(self_intersect=False), doc="""


### PR DESCRIPTION
fixes #5975

This PR disables the self-intersect option for a Datashader count aggregator, which controls whether pixel-crossings of the same line contribute toward a pixel's count. 

Why? In some cases, showing self-intersection counts (showing where a line crosses through the same pixel multiple times) is preferred, as it provides information about how the signal varies even when the variations involved are smaller than the pixels on the screen. However, in order to be more consistent with how a non-Datashader curve would appear, it was decided that a more reasonable default behavior would be to disable self-intersect for individual (non-categorical) curves.

As this PR is currently composed, not providing any `aggregator` argument for hvPlot will adopt the new default. One issue is that setting a count aggregator without any kwargs will revert to adopting Datashader's default (`self_intersect=True`), is this acceptable?

<details> <summary> Code </summary>

```python
import datashader as ds
import pandas as pd
import holoviews as hv
hv.extension('bokeh')
import hvplot.pandas

df = pd.read_parquet("./tseriesviz.parq")
df0 = df[df.sensor=='0']
df

width=600
colorbar=False
(df0.hvplot.line('time', 'value', rasterize=True, title='default [count]', line_width=1).opts(width=width, colorbar=colorbar) +\
df0.hvplot.line('time', 'value', rasterize=True, title='Set ds.count()', line_width=1, aggregator=ds.count()).opts(width=width, colorbar=colorbar) +\
 df0.hvplot.line('time', 'value', rasterize=True, title='Set ds.count(self-intersect=False)', line_width=1, aggregator=ds.count(self_intersect=False)).opts(width=width, colorbar=colorbar) +\
df0.hvplot.line('time', 'value', rasterize=True, title='Set ds.count(self-intersect=True)', line_width=1, aggregator=ds.count(self_intersect=True)).opts(width=width, colorbar=colorbar) +\
df.hvplot.line('time', 'value', rasterize=True, by='sensor', title='default [count_cat]', line_width=1).opts(width=width, colorbar=colorbar)).cols(2)
```

</details>

![image](https://github.com/holoviz/holoviews/assets/6613202/57635d0b-7023-44c3-82c0-ba6889a4b481)


