### PR TITLE
Freeze models while updating plot(s)

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -863,11 +863,13 @@ def hold_render(f):
     """
     def wrapper(self, *args, **kwargs):
         hold = self.state.hold_render
+        doc = self.state.document
         self.state.hold_render = True
-        try:
-            return f(self, *args, **kwargs)
-        finally:
-            self.state.hold_render = hold
+        with doc.models.freeze():
+            try:
+                return f(self, *args, **kwargs)
+            finally:
+                self.state.hold_render = hold
     return wrapper
 
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -865,7 +865,13 @@ def hold_render(f):
         hold = self.state.hold_render
         doc = self.state.document
         self.state.hold_render = True
-        with doc.models.freeze():
+        if doc:
+            with doc.models.freeze():
+                try:
+                    return f(self, *args, **kwargs)
+                finally:
+                    self.state.hold_render = hold
+        else:
             try:
                 return f(self, *args, **kwargs)
             finally:

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,6 +40,7 @@ plotly = ">=4.0"
 
 [feature.py39.dependencies]
 python = "3.9.*"
+ffmpeg = "<7"
 
 [feature.py310.dependencies]
 python = "3.10.*"


### PR DESCRIPTION
Uses the ability to freeze the Bokeh `Document` model graph while a plot is being updated to avoid needlessly recomputing the graph over and over. Results in about a 10% speed improvement during plot updates.