### PR TITLE
Ensure CI version check only tests compatible versions

### DIFF
--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -6,6 +6,7 @@ HoloViews lets you focus on what you are trying to explore and convey, not on
 the process of plotting.
 
 HoloViews
+dummy
 
 - supports a wide range of data sources including Pandas, Dask, XArray
 Rapids cuDF, Streamz, Intake, Geopandas, NetworkX and Ibis.

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -6,7 +6,6 @@ HoloViews lets you focus on what you are trying to explore and convey, not on
 the process of plotting.
 
 HoloViews
-dummy
 
 - supports a wide range of data sources including Pandas, Dask, XArray
 Rapids cuDF, Streamz, Intake, Geopandas, NetworkX and Ibis.

--- a/scripts/check_latest_packages.py
+++ b/scripts/check_latest_packages.py
@@ -4,7 +4,10 @@ from datetime import date, datetime, timedelta
 from importlib.metadata import version
 
 import requests
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+
+PY_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 
 if sys.stdout.isatty() or os.environ.get("GITHUB_ACTIONS"):
     GREEN, RED, RESET = "\033[92m", "\033[91m", "\033[0m"
@@ -12,23 +15,55 @@ else:
     GREEN = RED = RESET = ""
 
 
+def compare_versions(version_str, constraint_str):
+    try:
+        # Convert version string to a Version object
+        version = Version(version_str)
+
+        # Convert constraint string to a SpecifierSet object
+        constraint = SpecifierSet(constraint_str)
+
+        # Check if the version satisfies the constraint
+        if version in constraint:
+            return True
+        else:
+            return False
+    except Exception as e:
+        return str(e)
+
+
 def main(*packages):
     allowed_date = date.today() - timedelta(days=5)
     all_latest = True
     for package in sorted(packages):
         url = f"https://pypi.org/pypi/{package}/json"
-        resp = requests.get(url, timeout=20).json()
-        latest = resp["info"]["version"]
-        current = version(package)
+        resp = requests.get(url, timeout=1).json()
 
-        # Remove suffix because older Python versions does not support it
-        latest_release_date = datetime.fromisoformat(
-            resp["releases"][latest][0]["upload_time_iso_8601"].removesuffix("Z")
-        ).date()
+        found = False
+        for vrelease, release in list(resp["releases"].items())[::-1]:
+            if Version(vrelease).is_devrelease or Version(vrelease).is_prerelease:
+                continue
+            for info in release:
+                if not compare_versions(PY_VERSION, info['requires_python']):
+                    continue
+
+                latest = vrelease
+
+                # Remove suffix because older Python versions does not support it
+                latest_release_date = datetime.fromisoformat(
+                    info["upload_time_iso_8601"].removesuffix("Z")
+                ).date()
+                found = True
+                break
+            if found:
+                break
+        else:
+            raise RuntimeError('Could not find matching version')
+
+        current = version(package)
         current_release_date = datetime.fromisoformat(
             resp["releases"][current][0]["upload_time_iso_8601"].removesuffix("Z")
         ).date()
-
         version_check = Version(current) >= Version(latest)
         date_check = latest_release_date >= allowed_date
         is_latest = version_check or date_check


### PR DESCRIPTION
Previously it was considering versions even if the Python version was not compatible.