### PR TITLE
Bump minimum version of param to 2.0 and add stream transform

### DIFF
--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -132,6 +132,8 @@ class Apply(metaclass=AccessorPipelineMeta):
             A new object where the function was applied to all
             contained (Nd)Overlay or Element objects.
         """
+        from panel.widgets.base import Widget
+
         from ..util import Dynamic
         from .data import Dataset
         from .dimension import ViewableElement
@@ -167,7 +169,10 @@ class Apply(metaclass=AccessorPipelineMeta):
                                          'method exists on the object.')
                 return method(*args, **kwargs)
 
-        kwargs = {k: param.parameterized.resolve_ref(v) for k, v in kwargs.items()}
+        kwargs = {
+            k: v.param.value if isinstance(v, Widget) else v
+            for k, v in kwargs.items()
+        }
 
         spec = Element if per_element else ViewableElement
         applies = isinstance(self._obj, spec)

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -2,7 +2,6 @@
 Module for accessor objects for viewable HoloViews objects.
 """
 import copy
-import sys
 from functools import wraps
 from types import FunctionType
 
@@ -168,10 +167,7 @@ class Apply(metaclass=AccessorPipelineMeta):
                                          'method exists on the object.')
                 return method(*args, **kwargs)
 
-        if 'panel' in sys.modules:
-            from panel.widgets.base import Widget
-            kwargs = {k: v.param.value if isinstance(v, Widget) else v
-                      for k, v in kwargs.items()}
+        kwargs = {k: param.parameterized.resolve_ref(v) for k, v in kwargs.items()}
 
         spec = Element if per_element else ViewableElement
         applies = isinstance(self._obj, spec)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -458,8 +458,8 @@ class Callable(param.Parameterized):
     information see the DynamicMap tutorial at holoviews.org.
     """
 
-    callable = param.Callable(default=None, constant=True, doc="""
-         The callable function being wrapped.""", **util.disallow_refs)
+    callable = param.Callable(default=None, constant=True, allow_refs=False, doc="""
+         The callable function being wrapped.""")
 
     inputs = param.List(default=[], constant=True, doc="""
          The list of inputs the callable function is wrapping. Used

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -546,7 +546,7 @@ class Callable(param.Parameterized):
         # Nothing to do for callbacks that accept no arguments
         kwarg_hash = kwargs.pop('_memoization_hash_', ())
         (self.args, self.kwargs) = (args, kwargs)
-        if util.param_version >= util.Version('2.0.0') and isinstance(self.callable, param.rx):
+        if isinstance(self.callable, param.rx):
             return self.callable.rx.value
         elif not args and not kwargs and not any(kwarg_hash):
             return self.callable()
@@ -774,7 +774,7 @@ class DynamicMap(HoloMap):
             streams = streams_list_from_dict(streams)
 
         # If callback is a parameterized method and watch is disabled add as stream
-        if util.param_version > util.Version('2.0.0rc1') and param.parameterized.resolve_ref(callback):
+        if param.parameterized.resolve_ref(callback):
             streams.append(callback)
         elif (params.get('watch', True) and (util.is_param_method(callback, has_deps=True) or
             (isinstance(callback, FunctionType) and hasattr(callback, '_dinfo')))):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -42,7 +42,7 @@ masked_types = ()
 
 anonymous_dimension_label = '_'
 
-disallow_refs = {'allow_refs': False} if param_version > Version('2.0.0rc1') else {}
+disallow_refs = {'allow_refs': False}
 
 # Argspec was removed in Python 3.11
 ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
