### PR TITLE
subcoordinate_y: reverse the renderers by default

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2941,6 +2941,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             self._update_ranges(element, ranges)
 
         panels = []
+        subcoord_y_glyph_renderers = []
         for key, subplot in self.subplots.items():
             frame = None
             if self.tabs:
@@ -2959,6 +2960,19 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                     title = get_tab_title(key, frame, self.hmap.last)
                 panels.append(TabPanel(child=child, title=title))
             self._merge_tools(subplot)
+            if subplot.subcoordinate_y and (glyph_renderer := subplot.handles.get('glyph_renderer')):
+                subcoord_y_glyph_renderers.append(glyph_renderer)
+
+        if self.subcoordinate_y:
+            # Reverse the subcoord-y renderers only.
+            reversed_renderers = subcoord_y_glyph_renderers[::-1]
+            reordered = []
+            for item in plot.renderers:
+                if item not in subcoord_y_glyph_renderers:
+                    reordered.append(item)
+                else:
+                    reordered.append(reversed_renderers.pop(0))
+            plot.renderers = reordered
 
         if self.tabs:
             self.handles['plot'] = Tabs(

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2219,7 +2219,6 @@ class CompositeElementPlot(ElementPlot):
         return renderer, renderer.glyph
 
 
-
 class ColorbarPlot(ElementPlot):
     """
     ColorbarPlot provides methods to create colormappers and colorbar
@@ -2635,7 +2634,6 @@ class LegendPlot(ElementPlot):
                         r.muted = self.legend_muted
 
 
-
 class AnnotationPlot:
     """
     Mix-in plotting subclass for AnnotationPlots which do not have a legend.
@@ -2800,7 +2798,6 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                 for r in item.renderers:
                     r.muted = self.legend_muted or r.muted
 
-
     def _init_tools(self, element, callbacks=None):
         """
         Processes the list of tools to be supplied to the plot.
@@ -2842,7 +2839,6 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                     init_tools.append(tool)
         self.handles['hover_tools'] = hover_tools
         return init_tools
-
 
     def _merge_tools(self, subplot):
         """
@@ -2960,7 +2956,9 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                     title = get_tab_title(key, frame, self.hmap.last)
                 panels.append(TabPanel(child=child, title=title))
             self._merge_tools(subplot)
-            if subplot.subcoordinate_y and (glyph_renderer := subplot.handles.get('glyph_renderer')):
+            if getattr(subplot, "subcoordinate_y", False) and (
+                glyph_renderer := subplot.handles.get("glyph_renderer")
+            ):
                 subcoord_y_glyph_renderers.append(glyph_renderer)
 
         if self.subcoordinate_y:

--- a/holoviews/tests/plotting/bokeh/test_subcoordy.py
+++ b/holoviews/tests/plotting/bokeh/test_subcoordy.py
@@ -40,6 +40,17 @@ class TestSubcoordinateY(TestBokehPlot):
         assert plot.state.yaxis.ticker.ticks == [0, 1]
         assert plot.state.yaxis.major_label_overrides == {0: 'Data 0', 1: 'Data 1'}
 
+    def test_renderers_reversed(self):
+        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = VSpan(0, 1, label='back') * overlay * VSpan(2, 3, label='front')
+        plot = bokeh_renderer.get_plot(overlay)
+        renderers = plot.handles['plot'].renderers
+        assert (renderers[0].left, renderers[0].right) == (0, 1)
+        # Only the subcoord-y renderers are reversed by default.
+        assert renderers[1].name == 'Data 1'
+        assert renderers[2].name == 'Data 0'
+        assert (renderers[3].left, renderers[3].right) == (2, 3)
+
     def test_bool_scale(self):
         test_data = [
             (0.5, (-0.25, 0.25), (0.75, 1.25), (-0.25, 1.25)),


### PR DESCRIPTION
Addresses https://github.com/holoviz/holoviews/issues/6027

By reverting the orders of the subcoordinate-y glyph renderers.

```python
import numpy as np
import holoviews as hv; hv.extension('bokeh')
from scipy.stats import gaussian_kde

categories = ['A', 'B', 'C', 'D', 'E']
data = {cat: np.random.normal(loc=i-2, scale=1.0, size=100) for i, cat in enumerate(categories)}
x = np.linspace(-5, 5, 100)

areas = []
for i, (cat, values) in enumerate(data.items()):
    pdf = gaussian_kde(values)(x)
        
    area = hv.Area((x, pdf), label=cat).opts(
        subcoordinate_y=True, 
        subcoordinate_scale=1.5,
    )
    areas.append(area)

ridge_plot_areas = (hv.VSpan(-4, -3) * hv.Overlay(areas) * hv.VSpan(3, 4)).opts(
    width=900,
    height=400,
)

ridge_plot_areas.opts(show_legend=False)
```

- The blue VSpan is rendered first, that's the regular behavior as it's the first element in the overlay
- The subcoord-y plots are rendered in the reversed order
- The red VSpan is rendered last, that's the regular behavior

![image](https://github.com/holoviz/holoviews/assets/35924738/1052abbf-1101-4ae9-a97a-42c5eab52619)
