### PR TITLE
subcoordinate_y: respect `ylim`

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -508,11 +508,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 l, b, r, t = b, l, t, r
             if pos == 1 and self._subcoord_overlaid:
                 if isinstance(self.subcoordinate_y, bool):
-                    offset = self.subcoordinate_scale / 2.
-                    # This sum() is equal to n+1, n being the number of elements contained
-                    # in the overlay with subcoordinate_y=True, as the traversal goes through
-                    # the root overlay that has subcoordinate_y=True too since it's propagated.
-                    v0, v1 = 0-offset, sum(self.traverse(lambda p: p.subcoordinate_y))-2+offset
+                    if self.ylim and all(np.isfinite(val) for val in self.ylim):
+                        v0, v1 = self.ylim
+                    else:
+                        offset = self.subcoordinate_scale / 2.
+                        # This sum() is equal to n+1, n being the number of elements contained
+                        # in the overlay with subcoordinate_y=True, as the traversal goes through
+                        # the root overlay that has subcoordinate_y=True too since it's propagated.
+                        v0, v1 = 0-offset, sum(self.traverse(lambda p: p.subcoordinate_y))-2+offset
                 else:
                     v0, v1 = 0, 1
             else:
@@ -1043,7 +1046,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             for m in models:
                 setattr(m, attr_accessor, val)
 
-
     def _update_grid(self, plot):
         if not self.show_grid:
             plot.xgrid.grid_line_color = None
@@ -1447,7 +1449,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 (isinstance(column, list) or column.dtype.kind not in 'SU')):
                 data[col] = [dims[i].pprint_value(v) for v in column]
 
-
     def get_aspect(self, xspan, yspan):
         """
         Computes the aspect ratio of the plot
@@ -1682,7 +1683,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         return new_style
 
-
     def _glyph_properties(self, plot, element, source, ranges, style, group=None):
         properties = dict(style, source=source)
         if self.show_legend:
@@ -1694,7 +1694,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if legend and self.overlaid:
                 properties['legend_label'] = legend
         return properties
-
 
     def _filter_properties(self, properties, glyph_type, allowed):
         glyph_props = dict(properties)
@@ -1713,7 +1712,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             else:
                 glyph_props.update(props)
         return {k: v for k, v in glyph_props.items() if k in allowed}
-
 
     def _update_glyph(self, renderer, properties, mapping, glyph, source, data):
         allowed_properties = glyph.properties()
@@ -1793,7 +1791,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         if data is not None and cds_replace and not self.static_source:
             self._update_datasource(source, data)
-
 
     def _postprocess_hover(self, renderer, source):
         """
@@ -1986,7 +1983,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         elif not self.static_source:
             self._update_datasource(source, data)
 
-
     def _reset_ranges(self):
         """
         Resets RangeXY streams if norm option is set to framewise
@@ -2065,12 +2061,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self._update_glyphs(element, ranges, self.style[self.cyclic_index])
         self._execute_hooks(element)
 
-
     def _execute_hooks(self, element):
         dtype_fix_hook(self, element)
         super()._execute_hooks(element)
         self._update_backend_opts()
-
 
     def model_changed(self, model):
         """
@@ -2217,7 +2211,6 @@ class CompositeElementPlot(ElementPlot):
         plot_method = '_'.join(key.split('_')[:-1])
         renderer = getattr(plot, plot_method)(**dict(properties, **mapping))
         return renderer, renderer.glyph
-
 
 
 class ColorbarPlot(ElementPlot):
@@ -2633,7 +2626,6 @@ class LegendPlot(ElementPlot):
                 for item in leg.items:
                     for r in item.renderers:
                         r.muted = self.legend_muted
-
 
 
 class AnnotationPlot:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1046,6 +1046,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             for m in models:
                 setattr(m, attr_accessor, val)
 
+
     def _update_grid(self, plot):
         if not self.show_grid:
             plot.xgrid.grid_line_color = None
@@ -1449,6 +1450,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 (isinstance(column, list) or column.dtype.kind not in 'SU')):
                 data[col] = [dims[i].pprint_value(v) for v in column]
 
