### PR TITLE
Package update - build and publish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
-          fetch-tags: true
+      - name: Fetch unshallow
+        run: git fetch --prune --tags --unshallow -f
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
@@ -91,7 +92,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
-          fetch-tags: true
+      - name: Fetch unshallow
+        run: git fetch --prune --tags --unshallow -f
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
     environment:
       name: publish
     steps:
-      - run: echo "All builds has finished and ready to publish"
+      - run: echo "All builds has finished, have been approved, and ready to publish"
 
   pip_build:
     name: Build PyPI Package

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,9 +24,9 @@ jobs:
     name: Waiting Room
     runs-on: ubuntu-latest
     needs: [conda_build, pip_install]
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    # environment:
-    #   name: publish
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: publish
     steps:
       - run: echo "All builds have finished, have been approved, and ready to publish"
 
@@ -61,7 +61,7 @@ jobs:
     name: Publish Conda
     runs-on: ubuntu-latest
     needs: [conda_build, waiting_room]
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -77,14 +77,14 @@ jobs:
       - name: conda setup
         run: |
           conda install -y anaconda-client
-      # - name: conda dev upload
-      #   if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
-      #   run: |
-      #     anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
-      # - name: conda main upload
-      #   if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
-      #   run: |
-      #     anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
+      - name: conda dev upload
+        if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
+        run: |
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
+      - name: conda main upload
+        if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
+        run: |
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
 
   pip_build:
     name: Build PyPI
@@ -131,15 +131,15 @@ jobs:
     name: Publish PyPI
     runs-on: ubuntu-latest
     needs: [pip_build, waiting_room]
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: pip
           path: dist/
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: ${{ secrets.PPU }}
-      #     password: ${{ secrets.PPP }}
-      #     repository-url: "https://upload.pypi.org/legacy/"
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PPU }}
+          password: ${{ secrets.PPP }}
+          repository-url: "https://upload.pypi.org/legacy/"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,9 +22,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     defaults:
       run:
-        shell: bash -l {0}
-    env:
-      CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
+        shell: bash -el {0}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -35,15 +33,10 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow -f
-      - name: Set output
-        id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: conda setup
         run: |
-          conda config --set always_yes True
-          conda config --append channels pyviz/label/dev
           # pyct is for running setup.py
-          conda install -y conda-build anaconda-client build pyct
+          conda install -y conda-build build pyct -c pyviz/label/dev
       - name: conda build
         run: |
           source ./scripts/build_conda.sh
@@ -54,14 +47,40 @@ jobs:
           name: conda_build
           path: ${{ env.CONDA_FILE }}
           if-no-files-found: error
+
+  conda_publish:
+    name: Publish Conda Package
+    runs-on: ubuntu-latest
+    needs: conda_build
+    if: startsWith(github.ref, 'refs/tags/')
+    env:
+      CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: conda setup
+        run: |
+          conda install -y anaconda-client
+      - uses: actions/download-artifact@v3
+        with:
+          name: conda_build
+          path: ${{ needs.conda_build.env.CONDA_FILE }}
       - name: conda dev upload
-        if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+        if: contains(github.ref, 'a') || contains(github.ref, 'b') || contains(github.ref, 'rc'))
         run: |
-          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev $CONDA_FILE
+          # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev ${{ needs.conda_build.env.CONDA_FILE }}
+          echo "conda dev upload"
       - name: conda main upload
-        if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+        if: (!(contains(github.ref, 'a') || contains(github.ref, 'b') || contains(github.ref, 'rc'))))
         run: |
-          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main $CONDA_FILE
+          # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main ${{ needs.conda_build.env.CONDA_FILE }}
+          echo conda main upload
+
   pip_build:
     name: Build PyPI Package
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: conda build
         run: |
           source ./scripts/build_conda.sh
-          echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/panel-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
+          echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/holoviews-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         if: always()
         with:
@@ -52,13 +52,21 @@ jobs:
     name: Publish Conda Package
     runs-on: ubuntu-latest
     needs: conda_build
-    if: startsWith(github.ref, 'refs/tags/')
+    # if: startsWith(github.ref, 'refs/tags/')
     env:
       CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
     defaults:
       run:
         shell: bash -el {0}
     steps:
+      - name: Testing
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "Testing ${{ github.ref }}"
+      - name: Testing
+        if: (!startsWith(github.ref, 'refs/tags/'))
+        run: |
+          echo "Testing ${{ github.ref }}"
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
@@ -71,12 +79,12 @@ jobs:
           name: conda_build
           path: ${{ needs.conda_build.env.CONDA_FILE }}
       - name: conda dev upload
-        if: contains(github.ref, 'a') || contains(github.ref, 'b') || contains(github.ref, 'rc'))
+        if: contains(github.ref, 'a') || contains(github.ref, 'b') || contains(github.ref, 'rc')
         run: |
           # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev ${{ needs.conda_build.env.CONDA_FILE }}
           echo "conda dev upload"
       - name: conda main upload
