### PR TITLE
Fix issue with range lookups in (y)-axis creation

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -721,7 +721,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         elif pos == 1 and dim:
             dims = [dim]
             v0, v1 = util.max_range([
-                elrange.get(dim.name, {'combined': (None, None)})['combined']
+                elrange.get(dim.label, {'combined': (None, None)})['combined']
                 for elrange in ranges.values()
             ])
             axis_label = str(dim)
@@ -843,7 +843,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if self._subcoord_overlaid:
                 if opts.get('subcoordinate_y') is None:
                     continue
-                if element.kdims:
+                if sp.overlay_dims:
                     ax_name = ', '.join(d.pprint_value(k) for d, k in zip(element.kdims, sp_key))
                 else:
                     ax_name = el.label

--- a/holoviews/tests/plotting/bokeh/test_overlayplot.py
+++ b/holoviews/tests/plotting/bokeh/test_overlayplot.py
@@ -287,6 +287,45 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):
         assert plot.batched == False
         assert len(plot.subplots) == 10
 
+    def test_ndoverlay_subcoordinate_y_ranges(self):
+        data = {
+            'x': np.arange(10),
+            'A': np.arange(10),
+            'B': np.arange(10)*2,
+            'C': np.arange(10)*3
+        }
+        overlay = NdOverlay({
+            'A': Curve(data, 'x', ('A', 'y')).opts(subcoordinate_y=True),
+            'B': Curve(data, 'x', ('B', 'y')).opts(subcoordinate_y=True),
+            'C': Curve(data, 'x', ('C', 'y')).opts(subcoordinate_y=True),
+        })
+        plot = bokeh_renderer.get_plot(overlay)
+
+        assert plot.state.y_range.start == -0.5
+        assert plot.state.y_range.end == 2.5
+        for sp in plot.subplots.values():
+            assert sp.handles['y_range'].start == 0
+            assert sp.handles['y_range'].end == 27
+
+    def test_overlay_subcoordinate_y_ranges(self):
+        data = {
+            'x': np.arange(10),
+            'A': np.arange(10),
+            'B': np.arange(10)*2,
+            'C': np.arange(10)*3
+        }
+        overlay = Overlay([
+            Curve(data, 'x', ('A', 'y'), label='A').opts(subcoordinate_y=True),
+            Curve(data, 'x', ('B', 'y'), label='B').opts(subcoordinate_y=True),
+            Curve(data, 'x', ('C', 'y'), label='C').opts(subcoordinate_y=True),
+        ])
+        plot = bokeh_renderer.get_plot(overlay)
+
+        assert plot.state.y_range.start == -0.5
+        assert plot.state.y_range.end == 2.5
+        for sp in plot.subplots.values():
+            assert sp.handles['y_range'].start == 0
+            assert sp.handles['y_range'].end == 27
 
 
 class TestLegends(TestBokehPlot):


### PR DESCRIPTION
An issue introduced by https://github.com/holoviz/holoviews/pull/6262 where the dimension was not correctly looked up.

Also makes a change to more robustly look up overlay dimensions on subplots (sorry for sneaking that in here).