### PR TITLE
Hold streams together for faster plot callbacks

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -225,8 +225,12 @@ class Callback:
             streams.append(stream)
 
         try:
+            self.plot.document.hold()
             with set_curdoc(self.plot.document):
                 Stream.trigger(streams)
+                if self.plot.comm:
+                    push_on_root(self.plot.root.ref['id'])
+            self.plot.document.unhold()
         except CallbackError as e:
             if self.plot.root and self.plot.root.ref['id'] in state._handles:
                 handle, _ = state._handles[self.plot.root.ref['id']]

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -225,9 +225,12 @@ class Callback:
             streams.append(stream)
 
         try:
-            with self.plot.state.hold_render():
                 with set_curdoc(self.plot.document):
-                    Stream.trigger(streams)
+                    self.plot.state.hold_render = True
+                    try:
+                        Stream.trigger(streams)
+                    finally:
+                        self.plot.state.hold_render = False
         except CallbackError as e:
             if self.plot.root and self.plot.root.ref['id'] in state._handles:
                 handle, _ = state._handles[self.plot.root.ref['id']]

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -225,12 +225,12 @@ class Callback:
             streams.append(stream)
 
         try:
-                with set_curdoc(self.plot.document):
-                    self.plot.state.hold_render = True
-                    try:
-                        Stream.trigger(streams)
-                    finally:
-                        self.plot.state.hold_render = False
+            with set_curdoc(self.plot.document):
+                self.plot.state.hold_render = True
+                try:
+                    Stream.trigger(streams)
+                finally:
+                    self.plot.state.hold_render = False
         except CallbackError as e:
             if self.plot.root and self.plot.root.ref['id'] in state._handles:
                 handle, _ = state._handles[self.plot.root.ref['id']]

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -225,9 +225,9 @@ class Callback:
             streams.append(stream)
 
         try:
-        with self.plot.state.hold_render():
-            with set_curdoc(self.plot.document):
-                Stream.trigger(streams)
+            with self.plot.state.hold_render():
+                with set_curdoc(self.plot.document):
+                    Stream.trigger(streams)
         except CallbackError as e:
             if self.plot.root and self.plot.root.ref['id'] in state._handles:
                 handle, _ = state._handles[self.plot.root.ref['id']]

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -225,12 +225,9 @@ class Callback:
             streams.append(stream)
 
         try:
-            self.plot.document.hold()
+        with self.plot.state.hold_render():
             with set_curdoc(self.plot.document):
                 Stream.trigger(streams)
-                if self.plot.comm:
-                    push_on_root(self.plot.root.ref['id'])
-            self.plot.document.unhold()
         except CallbackError as e:
             if self.plot.root and self.plot.root.ref['id'] in state._handles:
                 handle, _ = state._handles[self.plot.root.ref['id']]


### PR DESCRIPTION
Philipp suggested this; not sure if the following is necessary:
```
                if self.plot.comm:
                    push_on_root(self.plot.root.ref['id'])
```