### PR TITLE
Remove custom datetime hover conversion for Bokeh Raster plot

### DIFF
--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -11,7 +11,7 @@ from .chart import PointPlot
 from .element import ColorbarPlot, LegendPlot
 from .selection import BokehOverlaySelectionDisplay
 from .styles import base_properties, fill_properties, line_properties, mpl_to_bokeh
-from .util import bokeh33, colormesh
+from .util import bokeh33, bokeh34, colormesh
 
 
 class RasterPlot(ColorbarPlot):
@@ -72,18 +72,18 @@ class RasterPlot(ColorbarPlot):
                 formatter += '{custom}'
             tooltips.append((name, formatter))
 
-        # https://github.com/bokeh/bokeh/issues/13598
-        datetime_code = """
-        if (value === -9223372036854776) {
-            return "NaT"
-        } else {
-            const date = new Date(value);
-            return date.toISOString().slice(0, 19).replace('T', ' ')
-        }
-        """
-        for key in formatters:
-            if formatters[key].lower() == "datetime":
-                formatters[key] = CustomJSHover(code=datetime_code)
+        if not bokeh34:  # https://github.com/bokeh/bokeh/issues/13598
+            datetime_code = """
+            if (value === -9223372036854776) {
+                return "NaN"
+            } else {
+                const date = new Date(value);
+                return date.toISOString().slice(0, 19).replace('T', ' ')
+            }
+            """
+            for key in formatters:
+                if formatters[key].lower() == "datetime":
+                    formatters[key] = CustomJSHover(code=datetime_code)
 
         hover.tooltips = tooltips
         hover.formatters = formatters

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -63,6 +63,7 @@ from ..util import dim_axis_label
 bokeh_version = Version(bokeh.__version__)
 bokeh32 = bokeh_version >= Version("3.2")
 bokeh33 = bokeh_version >= Version("3.3")
+bokeh34 = bokeh_version >= Version("3.4")
 
 TOOL_TYPES = {
     'pan': tools.PanTool,

--- a/holoviews/tests/plotting/bokeh/test_rasterplot.py
+++ b/holoviews/tests/plotting/bokeh/test_rasterplot.py
@@ -7,6 +7,7 @@ from bokeh.models import CustomJSHover
 
 from holoviews.element import RGB, Image, ImageStack, Raster
 from holoviews.plotting.bokeh.raster import ImageStackPlot
+from holoviews.plotting.bokeh.util import bokeh34
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
@@ -148,8 +149,11 @@ class TestRasterPlot(TestBokehPlot):
         hover = plot.handles["hover"]
         assert hover.tooltips[-1] == ("Timestamp", "@{Timestamp}{%F %T}")
         assert "@{Timestamp}" in hover.formatters
-        assert isinstance(hover.formatters["@{Timestamp}"], CustomJSHover)
-        # assert hover.formatters["@{Timestamp}"] == "datetime"  # https://github.com/bokeh/bokeh/issues/13598
+
+        if bokeh34:  # https://github.com/bokeh/bokeh/issues/13598
+            assert hover.formatters["@{Timestamp}"] == "datetime"
+        else:
+            assert isinstance(hover.formatters["@{Timestamp}"], CustomJSHover)
 
 class _ImageStackBase(TestRasterPlot):
     __test__ = False


### PR DESCRIPTION
Follow up to https://github.com/holoviz/holoviews/pull/6023, and remove the custom datetime implementation if Bokeh 3.4 is installed.