@@ -1613,6 +1613,8 @@ def resolve_dependent_value(value):
        A new value where any parameter dependencies have been
        resolved.
     """
+    from panel.widgets import RangeSlider
+
     range_widget = False
     if isinstance(value, list):
         value = [resolve_dependent_value(v) for v in value]
@@ -1629,14 +1631,8 @@ def resolve_dependent_value(value):
             resolve_dependent_value(value.step),
         )
 
-    if 'panel' in sys.modules:
-        from panel.depends import param_value_if_widget
-        from panel.widgets import RangeSlider
-        range_widget = isinstance(value, RangeSlider)
-        if param_version > Version('2.0.0rc1'):
-            value = param.parameterized.resolve_value(value)
-        else:
-            value = param_value_if_widget(value)
+    range_widget = isinstance(value, RangeSlider)
+    value = param.parameterized.resolve_value(value)
 
     if is_param_method(value, has_deps=True):
         value = value()

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -42,8 +42,6 @@ masked_types = ()
 
 anonymous_dimension_label = '_'
 
-disallow_refs = {'allow_refs': False}
-
 # Argspec was removed in Python 3.11
 ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1894,3 +1894,12 @@ class PolyEdit(PolyDraw):
             vertex_style = {}
         self.shared = shared
         super().__init__(vertex_style=vertex_style, **params)
+
+
+def _streams_transform(obj):
+    if isinstance(obj, Pipe):
+        return obj.param.data
+    return obj
+
+
+param.reactive.register_reference_transform(_streams_transform)

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -679,8 +679,8 @@ class Params(Stream):
 
     parameterized = param.ClassSelector(class_=(param.Parameterized,
                                                 param.parameterized.ParameterizedMetaclass),
-                                        constant=True, allow_None=True, doc="""
-        Parameterized instance to watch for parameter changes.""", **util.disallow_refs)
+                                        constant=True, allow_None=True, allow_refs=False, doc="""
+        Parameterized instance to watch for parameter changes.""")
 
     parameters = param.List(default=[], constant=True, doc="""
         Parameters on the parameterized to watch.""")

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -4,7 +4,6 @@ generate and respond to events, originating either in Python on the
 server-side or in Javascript in the Jupyter notebook (client-side).
 """
 
-import sys
 import weakref
 from collections import defaultdict
 from contextlib import contextmanager
@@ -16,7 +15,6 @@ from types import FunctionType
 import numpy as np
 import pandas as pd
 import param
-from packaging.version import Version
 
 from .core import util
 from .core.ndmapping import UniformNdMapping
@@ -49,12 +47,7 @@ def streams_list_from_dict(streams):
     "Converts a streams dictionary into a streams list"
     params = {}
     for k, v in streams.items():
-        if 'panel' in sys.modules:
-            if util.param_version > util.Version('2.0.0rc1'):
-                v = param.parameterized.transform_reference(v)
-            else:
-                from panel.depends import param_value_if_widget
-                v = param_value_if_widget(v)
+        v = param.parameterized.transform_reference(v)
         if isinstance(v, param.Parameter) and v.owner is not None:
             params[k] = v
         else:
@@ -225,10 +218,7 @@ class Stream(param.Parameterized):
                 rename = {(p.owner, p.name): k for k, p in deps.get('kw', {}).items()}
                 s = Params(parameters=dep_params, rename=rename)
             else:
-                if util.param_version > util.Version('2.0.0rc1'):
-                    deps = param.parameterized.resolve_ref(s)
-                else:
-                    deps = None
+                deps = param.parameterized.resolve_ref(s)
                 if deps:
                     s = Params(parameters=deps)
                 else:
@@ -696,9 +686,6 @@ class Params(Stream):
         Parameters on the parameterized to watch.""")
 
     def __init__(self, parameterized=None, parameters=None, watch=True, watch_only=False, **params):
-        if util.param_version < Version('1.8.0') and watch:
-            raise RuntimeError('Params stream requires param version >= 1.8.0, '
-                               'to support watching parameters.')
         if parameters is None:
             parameters = [parameterized.param[p] for p in parameterized.param if p != 'name']
         else:

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -921,6 +921,8 @@ class Dynamic(param.ParameterizedFunction):
         of supplied stream classes and instances are processed and
         added to the list.
         """
+        from panel.widgets.base import Widget
+
         if isinstance(self.p.streams, dict):
             streams = defaultdict(dict)
             stream_specs, params = [], {}
@@ -961,7 +963,8 @@ class Dynamic(param.ParameterizedFunction):
 
         params = {}
         for k, v in self.p.kwargs.items():
-            v = param.parameterized.resolve_ref(v)
+            if isinstance(v, Widget):
+                v = v.param.value
             if isinstance(v, param.Parameter) and isinstance(v.owner, param.Parameterized):
                 params[k] = v
         streams += Params.from_params(params)

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -961,10 +961,7 @@ class Dynamic(param.ParameterizedFunction):
 
         params = {}
         for k, v in self.p.kwargs.items():