+
     def get_aspect(self, xspan, yspan):
         """
         Computes the aspect ratio of the plot
@@ -1683,6 +1685,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         return new_style
 
+
     def _glyph_properties(self, plot, element, source, ranges, style, group=None):
         properties = dict(style, source=source)
         if self.show_legend:
@@ -1694,6 +1697,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if legend and self.overlaid:
                 properties['legend_label'] = legend
         return properties
+
 
     def _filter_properties(self, properties, glyph_type, allowed):
         glyph_props = dict(properties)
@@ -1712,6 +1716,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             else:
                 glyph_props.update(props)
         return {k: v for k, v in glyph_props.items() if k in allowed}
+
 
     def _update_glyph(self, renderer, properties, mapping, glyph, source, data):
         allowed_properties = glyph.properties()
@@ -1791,6 +1796,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         if data is not None and cds_replace and not self.static_source:
             self._update_datasource(source, data)
+
 
     def _postprocess_hover(self, renderer, source):
         """
@@ -1983,6 +1989,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         elif not self.static_source:
             self._update_datasource(source, data)
 
+
     def _reset_ranges(self):
         """
         Resets RangeXY streams if norm option is set to framewise
@@ -2061,10 +2068,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self._update_glyphs(element, ranges, self.style[self.cyclic_index])
         self._execute_hooks(element)
 
+
     def _execute_hooks(self, element):
         dtype_fix_hook(self, element)
         super()._execute_hooks(element)
         self._update_backend_opts()
+
 
     def model_changed(self, model):
         """
@@ -2211,6 +2220,7 @@ class CompositeElementPlot(ElementPlot):
         plot_method = '_'.join(key.split('_')[:-1])
         renderer = getattr(plot, plot_method)(**dict(properties, **mapping))
         return renderer, renderer.glyph
+
 
 
 class ColorbarPlot(ElementPlot):
@@ -2626,6 +2636,7 @@ class LegendPlot(ElementPlot):
                 for item in leg.items:
                     for r in item.renderers:
                         r.muted = self.legend_muted
+
 
 
 class AnnotationPlot:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -512,9 +512,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                         v0, v1 = self.ylim
                     else:
                         offset = self.subcoordinate_scale / 2.
-                        # This sum() is equal to n+1, n being the number of elements contained
-                        # in the overlay with subcoordinate_y=True, as the traversal goes through
-                        # the root overlay that has subcoordinate_y=True too since it's propagated.
+                        # This sum() is equal to n+1, where n is the number of elements contained
+                        # in the overlay with subcoordinate_y=True (including the the root overlay,
+                        # which has subcoordinate_y=True due to option propagation)
                         v0, v1 = 0-offset, sum(self.traverse(lambda p: p.subcoordinate_y))-2+offset
                 else:
                     v0, v1 = 0, 1

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1118,7 +1118,7 @@ class GenericElementPlot(DimensionedPlot):
        If specified, takes precedence over data and dimension ranges.""")
 
     ylim = param.Tuple(default=(np.nan, np.nan), length=2, doc="""
-       User-specified x-axis range limits for the plot, as a tuple (low,high).
+       User-specified y-axis range limits for the plot, as a tuple (low,high).
        If specified, takes precedence over data and dimension ranges.""")
 
     zlim = param.Tuple(default=(np.nan, np.nan), length=2, doc="""

--- a/holoviews/tests/plotting/bokeh/test_subcoordy.py
+++ b/holoviews/tests/plotting/bokeh/test_subcoordy.py
@@ -127,6 +127,14 @@ class TestSubcoordinateY(TestBokehPlot):
         plot = bokeh_renderer.get_plot(overlay)
         assert not plot.state.yaxis.visible
 
+    def test_overlay_set_ylim(self):
+        ylim = (1, 2.5)
+        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay.opts(ylim=ylim)
+        plot = bokeh_renderer.get_plot(overlay)
+        y_range = plot.handles['y_range']
+        assert y_range.start, y_range.end == ylim
+
     def test_axis_labels(self):
         overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         plot = bokeh_renderer.get_plot(overlay)


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/5952

![image](https://github.com/holoviz/holoviews/assets/35924738/766f661b-21f2-4b2a-880e-565c3dbf6853)

I want to wait for https://github.com/holoviz/holoviews/pull/6122 to be merged to fully set this PR. At the moment I think you can't zoom-out from the `ylim` which isn't good.