### PR TITLE
Move environment variables into Pixi.toml

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,13 +39,7 @@ jobs:
     outputs:
       tag: ${{ steps.vars.outputs.tag }}
     env:
-      MPLBACKEND: "Agg"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      MOZ_HEADLESS: 1
-      PANEL_EMBED: "true"
-      PANEL_EMBED_JSON: "true"
-      PANEL_EMBED_JSON_PREFIX: "json"
-      DASK_DATAFRAME__QUERY_PLANNING: false
     steps:
       - uses: holoviz-dev/holoviz_tasks/pixi_install@pixi
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,9 +34,7 @@ defaults:
 
 env:
   DISPLAY: ":99.0"
-  PYTHONIOENCODING: "utf-8"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  DASK_DATAFRAME__QUERY_PLANNING: false
   COV: "--cov=./holoviews --cov-report=xml"
 
 jobs:

--- a/pixi.toml
+++ b/pixi.toml
@@ -85,7 +85,6 @@ test-unit = 'pytest holoviews/tests'
 [feature.test.dependencies]
 cftime = "*"
 contourpy = "*"
-# dash >=1.16
 dask-core = "*"
 datashader = ">=0.11.1"
 ffmpeg = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,6 +8,10 @@ check-latest-packages = 'python scripts/check_latest_packages.py'
 download-data = 'python scripts/download_data.py'
 install = 'python -m pip install --no-deps --disable-pip-version-check -e .'
 
+[activation.env]
+DASK_DATAFRAME__QUERY_PLANNING = "False"
+PYTHONIOENCODING = "utf-8"
+
 [environments]
 test-39 = ["py39", "test-core", "test", "example", "test-example", "test-unit-task"]
 test-310 = ["py310", "test-core", "test", "example", "test-example", "test-unit-task"]
@@ -125,6 +129,9 @@ depends_on = ["_install-ui"]
 channels = ["pyviz/label/dev", "rapidsai", "conda-forge"]
 platforms = ["linux-64"]
 
+[feature.test-gpu.activation.env]
+NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS = "0"
+
 [feature.test-gpu.dependencies]
 cuda-version = "12.2.*"
 cudf = "24.04.*"
@@ -133,7 +140,7 @@ cuspatial = "*"
 rmm = { version = "*", channel = "rapidsai" }
 
 [feature.test-gpu.tasks]
-test-gpu = { cmd = "pytest holoviews/tests --gpu", env = { NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS = '0' } }
+test-gpu = "pytest holoviews/tests --gpu"
 
 [feature.numpy2]
 channels = ["pyviz/label/dev", "conda-forge/label/numpy_rc", "numba/label/dev", "conda-forge"]
@@ -177,6 +184,13 @@ nbsite = ">=0.8.4,<0.9.0"
 pooch = "*"
 python-kaleido = "*"
 selenium = "*"
+
+[feature.doc.activation.env]
+MOZ_HEADLESS = "1"
+MPLBACKEND = "Agg"
+PANEL_EMBED = "true"
+PANEL_EMBED_JSON = "true"
+PANEL_EMBED_JSON_PREFIX = "json"
 
 [feature.doc.tasks]
 _docs-generate-rst = 'nbsite generate-rst --org holoviz --project-name holoviews'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,6 @@ ignore = [
     "RUF005", # Consider {expr} instead of concatenation
     "RUF012", # Mutable class attributes should use `typing.ClassVar`
 ]
-
 extend-unsafe-fixes = [
     "F401", # Unused imports
     "F841", # Unused variables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,8 @@ ignore = [
     "RUF005", # Consider {expr} instead of concatenation
     "RUF012", # Mutable class attributes should use `typing.ClassVar`
 ]
-unfixable = [
+
+extend-unsafe-fixes = [
     "F401", # Unused imports
     "F841", # Unused variables
 ]


### PR DESCRIPTION
It seems better to set the environment variables in `pixi.toml` so that the local run mimics CI more. 


Also _sneaking_ in some other changes:
- Remove commented out dash
- Move custom unfixable to unsafe fixes. The main point still stands: I don't want formatters to automatically remove unused variables and imports. Could set pre-commit to unsafe fixes at some point. 