### PR TITLE
Remove recommended packages for pyviz receipe

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,9 +28,6 @@ requirements:
     {% for dep in sdata.get('install_requires',{}) %}
     - {{ dep }}
     {% endfor %}
-    {% for dep in sdata['extras_require']['recommended'] %}
-    - {{ dep }}
-    {% endfor %}
 
 
 about:


### PR DESCRIPTION
Talking with Maxime, we discussed removing the recommended section for conda.receipe as conda-forge and defaults should both be up-to-date. 

This should be merged so it will be in 1.19.