### PR TITLE
Add a zoom tool per subcoordinate_y group

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2881,6 +2881,18 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
         """
         # First, just process and validate the groups and their content.
         groups = defaultdict(list)
+
+        # If there are groups AND there are subcoordinate_y elements without a group.
+        if any(el.group != type(el).__name__ for el in overlay) and any(
+            el.opts.get('plot').kwargs.get('subcoordinate_y', False)
+            and el.group == type(el).__name__
+            for el in overlay
+        ):
+            raise ValueError(
+                'The subcoordinate_y overlay contains elements with a defined group, each '
+                'subcoordinate_y element in the overlay must have a defined group.'
+            )
+
         for el in overlay:
             # group is the Element type per default (e.g. Curve, Spike).
             if el.group == type(el).__name__:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2846,7 +2846,6 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
         self.handles['hover_tools'] = hover_tools
         return init_tools
 
-
     def _merge_tools(self, subplot):
         """
         Merges tools on the overlay with those on the subplots.
@@ -2900,7 +2899,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             if not el.opts.get('plot').kwargs.get('subcoordinate_y', False):
                 raise ValueError(
                     f"All elements in group {el.group!r} must set the option "
-                    "'subcoordinate_y=True'. Not found for: {el}"
+                    f"'subcoordinate_y=True'. Not found for: {el}"
                 )
             groups[el.group].append(el)
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1,4 +1,5 @@
 import warnings
+from collections import defaultdict
 from itertools import chain
 from types import FunctionType
 
@@ -2871,8 +2872,64 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                 subplot.handles['zooms_subcoordy'].values(),
                 self.handles['zooms_subcoordy'].values(),
             ):
-                renderers = list(util.unique_iterator(subplot_zoom.renderers + overlay_zoom.renderers))
+                renderers = list(util.unique_iterator(overlay_zoom.renderers + subplot_zoom.renderers))
                 overlay_zoom.renderers = renderers
+
+    def _postprocess_subcoordinate_y_groups(self, overlay, plot):
+        """
+        Add a zoom tool per group to the overlay.
+        """
+        # First, just process and validate the groups and their content.
+        groups = defaultdict(list)
+        for el in overlay:
+            # group is the Element type per default (e.g. Curve, Spike).
+            if el.group == type(el).__name__:
+                continue
+            if not el.opts.get('plot').kwargs.get('subcoordinate_y', False):
+                raise ValueError(
+                    f"All elements in group {el.group!r} must set the option "
+                    "'subcoordinate_y=True'. Not found for: {el}"
+                )
+            groups[el.group].append(el)
+
+        # No need to go any further if there's just one group.
+        if len(groups) <= 1:
+            return
+
+        # At this stage, there's only one zoom tool (e.g. 1 wheel_zoom) that
+        # has all the renderers (e.g. all the curves in the overlay).
+        # We want to create as many zoom tools as groups, for each group
+        # the zoom tool must have the renderers of the elements of the group.
+        zoom_tools = self.handles['zooms_subcoordy']
+        for zoom_tool_name, zoom_tool in zoom_tools.items():
+            renderers_per_group = defaultdict(list)
+            # We loop through each overlay sub-elements and empty the list of
+            # renderers of the initial tool.
+            for el in overlay:
+                if el.group not in groups:
+                    continue
+                renderers_per_group[el.group].append(zoom_tool.renderers.pop(0))
+
+            if zoom_tool.renderers:
+                raise RuntimeError(f'Found unexpected zoom renderers {zoom_tool.renderers}')
+
+            new_ztools = []
+            # Create a new tool per group with the right renderers and a custom description.
+            for grp, grp_renderers in renderers_per_group.items():
+                new_tool = zoom_tool.clone()
+                new_tool.renderers = grp_renderers
+                new_tool.description = f"{zoom_tool_name.replace('_', ' ').title()} ({grp})"
+                new_ztools.append(new_tool)
+            # Revert tool order so the upper tool in the toolbar corresponds to the
+            # upper group in the overlay.
+            new_ztools = new_ztools[::-1]
+
+            # Update the handle for good measure.
+            zoom_tools[zoom_tool_name] = new_ztools
+
+            # Replace the original tool by the new ones
+            idx = plot.tools.index(zoom_tool)
+            plot.tools[idx:idx+1] = new_ztools
 
     def _get_dimension_factors(self, overlay, ranges, dimension):
         factors = []
