### PR TITLE
Expose setting hard navigable bounds

### DIFF
--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -300,6 +300,78 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Navigable Bounds\n",
+    "\n",
+    "Users may set the `apply_hard_bounds` option to constrain the navigable range (extent one could zoom or pan to). If `True`, the navigable bounds of the plot will be constrained to the range of the data. Go ahead and try to zoom in a out in the plot below, you should find that you cannot zoom beyond the extents of the data.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_values = np.linspace(0, 10, 100)\n",
+    "y_values = np.sin(x_values)\n",
+    "\n",
+    "hv.Curve((x_values, y_values)).opts(apply_hard_bounds=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If `xlim` or `ylim` is set for an element, the navigable bounds of the plot will be set based\n",
+    "on the combined extremes of extents between the data and xlim/ylim ranges. In the plot below, the `xlim` constrains the initial view, but you should be able to pan to the x-range between 0 and 12 - the combined extremes of ranges between the data (0,10) and `xlim` (2,12)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_values = np.linspace(0, 10, 100)\n",
+    "y_values = np.sin(x_values)\n",
+    "\n",
+    "hv.Curve((x_values, y_values)).opts(\n",
+    "    apply_hard_bounds=True,\n",
+    "    xlim=(2, 12),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If a dimension range is specified (e.g. with `.redim.range`), this range will be used as the hard bounds, regardless of the data range or xlim/ylim. This is because the dimension range is itended to be an override on the minimum and maximum allowable values for the dimension. Read more in [Annotating your Data](./01-Annotating_Data.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_values = np.linspace(0, 10, 100)\n",
+    "y_values = np.sin(x_values)\n",
+    "\n",
+    "hv.Curve((x_values, y_values)).opts(\n",
+    "    apply_hard_bounds=True,\n",
+    ").redim.range(x=(4, 6))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the plot above, you should not be able to navigate beyond the specified dimension ranges of `x` (4, 6). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Responsive\n",
     "\n",
     "Since bokeh plots are rendered within a browser window which can be resized dynamically it supports responsive sizing modes allowing the plot to rescale when the window it is placed in is changed. If enabled, the behavior of ``responsive`` modes depends on whether an aspect or width/height option is set. Specifically responsive mode will only work if at least one dimension of the plot is left undefined, e.g. when width and height or width and aspect are set the plot is set to a fixed size, ignoring any ``responsive`` option. This leaves four different ``responsive`` modes:\n",

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -107,7 +107,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
     apply_hard_bounds = param.Boolean(default=False, doc="""
         If True, the navigable bounds of the plot will be set based
-        on the larger of extents of the data+padding, xlim/ylim, dim ranges.""")
+        on the more extreme of extents between the data or xlim/ylim ranges.
+        If dim ranges are set, the hard bounds will be set to the dim ranges.""")
 
     autorange = param.ObjectSelector(default=None, objects=['x', 'y', None], doc="""
         Whether to auto-range along either the x- or y-axis, i.e.
@@ -1931,8 +1932,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         Apply hard bounds to the x and y ranges of the plot. If xlim/ylim is set, limit the
         initial viewable range to xlim/ylim, but allow navigation up to the abs max between
