### PR TITLE
Fix tests suite because of Pandas 2.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.7
+    rev: v3.1.0
     hooks:
       - id: prettier
         exclude: conda.recipe/meta.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: check-json
       - id: detect-private-key
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.1.14
     hooks:
       - id: ruff
         files: holoviews/|scripts/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ itself.**
 <!-- prettier-ignore -->
 |    |    |
 | --- | --- |
-| Build Status | [![Build Status](https://github.com/holoviz/holoviews/workflows/tests/badge.svg?query=branch:main)](https://github.com/holoviz/holoviews/actions/workflows/test.yaml?query=branch%3Amain) |
+| Build Status | [![Build Status](https://github.com/holoviz/holoviews/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/holoviz/holoviews/actions/workflows/test.yaml?query=branch%3Amain) |
 | Coverage | [![codecov](https://codecov.io/gh/holoviz/holoviews/branch/main/graph/badge.svg)](https://codecov.io/gh/holoviz/holoviews) |
 | Latest dev release | [![Github tag](https://img.shields.io/github/tag/holoviz/holoviews.svg?label=tag&colorB=11ccbb)](https://github.com/holoviz/holoviews/tags) [![dev-site](https://img.shields.io/website-up-down-green-red/http/dev.holoviews.org.svg?label=dev%20website)](http://dev.holoviews.org) |
 | Latest release | [![Github release](https://img.shields.io/github/release/holoviz/holoviews.svg?label=tag&colorB=11ccbb)](https://github.com/holoviz/holoviews/releases) [![PyPI version](https://img.shields.io/pypi/v/holoviews.svg?colorB=cc77dd)](https://pypi.python.org/pypi/holoviews) [![holoviews version](https://img.shields.io/conda/v/pyviz/holoviews.svg?colorB=4488ff&style=flat)](https://anaconda.org/pyviz/holoviews) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/holoviews.svg?label=conda%7Cconda-forge&colorB=4488ff)](https://anaconda.org/conda-forge/holoviews) [![defaults version](https://img.shields.io/conda/v/anaconda/holoviews.svg?label=conda%7Cdefaults&style=flat&colorB=4488ff)](https://anaconda.org/anaconda/holoviews) |

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -113,10 +113,10 @@ warnings.filterwarnings("ignore",
 
 if "IPython" in sys.modules:
     from .ipython import notebook_extension
-    extension = notebook_extension # noqa (name remapping)
+    extension = notebook_extension
 else:
     class notebook_extension(param.ParameterizedFunction):
-        def __call__(self, *args, **opts): # noqa (dummy signature)
+        def __call__(self, *args, **kwargs):
             raise Exception("Jupyter notebook not available: use hv.extension instead.")
 
 if '_pyodide' in sys.modules:

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -269,7 +269,7 @@ argument to specify a selection specification""")
 
         index_dim = self.nodes.kdims[2].name
         dimensions = self.kdims+self.vdims
-        node_selection = {index_dim: v for k, v in selection.items()
+        node_selection = {index_dim: v for k, v in selection.items()  # noqa: RUF011
                           if k in self.kdims}
         if selection_expr:
             mask = selection_expr.apply(self.nodes, compute=False, keep_index=True)

--- a/holoviews/tests/plotting/bokeh/test_renderer.py
+++ b/holoviews/tests/plotting/bokeh/test_renderer.py
@@ -4,6 +4,7 @@ from unittest import SkipTest
 import numpy as np
 import panel as pn
 import param
+import pytest
 from bokeh.io import curdoc
 from bokeh.themes.theme import Theme
 from panel.widgets import DiscreteSlider, FloatSlider, Player
@@ -154,6 +155,7 @@ class BokehRendererTest(ComparisonTestCase):
         self.assertEqual(obj.widget_location, 'top')
         self.assertEqual(obj.widget_type, 'individual')
 
+    @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm')
     def test_render_dynamicmap_with_dims(self):
         dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
         obj, _ = self.renderer._validate(dmap, None)
@@ -166,6 +168,7 @@ class BokehRendererTest(ComparisonTestCase):
         slider.value = 3.1
         self.assertEqual(cds.data['y'][2], 3.1)
 
+    @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm')
     def test_render_dynamicmap_with_stream(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y'], streams=[stream])
@@ -178,6 +181,7 @@ class BokehRendererTest(ComparisonTestCase):
         stream.event(y=3)
         self.assertEqual(cds.data['y'][2], 3)
 
+    @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm')
     def test_render_dynamicmap_with_stream_dims(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda x, y: Curve([x, 1, y]), kdims=['x', 'y'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ filterwarnings = [
     # 2024-01: Pandas 2.2
     "ignore:When grouping with a length-1 list::dask.dataframe.groupby",  # https://github.com/dask/dask/issues/10572
     "ignore:\\s*Pyarrow will become a required dependency of pandas:DeprecationWarning",  # Will go away by itself in Pandas 3.0
-    "ignore:None of the available storage backends were able to support the supplied data format. SpatialPandasInterface raised following error",  # https://github.com/holoviz/spatialpandas/issues/137
+    "ignore:Passing a (SingleBlockManager|BlockManager) to (Series|GeoSeries|DataFrame|GeoDataFrame) is deprecated:DeprecationWarning",  # https://github.com/holoviz/spatialpandas/issues/137
 ]
 
 [tool.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,10 @@ filterwarnings = [
     "ignore:datetime.datetime.utcfromtimestamp():DeprecationWarning:dateutil.tz.tz",  # https://github.com/dateutil/dateutil/pull/1285
     "ignore:datetime.datetime.utcfromtimestamp():DeprecationWarning:bokeh",  # https://github.com/bokeh/bokeh/issues/13125
     "ignore:datetime.datetime.utcnow():DeprecationWarning:bokeh",  # https://github.com/bokeh/bokeh/issues/13125
-    # 2024-01: Pandas 2.2 problems in Dask
+    # 2024-01: Pandas 2.2
     "ignore:When grouping with a length-1 list::dask.dataframe.groupby",  # https://github.com/dask/dask/issues/10572
+    "ignore:\\s*Pyarrow will become a required dependency of pandas:DeprecationWarning",  # Will go away by itself in Pandas 3.0
+    "ignore:None of the available storage backends were able to support the supplied data format. SpatialPandasInterface raised following error",  # https://github.com/holoviz/spatialpandas/issues/137
 ]
 
 [tool.coverage]

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ extras_require['tests'] = extras_require['tests_core'] + [
     'shapely',
     'ffmpeg',
     'cftime',
-    'scipy >=1.10,<1.12',  # Python 3.9 + Windows downloads 1.9, Scipy 1.12 on Windows emit warning
+    'scipy >=1.10',  # Python 3.9 + Windows downloads 1.9
     'selenium',
     'spatialpandas',
     'datashader >=0.11.1',

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ extras_require['tests'] = extras_require['tests_core'] + [
     'shapely',
     'ffmpeg',
     'cftime',
-    'scipy >=1.10',  # Python 3.9 + Windows downloads 1.9
+    'scipy >=1.10,<1.12',  # Python 3.9 + Windows downloads 1.9, Scipy 1.12 on Windows emit warning
     'selenium',
     'spatialpandas',
     'datashader >=0.11.1',


### PR DESCRIPTION
Also, I updated the pre-commit, which updated the ruff, and manually downgraded the prettier to a stable version.

Lastly, I updated the readme badge to reflect the actual status of the test run.

<s> Scipy have been upper pinned because of: https://github.com/conda-forge/scipy-feedstock/issues/264