### PR TITLE
Parallelize unit test

### DIFF
--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -79,10 +79,10 @@ def _plotting_backend(backend):
     if not hv.extension._loaded:
         hv.extension(backend)
     hv.renderer(backend)
-    prev_backend = hv.Store.current_backend
-    hv.Store.current_backend = backend
+    curent_backend = hv.Store.current_backend
+    hv.Store.set_current_backend(backend)
     yield
-    hv.Store.current_backend = prev_backend
+    hv.Store.set_current_backend(curent_backend)
 
 
 @pytest.fixture
@@ -132,7 +132,7 @@ def reset_store():
     _custom_options = {k: v.copy() for k, v in hv.Store._custom_options.items()}
     _options = hv.Store._options.copy()
     current_backend = hv.Store.current_backend
-    renderers = hv.Store.renderers
+    renderers = hv.Store.renderers.copy()
     yield
     hv.Store._custom_options = _custom_options
     hv.Store._options = _options

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -132,10 +132,12 @@ def serve_hv(page, port):  # noqa: F811
 def reset_store():
     _custom_options = deepcopy(hv.Store._custom_options)
     _options = hv.Store._options.copy()
+    _weakrefs = hv.Store._weakrefs.copy()
     current_backend = hv.Store.current_backend
     renderers = hv.Store.renderers
     yield
     hv.Store._custom_options = _custom_options
     hv.Store._options = _options
+    hv.Store._weakrefs = _weakrefs
     hv.Store.current_backend = current_backend
     hv.Store.renderers = renderers

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -129,7 +129,7 @@ def serve_hv(page, port):  # noqa: F811
 
 @pytest.fixture(autouse=True)
 def reset_store():
-    _custom_options = {k: v.copy() for k, v in hv.Store._custom_options.items()}
+    _custom_options = {k: {} for k in hv.Store._custom_options}
     _options = hv.Store._options.copy()
     current_backend = hv.Store.current_backend
     renderers = hv.Store.renderers.copy()

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -1,6 +1,7 @@
 import contextlib
 import sys
 from collections.abc import Callable
+from copy import deepcopy
 
 import panel as pn
 import pytest
@@ -125,3 +126,16 @@ def serve_hv(page, port):  # noqa: F811
         return page
 
     return serve_and_return_page
+
+
+@pytest.fixture(autouse=True)
+def reset_store():
+    _custom_options = deepcopy(hv.Store._custom_options)
+    _options = hv.Store._options.copy()
+    current_backend = hv.Store.current_backend
+    renderers = hv.Store.renderers
+    yield
+    hv.Store._custom_options = _custom_options
+    hv.Store._options = _options
+    hv.Store.current_backend = current_backend
+    hv.Store.renderers = renderers

--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -1,7 +1,6 @@
 import contextlib
 import sys
 from collections.abc import Callable
-from copy import deepcopy
 
 import panel as pn
 import pytest
@@ -130,14 +129,13 @@ def serve_hv(page, port):  # noqa: F811
 
 @pytest.fixture(autouse=True)
 def reset_store():
-    _custom_options = deepcopy(hv.Store._custom_options)
+    _custom_options = {k: v.copy() for k, v in hv.Store._custom_options.items()}
     _options = hv.Store._options.copy()
-    _weakrefs = hv.Store._weakrefs.copy()
     current_backend = hv.Store.current_backend
     renderers = hv.Store.renderers
     yield
     hv.Store._custom_options = _custom_options
     hv.Store._options = _options
-    hv.Store._weakrefs = _weakrefs
-    hv.Store.current_backend = current_backend
+    hv.Store._weakrefs = {}
     hv.Store.renderers = renderers
+    hv.Store.set_current_backend(current_backend)

--- a/holoviews/tests/core/data/test_imageinterface.py
+++ b/holoviews/tests/core/data/test_imageinterface.py
@@ -2,6 +2,7 @@ import datetime as dt
 from unittest import SkipTest
 
 import numpy as np
+import pytest
 
 from holoviews import HSV, RGB, Curve, Dataset, Dimension, Image, Table
 from holoviews.core.data.interface import DataError