-        the data + pad range and xlim/ylim. If dim range is set (e.g. via redim.range), use
-        it as the hard bounds.
+        the data range and xlim/ylim. If dim range is set (e.g. via redim.range), enforce
+        as hard bounds.
 
         """
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1949,7 +1949,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if min_extent == max_extent:
                 self.handles[axis].bounds = None
             else:
-                self.handles[axis].bounds = (min_extent, max_extent) if min_extent is not None or max_extent is not None else None
+                self.handles[axis].bounds = (min_extent, max_extent)
 
         set_bounds('x_range', min_extent_x, max_extent_x)
         set_bounds('y_range', min_extent_y, max_extent_y)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1899,9 +1899,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 if style_element.label in plot.extra_y_ranges:
                     self.handles['y_range'] = plot.extra_y_ranges.pop(style_element.label)
 
-        # If apply_hard_bound is not set but projection has been set, avoid applying hard bounds by default
-        # since a projection typically means that the plot is either geographic, polar, or 3d
-        if self.apply_hard_bounds or (self.projection is None and self.apply_hard_bounds is None):
+        if self.apply_hard_bounds:
             self._apply_hard_bounds(element, ranges)
 
         self.handles['plot'] = plot

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1946,10 +1946,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         def set_bounds(axis, min_extent, max_extent):
             """Set the bounds for a given axis, using None if both extents are None or identical"""
-            if min_extent == max_extent:
-                self.handles[axis].bounds = None
-            else:
-                self.handles[axis].bounds = (min_extent, max_extent)
+            self.handles[axis].bounds = None if min_extent == max_extent else (min_extent, max_extent)
 
         set_bounds('x_range', min_extent_x, max_extent_x)
         set_bounds('y_range', min_extent_y, max_extent_y)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -105,7 +105,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     align = param.ObjectSelector(default='start', objects=['start', 'center', 'end'], doc="""
         Alignment (vertical or horizontal) of the plot in a layout.""")
 
-    apply_hard_bounds = param.Boolean(default=True, allow_None=True, doc="""
+    apply_hard_bounds = param.Boolean(default=None, allow_None=True, doc="""
         If True, the navigable bounds of the plot will be set based
         on the extents of the data. If False, the bounds will not be set.""")
 
@@ -1899,8 +1899,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 if style_element.label in plot.extra_y_ranges:
                     self.handles['y_range'] = plot.extra_y_ranges.pop(style_element.label)
 
-        if self.apply_hard_bounds:
-            self._apply_hard_bound(element, ranges)
+        # If apply_hard_bound is not set but projection has been set, avoid applying hard bounds by default
+        # since a projection typically means that the plot is either geographic, polar, or 3d
+        if self.apply_hard_bounds or (self.projection is None and self.apply_hard_bounds is None):
+            self._apply_hard_bounds(element, ranges)
 
         self.handles['plot'] = plot
 
@@ -1927,7 +1929,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         return plot
 
-    def _apply_hard_bound(self, element, ranges):
+    def _apply_hard_bounds(self, element, ranges):
         """
         Apply hard bounds to the x and y ranges of the plot.
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1940,7 +1940,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         def validate_bound(bound):
             return bound if util.isfinite(bound) else None
 
-        min_extent_x, min_extent_y, max_extent_x, max_extent_y = map(validate_bound, self.get_extents(element, ranges, range_type='combined', lims_as_soft_ranges=True))
+        min_extent_x, min_extent_y, max_extent_x, max_extent_y = map(
+            validate_bound, self.get_extents(element, ranges, range_type='combined', lims_as_soft_ranges=True)
+        )
 
         def set_bounds(axis, min_extent, max_extent):
             """Set the bounds for a given axis, using None if both extents are None or identical"""

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1946,7 +1946,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         def set_bounds(axis, min_extent, max_extent):
             """Set the bounds for a given axis, using None if both extents are None or identical"""
-            self.handles[axis].bounds = None if min_extent == max_extent else (min_extent, max_extent)
+            try:
+                self.handles[axis].bounds = None if min_extent == max_extent else (min_extent, max_extent)
+            except ValueError:
+                self.handles[axis].bounds = None
 
         set_bounds('x_range', min_extent_x, max_extent_x)
         set_bounds('y_range', min_extent_y, max_extent_y)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1932,7 +1932,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         Apply hard bounds to the x and y ranges of the plot.
 
         Sets the navigable bounds of the plot based on the extents
-        of the given element and ranges. If an extend is numeric and not NaN, it is
+        of the given element and ranges. If an extent is numeric and not NaN, it is
         used as is. Otherwise, it is set to None, which means that end of the axis
         is unbounded.
         """

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1929,19 +1929,17 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
     def _apply_hard_bounds(self, element, ranges):
         """
-        Apply hard bounds to the x and y ranges of the plot.
+        Apply hard bounds to the x and y ranges of the plot. If xlim/ylim is set, limit the
+        initial viewable range to xlim/ylim, but allow navigation up to the abs max between
+        the data + pad range and xlim/ylim. If dim range is set (e.g. via redim.range), use
+        it as the hard bounds.
 
-        Sets the navigable bounds of the plot based on the extents
-        of the given element and ranges. If an extent is numeric and not NaN, it is
-        used as is. Otherwise, it is set to None, which means that end of the axis
-        is unbounded.
         """
 
         def validate_bound(bound):
