### PR TITLE
Force vdims to strings for ImageStack

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -406,7 +406,7 @@ class aggregate(LineAggregationOperation):
             eldata = agg if ds_version > Version('0.5.0') else (xs, ys, agg.data)
             return self.p.element_type(eldata, **params)
         else:
-            params['vdims'] = list(agg.coords[agg_fn.column].data)
+            params['vdims'] = list(map(str, agg.coords[agg_fn.column].data))
             return ImageStack(agg, **params)
 
     def _apply_datashader(self, dfdata, cvs_fn, agg_fn, agg_kwargs, x, y):

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1560,3 +1560,10 @@ def test_imagestack_datashader_color_key():
         color_key=cc.glasbey_light,
     )
     render(op)  # should not error out
+
+
+def test_imagestack_datashade_count_cat():
+    # Test for https://github.com/holoviz/holoviews/issues/6154
+    df = pd.DataFrame({"x": range(3), "y": range(3), "c": range(3)})
+    op = datashade(Points(df), aggregator=ds.count_cat("c"))
+    render(op)  # should not error out


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/6154


![image](https://github.com/holoviz/holoviews/assets/19758978/32ca946f-9193-4dc6-a6f1-68c741cdbbe9)
