### PR TITLE
Disable always on warnings

### DIFF
--- a/holoviews/util/warnings.py
+++ b/holoviews/util/warnings.py
@@ -81,7 +81,3 @@ class HoloviewsUserWarning(UserWarning):
     """A Holoviews-specific ``UserWarning`` subclass.
     Used to selectively filter Holoviews warnings for unconditional display.
     """
-
-
-warnings.simplefilter("always", HoloviewsDeprecationWarning)
-warnings.simplefilter("always", HoloviewsUserWarning)


### PR DESCRIPTION
Because of the use of `find_stack_level` we should not always emit the DeprecationWarning.

This means that only the module or user calling the deprecated function will receive the warning. 