-            """Validate a single bound, returning None if it is not a valid number"""
             return bound if util.isfinite(bound) else None
 
-        min_extent_x, min_extent_y, max_extent_x, max_extent_y = map(validate_bound, self.get_extents(element, ranges, lims_as_soft_ranges=True))
+        min_extent_x, min_extent_y, max_extent_x, max_extent_y = map(validate_bound, self.get_extents(element, ranges, range_type='combined', lims_as_soft_ranges=True))
 
         def set_bounds(axis, min_extent, max_extent):
             """Set the bounds for a given axis, using None if both extents are None or identical"""

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -105,7 +105,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     align = param.ObjectSelector(default='start', objects=['start', 'center', 'end'], doc="""
         Alignment (vertical or horizontal) of the plot in a layout.""")
 
-    apply_hard_bounds = param.Boolean(default=True, doc="""
+    apply_hard_bounds = param.Boolean(default=True, allow_None=True, doc="""
         If True, the navigable bounds of the plot will be set based
         on the extents of the data. If False, the bounds will not be set.""")
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2077,6 +2077,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 cds = self.handles['cds']
                 self._postprocess_hover(renderer, cds)
 
+        if self.apply_hard_bounds:
+            self._apply_hard_bounds(element, ranges)
+
         self._update_glyphs(element, ranges, self.style[self.cyclic_index])
         self._execute_hooks(element)
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -105,6 +105,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     align = param.ObjectSelector(default='start', objects=['start', 'center', 'end'], doc="""
         Alignment (vertical or horizontal) of the plot in a layout.""")
 
+    apply_hard_bounds = param.Boolean(default=True, doc="""
+        If True, the navigable bounds of the plot will be set based
+        on the extents of the data. If False, the bounds will not be set.""")
+
     autorange = param.ObjectSelector(default=None, objects=['x', 'y', None], doc="""
         Whether to auto-range along either the x- or y-axis, i.e.
         when panning or zooming along the orthogonal axis it will
@@ -1894,6 +1898,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if self._subcoord_overlaid:
                 if style_element.label in plot.extra_y_ranges:
                     self.handles['y_range'] = plot.extra_y_ranges.pop(style_element.label)
+
+        if self.apply_hard_bounds:
+            self._apply_hard_bound(element, ranges)
+
         self.handles['plot'] = plot
 
         if self.autorange:
@@ -1918,6 +1926,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self.drawn = True
 
         return plot
+
+    def _apply_hard_bound(self, element, ranges):
+        # Set the navigable bounds
+        xmin, ymin, xmax, ymax = self.get_extents(element, ranges)
+        if not all(np.isnan([xmin, ymin, xmax, ymax])):
+            self.handles['x_range'].bounds = (xmin, xmax)
+            self.handles['y_range'].bounds = (ymin, ymax)
 
     def _setup_data_callbacks(self, plot):
         if not self._js_on_data_callbacks:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1423,7 +1423,7 @@ class GenericElementPlot(DimensionedPlot):
 
         return (x0, y0, x1, y1)
 
-    def get_extents(self, element, ranges, range_type='combined', dimension=None, xdim=None, ydim=None, zdim=None, **kwargs):
+    def get_extents(self, element, ranges, range_type='combined', dimension=None, xdim=None, ydim=None, zdim=None, lims_as_soft_ranges=False, **kwargs):
         """
         Gets the extents for the axes from the current Element. The globally
         computed ranges can optionally override the extents.
@@ -1444,6 +1444,11 @@ class GenericElementPlot(DimensionedPlot):
 
         This allows Overlay plots to obtain each range and combine them
         appropriately for all the objects in the overlay.
+
+        If lims_as_soft_ranges is set to True, the xlim and ylim will be treated as
+        soft ranges instead of the default case as hard ranges while computing the extents.
+        This is useful when computing the maximum extents across data, padding, xlim/ylim,
+        and dimension ranges.
         """
         num = 6 if (isinstance(self.projection, str) and self.projection == '3d') else 4
         if self.apply_extents and range_type in ('combined', 'extents'):
@@ -1486,8 +1491,12 @@ class GenericElementPlot(DimensionedPlot):
         else:
             x0, y0, x1, y1 = combined
 
-        x0, x1 = util.dimension_range(x0, x1, self.xlim, (None, None))
-        y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))
+        if lims_as_soft_ranges:
+            x0, x1 = util.dimension_range(x0, x1, (None, None), self.xlim)
+            y0, y1 = util.dimension_range(y0, y1, (None, None), self.ylim)
+        else:
+            x0, x1 = util.dimension_range(x0, x1, self.xlim, (None, None))
+            y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))
 
         if not self.drawn:
             x_range, y_range = ((y0, y1), (x0, x1)) if self.invert_axes else ((x0, x1), (y0, y1))

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1449,7 +1449,7 @@ class GenericElementPlot(DimensionedPlot):
         soft ranges instead of the default case as hard ranges while computing the extents.
         This is used e.g. when apply_hard_bounds is True and xlim/ylim is set, in which
         case we limit the initial viewable range to xlim/ylim, but allow navigation up to
