### PR TITLE
Add support for subcoordinate_group drawn from NdOverlay dimensions

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1839,13 +1839,13 @@ class GenericOverlayPlot(GenericElementPlot):
                                 "in the Overlay.")
         return subplots
 
-    def _create_subplot(self, key, obj, streams, ranges):
+    def _create_subplot(self, key, obj, streams, ranges, **kwargs):
         registry = Store.registry[self.renderer.backend]
         ordering = util.layer_sort(self.hmap)
         overlay_type = 1 if self.hmap.type == Overlay else 2
         group_fn = lambda x: (x.type.__name__, x.last.group, x.last.label)
 
-        opts = {'overlaid': overlay_type}
+        opts = dict(kwargs, overlaid=overlay_type)
         if self.hmap.type == Overlay:
             style_key = (obj.type.__name__,) + key
             if self.overlay_dims:


### PR DESCRIPTION
Instead of drawing the subcoordinate grouping from the `Element.group` you can now specify a multi-dimensional NdOverlay and draw the group from one of the dimensions, e.g.:

```python
import numpy as np
import holoviews as hv

hv.extension('bokeh')

data = {
    ('EEG', f'EEG {i}'): hv.Curve(
        np.random.randn(100).cumsum()+i
    ).opts(subcoordinate_y=True)
    for i in range(3)
}
data.update({
    ('MEG', f'MEG {i}'): hv.Curve(
        -np.random.randn(100).cumsum()+i
    ).opts(subcoordinate_y=True)
    for i in range(3)
})

hv.NdOverlay(data, ['Group', 'Channel']).opts(
    responsive=True, height=400, subcoordinate_group='Group'
)

```

<img width="943" alt="Screenshot 2024-06-07 at 17 38 52" src="https://github.com/holoviz/holoviews/assets/1550771/2c7ad160-81c0-4924-8c94-aeb3b5a668d1">