@@ -465,17 +466,9 @@ class RGBElement_ImageInterfaceTests(BaseRGBElementInterfaceTests):
 
     __test__ = True
 
+    @pytest.mark.xfail(reason="Raises DataError in ImageInterface")
     def test_reduce_to_single_values(self):
-        try:
-            super().test_reduce_to_single_values()
-        except DataError:
-            msg = (
-                "RGB element can't run with this command: "
-                "'pytest holoviews/tests -k test_reduce_to_single_values'"
-                "but runs fine with 'pytest holoviews/tests/core/'"
-            )
-            raise SkipTest(msg)
-
+        super().test_reduce_to_single_values()
 
 class BaseHSVElementInterfaceTests(InterfaceTests):
 

--- a/holoviews/tests/core/test_dimensioned.py
+++ b/holoviews/tests/core/test_dimensioned.py
@@ -29,17 +29,6 @@ class CustomBackendTestCase(LoggingComparisonTestCase):
         self.register_custom(ExampleElement, 'backend_2', ['plot_custom2'])
         Store.set_current_backend('backend_1')
 
-    def tearDown(self):
-        super().tearDown()
-        Store._weakrefs = {}
-        Store._options.pop('backend_1')
-        Store._options.pop('backend_2')
-        Store._custom_options.pop('backend_1')
-        Store._custom_options.pop('backend_2')
-        Store.set_current_backend(self.current_backend)
-        Store.renderers.pop('backend_1')
-        Store.renderers.pop('backend_2')
-
     @classmethod
     def register_custom(cls, objtype, backend, custom_plot=None, custom_style=None):
         if custom_style is None:

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -958,6 +958,7 @@ class TestLookupOptions(ComparisonTestCase):
             self.assertNotIn("muted_alpha", options_matplotlib.keys())
 
 
