### PR TITLE
Disable batching when subcoordinate_y is enabled

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2113,7 +2113,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self.handles['xaxis'], self.handles['yaxis'] = axes
             self.handles['x_range'], self.handles['y_range'] = plot_ranges
             if self._subcoord_overlaid:
-
                 if style_element.label in plot.extra_y_ranges:
                     self.handles['subcoordinate_y_range'] = plot.y_range
                     self.handles['y_range'] = plot.extra_y_ranges.pop(style_element.label)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2113,6 +2113,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self.handles['xaxis'], self.handles['yaxis'] = axes
             self.handles['x_range'], self.handles['y_range'] = plot_ranges
             if self._subcoord_overlaid:
+
                 if style_element.label in plot.extra_y_ranges:
                     self.handles['subcoordinate_y_range'] = plot.y_range
                     self.handles['y_range'] = plot.extra_y_ranges.pop(style_element.label)
@@ -3003,6 +3004,10 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             if not isinstance(v._y_range_type, Range1d):
                 return v._y_range_type
         return self._y_range_type
+
+    @property
+    def _is_batched(self):
+        return super()._is_batched and not self.subcoordinate_y
 
     def _process_legend(self, overlay):
         plot = self.handles['plot']

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1797,10 +1797,14 @@ class GenericOverlayPlot(GenericElementPlot):
             collapsed = Compositor.collapse(holomap, (ranges, frame_ranges.keys()), mode='display')
         return collapsed
 
+    @property
+    def _is_batched(self):
+        return self.batched and type(self.hmap.last) is NdOverlay
+
     def _create_subplots(self, ranges):
         # Check if plot should be batched
         ordering = util.layer_sort(self.hmap)
-        batched = self.batched and type(self.hmap.last) is NdOverlay
+        batched = self._is_batched
         if batched:
             backend = self.renderer.backend
             batchedplot = Store.registry[backend].get(self.hmap.last.type)

--- a/holoviews/tests/core/test_layers.py
+++ b/holoviews/tests/core/test_layers.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from holoviews import Element, NdOverlay
+from holoviews import Curve, Element, NdOverlay, Overlay
 
 
 class CompositeTest(unittest.TestCase):
@@ -28,6 +28,12 @@ class OverlayTest(CompositeTest):
         overlay = NdOverlay(list(enumerate(views)))
         for el, v in zip(overlay, views):
             self.assertEqual(el, v)
+
+    def test_overlay_iterable(self):
+        # Related to https://github.com/holoviz/holoviews/issues/5315
+        c1 = Curve([0, 1])
+        c2 = Curve([10, 20])
+        Overlay({'a': c1, 'b': c2}.values())
 
     def test_overlay_integer_indexing(self):
         overlay = NdOverlay(list(enumerate([self.view1, self.view2, self.view3])))

--- a/holoviews/tests/plotting/bokeh/test_overlayplot.py
+++ b/holoviews/tests/plotting/bokeh/test_overlayplot.py
@@ -278,11 +278,15 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):
         _, vline_plot = plot.subplots.values()
         assert vline_plot.handles['glyph'].location == 1
 
-    def test_overlay_iterable(self):
-        # Related to https://github.com/holoviz/holoviews/issues/5315
-        c1 = Curve([0, 1])
-        c2 = Curve([10, 20])
-        Overlay({'a': c1, 'b': c2}.values())
+    def test_ndoverlay_subcoordinate_y_no_batching(self):
+        overlay = NdOverlay({
+            i: Curve(np.arange(10)*i).opts(subcoordinate_y=True) for i in range(10)
+        }).opts(legend_limit=1)
+        plot = bokeh_renderer.get_plot(overlay)
+
+        assert plot.batched == False
+        assert len(plot.subplots) == 10
+
 
 
 class TestLegends(TestBokehPlot):


### PR DESCRIPTION
Batching kicks in when you are plotting more than `legend_limit` elements inside an `NdOverlay`. However for a `subcoordinate_y` plot batching is not and cannot be supported since each element has to be plotted using a different renderer instance. Therefore we check if `subcoordinate_y` is enabled before enabling batching.