### PR TITLE
Ensure plot ranges for all renderers are combined in auto-ranging

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2968,6 +2968,9 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
         if self.top_level:
             self.init_links()
 
+        if self.autorange:
+            self._setup_autorange()
+
         self._execute_hooks(element)
 
         return self.handles['plot']

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2647,7 +2647,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                           'min_height', 'max_height', 'min_width', 'min_height',
                           'margin', 'aspect', 'data_aspect', 'frame_width',
                           'frame_height', 'responsive', 'fontscale', 'subcoordinate_y',
-                          'subcoordinate_scale']
+                          'subcoordinate_scale', 'autorange']
 
     def __init__(self, overlay, **kwargs):
         self._multi_y_propagation = self.lookup_options(overlay, 'plot').options.get('multi_y', False)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1327,7 +1327,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             p0, p1 = self.padding, self.padding
 
-        # Clean this up in bokeh 3.0 using View.find_one API
         callback = CustomJS(code=f"""
         const cb = function() {{
 

--- a/holoviews/tests/ui/bokeh/test_autorange.py
+++ b/holoviews/tests/ui/bokeh/test_autorange.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+
+from holoviews.element import Curve
+from holoviews.plotting.bokeh.renderer import BokehRenderer
+
+from .. import expect, wait_until
+
+pytestmark = pytest.mark.ui
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_autorange_single(serve_hv):
+    curve = Curve(np.arange(1000)).opts(autorange='y', active_tools=['box_zoom'])
+
+    plot = BokehRenderer.get_plot(curve)
+
+    page = serve_hv(plot)
+
+    hv_plot = page.locator('.bk-events')
+
+    expect(hv_plot).to_have_count(1)
+
+    bbox = hv_plot.bounding_box()
+    hv_plot.click()
+
+    page.mouse.move(bbox['x']+100, bbox['y']+100)
+    page.mouse.down()
+    page.mouse.move(bbox['x']+150, bbox['y']+150, steps=5)
+    page.mouse.up()
+
+    y_range = plot.handles['y_range']
+    wait_until(lambda: y_range.start == 163.2 and y_range.end == 448.8, page)
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_autorange_multiple(serve_hv):
+    c1 = Curve(np.arange(1000)).opts(autorange='y')
+    c2 = Curve(-np.arange(1000)).opts(autorange='y')
+
+    overlay = (c1*c2).opts(active_tools=['box_zoom'], autorange='y')
+
+    plot = BokehRenderer.get_plot(overlay)
+
+    page = serve_hv(plot)
+
+    hv_plot = page.locator('.bk-events')
+
+    expect(hv_plot).to_have_count(1)
+
+    bbox = hv_plot.bounding_box()
+    hv_plot.click()
+
+    page.mouse.move(bbox['x']+100, bbox['y']+100)
+    page.mouse.down()
+    page.mouse.move(bbox['x']+150, bbox['y']+150, steps=5)
+    page.mouse.up()
+
+    y_range = plot.handles['y_range']
+    wait_until(lambda: y_range.start == -486 and y_range.end == 486, page)

--- a/holoviews/tests/ui/bokeh/test_autorange.py
+++ b/holoviews/tests/ui/bokeh/test_autorange.py
@@ -83,5 +83,4 @@ def test_autorange_overlay(serve_hv):
     page.mouse.up()
 
     y_range = plot.handles['y_range']
-    expected = (-171.25714285714287, 318.0489795918367)
-    wait_until(lambda: np.allclose((y_range.start, y_range.end), expected) , page)
+    wait_until(lambda: y_range.start == -486 and y_range.end == 486, page)


### PR DESCRIPTION
Fixes a small oversight in the auto-ranging implementation by combining the ranges for all renderers instead of overwriting them. Also simplifies the code by using the new `Bokeh.index.find_one` API instead of rolling our own implementation.

Fixes https://github.com/holoviz/holoviews/issues/6033

- [x] Add UI test