### PR TITLE
Add Comm on_open handler to initialize the server comm

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -408,7 +408,8 @@ class Renderer(Exporter):
         client_comm = self.comm_manager.get_client_comm(
             on_msg=partial(plot._on_msg, ref, manager),
             on_error=partial(plot._on_error, ref),
-            on_stdout=partial(plot._on_stdout, ref)
+            on_stdout=partial(plot._on_stdout, ref),
+            on_open=lambda _: comm.init()
         )
         manager.client_comm_id = client_comm.id
         return render_mimebundle(model, doc, comm, manager)


### PR DESCRIPTION
Aligns the comm handling in HoloViews with the recent changes in https://github.com/holoviz/panel/pull/6229.