### PR TITLE
Improve following behavior when streaming

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1018,16 +1018,18 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         return fig
 
     def _disable_follow(self, event):
-        self._events.append(event)
-        self.state.hold_render = True
+        hold = self.state.hold_render
         for stream in self.streaming:
             stream.following = False
+        if not hold:
+            stream.trigger(self.streaming)
+            self.state.hold_render = True
 
     def _reset_follow(self, event):
-        self._events.append(event)
         self.state.hold_render = False
         for stream in self.streaming:
             stream.following = True
+        stream.trigger(self.streaming)
 
     def _plot_properties(self, key, element):
         """

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1483,6 +1483,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self._update_range(x_range, l, r, xfactors, self.invert_xaxis,
                                self._shared['x-main-range'], self.logx, streaming)
 
+        # If subcoordinate_y is enabled we iterate over each of the
+        # subcoordinate ranges and let the subplot handle the update
         if self.subcoordinate_y and yupdate and not subcoord:
             updated = set()
             for sp in (self.subplots or {}).values():
@@ -1494,7 +1496,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     sp.current_frame, sp.handles['x_range'], sp.handles['y_range'],
                     ranges, subcoord=True
                 )
-        elif (not (self.drawn or self.subcoordinate_y) or subcoord) and yupdate:
+        elif (not self.drawn or yupdate) and (not self.subcoordinate_y or subcoord):
             self._update_range(
                 y_range, b, t, yfactors, self._get_tag(y_range, 'invert_yaxis'),
                 self._shared['y-main-range'], self.logy, streaming

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1488,13 +1488,19 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if self.subcoordinate_y and yupdate and not subcoord:
             updated = set()
             for sp in (self.subplots or {}).values():
-                sp_range = sp.handles['y_range']
-                if sp_range.name in updated:
-                    continue
-                updated.add(sp_range.name)
+                if isinstance(sp, GenericOverlayPlot):
+                    subcoord = False
+                    el_ranges = ranges
+                else:
+                    sp_range = sp.handles.get('y_range')
+                    if not sp_range or sp_range.name in updated:
+                        continue
+                    el_ranges = util.match_spec(sp.current_frame, ranges)
+                    updated.add(sp_range.name)
+                    subcoord = True
                 sp._update_main_ranges(
                     sp.current_frame, sp.handles['x_range'], sp.handles['y_range'],
-                    ranges, subcoord=True
+                    el_ranges, subcoord=subcoord
                 )
         elif (not self.drawn or yupdate) and (not self.subcoordinate_y or subcoord):
             self._update_range(

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -177,11 +177,15 @@ class BokehPlot(DimensionedPlot, CallbackPlot):
         if (self.streaming and self.streaming[0].data is self.current_frame.data
             and self._stream_data and not empty):
             stream = self.streaming[0]
-            if stream._triggering and stream._count == ((self._stream_count or 0) + 1):
-                data = {k: v[-stream._chunk_length:] for k, v in data.items()}
-                source.stream(data, stream.length)
-                self._stream_count = stream._count
-            return
+            if stream._count == ((self._stream_count or 0) + 1):
+                if stream._triggering and stream.following:
+                    data = {k: v[-stream._chunk_length:] for k, v in data.items()}
+                    source.stream(data, stream.length)
+                    self._stream_count = stream._count
+                return
+            elif not stream.following:
+                return
+            self._stream_count = stream._count
 
         if cds_column_replace(source, data):
             source.data = data

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -177,9 +177,10 @@ class BokehPlot(DimensionedPlot, CallbackPlot):
         if (self.streaming and self.streaming[0].data is self.current_frame.data
             and self._stream_data and not empty):
             stream = self.streaming[0]
-            if stream._triggering:
+            if stream._triggering and stream._count == ((self._stream_count or 0) + 1):
                 data = {k: v[-stream._chunk_length:] for k, v in data.items()}
                 source.stream(data, stream.length)
+                self._stream_count = stream._count
             return
 
         if cds_column_replace(source, data):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -565,8 +565,6 @@ class Buffer(Pipe):
             data.stream.sink(self.send)
             self.sdf = data
 
-        if index and isinstance(example, pd.DataFrame):
-            example = example.reset_index()
         params['data'] = example
         super().__init__(**params)
         self.length = length
@@ -656,9 +654,6 @@ class Buffer(Pipe):
         """
         data = kwargs.get('data')
         if data is not None:
-            if (isinstance(data, pd.DataFrame) and
-                list(data.columns) != list(self.data.columns) and self._index):
-                data = data.reset_index()
             self.verify(data)
             kwargs['data'] = self._concat(data)
             self._count += 1

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -662,7 +662,7 @@ class Buffer(Pipe):
 
     @property
     def hashkey(self):
