### PR TITLE
Correctly handle y/xaxis=True/False/None

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -943,11 +943,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     if axis_label and axis in self.labelled:
                         properties[f'{axis}_axis_label'] = axis_label
                     locs = {'left': 'left', 'right': 'right'} if axis == 'y' else {'bottom': 'below', 'top': 'above'}
-                    if axis_position is None:
+                    if axis_position in (None, False):
                         axis_props[axis]['visible'] = False
                     axis_props[axis].update(fontsize)
                     for loc, pos in locs.items():
-                        if axis_position and loc in axis_position:
+                        if isinstance(axis_position, str) and loc in axis_position:
                             properties[f'{axis}_axis_location'] = pos
 
         if not self.show_frame:

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -111,6 +111,26 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(xaxis.major_tick_line_color, None)
         self.assertTrue(xaxis in plot.state.above)
 
+    def test_element_yaxis_true(self):
+        curve = Curve(range(10)).opts(yaxis=True)
+        plot = bokeh_renderer.get_plot(curve)
+        yaxis = plot.handles['yaxis']
+        assert yaxis in plot.state.left
+
+    def test_element_yaxis_false(self):
+        curve = Curve(range(10)).opts(yaxis=False)
+        plot = bokeh_renderer.get_plot(curve)
+        yaxis = plot.handles['yaxis']
+        assert yaxis in plot.state.left
+        assert not yaxis.visible
+
+    def test_element_yaxis_none(self):
+        curve = Curve(range(10)).opts(yaxis=None)
+        plot = bokeh_renderer.get_plot(curve)
+        yaxis = plot.handles['yaxis']
+        assert yaxis in plot.state.left
+        assert not yaxis.visible
+
     def test_element_yaxis_right(self):
         curve = Curve(range(10)).opts(yaxis='right')
         plot = bokeh_renderer.get_plot(curve)


### PR DESCRIPTION
Handling of `{y|x}axis=True/False/None` wasn't correct due to a missing check for string types in the positioning logic.