### PR TITLE
Implement support for retaining Pandas index

### DIFF
--- a/holoviews/core/data/ibis.py
+++ b/holoviews/core/data/ibis.py
@@ -9,7 +9,7 @@ from .. import util
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
 from . import pandas
-from .interface import Interface
+from .interface import DataError, Interface
 from .util import cached
 
 
@@ -93,6 +93,17 @@ class IbisInterface(Interface):
         elif keys == [] and values is None:
             values = list(data.columns[: nvdim if nvdim else None])
         return data, dict(kdims=keys, vdims=values), {}
+
+    @classmethod
+    def validate(cls, dataset, vdims=True):
+        dim_types = 'all' if vdims else 'key'
+        dimensions = dataset.dimensions(dim_types, label='name')
+        cols = list(dataset.data.columns)
+        not_found = [d for d in dimensions if d not in cols]
+        if not_found:
+            raise DataError("Supplied data does not contain specified "
+                            "dimensions, the following dimensions were "
+                            "not found: %s" % repr(not_found), cls)
 
     @classmethod
     def compute(cls, dataset):
@@ -216,7 +227,6 @@ class IbisInterface(Interface):
             **{v.name: dataset.data[k] for k, v in dimensions.items()}
         )
 
-    validate = pandas.PandasInterface.validate
     reindex = pandas.PandasInterface.reindex
 
     @classmethod

--- a/holoviews/core/data/ibis.py
+++ b/holoviews/core/data/ibis.py
@@ -8,7 +8,6 @@ from packaging.version import Version
 from .. import util
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
-from . import pandas
 from .interface import DataError, Interface
 from .util import cached
 
@@ -227,7 +226,9 @@ class IbisInterface(Interface):
             **{v.name: dataset.data[k] for k, v in dimensions.items()}
         )
 
-    reindex = pandas.PandasInterface.reindex
+    @classmethod
+    def reindex(cls, dataset, kdims=None, vdims=None):
+        return dataset.data
 
     @classmethod
     def _index_ibis_table(cls, data):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -325,7 +325,7 @@ class PandasInterface(Interface, PandasAPI):
     @classmethod
     def reindex(cls, dataset, kdims=None, vdims=None):
         data = dataset.data
-        if hasattr(data, 'index') and isinstance(data.index, pd.MultiIndex):
+        if isinstance(data.index, pd.MultiIndex):
             kdims = [kdims] if isinstance(kdims, (str, Dimension)) else kdims
             data = data.reset_index().set_index(list(map(str, kdims)), drop=True)
         return data
@@ -363,7 +363,7 @@ class PandasInterface(Interface, PandasAPI):
                 idx or "index": v
                 for idx in df.index.names
                 if isinstance((v := selection.get(idx)), slice)
-            }
+            } if not isinstance(df.index, pd.MultiIndex) else {}
             if selection.keys() - indexes.keys():
                 selection_mask = cls.select_mask(dataset, selection)
             else:
@@ -382,13 +382,13 @@ class PandasInterface(Interface, PandasAPI):
 
     @classmethod
     def values(
-            cls,
-            dataset,
-            dim,
-            expanded=True,
-            flat=True,
-            compute=True,
-            keep_index=False,
+        cls,
+        dataset,
+        dim,
+        expanded=True,
+        flat=True,
+        compute=True,
+        keep_index=False,
     ):
         dim = dataset.get_dimension(dim, strict=True)
         isindex = cls.isindex(dataset, dim)

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -71,9 +71,7 @@ class PandasInterface(Interface, PandasAPI):
                 )
 
             # Handle reset of index if kdims reference index by name
-            if len(kdims) == len(index_names) and {dimension_name(kd) for kd in kdims} == set(index_names):
-                pass
-            elif kdims:
+            if kdims and not (len(kdims) == len(index_names) and {dimension_name(kd) for kd in kdims} == set(index_names)):
                 kdim = dimension_name(kdims[0])
                 if eltype._auto_indexable_1d and ncols == 1 and kdim not in data.columns:
                     data = data.copy()

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -340,9 +340,10 @@ class PandasInterface(Interface, PandasAPI):
 
     @classmethod
     def reindex(cls, dataset, kdims=None, vdims=None):
-        # DataFrame based tables don't need to be reindexed
-        return dataset.data
-
+        data = dataset.data
+        if isinstance(data.index, pd.MultiIndex):
+            data = data.reset_index()
+        return data.set_index(kdims, drop=True)
 
     @classmethod
     def mask(cls, dataset, mask, mask_value=np.nan):
