### PR TITLE
Update show_versions to use package name

### DIFF
--- a/holoviews/util/_versions.py
+++ b/holoviews/util/_versions.py
@@ -8,7 +8,7 @@ PACKAGES = [
     # Data
     "cudf",
     "dask",
-    "ibis",
+    "ibis-framework",
     "networkx",
     "numpy",
     "pandas",
@@ -18,8 +18,9 @@ PACKAGES = [
     "xarray",
     # Processing
     "numba",
-    "skimage",
+    "scikit-image",
     "scipy",
+    "tsdownsample",
     # Plotting
     "bokeh",
     "colorcet",
@@ -27,7 +28,7 @@ PACKAGES = [
     "geoviews",
     "hvplot",
     "matplotlib",
-    "PIL",
+    "pillow",
     "plotly",
     # Jupyter
     "IPython",
@@ -63,3 +64,7 @@ def _panel_comms():
     import panel as pn
 
     print(f"{'Panel comms':20}:  {pn.config.comms}")
+
+
+if __name__ == "__main__":
+    show_versions()


### PR DESCRIPTION
Changes in #6072 to no use `importlib.metadata.version` meant that we should use the package name and not the import name. 

I also added a tsdownsample to the list. 