-        if: (!(contains(github.ref, 'a') || contains(github.ref, 'b') || contains(github.ref, 'rc'))))
+        if: (!(contains(github.ref, 'a') || contains(github.ref, 'b') || contains(github.ref, 'rc')))
         run: |
           # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main ${{ needs.conda_build.env.CONDA_FILE }}
           echo conda main upload

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,6 @@ jobs:
         run: |
           conda config --set always_yes True
           conda config --append channels pyviz/label/dev
-          conda config --append channels conda-forge
           # pyct is for running setup.py
           conda install -y conda-build anaconda-client build pyct
       - name: conda build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,12 +78,11 @@ jobs:
       - name: conda dev upload
         if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
         run: |
-          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev ${{ env.CONDA_FILE }}
+          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev $CONDA_FILE
       - name: conda main upload
         if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
         run: |
-          # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main ${{ env.CONDA_FILE }}
-          echo conda main upload
+          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main $CONDA_FILE
 
   pip_build:
     name: Build PyPI Package

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: '0 14 * * SUN'
 
+defaults:
+  run:
+    shell: bash -el {0}
+
 env:
   SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
   PYTHON_VERSION: "3.10"
@@ -20,9 +24,6 @@ jobs:
   conda_build:
     name: Build Conda Package
     runs-on: 'ubuntu-latest'
-    defaults:
-      run:
-        shell: bash -el {0}
     outputs:
       conda_file: ${{ env.CONDA_FILE }}
     steps:
@@ -55,9 +56,6 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     env:
       CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
-    defaults:
-      run:
-        shell: bash -el {0}
     steps:
       - name: Set environment variables
         run: |
@@ -86,9 +84,6 @@ jobs:
   pip_build:
     name: Build PyPI Package
     runs-on: 'ubuntu-latest'
-    defaults:
-      run:
-        shell: bash -el {0}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -113,9 +108,6 @@ jobs:
     name: Install PyPI Package
     runs-on: 'ubuntu-latest'
     needs: [pip_build]
-    defaults:
-      run:
-        shell: bash -el {0}
     steps:
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,8 +53,8 @@ jobs:
   conda_publish:
     name: Publish Conda Package
     runs-on: ubuntu-latest
-    needs: [conda_build]
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: [conda_build, waiting_room]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -64,23 +64,20 @@ jobs:
         run: |
           echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo "CONDA_FILE=$(ls dist/*.tar.bz2)" >> $GITHUB_ENV
-      - name: Check environment variables
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+      - name: conda setup
         run: |
-          echo $CONDA_FILE
-      # - uses: conda-incubator/setup-miniconda@v2
-      #   with:
-      #     miniconda-version: "latest"
-      # - name: conda setup
-      #   run: |
-      #     conda install -y anaconda-client
-      # - name: conda dev upload
-      #   if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
-      #   run: |
-      #     anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
-      # - name: conda main upload
-      #   if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
-      #   run: |
-      #     anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
+          conda install -y anaconda-client
+      - name: conda dev upload
+        if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
+        run: |
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
+      - name: conda main upload
+        if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
+        run: |
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
 
   pip_build:
     name: Build PyPI Package

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,29 +52,6 @@ jobs:
           path: ${{ env.CONDA_FILE }}
           if-no-files-found: error
 
-  conda_install:
-    name: Install Conda Package
-    runs-on: ubuntu-latest
-    needs: [conda_build]
-    steps:
-      - name: Set environment variables
-        run: |
-          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "CONDA_FILE=${{ needs.conda_build.outputs.conda_file }}" >> $GITHUB_ENV
-          echo "CONDA_PATH=${{ needs.conda_build.outputs.conda_path }}" >> $GITHUB_ENV
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: "latest"
-      - uses: actions/download-artifact@v3
-        with:
-          name: conda_build
-          path: ${{ env.CONDA_PATH }}
-      - name: conda setup
-        run: |
-          conda install python=$PYTHON_VERSION $CONDA_FILE -y
-      - name: Test package
-        run: python -c "import $PACKAGE; print($PACKAGE.__version__)"
-
   conda_publish:
     name: Publish Conda Package
     runs-on: ubuntu-latest
@@ -168,7 +145,7 @@ jobs:
   waiting_room:
     name: Waiting Room
     runs-on: ubuntu-latest
-    needs: [conda_install, pip_install]
+    needs: [conda_build, pip_install]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     environment:
       name: publish

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           source ./scripts/build_conda.sh
           echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: conda_build
@@ -56,7 +56,7 @@ jobs:
     needs: [conda_build, waiting_room]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: conda_build
           path: dist/
@@ -96,7 +96,7 @@ jobs:
           python -m pip install build
       - name: Build package
         run: python -m build .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: pip_build
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: pip_build
           path: dist/
@@ -126,7 +126,7 @@ jobs:
     needs: [pip_build, waiting_room]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: pip_build
           path: dist/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,8 +53,8 @@ jobs:
   conda_publish:
     name: Publish Conda Package
     runs-on: ubuntu-latest
-    needs: [conda_build, waiting_room]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: [conda_build]
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -64,20 +64,23 @@ jobs:
         run: |
           echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo "CONDA_FILE=$(ls dist/*.tar.bz2)" >> $GITHUB_ENV
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: "latest"
-      - name: conda setup
+      - name: Check environment variables
         run: |
