### PR TITLE
Add operation for group-wise normalisation

### DIFF
--- a/holoviews/operation/normalization.py
+++ b/holoviews/operation/normalization.py
@@ -190,6 +190,8 @@ class subcoordinate_group_ranges(Operation):
     """
 
     def _process(self, overlay, key=None):
+        if not getattr(overlay, 'subcoordinate_y', False):
+            return overlay
         vmins = defaultdict(list)
         vmaxs = defaultdict(list)
         include_chart = False

--- a/holoviews/operation/normalization.py
+++ b/holoviews/operation/normalization.py
@@ -206,6 +206,7 @@ class subcoordinate_group_ranges(Operation):
         new = []
         for el in overlay:
             if not isinstance(el, Chart):
+                new.append(el)
                 continue
             y_dimension = el.vdims[0]
             y_dimension = y_dimension.clone(range=minmax[el.group])

--- a/holoviews/operation/normalization.py
+++ b/holoviews/operation/normalization.py
@@ -20,7 +20,7 @@ import param
 from ..core import Overlay
 from ..core.operation import Operation
 from ..core.util import match_spec
-from ..element import Raster
+from ..element import Chart, Raster
 
 
 class Normalization(Operation):
@@ -188,6 +188,8 @@ class normalize_group(Operation):
         vmins = defaultdict(list)
         vmaxs = defaultdict(list)
         for el in overlay:
+            if not isinstance(el, Chart):
+                continue
             vmin, vmax = el.range(1)
             vmins[el.group].append(vmin)
             vmaxs[el.group].append(vmax)
@@ -198,6 +200,8 @@ class normalize_group(Operation):
         }
         new = []
         for el in overlay:
+            if not isinstance(el, Chart):
+                continue
             y_dimension = el.vdims[0]
             y_dimension = y_dimension.clone(range=minmax[el.group])
             new.append(el.redim(**{y_dimension.name: y_dimension}))

--- a/holoviews/operation/normalization.py
+++ b/holoviews/operation/normalization.py
@@ -192,12 +192,17 @@ class subcoordinate_group_ranges(Operation):
     def _process(self, overlay, key=None):
         vmins = defaultdict(list)
         vmaxs = defaultdict(list)
+        include_chart = False
         for el in overlay:
             if not isinstance(el, Chart):
                 continue
             vmin, vmax = el.range(1)
             vmins[el.group].append(vmin)
             vmaxs[el.group].append(vmax)
+            include_chart = True
+
+        if not include_chart:
+            return overlay
 
         minmax = {
             group: (np.min(vmins[group]), np.max(vmaxs[group]))

--- a/holoviews/operation/normalization.py
+++ b/holoviews/operation/normalization.py
@@ -200,6 +200,5 @@ class normalize_group(Operation):
         for el in overlay:
             y_dimension = el.vdims[0]
             y_dimension = y_dimension.clone(range=minmax[el.group])
-            el = el.redim(**{y_dimension.name: y_dimension})
-            new.append(el)
+            new.append(el.redim(**{y_dimension.name: y_dimension}))
         return overlay.clone(data=new)

--- a/holoviews/operation/normalization.py
+++ b/holoviews/operation/normalization.py
@@ -21,7 +21,6 @@ from ..core import Overlay
 from ..core.operation import Operation
 from ..core.util import match_spec
 from ..element import Raster
-from ..util.transform import dim
 
 
 class Normalization(Operation):
@@ -199,7 +198,8 @@ class normalize_group(Operation):
         }
         new = []
         for el in overlay:
-            dim_name = el.dimensions()[1].name
-            expr = (dim(dim_name) - minmax[el.group][0]) / (minmax[el.group][1] - minmax[el.group][0])
-            new.append(el.transform(**{dim_name: expr}))
+            y_dimension = el.vdims[0]
+            y_dimension = y_dimension.clone(range=minmax[el.group])
+            el = el.redim(**{y_dimension.name: y_dimension})
+            new.append(el)
         return overlay.clone(data=new)

--- a/holoviews/operation/normalization.py
+++ b/holoviews/operation/normalization.py
@@ -190,9 +190,6 @@ class subcoordinate_group_ranges(Operation):
     """
 
     def _process(self, overlay, key=None):
