### PR TITLE
Fixes popup being invisible forever after closing once

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -700,8 +700,8 @@ class PopupMixin:
 
         popup_pane = panel(popup)
         # offer the user ability to control when the popup bk panel shows up
-        # however, if the popup is not callable, we will have to assume
-        # it's always visible else if they make it invisible, it'll never re-appear
+        # however, if the popup is not callable (singleton), we cannot do this
+        # check--else, it'll never re-appear if they set `visible=False` once
         if popup_is_callable and not popup_pane.visible:
             return
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -687,9 +687,8 @@ class PopupMixin:
             if popup is not None:
                 break
 
-        popup_is_callable = False
-        if callable(popup):
-            popup_is_callable = True
+        popup_is_callable = callable(popup)
+        if popup_is_callable:
             with set_curdoc(self.plot.document):
                 popup = popup(**stream.contents)
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -609,23 +609,23 @@ class PopupMixin:
         }
         """],
         css_classes=["popup-close-btn"])
-        self._bk_panel = Panel(
+        self._panel = Panel(
             position=XY(x=np.nan, y=np.nan),
             anchor="top_left",
             elements=[close_button],
             visible=False,
             styles={"zIndex": "1000"},
         )
-        close_button.js_on_click(CustomJS(args=dict(panel=self._bk_panel), code="panel.visible = false"))
+        close_button.js_on_click(CustomJS(args=dict(panel=self._panel), code="panel.visible = false"))
 
-        self.plot.state.elements.append(self._bk_panel)
+        self.plot.state.elements.append(self._panel)
         self._watch_position()
 
     def _watch_position(self):
         geom_type = self.geom_type
         self.plot.state.on_event('selectiongeometry', self._update_selection_event)
         self.plot.state.js_on_event('selectiongeometry', CustomJS(
-            args=dict(panel=self._bk_panel),
+            args=dict(panel=self._panel),
             code=f"""
             export default ({{panel}}, cb_obj, _) => {{
               const el = panel.elements[1]
@@ -668,7 +668,7 @@ class PopupMixin:
 
     def on_msg(self, msg):
         super().on_msg(msg)
-        if hasattr(self, '_bk_panel'):
+        if hasattr(self, '_panel'):
             self._process_selection_event()
 
     def _process_selection_event(self):
@@ -695,8 +695,8 @@ class PopupMixin:
 
         # If no popup is defined, hide the bokeh panel wrapper
         if popup is None:
-            if self._bk_panel.visible:
-                self._bk_panel.visible = False
+            if self._panel.visible:
+                self._panel.visible = False
             return
 
         popup_pane = panel(popup)
@@ -707,7 +707,7 @@ class PopupMixin:
             return
 
         if not popup_pane.stylesheets:
-            self._bk_panel.stylesheets = [
+            self._panel.stylesheets = [
                 """
                 :host {
                     padding: 1em;
@@ -717,9 +717,9 @@ class PopupMixin:
                 """,
             ]
         else:
-            self._bk_panel.stylesheets = []
+            self._panel.stylesheets = []
 
-        self._bk_panel.visible = True
+        self._panel.visible = True
         # for existing popup, important to check if they're visible
         # otherwise, UnknownReferenceError: can't resolve reference 'p...'
         # meaning the popup has already been removed; we need to regenerate
@@ -727,14 +727,14 @@ class PopupMixin:
             self._existing_popup.visible = True
             position = self._get_position(event) if event else None
             if position:
-                self._bk_panel.position = XY(**position)
+                self._panel.position = XY(**position)
                 if self.plot.comm:  # update Jupyter Notebook
                     push_on_root(self.plot.root.ref['id'])
             return
 
         model = popup_pane.get_root(self.plot.document, self.plot.comm)
         model.js_on_change('visible', CustomJS(
-            args=dict(panel=self._bk_panel),
+            args=dict(panel=self._panel),
             code="""
             export default ({panel}, event, _) => {
               if (!event.visible) {
@@ -743,7 +743,7 @@ class PopupMixin:
             }""",
         ))
         # the first element is the close button
-        self._bk_panel.elements = [self._bk_panel.elements[0], model]
+        self._panel.elements = [self._panel.elements[0], model]
         if self.plot.comm:  # update Jupyter Notebook
             push_on_root(self.plot.root.ref['id'])
         self._existing_popup = popup_pane
@@ -1116,7 +1116,7 @@ class Selection1DCallback(PopupMixin, Callback):
         renderer = self.plot.handles['glyph_renderer']
         selected = self.plot.handles['selected']
         self.plot.state.js_on_event('selectiongeometry', CustomJS(
-            args=dict(panel=self._bk_panel, renderer=renderer, source=source, selected=selected),
+            args=dict(panel=self._panel, renderer=renderer, source=source, selected=selected),
             code="""
             export default ({panel, renderer, source, selected}, cb_obj, _) => {
               const el = panel.elements[1]

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -609,23 +609,23 @@ class PopupMixin:
         }
         """],
         css_classes=["popup-close-btn"])
-        self._panel = Panel(
+        self._bk_panel = Panel(
             position=XY(x=np.nan, y=np.nan),
             anchor="top_left",
             elements=[close_button],
             visible=False,
             styles={"zIndex": "1000"},
         )
-        close_button.js_on_click(CustomJS(args=dict(panel=self._panel), code="panel.visible = false"))
+        close_button.js_on_click(CustomJS(args=dict(panel=self._bk_panel), code="panel.visible = false"))
 
-        self.plot.state.elements.append(self._panel)
+        self.plot.state.elements.append(self._bk_panel)
         self._watch_position()
 
     def _watch_position(self):
         geom_type = self.geom_type
         self.plot.state.on_event('selectiongeometry', self._update_selection_event)
         self.plot.state.js_on_event('selectiongeometry', CustomJS(
-            args=dict(panel=self._panel),
+            args=dict(panel=self._bk_panel),
             code=f"""
             export default ({{panel}}, cb_obj, _) => {{
               const el = panel.elements[1]
@@ -668,7 +668,7 @@ class PopupMixin:
 
     def on_msg(self, msg):
         super().on_msg(msg)
-        if hasattr(self, '_panel'):
+        if hasattr(self, '_bk_panel'):
             self._process_selection_event()
 
     def _process_selection_event(self):
@@ -687,27 +687,27 @@ class PopupMixin:
             if popup is not None:
                 break
 
+        popup_is_callable = False
         if callable(popup):
+            popup_is_callable = True
             with set_curdoc(self.plot.document):
                 popup = popup(**stream.contents)
 
-        # If no popup is defined, hide the panel
+        # If no popup is defined, hide the bokeh panel wrapper
         if popup is None:
-            if self._panel.visible:
-                self._panel.visible = False
+            if self._bk_panel.visible:
+                self._bk_panel.visible = False
             return
 
-        if event is not None:
-            position = self._get_position(event)
-        else:
-            position = None
-
         popup_pane = panel(popup)
-        if not popup_pane.visible:
+        # offer the user ability to control when the popup bk panel shows up
+        # however, if the popup is not callable, we will have to assume
+        # it's always visible else if they make it invisible, it'll never re-appear
+        if popup_is_callable and not popup_pane.visible:
             return
 
         if not popup_pane.stylesheets:
-            self._panel.stylesheets = [
+            self._bk_panel.stylesheets = [
                 """
                 :host {
                     padding: 1em;
@@ -717,22 +717,24 @@ class PopupMixin:
                 """,
             ]
         else:
-            self._panel.stylesheets = []
+            self._bk_panel.stylesheets = []
 
-        self._panel.visible = True
+        self._bk_panel.visible = True
         # for existing popup, important to check if they're visible
         # otherwise, UnknownReferenceError: can't resolve reference 'p...'
         # meaning the popup has already been removed; we need to regenerate
         if self._existing_popup and not self._existing_popup.visible:
+            self._existing_popup.visible = True
+            position = self._get_position(event) if event else None
             if position:
-                self._panel.position = XY(**position)
+                self._bk_panel.position = XY(**position)
                 if self.plot.comm:  # update Jupyter Notebook
                     push_on_root(self.plot.root.ref['id'])
             return
 
         model = popup_pane.get_root(self.plot.document, self.plot.comm)
         model.js_on_change('visible', CustomJS(
-            args=dict(panel=self._panel),
+            args=dict(panel=self._bk_panel),
             code="""
             export default ({panel}, event, _) => {
               if (!event.visible) {
@@ -741,7 +743,7 @@ class PopupMixin:
             }""",
         ))
         # the first element is the close button
-        self._panel.elements = [self._panel.elements[0], model]
+        self._bk_panel.elements = [self._bk_panel.elements[0], model]
         if self.plot.comm:  # update Jupyter Notebook
             push_on_root(self.plot.root.ref['id'])
         self._existing_popup = popup_pane
@@ -1114,7 +1116,7 @@ class Selection1DCallback(PopupMixin, Callback):
         renderer = self.plot.handles['glyph_renderer']
         selected = self.plot.handles['selected']
         self.plot.state.js_on_event('selectiongeometry', CustomJS(
-            args=dict(panel=self._panel, renderer=renderer, source=source, selected=selected),
+            args=dict(panel=self._bk_panel, renderer=renderer, source=source, selected=selected),
             code="""
             export default ({panel, renderer, source, selected}, cb_obj, _) => {
               const el = panel.elements[1]

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -315,6 +315,11 @@ def test_stream_popup_close_button(serve_hv, points):
     page.click(".bk-btn.bk-btn-default")
     expect(locator).not_to_be_visible()
 
+    hv_plot.click()
+    locator = page.locator(".bk-btn.bk-btn-default")
+    expect(locator).to_have_count(1)
+    expect(locator).to_be_visible()
+
 
 @skip_popup
 @pytest.mark.usefixtures("bokeh_backend")
@@ -344,6 +349,47 @@ def test_stream_popup_selection1d_tap(serve_hv, points):
 
     locator = page.locator("#tap")
     expect(locator).to_have_count(1)
+
+
+@skip_popup
+@pytest.mark.usefixtures("bokeh_backend")
+def test_stream_popup_noncallable_reappear(serve_hv, points):
+    def popup_form(name):
+        text_input = pn.widgets.TextInput(name='Description')
+        button = pn.widgets.Button(
+            name='Save',
+            on_click=lambda _: layout.param.update(visible=False),
+            button_type="primary"
+        )
+        layout = pn.Column(f'# {name}', text_input, button)
+        return layout
+
+    points = points.opts(hit_dilation=5)
+    hv.streams.Tap(source=points, popup=popup_form('Tap'))
+    points.opts(tools=["tap"], active_tools=["tap"])
+
+    page = serve_hv(points)
+    hv_plot = page.locator('.bk-events')
+    expect(hv_plot).to_have_count(1)
+
+    hv_plot.click()
+
+    locator = page.locator("#tap")
+    expect(locator).to_have_count(1)
+    locator = page.locator(".bk-btn bk-btn-primary")
+    expect(locator).to_have_count(1)
+    expect(locator).to_be_visible()
+
+    page.click(".bk-btn bk-btn-primary")
+    expect(locator).not_to_be_visible()
+
+    hv_plot.click()
+
+    locator = page.locator("#tap")
+    expect(locator).to_have_count(1)
+    locator = page.locator(".bk-btn bk-btn-primary")
+    expect(locator).to_have_count(1)
+    expect(locator).to_be_visible()
 
 
 @skip_popup

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -376,18 +376,18 @@ def test_stream_popup_noncallable_reappear(serve_hv, points):
 
     locator = page.locator("#tap")
     expect(locator).to_have_count(1)
-    locator = page.locator(".bk-btn bk-btn-primary")
+    locator = page.locator(".bk-btn.bk-btn-primary")
     expect(locator).to_have_count(1)
     expect(locator).to_be_visible()
 
-    page.click(".bk-btn bk-btn-primary")
+    page.click(".bk-btn.bk-btn-primary")
     expect(locator).not_to_be_visible()
 
     hv_plot.click()
 
     locator = page.locator("#tap")
     expect(locator).to_have_count(1)
-    locator = page.locator(".bk-btn bk-btn-primary")
+    locator = page.locator(".bk-btn.bk-btn-primary")
     expect(locator).to_have_count(1)
     expect(locator).to_be_visible()
 


### PR DESCRIPTION
Changes from https://github.com/holoviz/holoviews/pull/6207 made some examples not useful

This closes https://github.com/holoviz/holoviews/issues/6342 by:

1. checking whether the popup stream is callable; if it isn't, we cannot do `if popup_is_callable and not popup_pane.visible`, or else it'll be invisible forever if user has a `on_click(layout.visible = False)` like the example below


```python
import panel as pn
import numpy as np
import holoviews as hv
hv.extension("bokeh")


points = hv.Points(np.random.randn(1000, 2))

def form(name):
    text_input = pn.widgets.TextInput(name='Description')
    button = pn.widgets.Button(name='Save', on_click=lambda _: layout.param.update(visible=False))
    layout = pn.Column(f'# {name}', text_input, button)
    return layout

hv.streams.BoundsXY(source=points, popup=form('Bounds'))
hv.streams.Lasso(source=points, popup=form('Lasso'))
hv.streams.Tap(source=points, popup=form('Tap'))

pn.panel(points.opts(tools=['box_select', 'lasso_select', 'tap'], width=600, height=600, size=6, color='black', fill_color=None)).servable()
```

Here's a demo applying these fixes:

https://github.com/user-attachments/assets/99b513f5-0211-428b-966d-caae8216cb96

2. if existing popup is invisible, we need to make it visible again or else it'll not show the user defined layout again

```python
import holoviews as hv
import panel as pn
import numpy as np
hv.extension("bokeh")
pn.extension()

def popup_form(index):
    def hide_popup(_):
        layout.visible = False

    if not index:
        return
    df = points.iloc[index].dframe().describe()
    button = pn.widgets.Button(name="Close", sizing_mode="stretch_width")
    layout = pn.Column(button, df)
    button.on_click(hide_popup)
    return layout


points = hv.Points(np.random.randn(1000, 2))
hv.streams.Selection1D(source=points, popup=popup_form)

points.opts(
    tools=["box_select", "lasso_select", "tap"],
    active_tools=["lasso_select"],
    size=6,
    color="black",
    fill_color=None,
    width=500,
    height=500
)
```

Demo after fix:

https://github.com/user-attachments/assets/24019a2d-1ee5-4887-8af3-247792f28f26

These changes also keep compatibility with holonote

```python
import panel as pn
import numpy as np
import pandas as pd
import hvplot.pandas
import numpy as np
import holoviews as hv

from holonote.annotate import SQLiteDB, Annotator
from holonote.app import PanelWidgets

pn.extension()

curve = pd.read_parquet("../holonote/examples/assets/example.parquet").hvplot(x="TIME")
connector = SQLiteDB(table_name="test_app")
fields = ["Stoppage", "Reason", "Category"]
annotator = Annotator({"TIME": np.datetime64}, fields=fields, connector=connector)
annotator_element = annotator * curve

fields_values = {
    "Stoppage": ["Yes", "No"],
    "Category": ["Mechanical", "Electrical", "Process", "Other"],
}

w = PanelWidgets(annotator, field_values=fields_values, as_popup=True)
pn.serve(annotator_element)
```

https://github.com/user-attachments/assets/aeb1f937-a917-42cb-a6cd-d997c1f9a18f

:) and welcome back Simon