### PR TITLE
Ensure downsample works with non-contiguous arrays

### DIFF
--- a/holoviews/operation/downsample.py
+++ b/holoviews/operation/downsample.py
@@ -100,6 +100,13 @@ def _lttb_inner(x, y, n_out, sampled_x, offset):
     )
 
 
+def _ensure_contiguous(x, y):
+    """
+    Ensures the arrays are contiguous in memory (required by tsdownsample).
+    """
+    return np.ascontiguousarray(x), np.ascontiguousarray(y)
+
+
 def _lttb(x, y, n_out, **kwargs):
     """
     Downsample the data using the LTTB algorithm.
@@ -115,6 +122,7 @@ def _lttb(x, y, n_out, **kwargs):
     """
     try:
         from tsdownsample import LTTBDownsampler
+        x, y = _ensure_contiguous(x, y)
         return LTTBDownsampler().downsample(x, y, n_out=n_out, **kwargs)
     except ModuleNotFoundError:
         pass
@@ -168,6 +176,7 @@ def _min_max(x, y, n_out, **kwargs):
             'The min-max downsampling algorithm requires the tsdownsample '
             'library to be installed.'
         ) from None
+    x, y = _ensure_contiguous(x, y)
     return MinMaxDownsampler().downsample(x, y, n_out=n_out, **kwargs)
 
 def _min_max_lttb(x, y, n_out, **kwargs):
@@ -178,6 +187,7 @@ def _min_max_lttb(x, y, n_out, **kwargs):
             'The minmax-lttb downsampling algorithm requires the tsdownsample '
             'library to be installed.'
         ) from None
+    x, y = _ensure_contiguous(x, y)
     return MinMaxLTTBDownsampler().downsample(x, y, n_out=n_out, **kwargs)
 
 def _m4(x, y, n_out, **kwargs):
@@ -188,6 +198,7 @@ def _m4(x, y, n_out, **kwargs):
             'The m4 downsampling algorithm requires the tsdownsample '
             'library to be installed.'
         ) from None
+    x, y = _ensure_contiguous(x, y)
     n_out = n_out - (n_out % 4)  # n_out must be a multiple of 4
     return M4Downsampler().downsample(x, y, n_out=n_out, **kwargs)
 
@@ -256,7 +267,7 @@ class downsample1d(ResampleOperation1D):
 
         if len(element) <= self.p.width:
             return element
-        xs, ys = (np.ascontiguousarray(element.dimension_values(i)) for i in range(2))
+        xs, ys = (element.dimension_values(i) for i in range(2))
         if ys.dtype == np.bool_:
             ys = ys.astype(np.int8)
         downsample = _ALGORITHMS[self.p.algorithm]

--- a/holoviews/operation/downsample.py
+++ b/holoviews/operation/downsample.py
@@ -256,8 +256,7 @@ class downsample1d(ResampleOperation1D):
 
         if len(element) <= self.p.width:
             return element
-        xs, ys = (element.dimension_values(i) for i in range(2))
-        ys = np.ascontiguousarray(ys)
+        xs, ys = (np.ascontiguousarray(element.dimension_values(i)) for i in range(2))
         if ys.dtype == np.bool_:
             ys = ys.astype(np.int8)
         downsample = _ALGORITHMS[self.p.algorithm]

--- a/holoviews/operation/downsample.py
+++ b/holoviews/operation/downsample.py
@@ -257,6 +257,7 @@ class downsample1d(ResampleOperation1D):
         if len(element) <= self.p.width:
             return element
         xs, ys = (element.dimension_values(i) for i in range(2))
+        ys = np.ascontiguousarray(ys)
         if ys.dtype == np.bool_:
             ys = ys.astype(np.int8)
         downsample = _ALGORITHMS[self.p.algorithm]

--- a/holoviews/tests/operation/test_downsample.py
+++ b/holoviews/tests/operation/test_downsample.py
@@ -31,14 +31,14 @@ def test_downsample1d_multi(plottype):
             assert value.size == downsample1d.width
 
 
-def test_downsample1d_non_contiguous():
-    x = np.arange(10)
-    y = np.arange(20).reshape(1, 20)[0, ::2]
+@pytest.mark.skipif(not tsdownsample, reason="tsdownsample not installed")
+@pytest.mark.parametrize("algorithm", algorithms)
+def test_downsample1d_non_contiguous(algorithm):
+    x = np.arange(20)
+    y = np.arange(40).reshape(1, 40)[0, ::2]
 
-    downsampled = downsample1d(Curve((x, y), datatype=['array']), dynamic=False, width=5)
-
-    np.testing.assert_equal(downsampled['x'], np.array([0, 1, 3, 6, 9]))
-    np.testing.assert_equal(downsampled['y'], np.array([ 0,  2,  6, 12, 18]))
+    downsampled = downsample1d(Curve((x, y), datatype=['array']), dynamic=False, width=10, algorithm=algorithm)
+    assert len(downsampled)
 
 
 def test_downsample1d_shared_data():


### PR DESCRIPTION
Many of the downsampling algorithms do not work with non-contiguous arrays. Therefore we ensure they are contiguous before passing them to the downsampling operation.