### PR TITLE
fix vectorfield hover

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -323,12 +323,15 @@ class VectorFieldPlot(ColorbarPlot):
             'x1': x1s,
             'y0': y0s,
             'y1': y1s,
-            # tile to match the length of the segments
-            "x": np.tile(xs, 3),
-            "y": np.tile(ys, 3),
-            "Angle": np.tile(rads, 3),
-            "Magnitude": np.tile(lens, 3)
         }
+        if 'hover' in self.handles:
+            data.update({
+                # tile to match the length of the segments
+                "x": np.tile(xs, 3),
+                "y": np.tile(ys, 3),
+                "Angle": np.tile(rads, 3),
+                "Magnitude": np.tile(lens, 3)
+            })
         mapping = dict(x0='x0', x1='x1', y0='y0', y1='y1')
         if cdim and color is not None:
             data[cdim.name] = color

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -318,14 +318,24 @@ class VectorFieldPlot(ColorbarPlot):
         elif cdim:
             color = cdata.get(cdim.name)
 
-        data = {'x0': x0s, 'x1': x1s, 'y0': y0s, 'y1': y1s}
+        data = {
+            'x0': x0s,
+            'x1': x1s,
+            'y0': y0s,
+            'y1': y1s,
+            # tile to match the length of the segments
+            "x": np.tile(xs, 3),
+            "y": np.tile(ys, 3),
+            "Angle": np.tile(rads, 3),
+            "Magnitude": np.tile(lens, 3)
+        }
         mapping = dict(x0='x0', x1='x1', y0='y0', y1='y1')
         if cdim and color is not None:
             data[cdim.name] = color
             mapping.update(cmapping)
 
+        print(data, mapping)
         return (data, mapping, style)
-
 
 
 class CurvePlot(ElementPlot):

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -334,7 +334,6 @@ class VectorFieldPlot(ColorbarPlot):
             data[cdim.name] = color
             mapping.update(cmapping)
 
-        print(data, mapping)
         return (data, mapping, style)
 
 

--- a/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
@@ -95,6 +95,6 @@ class TestVectorFieldPlot(TestBokehPlot):
         vectorfield = VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(tools=["hover"])
         plot = bokeh_renderer.get_plot(vectorfield)
-        keys = plot.handles["cds"].data.keys()
+        keys = sorted(plot.handles["cds"].data)
         assert len(keys) == 8
         assert keys == ["Angle", "Magnitude", "x", "x0", "x1", "y", "y0", "y1"]

--- a/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
@@ -83,3 +83,29 @@ class TestVectorFieldPlot(TestBokehPlot):
             "for 'line_color' option and declare a color_index; ignoring the color_index.\n"
         )
         self.assertEqual(log_msg, warning)
+
+    def test_vectorfield_no_hover_columns(self):
+        vectorfield = VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+                        vdims='color').opts(tools=[])
+        plot = bokeh_renderer.get_plot(vectorfield)
+        keys = plot.handles["cds"].data.keys()
+        assert len(keys) == 4
+        assert "x0" in keys
+        assert "y0" in keys
+        assert "x1" in keys
+        assert "y1" in keys
+
+    def test_vectorfield_hover_columns(self):
+        vectorfield = VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+                        vdims='color').opts(tools=["hover"])
+        plot = bokeh_renderer.get_plot(vectorfield)
+        keys = plot.handles["cds"].data.keys()
+        assert len(keys) == 8
+        assert "x0" in keys
+        assert "y0" in keys
+        assert "x1" in keys
+        assert "y1" in keys
+        assert "x" in keys
+        assert "y" in keys
+        assert "Angle" in keys
+        assert "Magnitude" in keys

--- a/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
@@ -96,5 +96,4 @@ class TestVectorFieldPlot(TestBokehPlot):
                         vdims='color').opts(tools=["hover"])
         plot = bokeh_renderer.get_plot(vectorfield)
         keys = sorted(plot.handles["cds"].data)
-        assert len(keys) == 8
         assert keys == ["Angle", "Magnitude", "x", "x0", "x1", "y", "y0", "y1"]

--- a/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
@@ -97,11 +97,4 @@ class TestVectorFieldPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(vectorfield)
         keys = plot.handles["cds"].data.keys()
         assert len(keys) == 8
-        assert "x0" in keys
-        assert "y0" in keys
-        assert "x1" in keys
-        assert "y1" in keys
-        assert "x" in keys
-        assert "y" in keys
-        assert "Angle" in keys
-        assert "Magnitude" in keys
+        assert keys == ["Angle", "Magnitude", "x", "x0", "x1", "y", "y0", "y1"]

--- a/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
@@ -88,12 +88,8 @@ class TestVectorFieldPlot(TestBokehPlot):
         vectorfield = VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(tools=[])
         plot = bokeh_renderer.get_plot(vectorfield)
-        keys = plot.handles["cds"].data.keys()
-        assert len(keys) == 4
-        assert "x0" in keys
-        assert "y0" in keys
-        assert "x1" in keys
-        assert "y1" in keys
+        keys = sorted(plot.handles["cds"].data)
+        assert keys == ["x0", "x1", "y0", "y1"]
 
     def test_vectorfield_hover_columns(self):
         vectorfield = VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],


### PR DESCRIPTION
```
import numpy as np
import holoviews as hv

hv.extension("bokeh")

hv.VectorField(
    ([-1, 0, 1, 2, 3], [-1, 0, 1, 2, 3], np.deg2rad([0, 45, 90, 180, 360]))
).opts(tools=["hover"])
```
Not sure there's a better solution, but I think it's better than no solution because hover is useful:

<img width="470" alt="image" src="https://github.com/holoviz/holoviews/assets/15331990/422b3127-a766-465c-a058-1fa443a46ad5">

Closes https://github.com/holoviz/holoviews/issues/3785