### PR TITLE
Don't pin notebook in conda receipe for pyviz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ filterwarnings = [
     "ignore:When grouping with a length-1 list::dask.dataframe.groupby",  # https://github.com/dask/dask/issues/10572
     "ignore:\\s*Pyarrow will become a required dependency of pandas:DeprecationWarning",  # Will go away by itself in Pandas 3.0
     "ignore:Passing a (SingleBlockManager|BlockManager) to (Series|GeoSeries|DataFrame|GeoDataFrame) is deprecated:DeprecationWarning",  # https://github.com/holoviz/spatialpandas/issues/137
+    # 2024-02
+    "ignore:The current Dask DataFrame implementation is deprecated:DeprecationWarning",  # https://github.com/dask/dask/issues/10917
 ]
 
 [tool.coverage]

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ extras_require['tests_nb'] = ['nbval']
 extras_require['ui'] = ['playwright', 'pytest-playwright']
 
 # Notebook dependencies
-extras_require["notebook"] = ["ipython >=5.4.0", "notebook >=7.0"]
+extras_require["notebook"] = ["ipython >=5.4.0", "notebook"]
 
 # IPython Notebook + pandas + matplotlib + bokeh
 extras_require["recommended"] = extras_require["notebook"] + [
@@ -102,6 +102,7 @@ extras_require["examples"] = extras_require["recommended"] + [
     "pyarrow",
     "pooch",
     "datashader >=0.11.1",
+    "notebook >=7.0",
 ]
 
 


### PR DESCRIPTION
Recommended was added to the pyviz conda.receipe, giving a weird solve for hvplot CI, because another dependency had likely pinned `notebook <7`  