### PR TITLE
Fix flaky pop up ui tests

### DIFF
--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -323,11 +323,11 @@ def test_stream_popup_selection1d_undefined(serve_hv):
 
 @pytest.mark.skipif(not bokeh34, reason="< Bokeh 3.4 does not support popup")
 @pytest.mark.usefixtures("bokeh_backend")
-def test_stream_popup_selection1d(serve_hv):
+def test_stream_popup_selection1d_tap(serve_hv):
     def popup_form(index):
         return "# Tap"
 
-    points = hv.Points(np.random.randn(1000, 2))
+    points = hv.Points(np.random.randn(1000, 2)).opts(hit_dilation=5)
     hv.streams.Selection1D(source=points, popup=popup_form)
     points.opts(tools=["tap"], active_tools=["tap"])
 

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -11,6 +11,8 @@ from .. import expect, wait_until
 
 pytestmark = pytest.mark.ui
 
+skip_popup = pytest.mark.skipif(not bokeh34, reason="Pop ups needs Bokeh 3.4")
+
 
 @pytest.mark.usefixtures("bokeh_backend")
 @pytest.mark.parametrize(
@@ -192,7 +194,8 @@ def test_bind_trigger(serve_hv):
 
     assert BOUND_COUNT[0] == 1
 
-@pytest.mark.skipif(not bokeh34, reason="< Bokeh 3.4 does not support popup")
+
+@skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
 def test_stream_popup(serve_hv):
     def popup_form(name):
@@ -210,7 +213,7 @@ def test_stream_popup(serve_hv):
     expect(locator).to_have_count(1)
 
 
-@pytest.mark.skipif(not bokeh34, reason="< Bokeh 3.4 does not support popup")
+@skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
 def test_stream_popup_none(serve_hv):
     def popup_form(name):
@@ -253,7 +256,7 @@ def test_stream_popup_callbacks(serve_hv):
     expect(locator).to_have_count(2)
 
 
-@pytest.mark.skipif(not bokeh34, reason="< Bokeh 3.4 does not support popup")
+@skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
 def test_stream_popup_visible(serve_hv):
     def popup_form(x, y):
@@ -287,7 +290,7 @@ def test_stream_popup_visible(serve_hv):
 
 
 
-@pytest.mark.skipif(not bokeh34, reason="< Bokeh 3.4 does not support popup")
+@skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
 def test_stream_popup_close_button(serve_hv):
     def popup_form(x, y):
@@ -309,7 +312,7 @@ def test_stream_popup_close_button(serve_hv):
     expect(locator).not_to_be_visible()
 
 
-@pytest.mark.skipif(not bokeh34, reason="< Bokeh 3.4 does not support popup")
+@skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
 def test_stream_popup_selection1d_undefined(serve_hv):
     points = hv.Points(np.random.randn(10, 2))
@@ -321,7 +324,7 @@ def test_stream_popup_selection1d_undefined(serve_hv):
     hv_plot.click()  # should not raise any error; properly guarded
 
 
-@pytest.mark.skipif(not bokeh34, reason="< Bokeh 3.4 does not support popup")
+@skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
 def test_stream_popup_selection1d_tap(serve_hv):
     def popup_form(index):
@@ -340,7 +343,7 @@ def test_stream_popup_selection1d_tap(serve_hv):
     expect(locator).to_have_count(1)
 
 
-@pytest.mark.skipif(not bokeh34, reason="< Bokeh 3.4 does not support popup")
+@skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
 def test_stream_popup_selection1d_lasso_select(serve_hv):
     def popup_form(index):

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -241,7 +241,7 @@ def test_stream_popup_none(serve_hv, points):
     expect(locator).to_have_count(0)
 
 
-@pytest.mark.skipif(not bokeh34, reason="< Bokeh 3.4 does not support popup")
+@skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
 def test_stream_popup_callbacks(serve_hv):
     def popup_form(x, y):

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -13,6 +13,10 @@ pytestmark = pytest.mark.ui
 
 skip_popup = pytest.mark.skipif(not bokeh34, reason="Pop ups needs Bokeh 3.4")
 
+@pytest.fixture
+def points():
+    rng = np.random.default_rng(10)
+    return hv.Points(rng.normal(size=(1000, 2)))
 
 @pytest.mark.usefixtures("bokeh_backend")
 @pytest.mark.parametrize(
@@ -215,11 +219,10 @@ def test_stream_popup(serve_hv):
 
 @skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
-def test_stream_popup_none(serve_hv):
+def test_stream_popup_none(serve_hv, points):
     def popup_form(name):
         return
 
-    points = hv.Points(np.random.randn(10, 2))
     hv.streams.Tap(source=points, popup=popup_form("Tap"))
 
     page = serve_hv(points)
@@ -258,7 +261,7 @@ def test_stream_popup_callbacks(serve_hv):
 
 @skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
-def test_stream_popup_visible(serve_hv):
+def test_stream_popup_visible(serve_hv, points):
     def popup_form(x, y):
         def hide(_):
             col.visible = False
@@ -270,7 +273,7 @@ def test_stream_popup_visible(serve_hv):
         col = pn.Column(button)
         return col
 
-    points = hv.Points(np.random.randn(10, 2)).opts(tools=["tap"])
+    points = points.opts(tools=["tap"])
     hv.streams.Tap(source=points, popup=popup_form)
 
     page = serve_hv(points)
@@ -292,11 +295,11 @@ def test_stream_popup_visible(serve_hv):
 
 @skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
-def test_stream_popup_close_button(serve_hv):
+def test_stream_popup_close_button(serve_hv, points):
     def popup_form(x, y):
         return "Hello"
 
-    points = hv.Points(np.random.randn(10, 2)).opts(tools=["tap", "box_select"])
+    points = points.opts(tools=["tap", "box_select"])
     hv.streams.Tap(source=points, popup=popup_form)
     hv.streams.BoundsXY(source=points, popup=popup_form)
 
@@ -314,8 +317,7 @@ def test_stream_popup_close_button(serve_hv):
 
 @skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
-def test_stream_popup_selection1d_undefined(serve_hv):
-    points = hv.Points(np.random.randn(10, 2))
+def test_stream_popup_selection1d_undefined(serve_hv, points):
     hv.streams.Selection1D(source=points)
 
     page = serve_hv(points)
@@ -326,11 +328,11 @@ def test_stream_popup_selection1d_undefined(serve_hv):
 
 @skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
-def test_stream_popup_selection1d_tap(serve_hv):
+def test_stream_popup_selection1d_tap(serve_hv, points):
     def popup_form(index):
         return "# Tap"
 
-    points = hv.Points(np.random.randn(1000, 2)).opts(hit_dilation=5)
+    points = points.opts(hit_dilation=5)
     hv.streams.Selection1D(source=points, popup=popup_form)
     points.opts(tools=["tap"], active_tools=["tap"])
 
@@ -345,12 +347,11 @@ def test_stream_popup_selection1d_tap(serve_hv):
 
 @skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
-def test_stream_popup_selection1d_lasso_select(serve_hv):
+def test_stream_popup_selection1d_lasso_select(serve_hv, points):
     def popup_form(index):
         if index:
             return f"# lasso\n{len(index)}"
 
-    points = hv.Points(np.random.randn(1000, 2))
     hv.streams.Selection1D(source=points, popup=popup_form)
     points.opts(tools=["tap", "lasso_select"], active_tools=["lasso_select"])
 


### PR DESCRIPTION
The flaky test is likely because the tap sometimes does not hit a value because the data is randomized. 

This will always use the same seed and expand the hit dilation for one of the tests. 