### PR TITLE
Fix data aspect issues

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1141,6 +1141,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                                'axes are %s, the option will '
                                'be ignored.' % ax_type)
         elif data_aspect:
+            if not options.get("responsive", False):
+                return
             plot = self.handles['plot']
             xspan = r-l if util.is_number(l) and util.is_number(r) else None
             yspan = t-b if util.is_number(b) and util.is_number(t) else None

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1141,13 +1141,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                                'axes are %s, the option will '
                                'be ignored.' % ax_type)
         elif data_aspect:
-            if not options.get("responsive", False):
-                return
             plot = self.handles['plot']
             xspan = r-l if util.is_number(l) and util.is_number(r) else None
             yspan = t-b if util.is_number(b) and util.is_number(t) else None
 
             if self.drawn or (fixed_width and fixed_height) or (constrained_width or constrained_height):
+                if not options.get("responsive", False):
+                    return
                 # After initial draw or if aspect is explicit
                 # adjust range to match the plot dimension aspect
                 ratio = self.data_aspect or 1


### PR DESCRIPTION
The main issue here is that the [`current_l, current_r = plot.x_range.start, plot.x_range.end`](https://github.com/holoviz/holoviews/blame/main/holoviews/plotting/bokeh/element.py#L1163-L1165) **arrives late (or isn't up to date)** so the data aspect calculation is messed up. There is, however, `l, b, r, t = self.get_extents(element, ranges, dimension=range_dim)` which is up to date.

Here, "current bounds" (inaccurate ylim) is 0.39 instead of 0.67 as seen on the plot axes. I could remove those lines, and the data aspect no longer bounces.

<img width="736" alt="image" src="https://github.com/holoviz/holoviews/assets/15331990/940ef100-c6ad-46bd-b84f-84c598734272">

It was introduced in this PR https://github.com/holoviz/holoviews/pull/4569 and fixes https://github.com/holoviz/hvplot/issues/462 so if I remove it, it reintroduces that error.

The only thing I'm pretty certain of is that if the plot isn't responsive, there's no need to re-calculate and ensure the data_aspect matches every time, which removes the bounciness:


https://github.com/holoviz/holoviews/assets/15331990/c6ec09ad-62d4-4549-979b-d2ead8b68fe4

I think if there's a way to introduce value throttling, it could help.

Ultimately, I don't fully understand the difference between ` l, b, r, t = self.get_extents(element, ranges, dimension=range_dim)` and `plot.x_range` & `plot.y_range`
