### PR TITLE
Add `sublabel_index` and `sublabel_skip` option for matplotlib backend

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -116,10 +116,6 @@ class MPLPlot(DimensionedPlot):
         plot object and the displayed object; other plotting handles
         can be accessed via plot.handles.""")
 
-    sublabel_index_offset = param.Number(default=0, doc="""
-        Offset added to the sublabel index. When total index is less than 0,
-        the sublabel is skipped.""")
-
     sublabel_format = param.String(default=None, allow_None=True, doc="""
         Allows labeling the subaxes in each plot with various formatters
         including {Alpha}, {alpha}, {numeric} and {roman}.""")
@@ -129,6 +125,9 @@ class MPLPlot(DimensionedPlot):
 
     sublabel_size = param.Number(default=18, doc="""
          Size of optional subfigure label.""")
+
+    sublabel_skip = param.List(default=None, doc="""
+        List of elements to skip when labeling subplots.""")
 
     projection = param.Parameter(default=None, doc="""
         The projection of the plot axis, default of None is equivalent to
@@ -211,8 +210,13 @@ class MPLPlot(DimensionedPlot):
 
 
     def _subplot_label(self, axis):
+        if self.sublabel_skip and self.layout_num in self.sublabel_skip:
+            return
         layout_num = self.layout_num if self.subplot else 1
-        sublabel_num = layout_num + self.sublabel_index_offset
+        if self.sublabel_skip:
+            sublabel_num = len(set(range(layout_num)) - set(self.sublabel_skip))
+        else:
+            sublabel_num = layout_num
         if self.sublabel_format and not self.adjoined and sublabel_num > 0:
             from matplotlib.offsetbox import AnchoredText
             labels = {}
@@ -221,7 +225,7 @@ class MPLPlot(DimensionedPlot):
             elif '{alpha}' in self.sublabel_format:
                 labels['alpha'] = int_to_alpha(sublabel_num-1, upper=False)
             elif '{numeric}' in self.sublabel_format:
-                labels['numeric'] = self.layout_num
+                labels['numeric'] = sublabel_num
             elif '{Roman}' in self.sublabel_format:
                 labels['Roman'] = int_to_roman(sublabel_num)
             elif '{roman}' in self.sublabel_format:

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -116,6 +116,10 @@ class MPLPlot(DimensionedPlot):
         plot object and the displayed object; other plotting handles
         can be accessed via plot.handles.""")
 
+    sublabel_index_offset = param.Number(default=0, doc="""
+        Offset added to the sublabel index. When total index is less than 0,
+        the sublabel is skipped.""")
+
     sublabel_format = param.String(default=None, allow_None=True, doc="""
         Allows labeling the subaxes in each plot with various formatters
         including {Alpha}, {alpha}, {numeric} and {roman}.""")
@@ -208,19 +212,20 @@ class MPLPlot(DimensionedPlot):
 
     def _subplot_label(self, axis):
         layout_num = self.layout_num if self.subplot else 1
-        if self.sublabel_format and not self.adjoined and layout_num > 0:
+        sublabel_num = layout_num + self.sublabel_index_offset
+        if self.sublabel_format and not self.adjoined and sublabel_num > 0:
             from matplotlib.offsetbox import AnchoredText
             labels = {}
             if '{Alpha}' in self.sublabel_format:
-                labels['Alpha'] = int_to_alpha(layout_num-1)
+                labels['Alpha'] = int_to_alpha(sublabel_num-1)
             elif '{alpha}' in self.sublabel_format:
-                labels['alpha'] = int_to_alpha(layout_num-1, upper=False)
+                labels['alpha'] = int_to_alpha(sublabel_num-1, upper=False)
             elif '{numeric}' in self.sublabel_format:
                 labels['numeric'] = self.layout_num
             elif '{Roman}' in self.sublabel_format:
-                labels['Roman'] = int_to_roman(layout_num)
+                labels['Roman'] = int_to_roman(sublabel_num)
             elif '{roman}' in self.sublabel_format:
-                labels['roman'] = int_to_roman(layout_num).lower()
+                labels['roman'] = int_to_roman(sublabel_num).lower()
             at = AnchoredText(self.sublabel_format.format(**labels), loc=3,
                               bbox_to_anchor=self.sublabel_position, frameon=False,
                               prop=dict(size=self.sublabel_size, weight='bold'),

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -129,8 +129,8 @@ class MPLPlot(DimensionedPlot):
     sublabel_size = param.Number(default=18, doc="""
          Size of optional subfigure label.""")
 
-    sublabel_skip = param.List(default=None, doc="""
-        List of elements to skip when labeling subplots.""")
+    sublabel_skip = param.List(default=None, item_type=int, doc="""
+        List of elements to skip when labeling subplots. Numbering starts at 1.""")
 
     projection = param.Parameter(default=None, doc="""
         The projection of the plot axis, default of None is equivalent to
