### PR TITLE
Fix datashader example in 16-Streaming_Data.ipynb

### DIFF
--- a/examples/user_guide/16-Streaming_Data.ipynb
+++ b/examples/user_guide/16-Streaming_Data.ipynb
@@ -532,6 +532,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import datashader\n",
     "from holoviews.operation.datashader import datashade\n",
     "from bokeh.palettes import Blues8\n",
     "\n",


### PR DESCRIPTION
This change stops `from holoviews.operation.datashader import datashade` from erroring.

Also, it seems quite odd to me specify streams without `RangeXY` as that prevents datashader from rerendering the plot when zooming in. If that can't be made to work, I think this example should be removed.
https://github.com/holoviz/holoviews/blob/e5f7aede7a58902677eb995b8fd67c54ae9ae3ab/examples/user_guide/16-Streaming_Data.ipynb#L541