@@ -350,7 +351,6 @@ class PandasInterface(Interface, PandasAPI):
         cols = [vd.name for vd in dataset.vdims]
         masked.loc[mask, cols] = mask_value
         return masked
-
 
     @classmethod
     def redim(cls, dataset, dimensions):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -32,6 +32,7 @@ class PandasInterface(Interface, PandasAPI):
 
     @classmethod
     def dimension_type(cls, dataset, dim):
+        return cls.dtype(dataset, dim).type
         dim = dataset.get_dimension(dim, strict=True)
         if cls.isindex(dataset, dim):
             return cls.index_values(dataset, dim).dtype.type
@@ -224,6 +225,8 @@ class PandasInterface(Interface, PandasAPI):
                 pass
             if not len(column):
                 return np.nan, np.nan
+            if isinstance(column, pd.Index):
+                return column[0], column[-1]
             return column.iloc[0], column.iloc[-1]
         else:
             if dimension.nodata is not None:

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -33,7 +33,7 @@ class PandasInterface(Interface, PandasAPI):
     @classmethod
     def dimension_type(cls, dataset, dim):
         dim = dataset.get_dimension(dim, strict=True)
-        if cls.is_index(dataset, dim):
+        if cls.isindex(dataset, dim):
             return cls.index_values(dataset, dim).dtype.type
         name = dim.name
         idx = list(dataset.data.columns).index(name)
@@ -180,7 +180,7 @@ class PandasInterface(Interface, PandasAPI):
         return index_names
 
     @classmethod
-    def is_index(cls, dataset, dimension):
+    def isindex(cls, dataset, dimension):
         dimension = dataset.get_dimension(dimension, strict=True)
         if dimension.name in dataset.data.columns:
             return False
@@ -208,7 +208,7 @@ class PandasInterface(Interface, PandasAPI):
     @classmethod
     def range(cls, dataset, dimension):
         dimension = dataset.get_dimension(dimension, strict=True)
-        if cls.is_index(dataset, dimension):
+        if cls.isindex(dataset, dimension):
             column = cls.index_values(dataset, dimension)
         else:
             column = dataset.data[dimension.name]
@@ -395,15 +395,15 @@ class PandasInterface(Interface, PandasAPI):
             keep_index=False,
     ):
         dim = dataset.get_dimension(dim, strict=True)
-        is_index = cls.is_index(dataset, dim)
-        if is_index:
+        isindex = cls.isindex(dataset, dim)
+        if isindex:
             data = cls.index_values(dataset, dim)
         else:
             data = dataset.data[dim.name]
         if keep_index:
             return data
         if data.dtype.kind == 'M' and getattr(data.dtype, 'tz', None):
-            data = (data if is_index else data.dt).tz_localize(None)
+            data = (data if isindex else data.dt).tz_localize(None)
         if not expanded:
             return pd.unique(data)
         return data.values if hasattr(data, 'values') else data
