### PR TITLE
Add support to define custom tooltip on LinkedStream

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1260,9 +1260,10 @@ class LinkedStream(Stream):
     supplying stream data.
     """
 
-    def __init__(self, linked=True, popup=None, **params):
+    def __init__(self, linked=True, popup=None, tooltip=None, **params):
         super().__init__(linked=linked, **params)
         self.popup = popup
+        self.tooltip = tooltip
 
 
 class PointerX(LinkedStream):


### PR DESCRIPTION
Extends the work on allowing custom popups on LinkedStream to also add support for adding custom tooltips.

- [ ] Fix bokeh issue preventing `Tooltip.content` from being updated.
- [ ] Add docs
- [ ] Add tests