### PR TITLE
Add radius to BoxWhisker

### DIFF
--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -191,11 +191,11 @@ class BoxWhiskerPlot(MultiDistributionMixin, CompositeElementPlot, ColorbarPlot,
         if self.invert_axes:
             vbar_map = {'y': 'index', 'left': 'top', 'right': 'bottom', 'height': width}
             seg_map = {'y0': 'x0', 'y1': 'x1', 'x0': 'y0', 'x1': 'y1'}
-            out_map = {'y': 'index', 'x': vdim}
+            out_map = {'y': 'index', 'x': vdim, 'radius': 0.01}
         else:
             vbar_map = {'x': 'index', 'top': 'top', 'bottom': 'bottom', 'width': width}
             seg_map = {'x0': 'x0', 'x1': 'x1', 'y0': 'y0', 'y1': 'y1'}
-            out_map = {'x': 'index', 'y': vdim}
+            out_map = {'x': 'index', 'y': vdim, 'radius': 0.01}
         vbar2_map = dict(vbar_map)
 
         # Get color values


### PR DESCRIPTION
Fixes #6166

We can add radius as a parameter. 

``` python
import holoviews as hv
import numpy as np

hv.extension("bokeh")

x = np.random.randn(1000)
hv.BoxWhisker(x, vdims="Value")
```

![image](https://github.com/holoviz/holoviews/assets/19758978/dae5995d-dbf8-4201-8dba-caf290d95521)
