### PR TITLE
Dynamic generate unit test matrix and add cache option

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,8 +74,24 @@ jobs:
               - 'setup.py'
               - 'pyproject.toml'
               - '.github/workflows/test.yaml'
+      - name: Set matrix option
+        run: |
+          if [[ -z "${{ github.event_name.workflow_dispatch }}" ]]; then
+            OPTION = ${{ github.event.inputs.target }}
+          elseif [[ -z "${{ github.event_name.schedule }}" ]]; then
+            OPTION = "full"
+          elseif [[ -z github.event_name == 'push' ]]; then
+            if [[ -z github.ref_type == 'tag' ]]; then
+              OPTION = "full"
+            else
+              OPTION = "default"
+            fi
+          else
+            OPTION = "default"
+          fi
+          echo "MATRIX_OPTION=$OPTION" >> $GITHUB_ENV
       - name: Set test matrix with 'default' option
-        if: github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'default')
+        if: env.MATRIX_OPTION == "default"
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
@@ -86,7 +102,7 @@ jobs:
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'full' option
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'full'
+        if: env.MATRIX_OPTION == "full"
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
@@ -94,7 +110,7 @@ jobs:
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'downstream' option
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'downstream'
+        if: env.MATRIX_OPTION == "downstream"
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest"],

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,7 @@ on:
       target:
         description: "How much of the test suite to run"
         type: choice
+        default: default
         options:
           - default
           - full

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
           fi
           echo "MATRIX_OPTION=$OPTION" >> $GITHUB_ENV
       - name: Set test matrix with 'default' option
-        if: contains(env.MATRIX_OPTION, "default")
+        if: env.MATRIX_OPTION == 'default'
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
@@ -102,7 +102,7 @@ jobs:
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'full' option
-        if: contains(env.MATRIX_OPTION, "full")
+        if: env.MATRIX_OPTION == 'full'
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
@@ -110,7 +110,7 @@ jobs:
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'downstream' option
-        if: contains(env.MATRIX_OPTION, "downstream")
+        if: env.MATRIX_OPTION == 'downstream'
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest"],

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,18 +76,14 @@ jobs:
               - '.github/workflows/test.yaml'
       - name: Set matrix option
         run: |
-          if [[ -z "${{ github.event_name.workflow_dispatch }}" ]]; then
-            OPTION = ${{ github.event.inputs.target }}
-          elseif [[ -z "${{ github.event_name.schedule }}" ]]; then
-            OPTION = "full"
-          elseif [[ -z github.event_name == 'push' ]]; then
-            if [[ -z github.ref_type == 'tag' ]]; then
-              OPTION = "full"
-            else
-              OPTION = "default"
-            fi
+          if [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+            OPTION=${{ github.event.inputs.target }}
+          elif [[ "${{ github.event_name }}" == 'schedule' ]]; then
+            OPTION="full"
+          elif [[ "${{ github.event_name }}" == 'push' && "${{ github.ref_type }}" == 'tag' ]]; then
+            OPTION="full"
           else
-            OPTION = "default"
+            OPTION="default"
           fi
           echo "MATRIX_OPTION=$OPTION" >> $GITHUB_ENV
       - name: Set test matrix with 'default' option

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
           fi
           echo "MATRIX_OPTION=$OPTION" >> $GITHUB_ENV
       - name: Set test matrix with 'default' option
-        if: env.MATRIX_OPTION == "default"
+        if: contains(env.MATRIX_OPTION, "default")
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
@@ -102,7 +102,7 @@ jobs:
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'full' option
-        if: env.MATRIX_OPTION == "full"
+        if: contains(env.MATRIX_OPTION, "full")
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
@@ -110,7 +110,7 @@ jobs:
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'downstream' option
-        if: env.MATRIX_OPTION == "downstream"
+        if: contains(env.MATRIX_OPTION, "downstream")
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest"],

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,10 @@ on:
           - default
           - full
           - downstream
+      cache:
+        description: "Use cache"
+        type: boolean
+        default: true
 
   schedule:
     - cron: "0 14 * * SUN"
@@ -118,7 +122,7 @@ jobs:
           channel-priority: strict
           channels: pyviz/label/dev,conda-forge,nodefaults
           envs: "-o flakes -o tests -o examples_tests -o tests_ci"
-          cache: true
+          cache: ${{ github.event.inputs.cache }}
           conda-update: true
         id: install
       - name: bokeh sampledata
@@ -167,7 +171,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: pyviz/label/dev,bokeh,conda-forge,nodefaults
           envs: "-o recommended -o tests -o build -o tests_ci"
-          cache: true
+          cache: ${{ github.event.inputs.cache }}
           playwright: true
         id: install
       - name: doit test_ui
@@ -206,7 +210,7 @@ jobs:
       #     # channel-priority: strict
       #     channels: pyviz/label/dev,conda-forge,nodefaults
       #     envs: "-o tests_core -o tests_ci"
-      #     cache: true
+      #     cache: ${{ github.event.inputs.cache }}
       #     conda-update: true
       #     id: install
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest"],
-              "python-version": ["3.10"]
+              "python-version": ["3.11"]
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,11 +76,11 @@ jobs:
               - '.github/workflows/test.yaml'
       - name: Set matrix option
         run: |
-          if [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]; then
             OPTION=${{ github.event.inputs.target }}
-          elif [[ "${{ github.event_name }}" == 'schedule' ]]; then
+          elif [[ '${{ github.event_name }}' == 'schedule' ]]; then
             OPTION="full"
-          elif [[ "${{ github.event_name }}" == 'push' && "${{ github.ref_type }}" == 'tag' ]]; then
+          elif [[ '${{ github.event_name }}' == 'push' && '${{ github.ref_type }}' == 'tag' ]]; then
             OPTION="full"
           else
             OPTION="default"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,13 +7,14 @@ on:
     branches:
       - "*"
   workflow_dispatch:
-    target:
-      description: "How much of the test suite to run"
-      type: choice
-      options:
-        - default
-        - full
-        - downstream
+    inputs:
+      target:
+        description: "How much of the test suite to run"
+        type: choice
+        options:
+          - default
+          - full
+          - downstream
 
   schedule:
     - cron: "0 14 * * SUN"


### PR DESCRIPTION
This PR makes it possible to generate the test matrix based on inputs. The options are default, full, and downstream. The main pain point this is trying to solve is to reduce the load on our CI when a package is released by only running one OS and Python version in the unit test suite. This will need https://github.com/holoviz-dev/holoviz_tasks/pull/31 to be merged and similar changes in our other repos.

Another problem is, as far as I can see, we also have a problem with downstream tests in general, where it would use the cache packages if the main branch had run before a release/dev-release from that day and, therefore, not install the latest package, making the downstream tests a bit inconsequential.   

Example of downstream dispatch run (only 1 unit test suite is run): 

![image](https://github.com/holoviz/holoviews/assets/19758978/56dfefad-924c-4c46-9544-a2688ad4909f)


Inspiration:  https://iscinumpy.dev/post/cibuildwheel-2-10-0/#only

Note: In #6042, I wrongly assumed I needed to merge it into the main before I could test dispatch. The problem was missing `inputs` in workflow dispatch.   I have reverted the change on the main branch and pushed it here for completeness' sake.