-        the abs max between the data + pad range and xlim/ylim.
+        the abs max between the data range and xlim/ylim.
         """
         num = 6 if (isinstance(self.projection, str) and self.projection == '3d') else 4
         if self.apply_extents and range_type in ('combined', 'extents'):
@@ -1493,8 +1493,11 @@ class GenericElementPlot(DimensionedPlot):
             x0, y0, x1, y1 = combined
 
         if lims_as_soft_ranges:
-            x0, x1 = util.dimension_range(x0, x1, (None, None), self.xlim)
-            y0, y1 = util.dimension_range(y0, y1, (None, None), self.ylim)
+            # run x|ylim through max_range to ensure datetime-dtype matching with ranges
+            xlim_soft_ranges = util.max_range([self.xlim])
+            ylim_soft_ranges = util.max_range([self.ylim])
+            x0, x1 = util.dimension_range(x0, x1, (None, None), xlim_soft_ranges)
+            y0, y1 = util.dimension_range(y0, y1, (None, None), ylim_soft_ranges)
         else:
             x0, x1 = util.dimension_range(x0, x1, self.xlim, (None, None))
             y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1447,8 +1447,9 @@ class GenericElementPlot(DimensionedPlot):
 
         If lims_as_soft_ranges is set to True, the xlim and ylim will be treated as
         soft ranges instead of the default case as hard ranges while computing the extents.
-        This is useful when computing the maximum extents across data, padding, xlim/ylim,
-        and dimension ranges.
+        This is used e.g. when apply_hard_bounds is True and xlim/ylim is set, in which
+        case we limit the initial viewable range to xlim/ylim, but allow navigation up to
+        the abs max between the data + pad range and xlim/ylim.
         """
         num = 6 if (isinstance(self.projection, str) and self.projection == '3d') else 4
         if self.apply_extents and range_type in ('combined', 'extents'):

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -17,7 +17,7 @@ from bokeh.models import (
 )
 
 from holoviews import opts
-from holoviews.core import DynamicMap, HoloMap, NdOverlay
+from holoviews.core import DynamicMap, HoloMap, NdOverlay, Overlay
 from holoviews.core.util import dt_to_int
 from holoviews.element import Curve, HeatMap, Image, Labels, Scatter
 from holoviews.plotting.util import process_cmap
@@ -996,6 +996,25 @@ class TestOverlayPlot(TestBokehPlot):
         assert high < 1
 
 class TestApplyHardBounds(TestBokehPlot):
+    def test_apply_hard_bounds(self):
+        """Test `apply_hard_bounds` with a single element."""
+        x_values = np.linspace(10, 50, 5)
+        y_values = np.array([10, 20, 30, 40, 50])
+        curve = Curve((x_values, y_values)).opts(apply_hard_bounds=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.handles['x_range'].bounds, (10, 50))
+
+    def test_apply_hard_bounds_overlay(self):
+        """Test `apply_hard_bounds` with an overlay of curves."""
+        x1_values = np.linspace(10, 50, 5)
+        x2_values = np.linspace(10, 90, 5)
+        y_values = np.array([10, 20, 30, 40, 50])
+        curve1 = Curve((x1_values, y_values))
+        curve2 = Curve((x2_values, y_values))
+        overlay = Overlay([curve1, curve2]).opts(opts.Curve(apply_hard_bounds=True))
+        plot = bokeh_renderer.get_plot(overlay)
+        # Check if the large of the data range can be navigated to
+        self.assertEqual(plot.handles['x_range'].bounds, (10, 90))
 
     def test_apply_hard_bounds_with_xlim(self):
         """Test `apply_hard_bounds` with `xlim` set. Initial view should be within xlim but allow panning to data range."""
