### PR TITLE
Add `test-gpu` task

### DIFF
--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -241,7 +241,7 @@ class cuDFInterface(PandasInterface):
         select_mask_neighbor = [False, True,  True, True, True,  False]
 
         """
-        mask = cls.select_mask(dataset, selection).fillna(False).to_cupy()
+        mask = cls.select_mask(dataset, selection).to_cupy()
         extra = (mask[1:] ^ mask[:-1])
         mask[1:] |= extra
         mask[:-1] |= extra

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -241,7 +241,11 @@ class cuDFInterface(PandasInterface):
         select_mask_neighbor = [False, True,  True, True, True,  False]
 
         """
-        raise NotImplementedError
+        mask = cls.select_mask(dataset, selection).fillna(False).to_cupy()
+        extra = (mask[1:] ^ mask[:-1])
+        mask[1:] |= extra
+        mask[:-1] |= extra
+        return mask
 
     @classmethod
     def select(cls, dataset, selection_mask=None, **selection):

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -83,12 +83,13 @@ def spatial_select_gridded(xvals, yvals, geometry):
 def spatial_select_columnar(xvals, yvals, geometry, geom_method=None):
     if 'cudf' in sys.modules:
         import cudf
+        import cupy as cp
         if isinstance(xvals, cudf.Series):
             xvals = xvals.values.astype('float')
             yvals = yvals.values.astype('float')
             try:
                 import cuspatial