@@ -449,7 +449,7 @@ class PandasInterface(Interface, PandasAPI):
         if it already a dataframe type.
         """
         if issubclass(dataset.interface, PandasInterface):
-            if any(cls.is_index(dataset, dim) for dim in dataset.dimensions()):
+            if any(cls.isindex(dataset, dim) for dim in dataset.dimensions()):
                 return dataset.data.reset_index()
             return dataset.data
         else:

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -163,7 +163,7 @@ class PandasInterface(Interface, PandasAPI):
         dim = dataset.get_dimension(dimension, strict=True)
         name = dim.name
         df = dataset.data
-        if cls.is_index(df, dim):
+        if cls.is_index(dataset, dim):
             data = df.index if isinstance(df.index, pd.MultiIndex) else df.index.get_level(name)
         else:
             data = df[name]

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -70,7 +70,6 @@ class PandasInterface(Interface, PandasAPI):
                     "Having a non-string as a column name in a DataFrame is not supported."
                 )
 
-            # Handle reset of index if kdims reference index by name
             if kdims and not (len(kdims) == len(index_names) and {dimension_name(kd) for kd in kdims} == set(index_names)):
                 kdim = dimension_name(kdims[0])
                 if eltype._auto_indexable_1d and ncols == 1 and kdim not in data.columns:

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -342,8 +342,9 @@ class PandasInterface(Interface, PandasAPI):
     def reindex(cls, dataset, kdims=None, vdims=None):
         data = dataset.data
         if isinstance(data.index, pd.MultiIndex):
-            data = data.reset_index()
-        return data.set_index(kdims, drop=True)
+            kdims = [kdims] if isinstance(kdims, (str, Dimension)) else kdims
+            data = data.reset_index().set_index(list(map(str, kdims)), drop=True)
+        return data
 
     @classmethod
     def mask(cls, dataset, mask, mask_value=np.nan):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -477,7 +477,7 @@ class PandasInterface(Interface, PandasAPI):
         else:
             cols = [dataset.get_dimension(d).name for d in cols]
         indexes = cls.indexes(dataset.data)
-        dropped_indexes = [cols for index in indexes if index not in cols]
+        dropped_indexes = [index for index in indexes if index not in cols]
         cols = [col for col in cols if col not in indexes]
         if dropped_indexes:
             if len(indexes) == 1:

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -486,12 +486,12 @@ class PandasInterface(Interface, PandasAPI):
         columns = list(data.columns)
         id_cols = [columns.index(c) for c in cols if c not in indexes]
         if not id_cols:
-            if scalar:
-                return data.index.values[rows[0]]
-            elif len(indexes) > 1:
-                return data.index.to_frame()[cols].iloc[rows].reset_index(drop=True)
+            if len(indexes) > 1:
+                data = data.index.to_frame()[cols].iloc[rows].reset_index(drop=True)
+                data = data.values.ravel()[0] if scalar else data
             else:
-                return data.index[rows]
+                data = data.index.values[rows[0]] if scalar else data.index[rows]
+            return data
         if scalar:
             return data.iloc[rows[0], id_cols[0]]
         return data.iloc[rows, id_cols]

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -325,7 +325,7 @@ class PandasInterface(Interface, PandasAPI):
     @classmethod
     def reindex(cls, dataset, kdims=None, vdims=None):
         data = dataset.data
-        if isinstance(data.index, pd.MultiIndex):
+        if hasattr(data, 'index') and isinstance(data.index, pd.MultiIndex):
             kdims = [kdims] if isinstance(kdims, (str, Dimension)) else kdims
             data = data.reset_index().set_index(list(map(str, kdims)), drop=True)
         return data

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -360,7 +360,7 @@ class PandasInterface(Interface, PandasAPI):
     @classmethod
     def sort_depth(cls, df):
         try:
-            from pandas.core.index.multi import _lexsort_depth
+            from pandas.core.indexes.multi import _lexsort_depth
         except Exception:
             return 0
         return _lexsort_depth(df.index.codes, df.index.nlevels)

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -361,9 +361,9 @@ class PandasInterface(Interface, PandasAPI):
     def sort_depth(cls, df):
         try:
             from pandas.core.indexes.multi import _lexsort_depth
-        except Exception:
+            return _lexsort_depth(df.index.codes, df.index.nlevels)
+        except (ImportError, AttributeError):
             return 0
-        return _lexsort_depth(df.index.codes, df.index.nlevels)
 
     @classmethod
     def index_selection(cls, df, selection):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -475,7 +475,10 @@ class PandasInterface(Interface, PandasAPI):
             cols = [d.name for d in dataset.dimensions()][cols]
         elif np.isscalar(cols):
             scalar = np.isscalar(rows)
-            cols = [dataset.get_dimension(cols).name]
+            dim = dataset.get_dimension(cols)
+            if dim is None:
+                raise ValueError('column is out of bounds')
+            cols = [dim.name]
         else:
             cols = [dataset.get_dimension(d).name for d in cols]
         if np.isscalar(rows):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -486,7 +486,7 @@ class PandasInterface(Interface, PandasAPI):
             if scalar:
                 return data.index.values[rows[0]]
             elif len(indexes) > 1:
-                return data.index.to_frame()[cols].reset_index(drop=True)
+                return data.index.to_frame()[cols].iloc[rows].reset_index(drop=True)
             else:
                 return data.index[rows]
         if scalar:

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -357,9 +357,10 @@ class PandasInterface(Interface, PandasAPI):
         df = dataset.data
         if selection_mask is None:
             indexes = {
-                idx or "index": v
-                for idx in df.index.names
-                if isinstance((v := selection.get(idx)), slice)
+                idx: v
+                for idx in cls.indexes(df)
+                if isinstance((v := selection.get(idx)), slice) or
+                isinstance(v, tuple) and len(v) < 4 and (v := slice(*v))
             } if not isinstance(df.index, pd.MultiIndex) else {}
             if selection.keys() - indexes.keys():
                 selection_mask = cls.select_mask(dataset, selection)

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -158,7 +158,7 @@ class PandasInterface(Interface, PandasAPI):
     def indexes(cls, data):
         index_names = data.index.names if isinstance(data, pd.DataFrame) else [data.index.name]
         if index_names == [None]:
-            index_names = ['index']
+            index_names = ['_index'] if 'index' in data.columns else ['index']
         return index_names
 
     @classmethod

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -33,12 +33,6 @@ class PandasInterface(Interface, PandasAPI):
     @classmethod
     def dimension_type(cls, dataset, dim):
         return cls.dtype(dataset, dim).type
-        dim = dataset.get_dimension(dim, strict=True)
-        if cls.isindex(dataset, dim):
-            return cls.index_values(dataset, dim).dtype.type
-        name = dim.name
-        idx = list(dataset.data.columns).index(name)
-        return dataset.data.dtypes.iloc[idx].type
 
     @classmethod
     def init(cls, eltype, data, kdims, vdims):
@@ -79,21 +73,11 @@ class PandasInterface(Interface, PandasAPI):
             # Handle reset of index if kdims reference index by name
             if len(kdims) == len(index_names) and {dimension_name(kd) for kd in kdims} == set(index_names):
                 pass
-            else:  # noqa: PLR5501
-                # for kd in kdims:  # TODO: Remove this if statement?
-                #     kd = dimension_name(kd)
-                #     if kd in data.columns:
-                #         continue
-                #     if any(kd == ('index' if name is None else name)
-                #            for name in index_names):
-                #         data = data.reset_index()
-                #         break
-
-                if kdims:
-                    kdim = dimension_name(kdims[0])
-                    if eltype._auto_indexable_1d and ncols == 1 and kdim not in data.columns:
-                        data = data.copy()
-                        data.insert(0, kdim, np.arange(len(data)))
+            elif kdims:
+                kdim = dimension_name(kdims[0])
+                if eltype._auto_indexable_1d and ncols == 1 and kdim not in data.columns:
+                    data = data.copy()
+                    data.insert(0, kdim, np.arange(len(data)))
 
             for d in kdims+vdims:
                 d = dimension_name(d)

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -373,7 +373,10 @@ class PandasInterface(Interface, PandasAPI):
         df = dataset.data
         if selection_mask is None:
             if index_sel:= cls.index_selection(df, selection):
-                df = df.loc[tuple(index_sel.values()), :]
+                if len(index_sel) == 1:
+                    df = df[next(iter(index_sel.values()))]
+                else:
+                    df = df.loc[tuple(index_sel.values()), :]
             column_sel = {k: v for k, v in selection.items() if k not in index_sel}
             if column_sel:
                 selection_mask = cls.select_mask(dataset, column_sel)

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -164,7 +164,7 @@ class PandasInterface(Interface, PandasAPI):
         name = dim.name
         df = dataset.data
         if cls.is_index(dataset, dim):
-            data = df.index if isinstance(df.index, pd.MultiIndex) else df.index.get_level(name)
+            data = df.index.get_level(name) if isinstance(df.index, pd.MultiIndex) else df.index
         else:
             data = df[name]
         if util.isscalar(data):
@@ -449,6 +449,8 @@ class PandasInterface(Interface, PandasAPI):
         if it already a dataframe type.
         """
         if issubclass(dataset.interface, PandasInterface):
