### PR TITLE
Add test for downsample algorithms

### DIFF
--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -1,4 +1,6 @@
 import contextlib
+import sys
+from collections.abc import Callable
 
 import pytest
 from panel.tests.conftest import (  # noqa
@@ -80,3 +82,17 @@ def plotly_backend():
     hv.Store.current_backend = 'plotly'
     yield
     hv.Store.current_backend = prev_backend
+
+@pytest.fixture
+def unimport(monkeypatch: pytest.MonkeyPatch) -> Callable[[str], None]:
+    """
+    Return a function for unimporting modules and preventing reimport.
+    """
+
+    def unimport_module(modname: str) -> None:
+        # Remove if already imported
+        monkeypatch.delitem(sys.modules, modname, raising=False)
+        # Prevent import:
+        monkeypatch.setattr(sys, "path", [])
+
+    return unimport_module

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -87,6 +87,8 @@ def plotly_backend():
 def unimport(monkeypatch: pytest.MonkeyPatch) -> Callable[[str], None]:
     """
     Return a function for unimporting modules and preventing reimport.
+
+    This will block any new modules from being imported.
     """
 
     def unimport_module(modname: str) -> None:

--- a/holoviews/tests/element/test_selection.py
+++ b/holoviews/tests/element/test_selection.py
@@ -657,7 +657,7 @@ class TestSpatialSelectColumnar:
                   -1,-1,-1]
         }, dtype=float)
 
-    @dd_available
+
     @pytest.fixture(scope="function")
     def dask_df(self, pandas_df):
         return dd.from_pandas(pandas_df, npartitions=2)

--- a/holoviews/tests/operation/test_downsample.py
+++ b/holoviews/tests/operation/test_downsample.py
@@ -1,7 +1,13 @@
+import numpy as np
 import pytest
 
 import holoviews as hv
-from holoviews.operation.downsample import downsample1d
+from holoviews.operation.downsample import _ALGORITHMS, downsample1d
+
+try:
+    import tsdownsample
+except ImportError:
+    tsdownsample = None
 
 
 @pytest.mark.parametrize("plottype", ["overlay", "ndoverlay"])
@@ -18,3 +24,27 @@ def test_downsample1d_multi(plottype):
     for n in figure_values:
         for value in n.data.values():
             assert value.size == downsample1d.width
+
+
+@pytest.mark.parametrize("algorithm", _ALGORITHMS.values(), ids=_ALGORITHMS)
+def test_downsample_algorithm(algorithm, unimport):
+    unimport("tsdownsample")
+    x = np.arange(1000)
+    y = np.random.rand(1000)
+    width = 20
+    try:
+        result = algorithm(x, y, width)
+    except NotImplementedError:
+        pytest.skip("not testing tsdownsample algorithms")
+    else:
+        assert result.size == width
+
+
+@pytest.mark.skipif(not tsdownsample, reason="tsdownsample not installed")
+@pytest.mark.parametrize("algorithm", _ALGORITHMS.values(), ids=_ALGORITHMS)
+def test_downsample_algorithm_with_tsdownsample(algorithm):
+    x = np.arange(1000)
+    y = np.random.rand(1000)
+    width = 20
+    result = algorithm(x, y, width)
+    assert result.size == width

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ extras_require['tests'] = extras_require['tests_core'] + [
     'spatialpandas',
     'datashader >=0.11.1',
     'dash >=1.16',
+    'tsdownsample',
 ]
 
 extras_require['tests_ci'] = [

--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,10 @@ extras_require['tests'] = extras_require['tests_core'] + [
     'spatialpandas',
     'datashader >=0.11.1',
     'dash >=1.16',
-    'tsdownsample',
 ]
+
+if os.name != "nt":
+    extras_require['tests'] += ['tsdownsample']
 
 extras_require['tests_ci'] = [
     'codecov',

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ extras_require['tests'] = extras_require['tests_core'] + [
 ]
 
 if os.name != "nt":
+    # Currently not available on Windows on conda-forge
     extras_require['tests'] += ['tsdownsample']
 
 extras_require['tests_ci'] = [


### PR DESCRIPTION
Add simple tests to check if we can run the downsample algorithms.

Unimport is inspired by this: https://mastodon.social/@sscherfke/111116160705738755

It seems like tsdownsample is not available on Windows on conda-forge. 