@@ -1034,7 +1053,6 @@ class TestApplyHardBounds(TestBokehPlot):
         # Validate navigation bounds include entire data range
         hard_bounds = (dt_to_int(plot.handles['x_range'].bounds[0]), dt_to_int(plot.handles['x_range'].bounds[1]))
         self.assertEqual(hard_bounds, (dt_to_int(dt.datetime(2020, 1, 1)), dt_to_int(dt.datetime(2020, 1, 10))))
-
 
     def test_dynamic_map_bounds_update(self):
         """Test that `apply_hard_bounds` applies correctly when DynamicMap is updated."""

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -3,6 +3,7 @@ from unittest import SkipTest
 
 import numpy as np
 import panel as pn
+import param
 import pytest
 from bokeh.document import Document
 from bokeh.models import (
@@ -21,7 +22,7 @@ from holoviews.core import DynamicMap, HoloMap, NdOverlay, Overlay
 from holoviews.core.util import dt_to_int
 from holoviews.element import Curve, HeatMap, Image, Labels, Scatter
 from holoviews.plotting.util import process_cmap
-from holoviews.streams import PointDraw, Stream, param
+from holoviews.streams import PointDraw, Stream
 from holoviews.util import render
 
 from ...utils import LoggingComparisonTestCase

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -16,6 +16,7 @@ from bokeh.models import (
     tools,
 )
 
+from holoviews import opts
 from holoviews.core import DynamicMap, HoloMap, NdOverlay
 from holoviews.core.util import dt_to_int
 from holoviews.element import Curve, HeatMap, Image, Labels, Scatter
@@ -994,14 +995,14 @@ class TestOverlayPlot(TestBokehPlot):
         assert low > 0
         assert high < 1
 
-class TestApplyHardBounds(LoggingComparisonTestCase, TestBokehPlot):
+class TestApplyHardBounds(TestBokehPlot):
 
     def test_apply_hard_bounds_with_xlim(self):
         """Test `apply_hard_bounds` with `xlim` set. Initial view should be within xlim but allow panning to data range."""
         x_values = np.linspace(10, 50, 5)
         y_values = np.array([10, 20, 30, 40, 50])
         curve = Curve((x_values, y_values)).opts(apply_hard_bounds=True, xlim=(15, 35))
-        plot = self.bokeh_renderer.get_plot(curve)
+        plot = bokeh_renderer.get_plot(curve)
         initial_view_range = (plot.handles['x_range'].start, plot.handles['x_range'].end)
         self.assertEqual(initial_view_range, (15, 35))
         # Check if data beyond xlim can be navigated to
@@ -1012,7 +1013,7 @@ class TestApplyHardBounds(LoggingComparisonTestCase, TestBokehPlot):
         x_values = np.linspace(10, 50, 5)
         y_values = np.array([10, 20, 30, 40, 50])
         curve = Curve((x_values, y_values)).redim.range(x=(25, None)).opts(apply_hard_bounds=True)
-        plot = self.bokeh_renderer.get_plot(curve)
+        plot = bokeh_renderer.get_plot(curve)
         # Expected to strictly adhere to any redim.range bounds, otherwise the data range
         self.assertEqual((plot.handles['x_range'].start, plot.handles['x_range'].end), (25, 50))
         self.assertEqual(plot.handles['x_range'].bounds, (25, 50))
@@ -1027,9 +1028,9 @@ class TestApplyHardBounds(LoggingComparisonTestCase, TestBokehPlot):
             apply_hard_bounds=True,
             xlim=(target_xlim_l, target_xlim_h)
         )
-        plot = self.bokeh_renderer.get_plot(curve)
+        plot = bokeh_renderer.get_plot(curve)
         initial_view_range = (dt_to_int(plot.handles['x_range'].start), dt_to_int(plot.handles['x_range'].end))