+            if any(cls.is_index(dataset, dim) for dim in dataset.dimensions()):
+                return dataset.data.reset_index()
             return dataset.data
         else:
             return dataset.dframe()
@@ -485,6 +487,11 @@ class PandasInterface(Interface, PandasAPI):
         cols = [columns.index(c) for c in cols]
         if np.isscalar(rows):
             rows = [rows]
+        if not cols:
+            if scalar:
+                return data.index.values[rows[0]]
+            else:
+                return data.index[rows]
         if scalar:
             return data.iloc[rows[0], cols[0]]
         return data.iloc[rows, cols]

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -388,7 +388,8 @@ class PandasInterface(Interface, PandasAPI):
                 sel = [sel]
             if isinstance(sel, slice) and nindex > 1 and not sorted_index and level>depth:
                 # If the index is not monotonic we cannot slice
-                return {}
+                # so return indexer up to the point it is valid
+                return index_sel
             index_sel[idx] = sel
         return {} if skip_index else index_sel
 

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -395,7 +395,6 @@ class PandasInterface(Interface, PandasAPI):
                 # If the index is not monotonic we cannot slice
                 return {}
             index_sel[idx] = sel
-        print(index_sel)
         return {} if skip_index else index_sel
 
     @classmethod

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -419,7 +419,6 @@ class PandasInterface(Interface, PandasAPI):
             return df[dataset.vdims[0].name].iloc[0]
         return df
 
