### PR TITLE
Bug fix for player example pause button

### DIFF
--- a/examples/reference/apps/bokeh/player.py
+++ b/examples/reference/apps/bokeh/player.py
@@ -38,13 +38,16 @@ def slider_update(attrname, old, new):
 slider = Slider(start=start, end=end, value=0, step=1, title="Year")
 slider.on_change('value', slider_update)
 
+callback_tasks = {}
+
 def animate():
-    if button.label == '► Play':
-        button.label = '❚❚ Pause'
-        curdoc().add_periodic_callback(animate_update, 200)
+    if button.label == "► Play":
+        button.label = "❚❚ Pause"
+        callback_tasks["animate"] = curdoc().add_periodic_callback(animate_update, 400)
     else:
-        button.label = '► Play'
-        curdoc().remove_periodic_callback(animate_update)
+        button.label = "► Play"
+        curdoc().remove_periodic_callback(callback_tasks["animate"])
+
 
 button = Button(label='► Play', width=60)
 button.on_click(animate)


### PR DESCRIPTION
when the pause button is pressed, an exception is thrown that the callback is already removed. This is because it cannot find the the task object. the current code is giving it the wrong object for it to remove. 

To fix, the animate task is stored in a dictionary so that it can be used later and removed as necessary.