### PR TITLE
Support all Bokeh Text style opts in hv.Labels and hv.Text

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -15,7 +15,8 @@ from ..plot import GenericElementPlot
 from .element import AnnotationPlot, ColorbarPlot, CompositeElementPlot, ElementPlot
 from .plot import BokehPlot
 from .selection import BokehOverlaySelectionDisplay
-from .styles import base_properties, fill_properties, line_properties, text_properties
+from .styles import (base_properties, fill_properties, line_properties,
+                     text_properties, border_properties, background_properties)
 from .util import bokeh32, date_to_integer
 
 arrow_start = {'<->': NormalHead, '<|-|>': NormalHead}
@@ -104,7 +105,8 @@ class VSpansAnnotationPlot(_SyntheticAnnotationPlot):
 
 class TextPlot(ElementPlot, AnnotationPlot):
 
-    style_opts = text_properties+['color', 'angle', 'visible']
+    style_opts = (text_properties + background_properties 
+                  + border_properties + ['color', 'angle', 'visible'])
     _plot_methods = dict(single='text', batched='text')
 
     selection_display = None
@@ -167,12 +169,13 @@ class LabelsPlot(ColorbarPlot, AnnotationPlot):
 
     selection_display = BokehOverlaySelectionDisplay()
 
-    style_opts = base_properties + text_properties + ['cmap', 'angle']
+    style_opts = (base_properties + text_properties 
+                  + background_properties + border_properties + ['cmap', 'angle'])
 
     _nonvectorized_styles = base_properties + ['cmap']
 
     _plot_methods = dict(single='text', batched='text')
-    _batched_style_opts = text_properties
+    _batched_style_opts = text_properties + background_properties + border_properties
 
     def get_data(self, element, ranges, style):
         style = self.style[self.cyclic_index]

--- a/holoviews/plotting/bokeh/styles.py
+++ b/holoviews/plotting/bokeh/styles.py
@@ -31,12 +31,14 @@ base_properties = ['visible', 'muted']
 
 line_base_properties = ['line_color', 'line_alpha', 'color', 'alpha', 'line_width',
                         'line_join', 'line_cap', 'line_dash', 'line_dash_offset']
-line_properties = line_base_properties + [
-    f'{prefix}_{prop}' for prop in line_base_properties for prefix in property_prefixes]
+line_properties = line_base_properties + [f'{prefix}_{prop}'
+                                          for prop in line_base_properties
+                                          for prefix in property_prefixes]
 
 fill_base_properties = ['fill_color', 'fill_alpha']
-fill_properties = fill_base_properties + [
-    f'{prefix}_{prop}' for prop in fill_base_properties for prefix in property_prefixes]
+fill_properties = fill_base_properties + [f'{prefix}_{prop}'
+                                          for prop in fill_base_properties
+                                          for prefix in property_prefixes]
 
 border_properties = ['border_' + prop for prop in line_base_properties + ['radius']]
 

--- a/holoviews/plotting/bokeh/styles.py
+++ b/holoviews/plotting/bokeh/styles.py
@@ -29,14 +29,20 @@ property_prefixes = ['selection', 'nonselection', 'muted', 'hover']
 
 base_properties = ['visible', 'muted']
 
-line_properties = ['line_color', 'line_alpha', 'color', 'alpha', 'line_width',
-                   'line_join', 'line_cap', 'line_dash']
-line_properties += [f'{prefix}_{prop}' for prop in line_properties
-                    for prefix in property_prefixes]
+line_base_properties = ['line_color', 'line_alpha', 'color', 'alpha', 'line_width',
+                        'line_join', 'line_cap', 'line_dash', 'line_dash_offset']
+line_properties = line_base_properties + [
+    f'{prefix}_{prop}' for prop in line_base_properties for prefix in property_prefixes]
 
-fill_properties = ['fill_color', 'fill_alpha']
-fill_properties += [f'{prefix}_{prop}' for prop in fill_properties
-                    for prefix in property_prefixes]
+fill_base_properties = ['fill_color', 'fill_alpha']
+fill_properties = fill_base_properties + [
+    f'{prefix}_{prop}' for prop in fill_base_properties for prefix in property_prefixes]
+
+border_properties = ['border_' + prop for prop in line_base_properties + ['radius']]
+
+hatch_properties = ['hatch_color', 'hatch_scale', 'hatch_weight',
+                    'hatch_extra', 'hatch_pattern', 'hatch_alpha']
+background_properties = ['background_' + prop for prop in fill_base_properties + hatch_properties]
 
 text_properties = ['text_font', 'text_font_size', 'text_font_style', 'text_color',
                    'text_alpha', 'text_align', 'text_baseline']


### PR DESCRIPTION
Fixes #6186 

All available `border_` and `background_` opts are added to both `LabelsPlot` and `TextPlot`. For the former, I think these are also batched opts.

Here the choice was made not to directly include these options in `text_properties` as I'm not sure `ArrowPlot` supports these additions. Instead there are separate `border_properties` and `background_properties` lists which can be reused independently.

I also found that the `line_dash_offset` was missing in `line_properties`.