-        if not getattr(overlay, 'subcoordinate_y', False):
-            return overlay
-
         # If there are groups AND there are subcoordinate_y elements without a group.
         if any(el.group != type(el).__name__ for el in overlay) and any(
             el.opts.get('plot').kwargs.get('subcoordinate_y', False)

--- a/holoviews/operation/normalization.py
+++ b/holoviews/operation/normalization.py
@@ -179,9 +179,14 @@ class raster_normalization(Normalization):
         return norm_raster
 
 
-class normalize_group(Operation):
+class subcoordinate_group_ranges(Operation):
     """
-    Group-wise min-max normalisation.
+    Compute the data range group-wise in a subcoordinate_y overlay,
+    and set the dimension range of each Chart element based on the
+    value computed for its group.
+
+    This operation is useful to visually apply a group-wise min-max
+    normalisation.
     """
 
     def _process(self, overlay, key=None):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -486,10 +486,15 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         range_el = el if self.batched and not isinstance(self, OverlayPlot) else element
 
+        if pos == 1 and 'subcoordinate_y' in range_tags_extras and dim and dim.range != (None, None):
+            dims = [dim]
+            v0, v1 = dim.range
+            axis_label = str(dim)
+            specs = ((dim.name, dim.label, dim.unit),)
         # For y-axes check if we explicitly passed in a dimension.
         # This is used by certain plot types to create an axis from
         # a synthetic dimension and exclusively supported for y-axes.
-        if pos == 1 and dim:
+        elif pos == 1 and dim:
             dims = [dim]
             v0, v1 = util.max_range([
                 elrange.get(dim.name, {'combined': (None, None)})['combined']

--- a/holoviews/tests/plotting/bokeh/test_subcoordy.py
+++ b/holoviews/tests/plotting/bokeh/test_subcoordy.py
@@ -5,6 +5,7 @@ from bokeh.models.tools import WheelZoomTool, ZoomInTool, ZoomOutTool
 from holoviews.core import Overlay
 from holoviews.element import Curve
 from holoviews.element.annotation import VSpan
+from holoviews.operation.normalization import subcoordinate_group_ranges
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
@@ -250,3 +251,33 @@ class TestSubcoordinateY(TestBokehPlot):
                     break
             else:
                 raise AssertionError('Provided zoom not found.')
+
+    def test_norm_subcoordinate_group_ranges(self):
+        x = np.linspace(0, 10 * np.pi, 21)
+        curves = []
+        j = 0
+        for group in ['A', 'B']:
+            for i in range(2):
+                yvals = j * np.sin(x)
+                curves.append(
+                    Curve((x + np.pi/2, yvals), label=f'{group}{i}', group=group).opts(subcoordinate_y=True)
+                )
+                j += 1
+
+        overlay = Overlay(curves)
+        noverlay = subcoordinate_group_ranges(overlay)
+
+        expected = [
+            (-1.0, 1.0),
+            (-1.0, 1.0),
+            (-3.0, 3.0),
+            (-3.0, 3.0),
+        ]
+        for i, el in enumerate(noverlay):
+            assert el.get_dimension('y').range == expected[i]
+
+        plot = bokeh_renderer.get_plot(noverlay)
+
+        for i, sp in enumerate(plot.subplots.values()):
+                y_source = sp.handles['glyph_renderer'].coordinates.y_source
+                assert (y_source.start, y_source.end) == expected[i]


### PR DESCRIPTION
resolves https://github.com/holoviz/holoviews/issues/6123

Very much WIP and I've never written any operation! But it works:

```python
import numpy as np
import panel as pn
import holoviews as hv

from holoviews.operation.normalization import normalize_group

hv.extension('bokeh')

x = np.linspace(0, 10*np.pi)
curves = []
j = 0.5
for group in ['A', 'B', 'C']:
    for i in range(2):
        yvals = j * np.sin(x)
        curve = hv.Curve((x + i*np.pi/2, yvals), label=f'{group}{i}', group=group).opts(
            subcoordinate_y=True,
        )
        curves.append(curve)
        j += 1

os = hv.Overlay(curves).opts(show_legend=False, width=400, height=400)
normalize_group(os)
```

![image](https://github.com/holoviz/holoviews/assets/35924738/577751da-86c0-409d-b6cc-c05dc15f8a4a)

@droumis let's chat more about the CZI use case we're trying to solve, with a much much larger dataset that comes with more constraints.