### PR TITLE
Add true if inputs.cache is not set

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -134,7 +134,7 @@ jobs:
           channel-priority: strict
           channels: pyviz/label/dev,conda-forge,nodefaults
           envs: "-o flakes -o tests -o examples_tests -o tests_ci"
-          cache: ${{ github.event.inputs.cache }}
+          cache: ${{ github.event.inputs.cache || github.event.inputs.cache == '' }}
           conda-update: true
         id: install
       - name: bokeh sampledata
@@ -183,7 +183,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: pyviz/label/dev,bokeh,conda-forge,nodefaults
           envs: "-o recommended -o tests -o build -o tests_ci"
-          cache: ${{ github.event.inputs.cache }}
+          cache: ${{ github.event.inputs.cache || github.event.inputs.cache == '' }}
           playwright: true
         id: install
       - name: doit test_ui
@@ -222,7 +222,7 @@ jobs:
       #     # channel-priority: strict
       #     channels: pyviz/label/dev,conda-forge,nodefaults
       #     envs: "-o tests_core -o tests_ci"
-      #     cache: ${{ github.event.inputs.cache }}
+      #     cache: ${{ github.event.inputs.cache || github.event.inputs.cache == '' }}
       #     conda-update: true
       #     id: install
       - uses: actions/checkout@v3


### PR DESCRIPTION
Follow up to https://github.com/holoviz/holoviews/pull/6043 

Actions triggered by a workflow dispatch will have `github.event.inputs.cache` as empty, meaning that cache not be set in the `holoviz-dev/holoviz_tasks/install` action and defaulting to false. 