@@ -217,6 +217,8 @@ class MPLPlot(DimensionedPlot):
             return
         layout_num = self.layout_num if self.subplot else 1
         if self.sublabel_skip:
+            if any(n < 1 for n in self.sublabel_skip):
+                raise ValueError('sublabel_skip values must be greater than 0')
             sublabel_num = len(set(range(layout_num)) - set(self.sublabel_skip))
         else:
             sublabel_num = layout_num

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -120,6 +120,9 @@ class MPLPlot(DimensionedPlot):
         Allows labeling the subaxes in each plot with various formatters
         including {Alpha}, {alpha}, {numeric} and {roman}.""")
 
+    sublabel_offset = param.Number(default=0, bounds=(0, None), doc="""
+        Allows offsetting the sublabel index.""")
+
     sublabel_position = param.NumericTuple(default=(-0.35, 0.85), doc="""
          Position relative to the plot for placing the optional subfigure label.""")
 
@@ -217,6 +220,7 @@ class MPLPlot(DimensionedPlot):
             sublabel_num = len(set(range(layout_num)) - set(self.sublabel_skip))
         else:
             sublabel_num = layout_num
+        sublabel_num += self.sublabel_offset
         if self.sublabel_format and not self.adjoined and sublabel_num > 0:
             from matplotlib.offsetbox import AnchoredText
             labels = {}

--- a/holoviews/tests/plotting/matplotlib/test_layoutplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_layoutplot.py
@@ -58,3 +58,25 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestMPLPlot):
         cp1, cp2 = plot.traverse(lambda x: x, [CurvePlot])
         self.assertTrue(cp1.handles['axis'].get_ylim(), (1, 3))
         self.assertTrue(cp2.handles['axis'].get_ylim(), (10, 30))
+
+    def test_layout_sublabel_offset(self):
+        from holoviews.plotting.mpl import CurvePlot
+        layout = Curve([]) + Curve([]) + Curve([]) + Curve([])
+        layout.opts(sublabel_offset=1)
+        plot = mpl_renderer.get_plot(layout)
+        cps = plot.traverse(lambda x: x, [CurvePlot])
+        assert cps[0].handles["sublabel"].get_text() == "B"
+        assert cps[1].handles["sublabel"].get_text() == "C"
+        assert cps[2].handles["sublabel"].get_text() == "D"
+        assert cps[3].handles["sublabel"].get_text() == "E"
+
+    def test_layout_sublabel_skip(self):
+        from holoviews.plotting.mpl import CurvePlot
+        layout = Curve([]) + Curve([]) + Curve([]) + Curve([])
+        layout.opts(sublabel_skip=[1, 3])
+        plot = mpl_renderer.get_plot(layout)
+        cps = plot.traverse(lambda x: x, [CurvePlot])
+        assert "sublabel" not in cps[0].handles
+        assert cps[1].handles["sublabel"].get_text() == "A"
+        assert "sublabel" not in cps[2].handles
+        assert cps[3].handles["sublabel"].get_text() == "B"


### PR DESCRIPTION
This allows to alter the index count of the sublabels, e.g. I have the following plot:
![Screenshot_20240917_145922](https://github.com/user-attachments/assets/a72e7492-2a5d-413f-8f7e-ec4be58a8797)

But the top element (`a)`) is not an actual subplot, just a colorbar for all the other. But exposing this option allows to basically ignore the first subplot. When numbering. In another situation I have an opposite problem, where I created a group of plots, but then I attach manually another subplot within LaTeX, then I want the numbering to skip a few labels.