-        self.assertEqual(initial_view_range, (dt_to_int(target_xlim_l), dt_to_int(target_xlim_l)))
+        self.assertEqual(initial_view_range, (dt_to_int(target_xlim_l), dt_to_int(target_xlim_h)))
         # Validate navigation bounds include entire data range
         hard_bounds = (dt_to_int(plot.handles['x_range'].bounds[0]), dt_to_int(plot.handles['x_range'].bounds[1]))
         self.assertEqual(hard_bounds, (dt_to_int(dt.datetime(2020, 1, 1)), dt_to_int(dt.datetime(2020, 1, 10))))
@@ -1052,9 +1053,9 @@ class TestApplyHardBounds(LoggingComparisonTestCase, TestBokehPlot):
         )
         choice_stream = ChoiceStream()
         dmap = DynamicMap(curve_data, kdims=[], streams=[choice_stream])
-        dmap = dmap.opts(apply_hard_bounds=True, xlim=(2,3), framewise=True)
+        dmap = dmap.opts(opts.Curve(apply_hard_bounds=True, xlim=(2,3), framewise=True))
         dmap = dmap.redim.values(choice=['set1', 'set2'])
-        plot = self.bokeh_renderer.get_plot(dmap)
+        plot = bokeh_renderer.get_plot(dmap)
 
         # Keeping the xlim consistent between updates, and change data range bounds
         # Initially select 'set1'

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -1002,7 +1002,7 @@ class TestApplyHardBounds(TestBokehPlot):
         y_values = np.array([10, 20, 30, 40, 50])
         curve = Curve((x_values, y_values)).opts(apply_hard_bounds=True)
         plot = bokeh_renderer.get_plot(curve)
-        self.assertEqual(plot.handles['x_range'].bounds, (10, 50))
+        assert plot.handles['x_range'].bounds == (10, 50)
 
     def test_apply_hard_bounds_overlay(self):
         """Test `apply_hard_bounds` with an overlay of curves."""
@@ -1014,7 +1014,7 @@ class TestApplyHardBounds(TestBokehPlot):
         overlay = Overlay([curve1, curve2]).opts(opts.Curve(apply_hard_bounds=True))
         plot = bokeh_renderer.get_plot(overlay)
         # Check if the large of the data range can be navigated to
-        self.assertEqual(plot.handles['x_range'].bounds, (10, 90))
+        assert plot.handles['x_range'].bounds == (10, 90)
 
     def test_apply_hard_bounds_with_xlim(self):
         """Test `apply_hard_bounds` with `xlim` set. Initial view should be within xlim but allow panning to data range."""
@@ -1023,9 +1023,9 @@ class TestApplyHardBounds(TestBokehPlot):
         curve = Curve((x_values, y_values)).opts(apply_hard_bounds=True, xlim=(15, 35))
         plot = bokeh_renderer.get_plot(curve)
         initial_view_range = (plot.handles['x_range'].start, plot.handles['x_range'].end)
-        self.assertEqual(initial_view_range, (15, 35))
+        assert initial_view_range == (15, 35)
         # Check if data beyond xlim can be navigated to
-        self.assertEqual(plot.handles['x_range'].bounds, (10, 50))
+        assert plot.handles['x_range'].bounds == (10, 50)
 
     def test_apply_hard_bounds_with_redim_range(self):
         """Test `apply_hard_bounds` with `.redim.range(x=...)`. Hard bounds should strictly apply."""
@@ -1034,8 +1034,8 @@ class TestApplyHardBounds(TestBokehPlot):
         curve = Curve((x_values, y_values)).redim.range(x=(25, None)).opts(apply_hard_bounds=True)
         plot = bokeh_renderer.get_plot(curve)
         # Expected to strictly adhere to any redim.range bounds, otherwise the data range
-        self.assertEqual((plot.handles['x_range'].start, plot.handles['x_range'].end), (25, 50))
-        self.assertEqual(plot.handles['x_range'].bounds, (25, 50))
+        assert (plot.handles['x_range'].start, plot.handles['x_range'].end)  == (25, 50)
+        assert plot.handles['x_range'].bounds == (25, 50)
 
     def test_apply_hard_bounds_datetime(self):
         """Test datetime axes with hard bounds."""
@@ -1049,10 +1049,10 @@ class TestApplyHardBounds(TestBokehPlot):
         )
         plot = bokeh_renderer.get_plot(curve)
         initial_view_range = (dt_to_int(plot.handles['x_range'].start), dt_to_int(plot.handles['x_range'].end))