-            if 'panel' in sys.modules:
-                from panel.widgets.base import Widget
-                if isinstance(v, Widget):
-                    v = v.param.value
+            v = param.parameterized.resolve_ref(v)
             if isinstance(v, param.Parameter) and isinstance(v.owner, param.Parameterized):
                 params[k] = v
         streams += Params.from_params(params)

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -890,8 +890,8 @@ class Dynamic(param.ParameterizedFunction):
     shared_data = param.Boolean(default=False, doc="""
         Whether the cloned DynamicMap will share the same cache.""")
 
-    streams = param.ClassSelector(default=[], class_=(list, dict), doc="""
-        List of streams to attach to the returned DynamicMap""", **util.disallow_refs)
+    streams = param.ClassSelector(default=[], class_=(list, dict), allow_refs=False, doc="""
+        List of streams to attach to the returned DynamicMap""")
 
     def __call__(self, map_obj, **params):
         watch = params.pop('watch', True)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -359,6 +359,7 @@ class dim:
 
     @property
     def params(self):
+        from panel.widgets.base import Widget
         params = {}
         for op in self.ops:
             op_args = list(op['args'])+list(op['kwargs'].values())
@@ -367,14 +368,18 @@ class dim:
                 op_args += [op['fn'].index]
             op_args = flatten(op_args)
             for op_arg in op_args:
-                op_arg = param.parameterized.resolve_ref(op_arg)
+                if isinstance(op_arg, Widget):
+                    op_arg = op_arg.param.value
                 if isinstance(op_arg, dim):
                     params.update(op_arg.params)
                 elif isinstance(op_arg, slice):
                     (start, stop, step) = (op_arg.start, op_arg.stop, op_arg.step)
-                    start = param.parameterized.resolve_ref(start)
-                    stop = param.parameterized.resolve_ref(stop)
-                    step = param.parameterized.resolve_ref(step)
+                    if isinstance(start, Widget):
+                        start = start.param.value
+                    if isinstance(stop, Widget):
+                        stop = stop.param.value
+                    if isinstance(step, Widget):
+                        step = step.param.value
 
                     if isinstance(start, param.Parameter):
                         params[start.name+str(id(start))] = start

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -1,5 +1,4 @@
 import operator
-import sys
 from types import BuiltinFunctionType, BuiltinMethodType, FunctionType, MethodType
 
 import numpy as np
@@ -360,11 +359,6 @@ class dim:
 
     @property
     def params(self):
-        if 'panel' in sys.modules:
-            from panel.widgets.base import Widget
-        else:
-            Widget = None
-
         params = {}
         for op in self.ops:
             op_args = list(op['args'])+list(op['kwargs'].values())
@@ -373,19 +367,14 @@ class dim:
                 op_args += [op['fn'].index]
             op_args = flatten(op_args)
             for op_arg in op_args:
-                if Widget and isinstance(op_arg, Widget):
-                    op_arg = op_arg.param.value
+                op_arg = param.parameterized.resolve_ref(op_arg)
                 if isinstance(op_arg, dim):
                     params.update(op_arg.params)
                 elif isinstance(op_arg, slice):
                     (start, stop, step) = (op_arg.start, op_arg.stop, op_arg.step)
-
-                    if Widget and isinstance(start, Widget):
-                        start = start.param.value
-                    if Widget and isinstance(stop, Widget):
-                        stop = stop.param.value
-                    if Widget and isinstance(step, Widget):
-                        step = step.param.value
+                    start = param.parameterized.resolve_ref(start)
+                    stop = param.parameterized.resolve_ref(stop)
+                    step = param.parameterized.resolve_ref(step)
 
                     if isinstance(start, param.Parameter):
                         params[start.name+str(id(start))] = start

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,7 +26,7 @@ numpy = ">=1.0"
 packaging = "*"
 pandas = ">=0.20.0"
 panel = ">=1.0"
-param = ">=1.12.0,<3.0"
+param = ">=2.0,<3.0"
 pip = "*"
 pyviz_comms = ">=2.1"
 # Recommended

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "param >=1.12.0,<3.0",
+    "param >=2.0,<3.0",
     "numpy >=1.0",
     "pyviz_comms >=2.1",
     "panel >=1.0",


### PR DESCRIPTION
- Bumps minimum version of param to 2.0
- <s>Remove Panel Widget and replace with `param.parameterized.resolve_ref` </s> did not work, because `resolve_ref` returns a list no matter what, and I only want the value parameter. 
- Add `Pipe` and therefore `Streams` to reactive transform and therefore fixes #6229 
