### PR TITLE
Use psutil for pytest-xdist logical option

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -98,9 +98,10 @@ xyzservices = "*"
 tsdownsample = "*"  # currently not available on Windows
 
 [feature.test-example.tasks]
-test-example = 'pytest -n auto --dist loadscope --nbval-lax examples'
+test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'
 
 [feature.test-example.dependencies]
+psutil = "*"
 nbval = "*"
 pytest-xdist = "*"
 


### PR DESCRIPTION
|Without psutil|With psutil|
|---|---|
|![image](https://github.com/holoviz/holoviews/assets/19758978/a25e53a3-6202-4f2b-b4af-6609d9fcccb4) |![image](https://github.com/holoviz/holoviews/assets/19758978/f0b0c596-f271-4253-a118-a764687b495c) | 

Increases workers from 2 to 4 on Windows and Linux. MacOS has the same workers, so it should be ignored in the image above. 