### PR TITLE
Fix to broken urls in example gallery pages

### DIFF
--- a/examples/gallery/demos/bokeh/dot_example.ipynb
+++ b/examples/gallery/demos/bokeh/dot_example.ipynb
@@ -63,11 +63,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/bokeh/dot_example.ipynb
+++ b/examples/gallery/demos/bokeh/dot_example.ipynb
@@ -63,22 +63,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/dot_example.ipynb
+++ b/examples/gallery/demos/bokeh/dot_example.ipynb
@@ -1,13 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/dot.html"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/examples/gallery/demos/bokeh/histogram_example.ipynb
+++ b/examples/gallery/demos/bokeh/histogram_example.ipynb
@@ -127,22 +127,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/histogram_example.ipynb
+++ b/examples/gallery/demos/bokeh/histogram_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/histogram.html\n",
+    "URL: https://docs.bokeh.org/en/latest/docs/examples/topics/stats/histogram.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -127,11 +127,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/bokeh/iris_example.ipynb
+++ b/examples/gallery/demos/bokeh/iris_example.ipynb
@@ -57,22 +57,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/iris_example.ipynb
+++ b/examples/gallery/demos/bokeh/iris_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/iris.html\n",
+    "URL: https://docs.bokeh.org/en/2.4.1/docs/gallery/iris.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -57,11 +57,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/bokeh/iris_splom_example.ipynb
+++ b/examples/gallery/demos/bokeh/iris_splom_example.ipynb
@@ -62,22 +62,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/iris_splom_example.ipynb
+++ b/examples/gallery/demos/bokeh/iris_splom_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/iris_splom.html\n",
+    "URL: https://docs.bokeh.org/en/2.4.1/docs/gallery/iris_splom.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -62,11 +62,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/bokeh/lesmis_example.ipynb
+++ b/examples/gallery/demos/bokeh/lesmis_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/les_mis.html"
+    "URL: https://docs.bokeh.org/en/latest/docs/examples/topics/categorical/les_mis.html"
    ]
   },
   {
@@ -98,11 +98,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/bokeh/lesmis_example.ipynb
+++ b/examples/gallery/demos/bokeh/lesmis_example.ipynb
@@ -98,22 +98,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/lorenz_attractor_example.ipynb
+++ b/examples/gallery/demos/bokeh/lorenz_attractor_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/lorenz.html\n",
+    "URL: https://docs.bokeh.org/en/latest/docs/examples/basic/lines/lorenz.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -83,11 +83,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/bokeh/lorenz_attractor_example.ipynb
+++ b/examples/gallery/demos/bokeh/lorenz_attractor_example.ipynb
@@ -83,22 +83,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/step_chart.ipynb
+++ b/examples/gallery/demos/bokeh/step_chart.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/step_chart.html\n",
-    "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
     "* [Matplotlib - step_chart example](../bokeh/step_chart_example.ipynb)"
@@ -61,7 +59,7 @@
    "outputs": [],
    "source": [
     "postage.opts(\n",
-    "    opts.Curve(interpolation='steps-mid', width=400, height=400, \n",
+    "    opts.Curve(interpolation='steps-mid', width=400, height=400,\n",
     "               line_dash=hv.Cycle(values=['dashed', 'solid'])),\n",
     "    opts.Overlay(legend_position='top_left'))"
    ]

--- a/examples/gallery/demos/bokeh/stocks_example.ipynb
+++ b/examples/gallery/demos/bokeh/stocks_example.ipynb
@@ -81,22 +81,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/stocks_example.ipynb
+++ b/examples/gallery/demos/bokeh/stocks_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/stocks.html\n",
+    "URL: https://docs.bokeh.org/en/2.4.1/docs/gallery/stocks.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -81,11 +81,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/bokeh/texas_choropleth_example.ipynb
+++ b/examples/gallery/demos/bokeh/texas_choropleth_example.ipynb
@@ -67,22 +67,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/texas_choropleth_example.ipynb
+++ b/examples/gallery/demos/bokeh/texas_choropleth_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/texas.html\n",
+    "URL: https://docs.bokeh.org/en/latest/docs/examples/topics/geo/texas_hover_map.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -67,9 +67,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/us_unemployment.ipynb
+++ b/examples/gallery/demos/bokeh/us_unemployment.ipynb
@@ -64,22 +64,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/us_unemployment.ipynb
+++ b/examples/gallery/demos/bokeh/us_unemployment.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/unemployment.html\n",
+    "URL: https://docs.bokeh.org/en/latest/docs/examples/topics/categorical/heatmap_unemployment.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -64,11 +64,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/matplotlib/histogram_example.ipynb
+++ b/examples/gallery/demos/matplotlib/histogram_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/histogram.html\n",
+    "URL: https://docs.bokeh.org/en/latest/docs/examples/topics/stats/histogram.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -128,11 +128,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/matplotlib/histogram_example.ipynb
+++ b/examples/gallery/demos/matplotlib/histogram_example.ipynb
@@ -128,22 +128,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/iris_example.ipynb
+++ b/examples/gallery/demos/matplotlib/iris_example.ipynb
@@ -59,22 +59,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/iris_example.ipynb
+++ b/examples/gallery/demos/matplotlib/iris_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/iris.html\n",
+    "URL: https://docs.bokeh.org/en/2.4.1/docs/gallery/iris.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -59,11 +59,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/matplotlib/iris_splom_example.ipynb
+++ b/examples/gallery/demos/matplotlib/iris_splom_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/iris_splom.html\n",
+    "URL: https://docs.bokeh.org/en/2.4.1/docs/gallery/iris_splom.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -63,11 +63,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/matplotlib/iris_splom_example.ipynb
+++ b/examples/gallery/demos/matplotlib/iris_splom_example.ipynb
@@ -63,22 +63,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/lorenz_attractor_example.ipynb
+++ b/examples/gallery/demos/matplotlib/lorenz_attractor_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/lorenz.html\n",
+    "URL: https://docs.bokeh.org/en/latest/docs/examples/basic/lines/lorenz.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -82,11 +82,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/matplotlib/lorenz_attractor_example.ipynb
+++ b/examples/gallery/demos/matplotlib/lorenz_attractor_example.ipynb
@@ -82,22 +82,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/step_chart.ipynb
+++ b/examples/gallery/demos/matplotlib/step_chart.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/step_chart.html\n",
-    "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
     "* [Bokeh - step_chart example](../bokeh/step_chart.ipynb)"

--- a/examples/gallery/demos/matplotlib/stocks_example.ipynb
+++ b/examples/gallery/demos/matplotlib/stocks_example.ipynb
@@ -88,22 +88,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/stocks_example.ipynb
+++ b/examples/gallery/demos/matplotlib/stocks_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/stocks.html\n",
+    "URL: https://docs.bokeh.org/en/2.4.1/docs/gallery/stocks.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -88,11 +88,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/gallery/demos/matplotlib/texas_choropleth_example.ipynb
+++ b/examples/gallery/demos/matplotlib/texas_choropleth_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/texas.html\n",
+    "URL: https://docs.bokeh.org/en/latest/docs/examples/topics/geo/texas_hover_map.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -69,9 +69,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/texas_choropleth_example.ipynb
+++ b/examples/gallery/demos/matplotlib/texas_choropleth_example.ipynb
@@ -69,22 +69,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/us_unemployment.ipynb
+++ b/examples/gallery/demos/matplotlib/us_unemployment.ipynb
@@ -62,22 +62,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/us_unemployment.ipynb
+++ b/examples/gallery/demos/matplotlib/us_unemployment.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "URL: http://bokeh.pydata.org/en/latest/docs/gallery/unemployment.html\n",
+    "URL: https://docs.bokeh.org/en/latest/docs/examples/topics/categorical/heatmap_unemployment.html\n",
     "\n",
     "Most examples work across multiple plotting backends, this example is also available for:\n",
     "\n",
@@ -62,11 +62,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
I fixed some of the broken links mentioned in #6006 

**Bokeh:**
- [X] [examples/gallery/demos/bokeh/us_unemployment.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/bokeh/us_unemployment.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/unemployment.html`
- [X] [examples/gallery/demos/bokeh/iris_splom_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/bokeh/iris_splom_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/iris_splom.html` _No longer exists in Bokeh Gallery, thus a page from a previous version of Bokeh is used_
- [ ] [examples/gallery/demos/bokeh/dot_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/bokeh/dot_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/dot.html` _No longer exists in Bokeh Gallery and no previous versions were found_
- [ ] [examples/gallery/demos/bokeh/step_chart.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/bokeh/step_chart.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/step_chart.html` _No longer exists in Bokeh Gallery and no previous versions were found_
- [X] [examples/gallery/demos/bokeh/texas_choropleth_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/bokeh/texas_choropleth_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/texas.html`
- [X] [examples/gallery/demos/bokeh/stocks_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/bokeh/stocks_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/stocks.html` _No longer exists in Bokeh Gallery, thus a page from a previous version of Bokeh is used_
- [X] [examples/gallery/demos/bokeh/lesmis_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/bokeh/lesmis_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/les_mis.html`
- [X] [examples/gallery/demos/bokeh/histogram_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/bokeh/histogram_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/histogram.html`
- [X] [examples/gallery/demos/bokeh/lorenz_attractor_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/bokeh/lorenz_attractor_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/lorenz.html`
- [X] [examples/gallery/demos/bokeh/iris_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/bokeh/iris_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/iris.html` _No longer exists in Bokeh Gallery, thus a page from a previous version of Bokeh is used_


**Matplotlib:**
- [X] [examples/gallery/demos/matplotlib/us_unemployment.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/matplotlib/us_unemployment.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/unemployment.html`
- [X] [examples/gallery/demos/matplotlib/iris_splom_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/matplotlib/iris_splom_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/iris_splom.html` _No longer exists in Bokeh Gallery, thus a page from a previous version of Bokeh is used_
- [ ] [examples/gallery/demos/matplotlib/step_chart.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/matplotlib/step_chart.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/step_chart.html` _No longer exists in Bokeh Gallery and no previous versions were found_
- [X] [examples/gallery/demos/matplotlib/texas_choropleth_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/matplotlib/texas_choropleth_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/texas.html`
- [X] [examples/gallery/demos/matplotlib/stocks_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/matplotlib/stocks_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/stocks.html` _No longer exists in Bokeh Gallery, thus a page from a previous version of Bokeh is used_
- [X] [examples/gallery/demos/matplotlib/histogram_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/matplotlib/histogram_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/histogram.html`
- [X] [examples/gallery/demos/matplotlib/lorenz_attractor_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/matplotlib/lorenz_attractor_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/lorenz.html`
- [X] [examples/gallery/demos/matplotlib/iris_example.ipynb](https://github.com/holoviz/holoviews/blob/main/examples/gallery/demos/matplotlib/iris_example.ipynb) - URL `http://bokeh.pydata.org/en/latest/docs/gallery/iris.html` _No longer exists in Bokeh Gallery, thus a page from a previous version of Bokeh is used_