-          conda install -y anaconda-client
-      - name: conda dev upload
-        if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
-        run: |
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
-      - name: conda main upload
-        if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
-        run: |
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
+          echo $CONDA_FILE
+      # - uses: conda-incubator/setup-miniconda@v2
+      #   with:
+      #     miniconda-version: "latest"
+      # - name: conda setup
+      #   run: |
+      #     conda install -y anaconda-client
+      # - name: conda dev upload
+      #   if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
+      #   run: |
+      #     anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
+      # - name: conda main upload
+      #   if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
+      #   run: |
+      #     anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
 
   pip_build:
     name: Build PyPI Package

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,8 +12,6 @@ on:
     - cron: '0 14 * * SUN'
 
 env:
-  PYTHON_VERSION: "3.9"
-  MPLBACKEND: "Agg"
   SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
 
 jobs:
@@ -32,7 +30,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: ${{ env.PYTHON_VERSION }}
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow -f
       - name: conda setup
@@ -71,7 +68,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: ${{ env.PYTHON_VERSION }}
       - name: conda setup
         run: |
           conda install -y anaconda-client
@@ -94,7 +90,7 @@ jobs:
     name: Waiting Room
     runs-on: ubuntu-latest
     needs: [conda_build, pip_build]
-    # if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     environment:
       name: publish
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,14 +2,14 @@ name: packages
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+'
-    - 'v[0-9]+.[0-9]+.[0-9]+a[0-9]+'
-    - 'v[0-9]+.[0-9]+.[0-9]+b[0-9]+'
-    - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+a[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+b[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
   # Dry-run only
   workflow_dispatch:
   schedule:
-    - cron: '0 14 * * SUN'
+    - cron: "0 14 * * SUN"
 
 defaults:
   run:
@@ -23,7 +23,7 @@ env:
 jobs:
   conda_build:
     name: Build Conda Package
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     outputs:
       conda_file: ${{ env.CONDA_FILE }}
       conda_path: ${{ env.CONDA_PATH }}
@@ -44,7 +44,6 @@ jobs:
           source ./scripts/build_conda.sh
           echo "CONDA_PATH="$CONDA_PREFIX/conda-bld/noarch/"" >> $GITHUB_ENV
           echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
-          ls $CONDA_PREFIX/conda-bld/noarch
       - uses: actions/upload-artifact@v3
         if: always()
         with:
@@ -87,7 +86,7 @@ jobs:
 
   pip_build:
     name: Build PyPI Package
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -110,7 +109,7 @@ jobs:
 
   pip_install:
     name: Install PyPI Package
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     needs: [pip_build]
     steps:
       - uses: actions/setup-python@v4
@@ -138,7 +137,7 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user:  ${{ secrets.PPU }}
+          user: ${{ secrets.PPU }}
           password: ${{ secrets.PPP }}
           repository-url: "https://upload.pypi.org/legacy/"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,12 +112,25 @@ jobs:
           name: pip_build
           path: dist/
           if-no-files-found: error
-      # - name: pip upload
-      #   if: github.event_name == 'push'
-      #   run: |
-      #     conda activate test-environment
-      #     doit ecosystem=pip package_upload -u $PPU -p $PPP -r $PYPI
 
+  pip_publish:
+    name: Publish pip Package
+    runs-on: ubuntu-latest
+    needs: [pip_build]
+    # needs: [pip_build, waiting_room]
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: pip_build
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user:  ${{ secrets.PPU }}
+          password: ${{ secrets.PPP }}
+          repository-url: "https://test.pypi.org/legacy/"
+          # repository-url: "https://upload.pypi.org/legacy/"
 
   waiting_room:
     name: Waiting Room

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,7 @@ jobs:
           ls $CONDA_PATH
       - name: conda setup
         run: |
+          conda install python=$PYTHON_VERSION -y
           conda install -y $CONDA_FILE
       - name: Test package
         run: python -c "import $PACKAGE; print($PACKAGE.__version__)"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
   workflow_dispatch:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "0 14 * * SUN"
 
 defaults:
   run:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,11 +27,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
+          fetch-tags: true
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-      - name: Fetch unshallow
-        run: git fetch --prune --tags --unshallow -f
       - name: conda setup
         run: |
           # pyct is for running setup.py
@@ -123,7 +122,7 @@ jobs:
         run: |
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
-          doit env_create $CHANS_DEV --python=$PYTHON_VERSION
+          doit env_create $CHANS_DEV --python=3.9
       - name: env setup
         run: |
           conda activate test-environment
@@ -138,8 +137,14 @@ jobs:
         run: |
           conda activate test-environment
           doit ecosystem=pip package_build --test-group=simple
-      - name: pip upload
-        if: github.event_name == 'push'
-        run: |
-          conda activate test-environment
-          doit ecosystem=pip package_upload -u $PPU -p $PPP -r $PYPI
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: pip_build
+          path: dist
+          if-no-files-found: error
+      # - name: pip upload
+      #   if: github.event_name == 'push'
+      #   run: |
+      #     conda activate test-environment
+      #     doit ecosystem=pip package_upload -u $PPU -p $PPP -r $PYPI

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,8 @@ on:
 
 env:
   SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
+  PYTHON_VERSION: "3.10"
+
 
 jobs:
   conda_build:
@@ -85,16 +87,6 @@ jobs:
           # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main ${{ env.CONDA_FILE }}
           echo conda main upload
 
-  waiting_room:
-    name: Waiting Room
-    runs-on: ubuntu-latest
-    needs: [conda_build, pip_build]
-    if: startsWith(github.ref, 'refs/tags/')
-    environment:
-      name: publish
-    steps:
-      - run: echo "All builds has finished, have been approved, and ready to publish"
-
   pip_build:
     name: Build PyPI Package
     runs-on: 'ubuntu-latest'
@@ -111,6 +103,8 @@ jobs:
           fetch-depth: "100"
           fetch-tags: true
       - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install build
         run: |
           python -m pip install build
@@ -127,3 +121,14 @@ jobs:
       #   run: |
       #     conda activate test-environment
       #     doit ecosystem=pip package_upload -u $PPU -p $PPP -r $PYPI
+
+
+  waiting_room:
+    name: Waiting Room
+    runs-on: ubuntu-latest
+    needs: [conda_build, pip_build]
+    if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: publish
+    steps:
+      - run: echo "All builds have finished, have been approved, and ready to publish"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,14 +69,9 @@ jobs:
         with:
           name: conda_build
           path: ${{ env.CONDA_PATH }}
-      - run: |
-          file ${{ env.CONDA_FILE }}
-          ls $CONDA_PREFIX/conda-bld/noarch
-          ls $CONDA_PATH
       - name: conda setup
         run: |
-          conda install python=$PYTHON_VERSION -y
-          conda install -y $CONDA_FILE
+          conda install python=$PYTHON_VERSION $CONDA_FILE -y
       - name: Test package
         run: python -c "import $PACKAGE; print($PACKAGE.__version__)"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,9 +24,9 @@ jobs:
     name: Waiting Room
     runs-on: ubuntu-latest
     needs: [conda_build, pip_install]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    environment:
-      name: publish
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    # environment:
+    #   name: publish
     steps:
       - run: echo "All builds have finished, have been approved, and ready to publish"
 
@@ -61,7 +61,7 @@ jobs:
     name: Publish Conda
     runs-on: ubuntu-latest
     needs: [conda_build, waiting_room]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -77,14 +77,14 @@ jobs:
       - name: conda setup
         run: |
           conda install -y anaconda-client
-      - name: conda dev upload
-        if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
-        run: |
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
-      - name: conda main upload
-        if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
-        run: |
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
+      # - name: conda dev upload
+      #   if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
+      #   run: |
+      #     anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
+      # - name: conda main upload
+      #   if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
+      #   run: |
+      #     anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
 
   pip_build:
     name: Build PyPI
@@ -131,15 +131,15 @@ jobs:
     name: Publish PyPI
     runs-on: ubuntu-latest
     needs: [pip_build, waiting_room]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: pip
           path: dist/
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: ${{ secrets.PPU }}
-          password: ${{ secrets.PPP }}
-          repository-url: "https://upload.pypi.org/legacy/"
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     user: ${{ secrets.PPU }}
+      #     password: ${{ secrets.PPP }}
+      #     repository-url: "https://upload.pypi.org/legacy/"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,6 +112,26 @@ jobs:
           path: dist/
           if-no-files-found: error
 
+  pip_install:
+    name: Install PyPI Package
+    runs-on: 'ubuntu-latest'
+    needs: [pip_build]
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: pip_build
+          path: dist/
+      - name: Install package
+        run: python -m pip install dist/*.whl
+      - name: Test package
+        run: python -c "import $PACKAGE"
+
   pip_publish:
     name: Publish PyPI Package
     runs-on: ubuntu-latest
@@ -132,7 +152,7 @@ jobs:
   waiting_room:
     name: Waiting Room
     runs-on: ubuntu-latest
-    needs: [conda_build, pip_build]
+    needs: [conda_build, pip_install]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     environment:
       name: publish

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,9 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+a[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+b[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
-  # Dry-run only
+  pull_request:
+    branches:
+      - "*"
   workflow_dispatch:
   schedule:
     - cron: "0 14 * * SUN"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,11 @@ on:
   schedule:
     - cron: '0 14 * * SUN'
 
+env:
+  PYTHON_VERSION: "3.9"
+  MPLBACKEND: "Agg"
+  SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
+
 jobs:
   conda_build:
     name: Build Conda Packages
@@ -19,13 +24,7 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh"
-      PKG_TEST_PYTHON: "--test-python=py39"
-      PYTHON_VERSION: "3.9"
-      CHANS: "-c pyviz"
-      MPLBACKEND: "Agg"
       CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
-      SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -69,9 +68,7 @@ jobs:
     env:
       CHANS_DEV: "-c pyviz/label/dev -c bokeh"
       PKG_TEST_PYTHON: "--test-python=py39"
-      PYTHON_VERSION: "3.9"
       CHANS: "-c pyviz"
-      MPLBACKEND: "Agg"
       PPU: ${{ secrets.PPU }}
       PPP: ${{ secrets.PPP }}
       PYPI: "https://upload.pypi.org/legacy/"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
     name: Publish Conda Package
     runs-on: ubuntu-latest
     needs: [conda_build, waiting_room]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     env:
       CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
     defaults:
@@ -92,11 +92,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     defaults:
       run:
-        shell: bash -l {0}
-    env:
-      PPU: ${{ secrets.PPU }}
-      PPP: ${{ secrets.PPP }}
-      PYPI: "https://upload.pypi.org/legacy/"
+        shell: bash -el {0}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -114,7 +110,7 @@ jobs:
         if: always()
         with:
           name: pip_build
-          path: dist
+          path: dist/
           if-no-files-found: error
       # - name: pip upload
       #   if: github.event_name == 'push'
@@ -127,7 +123,7 @@ jobs:
     name: Waiting Room
     runs-on: ubuntu-latest
     needs: [conda_build, pip_build]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     environment:
       name: publish
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           conda install -y $CONDA_FILE
       - name: Test package
-        run: python -c "import $PACKAGE; print($PACKAGE.__version__))"
+        run: python -c "import $PACKAGE; print($PACKAGE.__version__)"
 
   conda_publish:
     name: Publish Conda Package
@@ -86,13 +86,13 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-      - name: conda setup
-        run: |
-          conda install -y anaconda-client
       - uses: actions/download-artifact@v3
         with:
           name: conda_build
           path: ${{ env.CONDA_FILE }}
+      - name: conda setup
+        run: |
+          conda install -y anaconda-client
       - name: conda dev upload
         if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
         run: |
@@ -141,7 +141,7 @@ jobs:
       - name: Install package
         run: python -m pip install dist/*.whl
       - name: Test package
-        run: python -c "import $PACKAGE; print($PACKAGE.__version__))"
+        run: python -c "import $PACKAGE; print($PACKAGE.__version__)"
 
   pip_publish:
     name: Publish PyPI Package

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ on:
 env:
   SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
   PYTHON_VERSION: "3.10"
-
+  PACKAGE: "holoviews"
 
 jobs:
   conda_build:
@@ -40,7 +40,7 @@ jobs:
       - name: conda build
         run: |
           source ./scripts/build_conda.sh
-          echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/holoviews-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
+          echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         if: always()
         with:
@@ -79,8 +79,7 @@ jobs:
       - name: conda dev upload
         if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
         run: |
-          # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev ${{ env.CONDA_FILE }}
-          echo "conda dev upload"
+          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev ${{ env.CONDA_FILE }}
       - name: conda main upload
         if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     outputs:
       conda_file: ${{ env.CONDA_FILE }}
+      conda_path: ${{ env.CONDA_PATH }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -41,6 +42,7 @@ jobs:
       - name: conda build
         run: |
           source ./scripts/build_conda.sh
+          echo "CONDA_PATH="$CONDA_PREFIX/conda-bld/noarch/"" >> $GITHUB_ENV
           echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
           ls $CONDA_PREFIX/conda-bld/noarch
       - uses: actions/upload-artifact@v3
@@ -59,16 +61,18 @@ jobs:
         run: |
           echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo "CONDA_FILE=${{ needs.conda_build.outputs.conda_file }}" >> $GITHUB_ENV
+          echo "CONDA_PATH=${{ needs.conda_build.outputs.conda_path }}" >> $GITHUB_ENV
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
       - uses: actions/download-artifact@v3
         with:
           name: conda_build
-          path: ${{ env.CONDA_FILE }}
+          path: ${{ env.CONDA_PATH }}
       - run: |
           file ${{ env.CONDA_FILE }}
           ls $CONDA_PREFIX/conda-bld/noarch
+          ls $CONDA_PATH
       - name: conda setup
         run: |
           conda install -y $CONDA_FILE
@@ -87,13 +91,14 @@ jobs:
         run: |
           echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo "CONDA_FILE=${{ needs.conda_build.outputs.conda_file }}" >> $GITHUB_ENV
+          echo "CONDA_PATH=${{ needs.conda_build.outputs.conda_path }}" >> $GITHUB_ENV
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
       - uses: actions/download-artifact@v3
         with:
           name: conda_build
-          path: ${{ env.CONDA_FILE }}
+          path: ${{ env.CONDA_PATH }}
       - name: conda setup
         run: |
           conda install -y anaconda-client

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,8 +53,8 @@ jobs:
   conda_publish:
     name: Publish Conda Package
     runs-on: ubuntu-latest
-    needs: conda_build
-    # if: startsWith(github.ref, 'refs/tags/')
+    needs: [conda_build, waiting_room]
+    if: startsWith(github.ref, 'refs/tags/')
     env:
       CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
     defaults:
@@ -89,6 +89,16 @@ jobs:
         run: |
           # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main ${{ env.CONDA_FILE }}
           echo conda main upload
+
+  waiting_room:
+    name: Waiting Room
+    runs-on: ubuntu-latest
+    needs: [conda_build, pip_build]
+    # if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: publish
+    steps:
+      - run: echo "All builds has finished and ready to publish"
 
   pip_build:
     name: Build PyPI Package

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,6 @@ jobs:
   conda_build:
     name: Build Conda Package
     runs-on: "ubuntu-latest"
-    outputs:
-      conda_file: ${{ env.CONDA_FILE }}
-      conda_path: ${{ env.CONDA_PATH }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -45,7 +42,6 @@ jobs:
       - name: conda build
         run: |
           source ./scripts/build_conda.sh
-          echo "CONDA_PATH="$CONDA_PREFIX/conda-bld/noarch/"" >> $GITHUB_ENV
           echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         if: always()
@@ -59,32 +55,29 @@ jobs:
     runs-on: ubuntu-latest
     needs: [conda_build, waiting_room]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    env:
-      CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
     steps:
-      - name: Set environment variables
-        run: |
-          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "CONDA_FILE=${{ needs.conda_build.outputs.conda_file }}" >> $GITHUB_ENV
-          echo "CONDA_PATH=${{ needs.conda_build.outputs.conda_path }}" >> $GITHUB_ENV
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: "latest"
       - uses: actions/download-artifact@v3
         with:
           name: conda_build
-          path: ${{ env.CONDA_PATH }}
+          path: dist/
+      - name: Set environment variables
+        run: |
+          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "CONDA_FILE=$(ls dist/*.tar.bz2)" >> $GITHUB_ENV
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
       - name: conda setup
         run: |
           conda install -y anaconda-client
       - name: conda dev upload
         if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
         run: |
-          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev $CONDA_FILE
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
       - name: conda main upload
         if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
         run: |
-          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main $CONDA_FILE
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
 
   pip_build:
     name: Build PyPI Package

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       run:
         shell: bash -el {0}
     outputs:
-      conda_file: ${{ steps.vars.outputs.conda_file }}
+      conda_file: ${{ env.CONDA_FILE }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -40,15 +40,14 @@ jobs:
           # pyct is for running setup.py
           conda install -y conda-build build pyct -c pyviz/label/dev
       - name: conda build
-        id: vars
         run: |
           source ./scripts/build_conda.sh
-          echo "conda_file="$CONDA_PREFIX/conda-bld/noarch/holoviews-$VERSION-py_0.tar.bz2"" >> $GITHUB_OUTPUT
+          echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/holoviews-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: conda_build
-          path: ${{ steps.vars.outputs.conda_file }}
+          path: ${{ env.CONDA_FILE }}
           if-no-files-found: error
 
   conda_publish:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,12 +6,9 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+a[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+b[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
-  pull_request:
-    branches:
-      - "*"
   workflow_dispatch:
   schedule:
-    - cron: "0 14 * * SUN"
+    - cron: "0 2 * * *"
 
 defaults:
   run:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,9 +102,6 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh"
-      PKG_TEST_PYTHON: "--test-python=py39"
-      CHANS: "-c pyviz"
       PPU: ${{ secrets.PPU }}
       PPP: ${{ secrets.PPP }}
       PYPI: "https://upload.pypi.org/legacy/"
@@ -112,31 +109,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: "latest"
-          python-version: 3.9
-      - name: Fetch unshallow
-        run: git fetch --prune --tags --unshallow -f
-      - name: conda setup
+          fetch-tags: true
+      - uses: actions/setup-python@v4
+      - name: Install build
         run: |
-          conda install -c pyviz "pyctdev>=0.5"
-          doit ecosystem_setup
-          doit env_create $CHANS_DEV --python=3.9
-      - name: env setup
-        run: |
-          conda activate test-environment
-          doit develop_install $CHANS_DEV
-          pip uninstall -y holoviews
-          doit pip_on_conda
-      - name: doit env_capture
-        run: |
-          conda activate test-environment
-          doit env_capture
-      - name: pip build
-        run: |
-          conda activate test-environment
-          doit ecosystem=pip package_build --test-group=simple
+          python -m pip install build
+      - name: Build package
+        run: python -m build .
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -114,11 +114,10 @@ jobs:
           if-no-files-found: error
 
   pip_publish:
-    name: Publish pip Package
+    name: Publish PyPI Package
     runs-on: ubuntu-latest
-    needs: [pip_build]
-    # needs: [pip_build, waiting_room]
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: [pip_build, waiting_room]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -129,8 +128,7 @@ jobs:
         with:
           user:  ${{ secrets.PPU }}
           password: ${{ secrets.PPP }}
-          repository-url: "https://test.pypi.org/legacy/"
-          # repository-url: "https://upload.pypi.org/legacy/"
+          repository-url: "https://upload.pypi.org/legacy/"
 
   waiting_room:
     name: Waiting Room

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,8 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
+    outputs:
+      conda_file: ${{ steps.vars.outputs.conda_file }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -38,14 +40,15 @@ jobs:
           # pyct is for running setup.py
           conda install -y conda-build build pyct -c pyviz/label/dev
       - name: conda build
+        id: vars
         run: |
           source ./scripts/build_conda.sh
-          echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/holoviews-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
+          echo "conda_file="$CONDA_PREFIX/conda-bld/noarch/holoviews-$VERSION-py_0.tar.bz2"" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: conda_build
-          path: ${{ env.CONDA_FILE }}
+          path: ${{ steps.vars.outputs.conda_file }}
           if-no-files-found: error
 
   conda_publish:
@@ -59,14 +62,13 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - name: Testing
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Set environment variables
         run: |
-          echo "Testing ${{ github.ref }}"
-      - name: Testing
-        if: (!startsWith(github.ref, 'refs/tags/'))
+          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "CONDA_FILE=${{ needs.conda_build.outputs.conda_file }}" >> $GITHUB_ENV
+      - name: Check environment variables
         run: |
-          echo "Testing ${{ github.ref }}"
+          echo $TAG $CONDA_FILE
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
@@ -77,16 +79,16 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: conda_build
-          path: ${{ needs.conda_build.env.CONDA_FILE }}
+          path: ${{ env.CONDA_FILE }}
       - name: conda dev upload
-        if: contains(github.ref, 'a') || contains(github.ref, 'b') || contains(github.ref, 'rc')
+        if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
         run: |
-          # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev ${{ needs.conda_build.env.CONDA_FILE }}
+          # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev ${{ env.CONDA_FILE }}
           echo "conda dev upload"
       - name: conda main upload
-        if: (!(contains(github.ref, 'a') || contains(github.ref, 'b') || contains(github.ref, 'rc')))
+        if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
         run: |
-          # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main ${{ needs.conda_build.env.CONDA_FILE }}
+          # anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main ${{ env.CONDA_FILE }}
           echo conda main upload
 
   pip_build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,7 @@ jobs:
         run: |
           source ./scripts/build_conda.sh
           echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
+          ls $CONDA_PREFIX/conda-bld/noarch
       - uses: actions/upload-artifact@v3
         if: always()
         with:
@@ -65,6 +66,9 @@ jobs:
         with:
           name: conda_build
           path: ${{ env.CONDA_FILE }}
+      - run: |
+          file ${{ env.CONDA_FILE }}
+          ls $CONDA_PREFIX/conda-bld/noarch
       - name: conda setup
         run: |
           conda install -y $CONDA_FILE

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,16 @@ env:
   PACKAGE: "holoviews"
 
 jobs:
+  waiting_room:
+    name: Waiting Room
+    runs-on: ubuntu-latest
+    needs: [conda_build, pip_install]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: publish
+    steps:
+      - run: echo "All builds have finished, have been approved, and ready to publish"
+
   conda_build:
     name: Build Conda Package
     runs-on: "ubuntu-latest"
@@ -133,13 +143,3 @@ jobs:
           user: ${{ secrets.PPU }}
           password: ${{ secrets.PPP }}
           repository-url: "https://upload.pypi.org/legacy/"
-
-  waiting_room:
-    name: Waiting Room
-    runs-on: ubuntu-latest
-    needs: [conda_build, pip_install]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    environment:
-      name: publish
-    steps:
-      - run: echo "All builds have finished, have been approved, and ready to publish"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,9 +63,6 @@ jobs:
         run: |
           echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo "CONDA_FILE=${{ needs.conda_build.outputs.conda_file }}" >> $GITHUB_ENV
-      - name: Check environment variables
-        run: |
-          echo $TAG $CONDA_FILE
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
@@ -130,7 +127,7 @@ jobs:
       - name: Install package
         run: python -m pip install dist/*.whl
       - name: Test package
-        run: python -c "import $PACKAGE"
+        run: python -c "import $PACKAGE; print($PACKAGE.__version__))"
 
   pip_publish:
     name: Publish PyPI Package

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   conda_build:
-    name: Build Conda Packages
+    name: Build Conda Package
     runs-on: 'ubuntu-latest'
     defaults:
       run:
@@ -63,7 +63,7 @@ jobs:
         run: |
           anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main $CONDA_FILE
   pip_build:
-    name: Build PyPI Packages
+    name: Build PyPI Package
     runs-on: 'ubuntu-latest'
     defaults:
       run:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,6 +49,28 @@ jobs:
           path: ${{ env.CONDA_FILE }}
           if-no-files-found: error
 
+  conda_install:
+    name: Install Conda Package
+    runs-on: ubuntu-latest
+    needs: [conda_build]
+    steps:
+      - name: Set environment variables
+        run: |
+          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "CONDA_FILE=${{ needs.conda_build.outputs.conda_file }}" >> $GITHUB_ENV
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+      - uses: actions/download-artifact@v3
+        with:
+          name: conda_build
+          path: ${{ env.CONDA_FILE }}
+      - name: conda setup
+        run: |
+          conda install -y $CONDA_FILE
+      - name: Test package
+        run: python -c "import $PACKAGE; print($PACKAGE.__version__))"
+
   conda_publish:
     name: Publish Conda Package
     runs-on: ubuntu-latest
@@ -141,7 +163,7 @@ jobs:
   waiting_room:
     name: Waiting Room
     runs-on: ubuntu-latest
-    needs: [conda_build, pip_install]
+    needs: [conda_install, pip_install]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     environment:
       name: publish

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,19 +46,22 @@ jobs:
           conda install -y conda-build anaconda-client build pyct
       - name: conda build
         run: |
-          bash ./scripts/build_conda.sh
+          source ./scripts/build_conda.sh
+          echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/panel-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: conda_build
+          path: ${{ env.CONDA_FILE }}
+          if-no-files-found: error
       - name: conda dev upload
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
-          VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
-          FILE="$CONDA_PREFIX/conda-bld/noarch/holoviews-$VERSION-py_0.tar.bz2"
-          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev $FILE
+          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev $CONDA_FILE
       - name: conda main upload
         if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
-          VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
-          FILE="$CONDA_PREFIX/conda-bld/noarch/holoviews-$VERSION-py_0.tar.bz2"
-          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main $FILE
+          anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main $CONDA_FILE
   pip_build:
     name: Build PyPI Packages
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ defaults:
 
 env:
   SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.11"
   PACKAGE: "holoviews"
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
       - run: echo "All builds have finished, have been approved, and ready to publish"
 
   conda_build:
-    name: Build Conda Package
+    name: Build Conda
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
@@ -53,19 +53,19 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: conda_build
+          name: conda
           path: ${{ env.CONDA_FILE }}
           if-no-files-found: error
 
   conda_publish:
-    name: Publish Conda Package
+    name: Publish Conda
     runs-on: ubuntu-latest
     needs: [conda_build, waiting_room]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: conda_build
+          name: conda
           path: dist/
       - name: Set environment variables
         run: |
@@ -87,7 +87,7 @@ jobs:
           anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
 
   pip_build:
-    name: Build PyPI Package
+    name: Build PyPI
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
@@ -106,12 +106,12 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: pip_build
+          name: pip
           path: dist/
           if-no-files-found: error
 
   pip_install:
-    name: Install PyPI Package
+    name: Install PyPI
     runs-on: "ubuntu-latest"
     needs: [pip_build]
     steps:
@@ -120,7 +120,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/download-artifact@v4
         with:
-          name: pip_build
+          name: pip
           path: dist/
       - name: Install package
         run: python -m pip install dist/*.whl
@@ -128,14 +128,14 @@ jobs:
         run: python -c "import $PACKAGE; print($PACKAGE.__version__)"
 
   pip_publish:
-    name: Publish PyPI Package
+    name: Publish PyPI
     runs-on: ubuntu-latest
     needs: [pip_build, waiting_room]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: pip_build
+          name: pip
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,12 +34,12 @@ jobs:
     name: Build Conda
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "100"
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow -f
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
       - name: conda setup
@@ -71,7 +71,7 @@ jobs:
         run: |
           echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo "CONDA_FILE=$(ls dist/*.tar.bz2)" >> $GITHUB_ENV
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
       - name: conda setup
@@ -90,12 +90,12 @@ jobs:
     name: Build PyPI
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "100"
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow -f
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install build
@@ -115,7 +115,7 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: [pip_build]
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/download-artifact@v4

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,6 +32,13 @@ requirements:
     - {{ dep }}
     {% endfor %}
 
+test:
+  imports:
+    - {{ sdata['name'] }}
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://holoviews.org

--- a/scripts/build_conda.sh
+++ b/scripts/build_conda.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 git status
 
 export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
-python -m build .
+python -m build -w .
 
 git diff --exit-code
 

--- a/scripts/build_conda.sh
+++ b/scripts/build_conda.sh
@@ -11,4 +11,4 @@ git diff --exit-code
 
 VERSION=$(find dist -name "*.whl" -exec basename {} \; | cut -d- -f2)
 export VERSION
-conda build conda.recipe/ --no-test --no-anaconda-upload --no-verify
+conda build conda.recipe/ --no-anaconda-upload --no-verify


### PR DESCRIPTION
The following updates:

- Don't use pyctdev for the PyPI package. Instead, use the build package.
- Splitting building and publishing up for both PyPI and Conda.
- Add artifacts to both
- Add pip install step to check if the wheel can be installed, and do an import.
- Add an approval step after the build and wait for all builds.
- As both build steps take under two minutes to finish, I have set it up so they run on PRs. I am not sure about if this is needed. I can remove it again.

Example of workflow: https://github.com/holoviz/holoviews/actions/runs/7210047765

Screenshots of workflow:
![ Screenshot 2023-12-14 15 13 09](https://github.com/holoviz/holoviews/assets/19758978/633326b8-8de7-45f3-9fb1-935dc0872778)
![ Screenshot 2023-12-14 15 13 22](https://github.com/holoviz/holoviews/assets/19758978/79844085-021b-4a79-aae8-7547b624e131)

![ Screenshot 2023-12-14 15 56 22](https://github.com/holoviz/holoviews/assets/19758978/d5694a31-d227-42e1-b2c1-6ace95f5bc50)
![ Screenshot 2023-12-14 15 56 44](https://github.com/holoviz/holoviews/assets/19758978/fe95956e-35e3-491f-a13a-baa89678bba4)
![ Screenshot 2023-12-14 15 58 12](https://github.com/holoviz/holoviews/assets/19758978/acdf6a72-77db-4528-8579-0e56b54e3ce6)


Ref:
- https://timheuer.com/blog/add-approval-workflow-to-github-actions/
- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/