### PR TITLE
Ensure no auto index is created when a kdim is part of a multi index

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -1,3 +1,5 @@
+from itertools import chain
+
 import numpy as np
 import pandas as pd
 from packaging.version import Version
@@ -72,7 +74,7 @@ class PandasInterface(Interface, PandasAPI):
 
             if kdims and not (len(kdims) == len(index_names) and {dimension_name(kd) for kd in kdims} == set(index_names)):
                 kdim = dimension_name(kdims[0])
-                if eltype._auto_indexable_1d and ncols == 1 and kdim not in data.columns:
+                if eltype._auto_indexable_1d and ncols == 1 and kdim not in chain(data.columns, cls.indexes(data)):
                     data = data.copy()
                     data.insert(0, kdim, np.arange(len(data)))
 

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -1,5 +1,3 @@
-from itertools import chain
-
 import numpy as np
 import pandas as pd
 from packaging.version import Version
@@ -74,7 +72,7 @@ class PandasInterface(Interface, PandasAPI):
 
             if kdims and not (len(kdims) == len(index_names) and {dimension_name(kd) for kd in kdims} == set(index_names)):
                 kdim = dimension_name(kdims[0])
-                if eltype._auto_indexable_1d and ncols == 1 and kdim not in chain(data.columns, cls.indexes(data)):
+                if eltype._auto_indexable_1d and ncols == 1 and kdim not in [*data.columns, *cls.indexes(data)]:
                     data = data.copy()
                     data.insert(0, kdim, np.arange(len(data)))
 

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -391,3 +391,9 @@ class PandasInterfaceMultiIndex(HeterogeneousColumnTests, InterfaceTests):
         assert list(grouped.keys()) == [0, 1, 2, 3]
         for k, v in grouped.items():
             pd.testing.assert_frame_equal(v.data, ds.select(values=k).data)
+
+    def test_regression_no_auto_index(self):
+        # https://github.com/holoviz/holoviews/issues/6298
+
+        plot = Scatter(self.df, kdims="number")
+        np.testing.assert_equal(plot.dimension_values('number'), self.df.index.get_level_values('number'))


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/6298

<details><summary>Code</summary>
<p>

```python
import numpy as np
import pandas as pd
import holoviews as hv

hv.extension('bokeh')

dti = pd.date_range(start='1/1/2018', end='1/08/2018')

other = list(range(len(dti)))

t = pd.DataFrame(
    dict(
        n=range(5, len(dti) + 5),
        m=range(10, len(dti) + 10),
    )
)
dfm = pd.MultiIndex.from_frame(t)
df = pd.DataFrame(np.random.randn(len(dfm)), index=dfm, columns=['test'])
df.head()

p = hv.Curve(df, 'm', 'test')
p
```

</p>
</details> 

![image](https://github.com/holoviz/holoviews/assets/35924738/fd77affd-a694-43e8-928f-21220c13d387)