@@ -2961,6 +3018,9 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                     title = get_tab_title(key, frame, self.hmap.last)
                 panels.append(TabPanel(child=child, title=title))
             self._merge_tools(subplot)
+
+        if self.subcoordinate_y:
+            self._postprocess_subcoordinate_y_groups(element, plot)
 
         if self.tabs:
             self.handles['plot'] = Tabs(

--- a/holoviews/tests/plotting/bokeh/test_subcoordy.py
+++ b/holoviews/tests/plotting/bokeh/test_subcoordy.py
@@ -356,3 +356,27 @@ class TestSubcoordinateY(TestBokehPlot):
         ])
         with_span = VSpan(1, 2) * overlay * VSpan(3, 4)
         bokeh_renderer.get_plot(with_span)
+
+    def test_missing_group_error(self):
+        curves = []
+        for i, group in enumerate(['A', 'B', 'C']):
+            for i in range(2):
+                label = f'{group}{i}'
+                if group == "B":
+                    curve = Curve(range(10), label=label, group=group).opts(
+                        subcoordinate_y=True
+                    )
+                else:
+                    curve = Curve(range(10), label=label).opts(
+                        subcoordinate_y=True
+                    )
+                curves.append(curve)
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                'The subcoordinate_y overlay contains elements with a defined group, each '
+                'subcoordinate_y element in the overlay must have a defined group.'
+            )
+        ):
+            bokeh_renderer.get_plot(Overlay(curves))


### PR DESCRIPTION
closes https://github.com/holoviz/holoviews/issues/5901

When users assign a `group` to an Element with `subcoordinate_y` enabled, a dedicated `wheel_zoom` is created per group. The order of the zoom tools matches how the groups are displayed, i.e. the top tool controls the group displayed at the top of the chart. Each tool has a custom tooltip that contains the group name.

```python
import numpy as np
import panel as pn
import holoviews as hv
hv.extension('bokeh')

x = np.linspace(0, 10*np.pi)
curves = []
j = 0.5
for group in ['A', 'B', 'C']:
    for i in range(2):
        yvals = j * np.sin(x)
        curve = hv.Curve((x + i*np.pi/2, yvals), label=f'{group}{i}', group=group).opts(
            subcoordinate_y=True
        )
        curves.append(curve)
        j += 1

hv.Overlay(curves).opts(show_legend=False, width=400, height=400)
```
![Kapture 2024-02-20 at 15 18 03](https://github.com/holoviz/holoviews/assets/35924738/ee77e1bb-ed21-486b-b7d4-0c9ddbbdcff3)

Users can add extra `zoom_in` and `zoom_out` tools. The UX isn't great but we agreed not to spend too much time trying to improve it (I've seen worse!).

```python
for group in ['A', 'B', 'C']:
    for i in range(2):
        yvals = j * np.sin(x)
        curve = hv.Curve((x + i*np.pi/2, yvals), label=f'{group}{i}', group=group).opts(
            subcoordinate_y=True, tools=['zoom_in', 'zoom_out']
        )
        curves.append(curve)
        j += 1

hv.Overlay(curves).opts(show_legend=False, width=400, height=800)
```
![Kapture 2024-02-20 at 15 21 29](https://github.com/holoviz/holoviews/assets/35924738/8263f31e-a4a0-443f-8ffb-167ada46420f)

When overlaid with other non subcoordinate_y elements, the default zoom tool is displayed.
```python
for group in ['A', 'B', 'C']:
    for i in range(2):
        yvals = j * np.sin(x)
        curve = hv.Curve((x + i*np.pi/2, yvals), label=f'{group}{i}', group=group).opts(
            subcoordinate_y=True,
        )
        curves.append(curve)
        j += 1

(hv.Overlay(curves) * hv.Overlay([hv.VSpan(i, i + 2) for i in range(2, 20, 4)])).opts(
    show_legend=False, width=400, height=500
)
```
![Kapture 2024-02-20 at 15 25 40](https://github.com/holoviz/holoviews/assets/35924738/2c61fc23-0e26-421a-9ca3-0f39b727696c)

Implementation-wise, I opted for adding a post-processing step, instead of having to changing the structure of the zoom handle directory (accounting for groups) as it required changes in various places that are hard to follow. In the end, the implementation isn't so complex.