### PR TITLE
Update ruff to 0.5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: check-json
       - id: detect-private-key
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.10
+    rev: v0.5.0
     hooks:
       - id: ruff
         files: holoviews/|scripts/

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -129,11 +129,11 @@ class annotate(param.ParameterizedFunction):
 
         layers = []
         annotator_type = None
-        for element in overlay:
+        for el in overlay:
             matches = []
             for eltype, atype in self._annotator_types.items():
-                if isinstance(element, eltype):
-                    matches.append((getmro(type(element)).index(eltype), atype))
+                if isinstance(el, eltype):
+                    matches.append((getmro(type(el)).index(eltype), atype))
             if matches:
                 if annotator_type is not None:
                     msg = ('An annotate call may only annotate a single element. '
@@ -142,12 +142,12 @@ class annotate(param.ParameterizedFunction):
                            'method to combine them into a single layout.')
                     raise ValueError(msg)
                 annotator_type = sorted(matches)[0][1]
-                self.annotator = annotator_type(element, **params)
+                self.annotator = annotator_type(el, **params)
                 tables = Overlay([t[0].object for t in self.annotator.editor], group='Annotator')
                 layout = (self.annotator.plot + tables)
                 layers.append(layout)
             else:
-                layers.append(element)
+                layers.append(el)
 
         if annotator_type is None:
             obj = overlay if isinstance(overlay, Overlay) else element

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -518,7 +518,7 @@ class Opts(metaclass=AccessorPipelineMeta):
         keywords = {}
         groups = Options._option_groups if group is None else [group]
         backend = backend if backend else Store.current_backend
-        for group in groups:
+        for group in groups:  # noqa: PLR1704
             optsobj = Store.lookup_options(backend, self._obj, group,
                                            defaults=defaults)
             keywords = dict(keywords, **optsobj.kwargs)

--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -735,11 +735,11 @@ def to_spatialpandas(data, xdim, ydim, columns=None, geom='point'):
 
     array_type = None
     hole_arrays, geom_arrays = [], []
-    for geom in data:
-        geom = dict(geom)
-        if xdim not in geom or ydim not in geom:
+    for geom_data in data:
+        geom_data = dict(geom_data)
+        if xdim not in geom_data or ydim not in geom_data:
             raise ValueError('Could not find geometry dimensions')
-        xs, ys = geom.pop(xdim), geom.pop(ydim)
+        xs, ys = geom_data.pop(xdim), geom_data.pop(ydim)
         xscalar, yscalar = isscalar(xs), isscalar(ys)
         if xscalar and yscalar:
             xs, ys = np.array([xs]), np.array([ys])
@@ -754,7 +754,7 @@ def to_spatialpandas(data, xdim, ydim, columns=None, geom='point'):
 
         splits = np.where(np.isnan(geom_array[:, :2].astype('float')).sum(axis=1))[0]
         split_geoms = np.split(geom_array, splits+1) if len(splits) else [geom_array]