-        self.assertEqual(initial_view_range, (dt_to_int(target_xlim_l), dt_to_int(target_xlim_h)))
+        assert initial_view_range == (dt_to_int(target_xlim_l), dt_to_int(target_xlim_h))
         # Validate navigation bounds include entire data range
         hard_bounds = (dt_to_int(plot.handles['x_range'].bounds[0]), dt_to_int(plot.handles['x_range'].bounds[1]))
-        self.assertEqual(hard_bounds, (dt_to_int(dt.datetime(2020, 1, 1)), dt_to_int(dt.datetime(2020, 1, 10))))
+        assert hard_bounds == (dt_to_int(dt.datetime(2020, 1, 1)), dt_to_int(dt.datetime(2020, 1, 10)))
 
     def test_dynamic_map_bounds_update(self):
         """Test that `apply_hard_bounds` applies correctly when DynamicMap is updated."""
@@ -1078,12 +1078,12 @@ class TestApplyHardBounds(TestBokehPlot):
         # Keeping the xlim consistent between updates, and change data range bounds
         # Initially select 'set1'
         dmap.event(choice='set1')
-        self.assertEqual(plot.handles['x_range'].start, 2)
-        self.assertEqual(plot.handles['x_range'].end, 3)
-        self.assertEqual(plot.handles['x_range'].bounds, (0, 5))
+        assert plot.handles['x_range'].start == 2
+        assert plot.handles['x_range'].end == 3
+        assert plot.handles['x_range'].bounds == (0, 5)
 
         # Update to 'set2'
         dmap.event(choice='set2')
-        self.assertEqual(plot.handles['x_range'].start, 2)
-        self.assertEqual(plot.handles['x_range'].end, 3)
-        self.assertEqual(plot.handles['x_range'].bounds, (0, 20))
+        assert plot.handles['x_range'].start == 2
+        assert plot.handles['x_range'].end == 3
+        assert plot.handles['x_range'].bounds == (0, 20)

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -127,9 +127,9 @@ def test_rangexy(serve_hv):
     wait_until(lambda: rangexy.x_range == expected_xrange and rangexy.y_range == expected_yrange, page)
 
 @pytest.mark.usefixtures("bokeh_backend")
-def test_multi_axis_rangexy(serve_hv):
-    c1 = Curve(np.arange(100).cumsum(), vdims='y')
-    c2 = Curve(-np.arange(100).cumsum(), vdims='y2')
+def test_multi_axis_rangexy(page, port):
+    c1 = Curve(np.arange(100).cumsum(), vdims='y').opts(apply_hard_bounds=False)
+    c2 = Curve(-np.arange(100).cumsum(), vdims='y2').opts(apply_hard_bounds=False)
     s1 = RangeXY(source=c1)
     s2 = RangeXY(source=c2)
 

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -127,7 +127,7 @@ def test_rangexy(serve_hv):
     wait_until(lambda: rangexy.x_range == expected_xrange and rangexy.y_range == expected_yrange, page)
 
 @pytest.mark.usefixtures("bokeh_backend")
-def test_multi_axis_rangexy(page, port):
+def test_multi_axis_rangexy(serve_hv):
     c1 = Curve(np.arange(100).cumsum(), vdims='y').opts(apply_hard_bounds=False)
     c2 = Curve(-np.arange(100).cumsum(), vdims='y2').opts(apply_hard_bounds=False)
     s1 = RangeXY(source=c1)

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -128,8 +128,8 @@ def test_rangexy(serve_hv):
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_multi_axis_rangexy(serve_hv):
-    c1 = Curve(np.arange(100).cumsum(), vdims='y').opts(apply_hard_bounds=False)
-    c2 = Curve(-np.arange(100).cumsum(), vdims='y2').opts(apply_hard_bounds=False)
+    c1 = Curve(np.arange(100).cumsum(), vdims='y')
+    c2 = Curve(-np.arange(100).cumsum(), vdims='y2')
     s1 = RangeXY(source=c1)
     s2 = RangeXY(source=c2)
 


### PR DESCRIPTION
This PR closes #1019, which pertains to the lack of hard bounds when panning and zooming using the Bokeh backend. 

