### PR TITLE
Implement clim_percentile for RGB

### DIFF
--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -187,12 +187,12 @@ class RGBPlot(LegendPlot):
                          for d in element.vdims])
 
         if self.clim_percentile:
-            if isinstance(self.clim_percentile, (int, float)):
-                low, high = np.percentile(img, (self.clim_percentile, 100 - self.clim_percentile))
-            else:  # True
+            if isinstance(self.clim_percentile, bool):
                 low, high = np.percentile(img, (2, 98))
+            else:  # True
+                low, high = np.percentile(img, (self.clim_percentile, 100 - self.clim_percentile))
             img = np.clip(img, low, high)
-            img = img / img.max((0, 1)) * 255
+            img = img / high * 255
 
         nan_mask = np.isnan(img)
         img[nan_mask] = 0

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -136,6 +136,11 @@ class RGBPlot(LegendPlot):
 
     padding = param.ClassSelector(default=0, class_=(int, float, tuple))
 
+    clim_percentile = param.ClassSelector(default=False, class_=(int, float, bool), doc="""
+        Percentile value to compute colorscale robust to outliers. If
+        True, uses 2nd and 98th percentile; otherwise uses the specified
+        numerical percentile value.""")
+
     style_opts = ['alpha'] + base_properties
 
     _nonvectorized_styles = style_opts
@@ -180,6 +185,14 @@ class RGBPlot(LegendPlot):
 
         img = np.dstack([element.dimension_values(d, flat=False)
                          for d in element.vdims])
+
+        if self.clim_percentile:
+            if isinstance(self.clim_percentile, (int, float)):
+                low, high = np.percentile(img, (self.clim_percentile, 100 - self.clim_percentile))
+            else:  # True
+                low, high = np.percentile(img, (2, 98))
+            img = np.clip(img, low, high)
+            img = img / img.max((0, 1)) * 255
 
         nan_mask = np.isnan(img)
         img[nan_mask] = 0


### PR DESCRIPTION
Addresses part of https://github.com/holoviz/hvplot/issues/1251

<img width="943" alt="image" src="https://github.com/holoviz/holoviews/assets/15331990/66e25120-fc63-4c3d-8fdc-5395f87aec26">

```python
from pystac_client import Client
from odc.stac import load
import numpy as np

client = Client.open("https://earth-search.aws.element84.com/v1")
collection = "sentinel-2-l2a"
tas_bbox = [146.5, -43.6, 146.7, -43.4]
search = client.search(collections=[collection], bbox=tas_bbox, datetime="2023-12")

ds = load(search.items(), bbox=tas_bbox, groupby="solar_day", chunks={})
da = ds[["red", "green", "blue"]].isel(time=2).load().to_array()
low, high = np.nanpercentile(da, (2, 98))
img = np.clip(da, low, high)
img /= img.max(["x", "y"])

import matplotlib.pyplot as plt
fig, axes = plt.subplots(2, figsize=(10, 10))
da.plot.imshow(ax=axes[0], robust=True)
axes[0].set_title("ORIGINAL; GOLD STANDARD")
img.plot.imshow(ax=axes[1])
axes[1].set_title("MIMICKED XARRAY")

import hvplot.xarray
da.hvplot.rgb(x="x", y="y", bands="variable").opts(clim_percentile=True, title="INTERNAL CHANGES") + \
img.hvplot.rgb(x="x", y="y", bands="variable").opts(title="MIMICKED XARRAY")
```

Now, I'm have trouble figuring out how to apply this logic into HoloViews internally.

I took a stab at it anyway, but it looks a little different than the original imshow with robust=True because imshow uses vmin/vmax of the colorbar, but colorbars aren't a concept in HoloView's RGB (I think), so I'm forced to clip?