-        split_holes = geom.pop(Polygons._hole_key, None)
+        split_holes = geom_data.pop(Polygons._hole_key, None)
         if split_holes is not None:
             if len(split_holes) != len(split_geoms):
                 raise DataError('Polygons with holes containing multi-geometries '
@@ -776,7 +776,7 @@ def to_spatialpandas(data, xdim, ydim, columns=None, geom='point'):
             array_type = single_array
 
     converted = defaultdict(list)
-    for geom, arrays, holes in zip(data, geom_arrays, hole_arrays):
+    for geom_data, arrays, holes in zip(data, geom_arrays, hole_arrays):
         parts = []
         for i, g in enumerate(arrays):
             if i != (len(arrays)-1):
@@ -792,7 +792,7 @@ def to_spatialpandas(data, xdim, ydim, columns=None, geom='point'):
             if poly and holes is not None:
                 subparts += [np.array(h) for h in holes[i]]
 
-        for c, v in geom.items():
+        for c, v in geom_data.items():
             converted[c].append(v)
 
         if array_type is PointArray:

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1418,9 +1418,9 @@ class Store:
         class_hierarchy = inspect.getmro(type(obj))
         hooks = []
         for _, type_hooks in cls._display_hooks.items():
-            for cls in class_hierarchy:
-                if cls in type_hooks:
-                    hooks.append(type_hooks[cls])
+            for subcls in class_hierarchy:
+                if subcls in type_hooks:
+                    hooks.append(type_hooks[subcls])
                     break
 
         data, metadata = {}, {}
@@ -1600,9 +1600,9 @@ class StoreOptions:
                 error_info[error_key+(backend,)] = error.allowed_keywords
                 backend_errors[error_key].add(backend)
 
-        for ((keyword, target, group_name), backends) in backend_errors.items():
+        for ((keyword, target, group_name), backend_error) in backend_errors.items():
             # If the keyword failed for the target across all loaded backends...
-            if set(backends) == set(loaded_backends):
+            if set(backend_error) == set(loaded_backends):
                 key = (keyword, target, group_name, Store.current_backend)
                 raise OptionError(keyword,
                                   group_name=group_name,

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -308,7 +308,7 @@ class PrettyPrinter(param.Parameterized):
         level, lines = cls_or_slf.node_info(node, attrpath, attrpaths, siblings, level, value_dims)
         attrpaths = ['.'.join(k) for k in node.keys()] if  hasattr(node, 'children') else []
         siblings = [node.get(child) for child in attrpaths]
-        for attrpath in attrpaths:
+        for attrpath in attrpaths:  # noqa: PLR1704
             lines += cls_or_slf.recurse(node.get(attrpath), attrpath, attrpaths=attrpaths,
                                  siblings=siblings, level=level+1, value_dims=value_dims)
         return lines

--- a/holoviews/ipython/archive.py
+++ b/holoviews/ipython/archive.py
@@ -44,9 +44,6 @@ class NotebookArchive(FileArchive):
         Similar to FileArchive.filename_formatter except with support
         for the notebook name field as {notebook}.""")
 
-
-    auto = param.Boolean(False)
-
     # Used for debugging to view Exceptions raised from Javascript
     traceback = None
 

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -176,7 +176,7 @@ class OptsCompleter:
         for i, token in enumerate(tokens):
             key_checks =[]
             if i >= 0:  # Undotted key
-                key_checks.append(tokens[i])
+                key_checks.append(token)
             if i >= 1:  # Single dotted key
                 key_checks.append('.'.join([key_checks[-1], tokens[i-1]]))
             if i >= 2:  # Double dotted key
@@ -279,11 +279,11 @@ class OptsMagic(Magics):
         """
         if cell is None: return (line, cell)
         specs, code = [line], []
-        for line in cell.splitlines():
-            if line.strip().startswith('%%opts'):
-                specs.append(line.strip()[7:])
+        for cell_line in cell.splitlines():
+            if cell_line.strip().startswith('%%opts'):
+                specs.append(cell_line.strip()[7:])
             else:
-                code.append(line)
+                code.append(cell_line)
         return ' '.join(specs), '\n'.join(code)
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1175,11 +1175,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if wheel_zoom:
                 wheel_zoom[0].zoom_on_axis = False
         elif isinstance(axis_obj, CategoricalAxis):
-            for key in list(axis_props):
-                if key.startswith('major_label'):
+            for axis_prop in list(axis_props):
+                if axis_prop.startswith('major_label'):
                     # set the group labels equal to major (actually minor)
-                    new_key = key.replace('major_label', 'group')
-                    axis_props[new_key] = axis_props[key]
+                    new_axis_prop = axis_prop.replace('major_label', 'group')
+                    axis_props[new_axis_prop] = axis_props[axis_prop]
 
             # major ticks are actually minor ticks in a categorical
             # so if user inputs minor ticks sizes, then use that;
@@ -1846,7 +1846,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             new_style[k] = key
 
         # Process color/alpha styles and expand to fill/line style
-        for style, val in list(new_style.items()):
+        for style, val in new_style.items():  # noqa: PLR1704
             for s in ('alpha', 'color'):
                 if prefix+s != style or style not in data or validate(s, val, True):
                     continue

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1846,7 +1846,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             new_style[k] = key
 
         # Process color/alpha styles and expand to fill/line style
-        for style, val in new_style.items():  # noqa: PLR1704
+        for style, val in new_style.copy().items():  # noqa: PLR1704
             for s in ('alpha', 'color'):
                 if prefix+s != style or style not in data or validate(s, val, True):
                     continue

--- a/holoviews/plotting/bokeh/links.py
+++ b/holoviews/plotting/bokeh/links.py
@@ -124,14 +124,14 @@ class LinkCallback:
                 if not plot._sources_match(link_src, source):
                     continue
                 links = []
-                for link in src_links:
+                for src_link in src_links:
                     # Skip if Link.target is an overlay but the plot isn't
                     # or if the target is an element but the plot isn't
-                    src = getattr(link, attr)
+                    src = getattr(src_link, attr)
                     src_el = src.last if isinstance(src, HoloMap) else src
                     if not plot._matching_plot_type(src_el):
                         continue
-                    links.append(link)
+                    links.append(src_link)
                 if links:
                     return (plot, links)
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -552,7 +552,7 @@ class DimensionedPlot(Plot):
         if unknown_keys:
             msg = "Popping unknown keys %r from fontsize dictionary.\nValid keys: %r"
             self.param.warning(msg %  (list(unknown_keys), self._fontsize_keys))
-            for key in unknown_keys: fontsize.pop(key, None)
+            for unknown_key in unknown_keys: fontsize.pop(unknown_key, None)
 
         defaults = self._get_fontsize_defaults()
         size = None
@@ -910,11 +910,11 @@ class DimensionedPlot(Plot):
         traversed = obj.traverse(lookup, specs)
         options = {}
         default_opts = defaultdict(lambda: defaultdict(list))
-        for key, opts in traversed:
-            defaults = opts.pop('defaults', {})
+        for key, topts in traversed:
+            defaults = topts.pop('defaults', {})
             if key not in options:
                 options[key] = {}
-            for opt, v in opts.items():
+            for opt, v in topts.items():
                 if opt not in options[key]:
                     options[key][opt] = []
                 options[key][opt].append(v)
@@ -922,8 +922,8 @@ class DimensionedPlot(Plot):
                 default_opts[key][opt].append(v)
 
         # Merge defaults into dictionary if not explicitly specified
-        for key, opts in default_opts.items():
-            for opt, v in opts.items():
+        for key, dopts in default_opts.items():
+            for opt, v in dopts.items():
                 if opt not in options[key]:
                     options[key][opt] = v
         return options if keyfn else options.get(None, {})


### PR DESCRIPTION
``` bash
❯ ruff check holoviews --output-format=concise --no-fix
holoviews/annotators.py:132:13: PLR1704 Redefining argument with the local name `element`
holoviews/core/accessors.py:521:13: PLR1704 Redefining argument with the local name `group`
holoviews/core/data/spatialpandas.py:738:9: PLR1704 Redefining argument with the local name `geom`
holoviews/core/options.py:1421:17: PLR1704 Redefining argument with the local name `cls`
holoviews/core/options.py:1603:45: PLR1704 Redefining argument with the local name `backends`
holoviews/core/pprint.py:311:13: PLR1704 Redefining argument with the local name `attrpath`
holoviews/ipython/archive.py:102:9: F811 Redefinition of unused `auto` from line 48
holoviews/ipython/magics.py:179:35: PLR1736 [*] List index lookup in `enumerate()` loop
holoviews/ipython/magics.py:282:13: PLR1704 Redefining argument with the local name `line`
holoviews/plotting/bokeh/element.py:1178:17: PLR1704 Redefining argument with the local name `key`
holoviews/plotting/bokeh/element.py:1849:13: PLR1704 Redefining argument with the local name `style`
holoviews/plotting/bokeh/links.py:127:21: PLR1704 Redefining argument with the local name `link`
holoviews/plotting/plot.py:555:17: PLR1704 Redefining argument with the local name `key`
holoviews/plotting/plot.py:913:18: PLR1704 Redefining argument with the local name `opts`
```