-                result = cuspatial.point_in_polygon(
+                result = cuspatial.point_in_polygon(  # TODO: now only takes two arguments
                     xvals,
                     yvals,
                     cudf.Series([0], index=["selection"]),
@@ -98,8 +99,8 @@ def spatial_select_columnar(xvals, yvals, geometry, geom_method=None):
                 )
                 return result.values
             except ImportError:
-                xvals = np.asarray(xvals)
-                yvals = np.asarray(yvals)
+                xvals = cp.asnumpy(xvals)
+                yvals = cp.asnumpy(yvals)
     if 'dask' in sys.modules:
         import dask.dataframe as dd
         if isinstance(xvals, dd.Series):

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -80,6 +80,38 @@ def spatial_select_gridded(xvals, yvals, geometry):
         sel_mask = spatial_select_columnar(xvals.flatten(), yvals.flatten(), geometry)
         return sel_mask.reshape(xvals.shape)
 
+def _cuspatial_old(xvals, yvals, geometry):
+    import cudf
+    import cuspatial
+
+    result = cuspatial.point_in_polygon(
+        xvals,
+        yvals,
+        cudf.Series([0], index=["selection"]),
+        [0],
+        geometry[:, 0],
+        geometry[:, 1],
+    )
+    return result.values
+
+
+def _cuspatial_new(xvals, yvals, geometry):
+    import cudf
+    import cuspatial
+    import geopandas
+    from shapely.geometry import Polygon
+
+    df = cudf.DataFrame({'x':xvals, 'y':yvals})
+    points = cuspatial.GeoSeries.from_points_xy(
+       df.interleave_columns().astype('float')
+    )
+    polygons = cuspatial.GeoSeries(
+       geopandas.GeoSeries(Polygon(geometry)), index=["selection"]
+    )
+    result = cuspatial.point_in_polygon(points,polygons)
+    return result.values.ravel()
+
+
 def spatial_select_columnar(xvals, yvals, geometry, geom_method=None):
     if 'cudf' in sys.modules:
         import cudf
@@ -88,16 +120,10 @@ def spatial_select_columnar(xvals, yvals, geometry, geom_method=None):
             xvals = xvals.values.astype('float')
             yvals = yvals.values.astype('float')
             try:
-                import cuspatial
-                result = cuspatial.point_in_polygon(  # TODO: now only takes two arguments
-                    xvals,
-                    yvals,
-                    cudf.Series([0], index=["selection"]),
-                    [0],
-                    geometry[:, 0],
-                    geometry[:, 1],
-                )
-                return result.values
+                try:
+                    return _cuspatial_old(xvals, yvals, geometry)
+                except TypeError:
+                    return _cuspatial_new(xvals, yvals, geometry)
             except ImportError:
                 xvals = cp.asnumpy(xvals)
                 yvals = cp.asnumpy(yvals)

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -4,16 +4,38 @@ from collections.abc import Callable
 
 import panel as pn
 import pytest
-from panel.tests.conftest import (  # noqa: F401
-    optional_markers,
-    port,
-    pytest_addoption,
-    pytest_configure,
-    server_cleanup,
-)
+from panel.tests.conftest import port, server_cleanup  # noqa: F401
 from panel.tests.util import serve_and_wait
 
 import holoviews as hv
+
+CUSTOM_MARKS = ("ui", "gpu")
+optional_markers = {
+    "ui": {
+        "help": "<Command line help text for flag1...>",
+        "marker-descr": "UI test marker",
+        "skip-reason": "Test only runs with the --ui option.",
+    },
+    "gpu": {
+        "help": "<Command line help text for flag1...>",
+        "marker-descr": "GPU test marker",
+        "skip-reason": "Test only runs with the --gpu option.",
+    },
+}
+
+
+def pytest_addoption(parser):
+    for marker, info in optional_markers.items():
+        parser.addoption(
+            f"--{marker}", action="store_true", default=False, help=info["help"]
+        )
+
+
+def pytest_configure(config):
+    for marker, info in optional_markers.items():
+        config.addinivalue_line(
+            "markers", "{}: {}".format(marker, info["marker-descr"])
+        )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -12,12 +12,12 @@ import holoviews as hv
 CUSTOM_MARKS = ("ui", "gpu")
 optional_markers = {
     "ui": {
-        "help": "<Command line help text for flag1...>",
+        "help": "Runs UI related tests",
         "marker-descr": "UI test marker",
         "skip-reason": "Test only runs with the --ui option.",
     },
     "gpu": {
-        "help": "<Command line help text for flag1...>",
+        "help": "Runs GPU related tests",
         "marker-descr": "GPU test marker",
         "skip-reason": "Test only runs with the --gpu option.",
     },

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -10,40 +10,29 @@ from panel.tests.util import serve_and_wait
 import holoviews as hv
 
 CUSTOM_MARKS = ("ui", "gpu")
-optional_markers = {
-    "ui": {
-        "help": "Runs UI related tests",
-        "marker-descr": "UI test marker",
-        "skip-reason": "Test only runs with the --ui option.",
-    },
-    "gpu": {
-        "help": "Runs GPU related tests",
-        "marker-descr": "GPU test marker",
-        "skip-reason": "Test only runs with the --gpu option.",
-    },
-}
 
 
 def pytest_addoption(parser):
-    for marker, info in optional_markers.items():
+    for marker in CUSTOM_MARKS:
         parser.addoption(
-            f"--{marker}", action="store_true", default=False, help=info["help"]
+            f"--{marker.lower()}",
+            action="store_true",
+            default=False,
+            help=f"Run {marker} related tests",
         )
 
 
 def pytest_configure(config):
-    for marker, info in optional_markers.items():
-        config.addinivalue_line(
-            "markers", "{}: {}".format(marker, info["marker-descr"])
-        )
+    for marker in CUSTOM_MARKS:
+        config.addinivalue_line("markers", f"{marker}: {marker} test marker")
 
 
 def pytest_collection_modifyitems(config, items):
     skipped, selected = [], []
-    markers = [m for m in optional_markers if config.getoption(f"--{m}")]
+    markers = [m for m in CUSTOM_MARKS if config.getoption(f"--{m}")]
     empty = not markers
     for item in items:
-        if empty and any(m in item.keywords for m in optional_markers):
+        if empty and any(m in item.keywords for m in CUSTOM_MARKS):
             skipped.append(item)
         elif empty:
             selected.append(item)

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -15,7 +15,7 @@ CUSTOM_MARKS = ("ui", "gpu")
 def pytest_addoption(parser):
     for marker in CUSTOM_MARKS:
         parser.addoption(
-            f"--{marker.lower()}",
+            f"--{marker}",
             action="store_true",
             default=False,
             help=f"Run {marker} related tests",

--- a/holoviews/tests/core/data/test_cudfinterface.py
+++ b/holoviews/tests/core/data/test_cudfinterface.py
@@ -1,17 +1,14 @@
 import logging
-from unittest import SkipTest
 
 import numpy as np
-
-try:
-    import cudf
-except ImportError:
-    raise SkipTest("Could not import cuDF, skipping cuDFInterface tests.")
+import pytest
 
 from holoviews.core.data import Dataset
 from holoviews.core.spaces import HoloMap
 
 from .base import HeterogeneousColumnTests, InterfaceTests
+
+pytestmark = pytest.mark.gpu
 
 
 class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
@@ -20,16 +17,21 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
     """
 
     datatype = 'cuDF'
-    data_type = cudf.DataFrame
 
     __test__ = True
+
+    @property
+    def data_type(self):
+        import cudf
+        return cudf.DataFrame
 
     def setUp(self):
         super().setUp()
         logging.getLogger('numba.cuda.cudadrv.driver').setLevel(30)
 
+    @pytest.mark.xfail(reason="cuDF does not support variance aggregation")
     def test_dataset_2D_aggregate_spread_fn_with_duplicates(self):
-        raise SkipTest("cuDF does not support variance aggregation")
+        super().test_dataset_2D_aggregate_spread_fn_with_duplicates()
 
     def test_dataset_mixed_type_range(self):
         ds = Dataset((['A', 'B', 'C', None],), 'A')
@@ -102,12 +104,13 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
                           kdims=['Age'])
         self.assertEqual(self.table.groupby(['Age']).apply('sort'), grouped)
 
+    @pytest.mark.xfail(reason="cuDF does not support variance aggregation")
     def test_dataset_aggregate_string_types_size(self):
-        raise SkipTest("cuDF does not support variance aggregation")
+        super().test_dataset_aggregate_string_types_size()
 
     def test_select_with_neighbor(self):
         try:
             # Not currently supported by CuDF
             super().test_select_with_neighbor()
         except NotImplementedError:
-            raise SkipTest("Not supported")
+            pytest.skip("Not supported")

--- a/holoviews/tests/core/data/test_cudfinterface.py
+++ b/holoviews/tests/core/data/test_cudfinterface.py
@@ -109,8 +109,10 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
         super().test_dataset_aggregate_string_types_size()
 
     def test_select_with_neighbor(self):
-        try:
-            # Not currently supported by CuDF
-            super().test_select_with_neighbor()
-        except NotImplementedError:
-            pytest.skip("Not supported")
+        import cupy as cp
+
+        select = self.table.interface.select_mask(self.table.dataset, {"Weight": 18})
+        select_neighbor = self.table.interface._select_mask_neighbor(self.table.dataset, dict(Weight=18))
+
+        np.testing.assert_almost_equal(cp.asnumpy(select), [False, True, False])
+        np.testing.assert_almost_equal(cp.asnumpy(select_neighbor), [True, True, True])

--- a/holoviews/tests/element/test_selection.py
+++ b/holoviews/tests/element/test_selection.py
@@ -692,7 +692,6 @@ class TestSpatialSelectColumnar:
             mask = spatial_select_columnar(df.x, df.y, geometry, _method)
             assert np.array_equal(cp.asnumpy(mask), pt_mask)
 
-        @pytest.mark.xfail(reason='cuspatial.point_in_polygon API has changed')
         @pytest.mark.gpu
         def test_cuspatial(self, geometry, pt_mask, pandas_df, _method):
             import cudf

--- a/holoviews/tests/element/test_selection.py
+++ b/holoviews/tests/element/test_selection.py
@@ -682,6 +682,25 @@ class TestSpatialSelectColumnar:
             mask = spatial_select_columnar(pandas_df.x.to_numpy(copy=True), pandas_df.y.to_numpy(copy=True), geometry, _method)
             assert np.array_equal(mask, pt_mask)
 
+        @pytest.mark.gpu
+        def test_cudf(self, geometry, pt_mask, pandas_df, _method, unimport):
+            import cudf
+            import cupy as cp
+            unimport('cuspatial')
+
+            df = cudf.from_pandas(pandas_df)
+            mask = spatial_select_columnar(df.x, df.y, geometry, _method)
+            assert np.array_equal(cp.asnumpy(mask), pt_mask)
+
+        @pytest.mark.xfail(reason='cuspatial.point_in_polygon API has changed')
+        @pytest.mark.gpu
+        def test_cuspatial(self, geometry, pt_mask, pandas_df, _method):
+            import cudf
+            import cupy as cp
+
+            df = cudf.from_pandas(pandas_df)
+            mask = spatial_select_columnar(df.x, df.y, geometry, _method)
+            assert np.array_equal(cp.asnumpy(mask), pt_mask)
 
     @pytest.mark.parametrize("geometry", [geometry_encl, geometry_noencl])
     class TestSpatialSelectColumnarDaskMeta:

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -61,18 +61,11 @@ except ImportError:
     raise SkipTest('Datashader not available')
 
 try:
-    import cudf
-    import cupy
-except ImportError:
-    cudf = None
-
-try:
     import spatialpandas
 except ImportError:
     spatialpandas = None
 
 spatialpandas_skip = skipIf(spatialpandas is None, "SpatialPandas not available")
-cudf_skip = skipIf(cudf is None, "cuDF not available")
 
 
 import logging
@@ -135,15 +128,18 @@ class DatashaderAggregateTests(ComparisonTestCase):
                          vdims=[Dimension('z Count', nodata=0)])
         self.assertEqual(img, expected)
 
-    @cudf_skip
+    @pytest.mark.gpu
     def test_aggregate_points_cudf(self):
+        import cudf
+        import cupy
+
         points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)], datatype=['cuDF'])
-        self.assertIsInstance(points.data, cudf.DataFrame)
+        assert isinstance(points.data, cudf.DataFrame)
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
         expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
                          vdims=[Dimension('Count', nodata=0)])
-        self.assertIsInstance(img.data.Count.data, cupy.ndarray)
+        assert isinstance(img.data.Count.data, cupy.ndarray)
         self.assertEqual(img, expected)
 
     def test_aggregate_zero_range_points(self):

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -16,6 +16,10 @@ try:
 except ImportError:
     ibis = None
 
+try:
+    import cudf
+except ImportError:
+    cudf = None
 
 from holoviews import (
     Area,
@@ -459,6 +463,38 @@ class OperationTests(ComparisonTestCase):
                          vdims=('x_count', 'Count'))
         self.assertEqual(op_hist, hist)
 
+    @pytest.mark.gpu
+    def test_dataset_histogram_cudf(self):
+        df = pd.DataFrame(dict(x=np.arange(10)))
+        t = cudf.from_pandas(df)
+        ds = Dataset(t, vdims='x')
+        op_hist = histogram(ds, dimension='x', num_bins=3, normed=True)
+
+        hist = Histogram(([0, 3, 6, 9], [0.1, 0.1, 0.133333]),
+                         vdims=('x_frequency', 'Frequency'))
+        self.assertEqual(op_hist, hist)
+
+    @pytest.mark.gpu
+    def test_dataset_cumulative_histogram_cudf(self):
+        df = pd.DataFrame(dict(x=np.arange(10)))
+        t = cudf.from_pandas(df)
+        ds = Dataset(t, vdims='x')
+        op_hist = histogram(ds, num_bins=3, cumulative=True, normed=True)
+
+        hist = Histogram(([0, 3, 6, 9], [0.3, 0.6, 1]),
+                         vdims=('x_frequency', 'Frequency'))
+        self.assertEqual(op_hist, hist)
+
+    @pytest.mark.gpu
+    def test_dataset_histogram_explicit_bins_cudf(self):
+        df = pd.DataFrame(dict(x=np.arange(10)))
+        t = cudf.from_pandas(df)
+        ds = Dataset(t, vdims='x')
+        op_hist = histogram(ds, bins=[0, 1, 3], normed=False)
+
+        hist = Histogram(([0, 1, 3], [1, 3]),
+                         vdims=('x_count', 'Count'))
+        self.assertEqual(op_hist, hist)
 
     def test_points_histogram_bin_range(self):
         points = Points([float(i) for i in range(10)])

--- a/pixi.toml
+++ b/pixi.toml
@@ -15,6 +15,7 @@ test-311 = ["py311", "test-core", "test", "example", "test-example", "test-unit-
 test-312 = ["py312", "test-core", "test", "example", "test-example", "test-unit-task"]
 test-ui = ["py312", "test-core", "test", "test-ui"]
 test-core = ["py312", "test-core", "test-unit-task"]
+test-gpu = ["py311", "test-core", "test", "test-gpu"]
 docs = ["py311", "example", "doc"]
 build = ["py311", "build"]
 lint = ["py311", "lint"]
@@ -118,6 +119,19 @@ _install-ui = 'playwright install chromium'
 [feature.test-ui.tasks.test-ui]
 cmd = 'pytest holoviews/tests/ui --ui --browser chromium'
 depends_on = ["_install-ui"]
+
+[feature.test-gpu]
+channels = ["pyviz/label/dev", "rapidsai", "conda-forge"]
+platforms = ["linux-64"]
+
+[feature.test-gpu.dependencies]
+cuda-version = "12.2.*"
+cudf = "24.04.*"
+cupy = { version = "*", channel = "conda-forge" }
+ucx = { version = "*", channel = "conda-forge" }
+
+[feature.test-gpu.tasks]
+test-gpu = "pytest holoviews/tests --gpu"
 
 # =============================================
 # =================== DOCS ====================

--- a/pixi.toml
+++ b/pixi.toml
@@ -127,9 +127,9 @@ platforms = ["linux-64"]
 [feature.test-gpu.dependencies]
 cuda-version = "12.2.*"
 cudf = "24.04.*"
+cupy = "*"
 cuspatial = "*"
-cupy = { version = "*", channel = "conda-forge" }
-ucx = { version = "*", channel = "conda-forge" }
+rmm = { version = "*", channel = "rapidsai" }
 
 [feature.test-gpu.tasks]
 test-gpu = { cmd = "pytest holoviews/tests --gpu", env = { NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS = '0' } }

--- a/pixi.toml
+++ b/pixi.toml
@@ -131,7 +131,7 @@ cupy = { version = "*", channel = "conda-forge" }
 ucx = { version = "*", channel = "conda-forge" }
 
 [feature.test-gpu.tasks]
-test-gpu = "pytest holoviews/tests --gpu"
+test-gpu = { cmd = "pytest holoviews/tests --gpu", env = { NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS = '0' } }
 
 # =============================================
 # =================== DOCS ====================

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,7 +27,7 @@ packaging = "*"
 pandas = ">=0.20.0"
 panel = ">=1.0"
 param = ">=1.12.0,<3.0"
-pip= "*"
+pip = "*"
 pyviz_comms = ">=2.1"
 # Recommended
 bokeh = ">=3.1"
@@ -96,7 +96,7 @@ xarray = ">=0.10.4"
 xyzservices = "*"
 
 [feature.test.target.unix.dependencies]
-tsdownsample = "*"  # currently not available on Windows
+tsdownsample = "*" # currently not available on Windows
 
 [feature.test-example.tasks]
 test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'

--- a/pixi.toml
+++ b/pixi.toml
@@ -127,6 +127,7 @@ platforms = ["linux-64"]
 [feature.test-gpu.dependencies]
 cuda-version = "12.2.*"
 cudf = "24.04.*"
+cuspatial = "*"
 cupy = { version = "*", channel = "conda-forge" }
 ucx = { version = "*", channel = "conda-forge" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,6 @@ filterwarnings = [
     "ignore:The current Dask DataFrame implementation is deprecated:DeprecationWarning",  # https://github.com/dask/dask/issues/10917
     # 2024-04
     "ignore:No data was collected:coverage.exceptions.CoverageWarning",  # https://github.com/pytest-dev/pytest-cov/issues/627
-    # 2024-05
-    "ignore::numba.core.errors.NumbaPerformanceWarning",  # Not important for tests
 ]
 
 [tool.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,9 @@ filterwarnings = [
     "ignore:The current Dask DataFrame implementation is deprecated:DeprecationWarning",  # https://github.com/dask/dask/issues/10917
     # 2024-04
     "ignore:No data was collected:coverage.exceptions.CoverageWarning",  # https://github.com/pytest-dev/pytest-cov/issues/627
+    # 2024-05
+    "ignore::numba.core.errors.NumbaPerformanceWarning",  # Not important for tests
+
 ]
 
 [tool.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,6 @@ filterwarnings = [
     "ignore:No data was collected:coverage.exceptions.CoverageWarning",  # https://github.com/pytest-dev/pytest-cov/issues/627
     # 2024-05
     "ignore::numba.core.errors.NumbaPerformanceWarning",  # Not important for tests
-
 ]
 
 [tool.coverage]


### PR DESCRIPTION
This should make it easier to test CuDF (locally). I'm using it as a marker as I only want to be able to run the GPU tests if this task is called. 

![image](https://github.com/holoviz/holoviews/assets/19758978/b403d777-6c62-4a4c-b651-c099a61ddfdd)


I have used the versions from https://github.com/rapidsai/cudf?tab=readme-ov-file#conda