+@pytest.mark.usefixtures("bokeh_backend")
 class TestCrossBackendOptionSpecification(ComparisonTestCase):
     """
     Test the style system can style a single object across backends.

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -300,7 +300,6 @@ class TestStoreInheritanceDynamic(ComparisonTestCase):
 
     def tearDown(self):
         Store.options(val=self.store_copy)
-        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
         super().tearDown()
 
     def initialize_option_tree(self):
@@ -503,7 +502,6 @@ class TestStoreInheritance(ComparisonTestCase):
 
     def tearDown(self):
         Store.options(val=self.store_copy)
-        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
         super().tearDown()
 
     def lookup_options(self, obj, group):
@@ -573,7 +571,6 @@ class TestOptionsMethod(ComparisonTestCase):
 
     def tearDown(self):
         Store.options(val=self.store_copy)
-        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
         super().tearDown()
 
     def lookup_options(self, obj, group):
@@ -626,7 +623,6 @@ class TestOptsMethod(ComparisonTestCase):
 
     def tearDown(self):
         Store.options(val=self.store_copy)
-        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
         super().tearDown()
 
     def lookup_options(self, obj, group):
@@ -732,7 +728,6 @@ class TestOptionTreeFind(ComparisonTestCase):
     def tearDown(self):
         Options._option_groups = self.original_option_groups
         Store.options(val=self.original_options)
-        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
 
     def test_optiontree_find1(self):
         self.assertEqual(self.options.find('MyType').options('group').options,
@@ -813,7 +808,6 @@ class TestCrossBackendOptions(ComparisonTestCase):
         Store.options(val=self.store_mpl, backend='matplotlib')
         Store.options(val=self.store_bokeh, backend='bokeh')
         Store.current_backend = 'matplotlib'
-        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
 
         if self.plotly_options is not None:
             Store._options['plotly'] = self.plotly_options
@@ -988,7 +982,6 @@ class TestCrossBackendOptionSpecification(ComparisonTestCase):
         Store.options(val=self.store_mpl, backend='matplotlib')
         Store.options(val=self.store_bokeh, backend='bokeh')
         Store.current_backend = 'matplotlib'
-        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
 
         if self.plotly_options is not None:
             Store._options['plotly'] = self.plotly_options

--- a/holoviews/tests/ipython/test_displayhooks.py
+++ b/holoviews/tests/ipython/test_displayhooks.py
@@ -16,7 +16,6 @@ class TestDisplayHooks(IPTestCase):
         Store.display_formats = self.format
 
     def tearDown(self):
-        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
         self.ip.run_line_magic("unload_ext", "holoviews.ipython")
         del self.ip
         Store.display_hooks = self.backup

--- a/holoviews/tests/ipython/test_magics.py
+++ b/holoviews/tests/ipython/test_magics.py
@@ -49,6 +49,7 @@ class TestOptsMagic(ExtensionTestCase):
             Store.lookup_options('matplotlib',
                                  self.get_object('mat1'), 'style').options.get('cmap',None),'hot')
 
+    @pytest.mark.flaky(reruns=3)
     def test_cell_opts_style_dynamic(self):
 
         self.cell("dmap = DynamicMap(lambda X: Curve(np.random.rand(5,2), name='dmap'), kdims=['x'])"
@@ -91,6 +92,7 @@ class TestOptsMagic(ExtensionTestCase):
                                  self.get_object('mat1'), 'plot').options.get('show_title',True),False)
 
 
+    @pytest.mark.flaky(reruns=3)
     def test_cell_opts_plot_dynamic(self):
 
         self.cell("dmap = DynamicMap(lambda X: Image(np.random.rand(5,5), name='dmap'), kdims=['x'])"

--- a/holoviews/tests/ipython/test_magics.py
+++ b/holoviews/tests/ipython/test_magics.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 import pytest
 from pyviz_comms import CommManager
 
@@ -13,21 +11,18 @@ except ImportError:
     pytest.skip("IPython required to test IPython magics", allow_module_level=True)
 
 
-@pytest.mark.xdist_group(name="ipython-magic")
 class ExtensionTestCase(IPTestCase):
 
     def setUp(self):
-        self.old_custom_options = deepcopy(Store._custom_options)
         super().setUp()
         self.ip.run_line_magic("load_ext", "holoviews.ipython")
         for renderer in Store.renderers.values():
-            renderer.comm_manager = CommManager
+            renderer.comm_manager = CommManager  # TODO: Should set it back
 
     def tearDown(self):
         self.ip.run_line_magic("unload_ext", "holoviews.ipython")
         del self.ip
         super().tearDown()
-        Store._custom_options = self.old_custom_options
 
 
 class TestOptsMagic(ExtensionTestCase):

--- a/holoviews/tests/ipython/test_magics.py
+++ b/holoviews/tests/ipython/test_magics.py
@@ -8,15 +8,13 @@ from holoviews.core.options import Store
 from holoviews.operation import Compositor
 
 try:
-    from holoviews import ipython  # noqa: F401
     from holoviews.ipython import IPTestCase
 except ImportError:
-    pytest.skip("IPython required to test IPython magics")
-    IPTestCase = None
+    pytest.skip("IPython required to test IPython magics", allow_module_level=True)
 
 
-@pytest.mark.xdist_group(name="ipython")
-class ExtensionTestCase(IPTestCase or object):
+@pytest.mark.xdist_group(name="ipython-magic")
+class ExtensionTestCase(IPTestCase):
 
     def setUp(self):
         self.old_custom_options = deepcopy(Store._custom_options)

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -56,7 +56,7 @@ class CallbackTestCase(ComparisonTestCase):
         Store.current_backend = self.previous_backend
         bokeh_server_renderer.last_plot = None
         bokeh_renderer.last_plot = None
-        Callback._callbacks.clear()
+        Callback._callbacks = {}
         bokeh_renderer.comm_manager = self.comm_manager
 
 
@@ -127,6 +127,7 @@ class TestCallbacks(CallbackTestCase):
         self.assertEqual(data['x'], np.arange(10))
         self.assertEqual(data['y'], np.arange(10, 20))
 
+    @pytest.mark.flaky(reruns=3)
     def test_callback_cleanup(self):
         stream = PointerX(x=0)
         dmap = DynamicMap(lambda x: Curve([x]), streams=[stream])

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -56,7 +56,7 @@ class CallbackTestCase(ComparisonTestCase):
         Store.current_backend = self.previous_backend
         bokeh_server_renderer.last_plot = None
         bokeh_renderer.last_plot = None
-        Callback._callbacks = {}
+        Callback._callbacks.clear()
         bokeh_renderer.comm_manager = self.comm_manager
 
 

--- a/holoviews/tests/plotting/bokeh/test_curveplot.py
+++ b/holoviews/tests/plotting/bokeh/test_curveplot.py
@@ -32,6 +32,7 @@ class TestCurvePlot(TestBokehPlot):
     def test_batched_curve_subscribers_correctly_linked(self):
         # Checks if a stream callback is created to link batched plot
         # to the stream
+        Callback._callbacks.clear()  # Reset to not be sensitive to other test
         posx = PointerX()
         opts = {'NdOverlay': dict(legend_limit=0),
                 'Curve': dict(line_color=Cycle(values=['red', 'blue']))}

--- a/holoviews/tests/plotting/bokeh/test_server.py
+++ b/holoviews/tests/plotting/bokeh/test_server.py
@@ -80,6 +80,7 @@ class TestBokehServerSetup(ComparisonTestCase):
 
 
 
+@pytest.mark.flaky(reruns=3)
 class TestBokehServer(ComparisonTestCase):
 
     def setUp(self):
@@ -115,7 +116,6 @@ class TestBokehServer(ComparisonTestCase):
         obj = Curve([])
         self._launcher(obj, port=6001)
 
-    @pytest.mark.flaky(reruns=3)
     def test_launch_server_with_stream(self):
         el = Curve([])
         stream = RangeXY(source=el)
@@ -129,7 +129,6 @@ class TestBokehServer(ComparisonTestCase):
         self.assertEqual(cb.streams, [stream])
         assert 'rangesupdate' in plot.state._event_callbacks
 
-    @pytest.mark.flaky(reruns=3)
     def test_launch_server_with_complex_plot(self):
         dmap = DynamicMap(lambda x_range, y_range: Curve([]), streams=[RangeXY()])
         overlay = dmap * HLine(0)
@@ -155,7 +154,6 @@ class TestBokehServer(ComparisonTestCase):
         cds = self.session.document.roots[0].select_one({'type': ColumnDataSource})
         self.assertEqual(cds.data['y'][2], 3.1)
 
-    @pytest.mark.flaky(reruns=3)
     def test_server_dynamicmap_with_stream(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y'], streams=[stream])
@@ -175,7 +173,6 @@ class TestBokehServer(ComparisonTestCase):
         cds = self.session.document.roots[0].select_one({'type': ColumnDataSource})
         self.assertEqual(cds.data['y'][2], 3)
 
-    @pytest.mark.flaky(reruns=3)
     def test_server_dynamicmap_with_stream_dims(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda x, y: Curve([x, 1, y]), kdims=['x', 'y'],

--- a/holoviews/tests/plotting/bokeh/test_server.py
+++ b/holoviews/tests/plotting/bokeh/test_server.py
@@ -115,6 +115,7 @@ class TestBokehServer(ComparisonTestCase):
         obj = Curve([])
         self._launcher(obj, port=6001)
 
+    @pytest.mark.flaky(reruns=3)
     def test_launch_server_with_stream(self):
         el = Curve([])
         stream = RangeXY(source=el)
@@ -154,6 +155,7 @@ class TestBokehServer(ComparisonTestCase):
         cds = self.session.document.roots[0].select_one({'type': ColumnDataSource})
         self.assertEqual(cds.data['y'][2], 3.1)
 
+    @pytest.mark.flaky(reruns=3)
     def test_server_dynamicmap_with_stream(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y'], streams=[stream])
@@ -173,6 +175,7 @@ class TestBokehServer(ComparisonTestCase):
         cds = self.session.document.roots[0].select_one({'type': ColumnDataSource})
         self.assertEqual(cds.data['y'][2], 3)
 
+    @pytest.mark.flaky(reruns=3)
     def test_server_dynamicmap_with_stream_dims(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda x, y: Curve([x, 1, y]), kdims=['x', 'y'],

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -150,6 +150,7 @@ class MPLRendererTest(ComparisonTestCase):
         self.assertEqual(obj.widget_location, 'top')
         self.assertEqual(obj.widget_type, 'individual')
 
+    @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_dims(self):
         dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
         obj, _ = self.renderer._validate(dmap, None)
@@ -164,6 +165,7 @@ class MPLRendererTest(ComparisonTestCase):
         (_, y) = artist.get_data()
         self.assertEqual(y[2], 3.1)
 
+    @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_stream(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y'], streams=[stream])
@@ -178,6 +180,7 @@ class MPLRendererTest(ComparisonTestCase):
         (_, y) = artist.get_data()
         self.assertEqual(y[2], 3)
 
+    @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_stream_dims(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda x, y: Curve([x, 1, y]), kdims=['x', 'y'],

--- a/holoviews/tests/plotting/plotly/test_renderer.py
+++ b/holoviews/tests/plotting/plotly/test_renderer.py
@@ -1,9 +1,9 @@
 """
 Test cases for rendering exporters
 """
-
 import panel as pn
 import param
+import pytest
 from panel.widgets import DiscreteSlider, FloatSlider, Player
 from pyviz_comms import CommManager
 
@@ -92,6 +92,7 @@ class PlotlyRendererTest(ComparisonTestCase):
         self.assertEqual(obj.widget_location, 'top')
         self.assertEqual(obj.widget_type, 'individual')
 
+    @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_dims(self):
         dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
         obj, _ = self.renderer._validate(dmap, None)
@@ -105,6 +106,7 @@ class PlotlyRendererTest(ComparisonTestCase):
         y = plot.handles['fig']['data'][0]['y']
         self.assertEqual(y[2], 3.1)
 
+    @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_stream(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y'], streams=[stream])
@@ -118,6 +120,7 @@ class PlotlyRendererTest(ComparisonTestCase):
         y = plot.handles['fig']['data'][0]['y']
         self.assertEqual(y[2], 3)
 
+    @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_stream_dims(self):
         stream = Stream.define('Custom', y=2)()
         dmap = DynamicMap(lambda x, y: Curve([x, 1, y]), kdims=['x', 'y'],

--- a/holoviews/tests/util/test_utils.py
+++ b/holoviews/tests/util/test_utils.py
@@ -93,7 +93,6 @@ class TestOptsUtil(LoggingComparisonTestCase):
     def tearDown(self):
         Store.current_backend = self.backend
         Store.options(val=self.store_copy)
-        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
         super().tearDown()
 
     def test_opts_builder_repr(self):

--- a/pixi.toml
+++ b/pixi.toml
@@ -69,13 +69,15 @@ xarray = ">=0.10.4"
 # =================== TESTS ===================
 # =============================================
 [feature.test-core.dependencies]
+psutil = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-github-actions-annotate-failures = "*"
 pytest-rerunfailures = "*"
+pytest-xdist = "*"
 
 [feature.test-unit-task.tasks] # So it is not showing up in the test-ui environment
-test-unit = 'pytest holoviews/tests'
+test-unit = 'pytest holoviews/tests -n logical --dist loadgroup'
 
 [feature.test.dependencies]
 cftime = "*"
@@ -102,9 +104,7 @@ tsdownsample = "*" # currently not available on Windows
 test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'
 
 [feature.test-example.dependencies]
-psutil = "*"
 nbval = "*"
-pytest-xdist = "*"
 
 [feature.test-ui]
 channels = ["pyviz/label/dev", "microsoft", "conda-forge"]


### PR DESCRIPTION
Fixes #5565

This time it has been in a much better state than when I looked over a year ago. I think this relates to work done in #5954 and #6200, where I made it possible to run tests with required dependencies + pytest. 

The main change in this PR is to reset `hv.Store` before each run. 