-
     @classmethod
     def values(
         cls,

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -78,15 +78,15 @@ class PandasInterface(Interface, PandasAPI):
             # Handle reset of index if kdims reference index by name
             if len(kdims) == len(index_names) and {dimension_name(kd) for kd in kdims} == set(index_names):
                 pass
-            else:
-                for kd in kdims:
-                    kd = dimension_name(kd)
-                    if kd in data.columns:
-                        continue
-                    if any(kd == ('index' if name is None else name)
-                           for name in index_names):
-                        data = data.reset_index()
-                        break
+            else:  # noqa: PLR5501
+                # for kd in kdims:  # TODO: Remove this if statement?
+                #     kd = dimension_name(kd)
+                #     if kd in data.columns:
+                #         continue
+                #     if any(kd == ('index' if name is None else name)
+                #            for name in index_names):
+                #         data = data.reset_index()
+                #         break
 
                 if kdims:
                     kdim = dimension_name(kdims[0])

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 from packaging.version import Version
 from pandas.api.types import is_numeric_dtype
-from pandas.core.dtypes.common import ensure_int64
 
 from .. import util
 from ..dimension import Dimension, dimension_name
@@ -361,14 +360,10 @@ class PandasInterface(Interface, PandasAPI):
     @classmethod
     def sort_depth(cls, df):
         try:
-            from pandas._libs.algos import is_lexsorted
+            from pandas.core.index.multi import _lexsort_depth
         except Exception:
             return 0
-        int64_codes = [ensure_int64(level_codes) for level_codes in df.index.codes]
-        for k in range(df.index.nlevels, 0, -1):
-            if is_lexsorted(int64_codes[:k]):
-                return k
-        return 0
+        return _lexsort_depth(df.index.codes, df.index.nlevels)
 
     @classmethod
     def index_selection(cls, df, selection):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -76,7 +76,7 @@ class PandasInterface(Interface, PandasAPI):
                 )
 
             # Handle reset of index if kdims reference index by name
-            if len(kdims) == len(index_names) and [dimension_name(kd) for kd in kdims] == index_names:
+            if len(kdims) == len(index_names) and {dimension_name(kd) for kd in kdims} == set(index_names):
                 pass
             else:
                 for kd in kdims:
@@ -163,8 +163,8 @@ class PandasInterface(Interface, PandasAPI):
         dim = dataset.get_dimension(dimension, strict=True)
         name = dim.name
         df = dataset.data
-        if cls.is_index(dataset, dim):
-            data = df.index.get_level(name) if isinstance(df.index, pd.MultiIndex) else df.index
+        if cls.isindex(dataset, dim):
+            data = df.index.get_level_values(name) if isinstance(df.index, pd.MultiIndex) else df.index
         else:
             data = df[name]
         if util.isscalar(data):

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from holoviews.core.data import Dataset
 from holoviews.core.data.interface import DataError
@@ -267,6 +268,11 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         selected = ds.iloc[0, :3]
         expected = self.df.iloc[[0], [0]]
         pd.testing.assert_frame_equal(selected.data, expected)