-        return {'hash': self._count}
+        return {'hash': (self._count, self._memoize_counter)}
 
 
 

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -938,7 +938,7 @@ class TestBufferDataFrameStream(ComparisonTestCase):
     def test_init_buffer_dframe_with_index(self):
         data = pd.DataFrame({'x': np.array([1]), 'y': np.array([2])})
         buff = Buffer(data)
-        self.assertEqual(buff.data, data.reset_index())
+        self.assertEqual(buff.data, data)
 
     def test_buffer_dframe_send(self):
         data = pd.DataFrame({'x': np.array([0]), 'y': np.array([1])})
@@ -952,7 +952,7 @@ class TestBufferDataFrameStream(ComparisonTestCase):
         buff = Buffer(data)
         buff.send(pd.DataFrame({'x': np.array([1]), 'y': np.array([2])}))
         dframe = pd.DataFrame({'x': np.array([0, 1]), 'y': np.array([1, 2])}, index=[0, 0])
-        self.assertEqual(buff.data.values, dframe.reset_index().values)
+        self.assertEqual(buff.data, dframe)
 
     def test_buffer_dframe_larger_than_length(self):
         data = pd.DataFrame({'x': np.array([0]), 'y': np.array([1])})
@@ -980,7 +980,7 @@ class TestBufferDataFrameStream(ComparisonTestCase):
         data = pd.DataFrame({'a': [1, 2, 3]})
         buff = Buffer(data)
         buff.clear()
-        self.assertEqual(buff.data, data.iloc[:0, :].reset_index())
+        self.assertEqual(buff.data, data.iloc[:0, :])
 
 
 class Sum(Derived):

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -952,7 +952,7 @@ class TestBufferDataFrameStream(ComparisonTestCase):
         buff = Buffer(data)
         buff.send(pd.DataFrame({'x': np.array([1]), 'y': np.array([2])}))
         dframe = pd.DataFrame({'x': np.array([0, 1]), 'y': np.array([1, 2])}, index=[0, 0])
-        self.assertEqual(buff.data, dframe)
+        pd.testing.assert_frame_equal(buff.data, dframe)
 
     def test_buffer_dframe_larger_than_length(self):
         data = pd.DataFrame({'x': np.array([0]), 'y': np.array([1])})
@@ -980,7 +980,7 @@ class TestBufferDataFrameStream(ComparisonTestCase):
         data = pd.DataFrame({'a': [1, 2, 3]})
         buff = Buffer(data)
         buff.clear()
-        self.assertEqual(buff.data, data.iloc[:0, :])
+        pd.testing.assert_frame_equal(buff.data, data.iloc[:0, :])
 
 
 class Sum(Derived):


### PR DESCRIPTION
- Automatically stops following when the user zooms in and starts following when the user resets
- Ensures that if the stream is out-of-sync with the plot the full data is synced

~~There still appears to be a race condition in bokeh where if a stream event arrives while the frontend is rendering it can cause "backtracking" glitches.~~

TODO:
- [x] Recompute range based on every new data point
- [x] Fix backtracking (fixed in Panel)

<details> <summary> Code </summary>

```python
import asyncio
import pandas as pd
import numpy as np

import holoviews as hv
hv.extension('bokeh')

nchannels = 25
buffer = hv.streams.Buffer(data=pd.DataFrame(np.random.randn(10, nchannels).cumsum(axis=1), columns=[chr(65+i) for i in range(nchannels)]))

def out(data):
    return hv.NdOverlay(
        {chr(65+i): hv.Curve(data, 'index', (chr(65+i), 'Amplitude')).opts(subcoordinate_y=True) for i in range(nchannels)}
    )

dmap = hv.DynamicMap(out, streams=[buffer]).opts(legend_position='right', legend_cols=2, responsive=True, min_height=600)

pane = pn.pane.HoloViews(dmap)

async def stream(event):
    for i in range(1, 1000):
        buffer.event(data=pd.DataFrame(np.random.randn(10, nchannels).cumsum(axis=1), columns=[chr(65+i) for i in range(nchannels)], index=np.arange(i*10, i*10+10)))
        await asyncio.sleep(0.01)

pn.Column(pn.widgets.Button(on_click=stream, name='Stream'), pane).servable()
```

</details>


![ezgif-3-bde2bf8b98](https://github.com/holoviz/holoviews/assets/1550771/e576fa6a-b84c-455b-b097-43ab6dcd9cf0)
