### PR TITLE
Create categorical legends for datashaded hvplot figures

### DIFF
--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -1341,7 +1341,7 @@ class categorical_legend(Operation):
         if not isinstance(agg, (ds.count_cat, ds.by)):
             return
         column = agg.column
-        if hasattr(hvds.data, 'dtypes'):
+        if hasattr(hvds.data, 'dtypes') and hasattr(hvds.data.dtypes[column], 'categories'):
             try:
                 cats = list(hvds.data.dtypes[column].categories)
             except TypeError:


### PR DESCRIPTION
This PR solves #6052 by checking if the category column dtype has a `categories` attribute before accessing.