### PR TITLE
Use the new conda package format

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
         if: always()
         with:
           name: conda
-          path: dist/*tar.bz2
+          path: dist/*.conda
           if-no-files-found: error
 
   conda_publish:
@@ -67,7 +67,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "CONDA_FILE=$(ls dist/*.tar.bz2)" >> $GITHUB_ENV
+          echo "CONDA_FILE=$(ls dist/*.conda)" >> $GITHUB_ENV
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"

--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -16,6 +16,7 @@ python -m build . # Can add -w when this is solved: https://github.com/pypa/hatc
 
 VERSION=$(find dist -name "*.whl" -exec basename {} \; | cut -d- -f2)
 export VERSION
+conda config --env --set conda_build.pkg_format 2
 conda build scripts/conda/recipe --no-anaconda-upload --no-verify
 
-mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2" dist
+mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.conda" dist


### PR DESCRIPTION
It seems logical to use the new format for conda packaging; it should be faster, which can't hurt.

https://conda.io/projects/conda-build/en/latest/resources/package-spec.html