Why? Previously, the axes were unbounded, allowing users to zoom and pan to potentially empty parts of the data space. This is particularly annoying when a plot captures the scroll of a webpage/notebook/app that it is a part of. This PR ~~changes the default behavior~~ adds a flag, preventing zooming or panning beyond the data range. update: uses the more extreme of data ranges or xlim/ylim. Update, if dim ranges are set, they are used as hard bounds.

To enable this new behavior, use `apply_hard_bounds=True`.

Limitation: Currently, setting hard navigable bounds with Bokeh means that if you hit a single extent (e.g. the lower x dim), the zoom won't continue to work for the remaining directions (upper x dim, or any y dim).. Bokeh has an option called `maintain_focus=False` for zoom tools to enable continued zoom. Future work could potentially enable this option in HoloViews when `apply_hard_bounds=True`.

Todo:
- [x] add tests
- [x] add tests for datetime axes
- [x] add test for dmap updates
- [x] add docs

Demo:

<details> <summary> code </summary>

```python

hb_default = hv.Curve(([1,2,3], [1,2,1]), label='apply hard bounds Default')
hb_false = hv.Curve(([1,2,3], [4,2,3]), label='apply hard bounds False').opts(apply_hard_bounds=False, color='black')
hb_true = hv.Curve(([-1,0,1,2,3,4], [3,2,1,0,-1,-2]), label='apply hard bounds True').opts(apply_hard_bounds=True, color='red')
hb_overlay = (hb_true * hb_false).opts(title='True/False overlay', show_legend=False)

(hb_default + hb_false + hb_true + hb_overlay).opts(shared_axes=False)
```

</details>

https://github.com/holoviz/holoviews/assets/6613202/c3e50116-18ff-44f0-b800-3211e790b802


Only limits the x dim for subcoord_y plots:

<details> <summary> code </summary>

```python
import numpy as np
import holoviews as hv
from bokeh.models import HoverTool
from holoviews.plotting.links import RangeToolLink
from scipy.stats import zscore

hv.extension('bokeh')

N_CHANNELS = 10
N_SECONDS = 5
SAMPLING_RATE = 200
INIT_FREQ = 2  # Initial frequency in Hz
FREQ_INC = 5  # Frequency increment
AMPLITUDE = 1

# Generate time and channel labels
total_samples = N_SECONDS * SAMPLING_RATE
time = np.linspace(0, N_SECONDS, total_samples)
channels = [f'EEG {i}' for i in range(N_CHANNELS)]

# Generate sine wave data
data = np.array([AMPLITUDE * np.sin(2 * np.pi * (INIT_FREQ + i * FREQ_INC) * time)
                     for i in range(N_CHANNELS)])

hover = HoverTool(tooltips=[
    ("Channel", "@channel"),
    ("Time", "$x s"),
    ("Amplitude", "$y µV")
])

channel_curves = []
for channel, channel_data in zip(channels, data):
    ds = hv.Dataset((time, channel_data, channel), ["Time", "Amplitude", "channel"])
    curve = hv.Curve(ds, "Time", ["Amplitude", "channel"], label=channel)
    curve.opts(
        subcoordinate_y=True, color="black", line_width=1, tools=[hover],
        apply_hard_bounds=True,
    )
    channel_curves.append(curve)

eeg = hv.Overlay(channel_curves, kdims="Channel").opts(
    xlabel="Time (s)", ylabel="Channel", show_legend=False, aspect=3, responsive=True,
)


y_positions = range(N_CHANNELS)
yticks = [(i , ich) for i, ich in enumerate(channels)]

z_data = zscore(data, axis=1)

minimap = hv.Image((time, y_positions , z_data), ["Time (s)", "Channel"], "Amplitude (uV)")
minimap = minimap.opts(
    cmap="RdBu_r", xlabel='Time (s)', alpha=.5, yticks=[yticks[0], yticks[-1]],
    height=150, responsive=True, default_tools=[], clim=(-z_data.std(), z_data.std())
)


RangeToolLink(
    minimap, eeg, axes=["x", "y"],
    boundsx=(None, 2), boundsy=(None, 6.5)
)

dashboard = (eeg + minimap).opts(merge_tools=False).cols(1)
dashboard
```

</details>


https://github.com/holoviz/holoviews/assets/6613202/2f9fb3d7-d9db-4950-a5fb-15860662b1ba




