### PR TITLE
Update pre-commit prettier repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,8 +45,8 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  - repo: https://github.com/hoxbro/prettier-pre-commit
+    rev: v3.2.5
     hooks:
       - id: prettier
         exclude: conda.recipe/meta.yaml


### PR DESCRIPTION
The official prettier pre-commit is now archived: https://github.com/pre-commit/mirrors-prettier

I have set up my own pre-commit repo, which also does not bump alpha/beta versions. 