+
+    def test_out_of_bounds(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        with pytest.raises(ValueError, match="column is out of bounds"):
+            ds.iloc[0, 3]
 
     def test_sort(self):
         ds = Dataset(self.df, kdims=["number", "color"])

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -205,6 +205,12 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         self.df = pd.DataFrame(range(4), index=index, columns=["values"])
         super().setUp()
 
+    def test_lexsort_depth_import(self):
+        # Indexing relies on knowing the lexsort_depth but this is a
+        # private import so we want to know should this import ever
+        # be changed
+        from pandas.core.index.multi import _lexsort_depth  # noqa
+
     def test_no_kdims(self):
         ds = Dataset(self.df)
         assert ds.kdims == [Dimension("values")]

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -229,6 +229,25 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         assert isinstance(selected.data.index, pd.MultiIndex)
         pd.testing.assert_frame_equal(selected.data, expected)
 
+    def test_index_select_all_indexes(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.select(number=1, color='red')
+        assert selected == 0
+
+    def test_index_select_all_indexes_lists(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.select(number=[1], color=['red'])
+        expected = pd.DataFrame({'color': ['red'], 'values': [0], 'number': [1]}).set_index(['number', 'color'])
+        assert isinstance(selected.data.index, pd.MultiIndex)
+        pd.testing.assert_frame_equal(selected.data, expected)
+
+    def test_index_select_all_indexes_slice_and_scalar(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.select(number=(0, 1), color='red')
+        expected = pd.DataFrame({'color': ['red'], 'values': [0], 'number': [1]}).set_index(['number', 'color'])
+        assert isinstance(selected.data.index, pd.MultiIndex)
+        pd.testing.assert_frame_equal(selected.data, expected)
+
     def test_iloc_scalar_scalar_only_index(self):
         ds = Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[0, 0]

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -322,3 +322,24 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
 
         df = ds.interface.reindex(ds, ['values'])
         assert df.index.names == ['values']
+
+    def test_groupby_one_index(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        grouped = ds.groupby("number")
+        assert list(grouped.keys()) == [1, 2]
+        for k, v in grouped.items():
+            pd.testing.assert_frame_equal(v.data, ds.select(number=k).data)
+
+    def test_groupby_two_indexes(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        grouped = ds.groupby(["number", "color"])
+        assert list(grouped.keys()) == list(self.df.index)
+        for k, v in grouped.items():
+            pd.testing.assert_frame_equal(v.data, ds.select(number=[k[0]], color=[k[1]]).data)
+
+    def test_groupby_one_index_one_column(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        grouped = ds.groupby('values')
+        assert list(grouped.keys()) == [0, 1, 2, 3]
+        for k, v in grouped.items():
+            pd.testing.assert_frame_equal(v.data, ds.select(values=k).data)

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -220,3 +220,9 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         selected = ds.iloc[:, 0]
         expected = self.df.reset_index()[["number"]]
         pd.testing.assert_frame_equal(selected.data, expected)
+
+    def test_index_iloc_slice_only_index(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.iloc[:, :2]
+        expected = self.df.reset_index()[["number", "color"]]
+        pd.testing.assert_frame_equal(selected.data, expected)

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -279,3 +279,11 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         sorted_ds = ds.sort("color")
         np.testing.assert_array_equal(sorted_ds.dimension_values("values"), [1, 3, 0, 2])
         np.testing.assert_array_equal(sorted_ds.dimension_values("number"), [1, 3, 0, 2])
+
+    def test_select(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.select(color="red")
+        pd.testing.assert_frame_equal(selected.data, self.df.iloc[[0, 2], :])
+
+        selected = ds.select(number=1, color='red')
+        assert selected == 0

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -214,3 +214,9 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         expected = pd.DataFrame({'color': ['red', 'blue'], 'values': [0, 1], 'number': [1, 1]}).set_index(['number', 'color'])
         assert isinstance(selected.data.index, pd.MultiIndex)
         pd.testing.assert_frame_equal(selected.data, expected)
+
+    def test_index_iloc_scalar(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.iloc[:, 0]
+        expected = self.df.reset_index()[["number"]]
+        pd.testing.assert_frame_equal(selected.data, expected)

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -209,7 +209,7 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         # Indexing relies on knowing the lexsort_depth but this is a
         # private import so we want to know should this import ever
         # be changed
-        from pandas.core.index.multi import _lexsort_depth  # noqa
+        from pandas.core.indexes.multi import _lexsort_depth  # noqa
 
     def test_no_kdims(self):
         ds = Dataset(self.df)

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -315,6 +315,24 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         selected = ds.select(number=1, color='red')
         assert selected == 0
 
+    @pytest.mark.xfail(reason="Not working")
+    def test_select_not_monotonic(self):
+        frame = pd.DataFrame({"number": [1, 1, 2, 2], "color": [2, 1, 2, 1]})
+        index = pd.MultiIndex.from_frame(frame, names=frame.columns)
+        df = pd.DataFrame(range(4), index=index, columns=["values"])
+        ds = Dataset(df, kdims=list(frame.columns))
+
+        data = ds.select(color=slice(2, 3)).data
+        expected = pd.DataFrame({"number": [1, 2], "color": [2, 2], "values": [1, 3]}).set_index(['number', 'color'])
+        pd.testing.assert_frame_equal(data, expected)
+
+    @pytest.mark.xfail(reason="Not working")
+    def test_select_not_in_index(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.select(number=[2, 3])
+        expected = ds.select(number=2)
+        pd.testing.assert_frame_equal(selected.data, expected.data)
+
     def test_sample(self):
         ds = Dataset(self.df, kdims=["number", "color"])
         sample = ds.interface.sample(ds, [1])

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -297,3 +297,9 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         ds = Dataset(self.df, kdims=["number", "color"])
         sample = ds.interface.sample(ds, [1])
         assert sample.to_dict() == {'values': {(1, 'red'): 1, (1, 'blue'): 1}}
+
+    def test_values(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        assert (ds.interface.values(ds, 'color') == ['red', 'blue', 'red', 'blue']).all()
+        assert (ds.interface.values(ds, 'number') == [1, 1, 2, 2]).all()
+        assert (ds.interface.values(ds, 'values') == [0, 1, 2, 3]).all()

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -163,6 +163,11 @@ class BasePandasInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
         ds = Dataset(df)
         self.assertEqual(list(ds.data.columns), ['interface'])
 
+    def test_dataset_range_with_object_index(self):
+        df = pd.DataFrame(range(4), columns=["values"], index=list("BADC"))
+        ds = Dataset(df, kdims='index')
+        assert ds.range('index') == ('A', 'D')
+
 
 class PandasInterfaceTests(BasePandasInterfaceTests):
 

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -278,7 +278,7 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         ds = Dataset(self.df, kdims=["number", "color"])
         sorted_ds = ds.sort("color")
         np.testing.assert_array_equal(sorted_ds.dimension_values("values"), [1, 3, 0, 2])
-        np.testing.assert_array_equal(sorted_ds.dimension_values("number"), [1, 3, 0, 2])
+        np.testing.assert_array_equal(sorted_ds.dimension_values("number"), [1, 2, 1, 2])
 
     def test_select(self):
         ds = Dataset(self.df, kdims=["number", "color"])

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -184,6 +184,7 @@ class PandasInterfaceTests(BasePandasInterfaceTests):
         data = Dataset(df).dimension_values("dates")
         np.testing.assert_equal(dates, data)
 
+    @pytest.mark.xfail(reason="Breaks hvplot")
     def test_reindex(self):
         ds = Dataset(pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)}))
         df = ds.interface.reindex(ds, ['x'])

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -267,3 +267,9 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         selected = ds.iloc[0, :3]
         expected = self.df.iloc[[0], [0]]
         pd.testing.assert_frame_equal(selected.data, expected)
+
+    def test_sort(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        sorted_ds = ds.sort("color")
+        np.testing.assert_array_equal(sorted_ds.dimension_values("values"), [1, 3, 0, 2])
+        np.testing.assert_array_equal(sorted_ds.dimension_values("number"), [1, 3, 0, 2])

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -215,14 +215,20 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         assert isinstance(selected.data.index, pd.MultiIndex)
         pd.testing.assert_frame_equal(selected.data, expected)
 
-    def test_index_iloc_scalar(self):
+    def test_index_iloc_slice_scalar(self):
         ds = Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[:, 0]
         expected = self.df.reset_index()[["number"]]
         pd.testing.assert_frame_equal(selected.data, expected)
 
-    def test_index_iloc_slice_only_index(self):
+    def test_index_iloc_slice_slice_only_index(self):
         ds = Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[:, :2]
         expected = self.df.reset_index()[["number", "color"]]
+        pd.testing.assert_frame_equal(selected.data, expected)
+
+    def test_index_iloc_scalar_slice_only_index(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.iloc[0, :2]
+        expected = pd.DataFrame({"number": 1, "color": "red"}, index=[0])
         pd.testing.assert_frame_equal(selected.data, expected)

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -220,20 +220,50 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         assert isinstance(selected.data.index, pd.MultiIndex)
         pd.testing.assert_frame_equal(selected.data, expected)
 
-    def test_index_iloc_slice_scalar(self):
+    def test_iloc_scalar_scalar_only_index(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.iloc[0, 0]
+        expected = 1
+        assert selected == expected
+
+    def test_iloc_slice_scalar_only_index(self):
         ds = Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[:, 0]
         expected = self.df.reset_index()[["number"]]
         pd.testing.assert_frame_equal(selected.data, expected)
 
-    def test_index_iloc_slice_slice_only_index(self):
+    def test_iloc_slice_slice_only_index(self):
         ds = Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[:, :2]
         expected = self.df.reset_index()[["number", "color"]]
         pd.testing.assert_frame_equal(selected.data, expected)
 
-    def test_index_iloc_scalar_slice_only_index(self):
+    def test_iloc_scalar_slice_only_index(self):
         ds = Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[0, :2]
         expected = pd.DataFrame({"number": 1, "color": "red"}, index=[0])
+        pd.testing.assert_frame_equal(selected.data, expected)
+
+    def test_iloc_scalar_scalar(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.iloc[0, 2]
+        expected = 0
+        assert selected == expected
+
+    def test_iloc_slice_scalar(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.iloc[:, 2]
+        expected = self.df.iloc[:, [0]]
+        pd.testing.assert_frame_equal(selected.data, expected)
+
+    def test_iloc_slice_slice(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.iloc[:, :3]
+        expected = self.df.iloc[:, [0]]
+        pd.testing.assert_frame_equal(selected.data, expected)
+
+    def test_iloc_scalar_slice(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        selected = ds.iloc[0, :3]
+        expected = self.df.iloc[[0], [0]]
         pd.testing.assert_frame_equal(selected.data, expected)

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -184,6 +184,13 @@ class PandasInterfaceTests(BasePandasInterfaceTests):
         data = Dataset(df).dimension_values("dates")
         np.testing.assert_equal(dates, data)
 
+    def test_reindex(self):
+        ds = Dataset(pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)}))
+        df = ds.interface.reindex(ds, ['x'])
+        assert df.index.names == ['x']
+        df = ds.interface.reindex(ds, ['y'])
+        assert df.index.names == ['y']
+
 
 class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
     datatype = 'dataframe'
@@ -303,3 +310,14 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         assert (ds.interface.values(ds, 'color') == ['red', 'blue', 'red', 'blue']).all()
         assert (ds.interface.values(ds, 'number') == [1, 1, 2, 2]).all()
         assert (ds.interface.values(ds, 'values') == [0, 1, 2, 3]).all()
+
+    def test_reindex(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        df = ds.interface.reindex(ds, ['number', 'color'])
+        assert df.index.names == ['number', 'color']
+
+        df = ds.interface.reindex(ds, ['number'])
+        assert df.index.names == ['number']
+
+        df = ds.interface.reindex(ds, ['values'])
+        assert df.index.names == ['values']

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -287,3 +287,13 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
 
         selected = ds.select(number=1, color='red')
         assert selected == 0
+
+    def test_sample(self):
+        ds = Dataset(self.df, kdims=["number", "color"])
+        sample = ds.interface.sample(ds, [1])
+        assert sample.to_dict() == {'values': {(1, 'blue'): 1}}
+
+        self.df.iloc[0, 0] = 1
+        ds = Dataset(self.df, kdims=["number", "color"])
+        sample = ds.interface.sample(ds, [1])
+        assert sample.to_dict() == {'values': {(1, 'red'): 1, (1, 'blue'): 1}}

--- a/holoviews/tests/operation/test_downsample.py
+++ b/holoviews/tests/operation/test_downsample.py
@@ -49,8 +49,6 @@ def test_downsample1d_shared_data():
     assert runs[0] == 1
 
 
-# Should be fixed when https://github.com/holoviz/holoviews/pull/6061 is merged
-@pytest.mark.xfail(reason="This will make a copy of the data")
 def test_downsample1d_shared_data_index():
     runs = [0]
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ extras_require['tests_core'] = [
     'plotly >=4.0',
     'ipython >=5.4.0',
     'contourpy',
-    'panel ==1.4.0',   # REMOVE BEFORE MERGE
 ]
 
 # Optional tests dependencies, i.e. one should be able

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ extras_require['tests_core'] = [
     'plotly >=4.0',
     'ipython >=5.4.0',
     'contourpy',
+    'panel ==1.4.0',   # REMOVE BEFORE MERGE
 ]
 
 # Optional tests dependencies, i.e. one should be able


### PR DESCRIPTION
The Pandas support in HoloViews has always been severely hampered by the fact that we do not properly support indexes, i.e. if a user references an index column we are forced to call `.reset_index()` which is inefficient and breaks one core principle of HoloViews, which is that we simply provide thin wrappers around data. It also has significant performance implications both from a memory perspective and from a speed perspective since indexes can provide significant speedups when indexing or performing aggregations. One other major issue solved by supporting indexes is the problem of having multiple elements providing a view onto the same DataFrame, e.g. when you have an NdOverlay of curves each visualizing a different column.

Implements https://github.com/holoviz/holoviews/issues/2537

- [x] Implement all operations correctly
  - [x] `__init__`
  - [x] `validate`
  - [x] `dtype`
  - [x] `dimension_type`
  - [x] `range`
  - [x] `iloc` (check multi-index)
  - [x] `values` (check multi-index)
  - [x] `sort`
  - [x] `reindex`
  - [x] `sample`
- [x] Optimized operations
  - [x] `select`
  - [x] `groupby`
- [x] Check operations that use `dataset.data` directly do not make (now invalid) assumptions about indexes
- [x] Add tests