### PR TITLE
Wrap popup in set_curdoc

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -688,7 +688,8 @@ class PopupMixin:
                 break
 
         if callable(popup):
-            popup = popup(**stream.contents)
+            with set_curdoc(self.plot.document):
+                popup = popup(**stream.contents)
 
         # If no popup is defined, hide the panel
         if popup is None:


### PR DESCRIPTION
Per conversation in #6332 , this change wraps the popup call in a `set_curdoc` context so that the document inside the popup is valid. I am the original reporter of this issue and making the PR from my personal account.