### PR TITLE
Handle datetimes and empty selections better for inspect operations

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -2012,13 +2012,11 @@ class inspect_points(inspect_base):
         # coordinate space to ensure that distance
         # in both direction is handled the same.
         if xtype != ytype and len(dx) and len(dy):
-            with warnings.catch_warnings():
-                warnings.filterwarnings('ignore', r'invalid value encountered in (divide)')
+            with np.errstate(divide='ignore'):
                 dx = (dx - dx.min()) / (dx.max() - dx.min())
                 dy = (dy - dy.min()) / (dy.max() - dy.min())
         distances = pd.Series(dx**2 + dy**2)
-        distances[distances.isna()] = 0
-        return df.iloc[distances.argsort().values]
+        return df.iloc[distances.fillna(0).argsort().values]
 
 
 class inspect_polygons(inspect_base):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1915,13 +1915,7 @@ class inspect_base(inspect):
                 raster = raster[..., raster.vdims[-1]]
             x_range, y_range = raster.range(0), raster.range(1)
             xdelta, ydelta = self._distance_args(raster, x_range, y_range, self.p.pixels)
-            arr = raster[
-                x-xdelta:x+xdelta, y-ydelta:y+ydelta
-            ].dimension_values(2, flat=False)
-            if arr.size:
-                val = np.nansum(arr)
-            else:
-                val = np.nan
+            val = raster[x-xdelta:x+xdelta, y-ydelta:y+ydelta].reduce(function=np.nansum)
             if np.isnan(val):
                 val = self.p.null_value
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -2004,17 +2004,20 @@ class inspect_points(inspect_base):
         xs, ys = (ds.dimension_values(kd) for kd in raster.kdims)
         dx, dy = xs - x, ys - y
         xtype, ytype = dx.dtype.kind, dy.dtype.kind
-        if xtype.kind in 'Mm':
+        if xtype in 'Mm':
             dx = dx.astype('int64')
-        if ytype.kind in 'Mm':
+        if ytype in 'Mm':
             dy = dx.astype('int64')
         # If coordinate types don't match normalize
         # coordinate space to ensure that distance
         # in both direction is handled the same.
         if xtype != ytype and len(dx) and len(dy):
-            dx = (dx - dx.min()) / (dx.max() - dx.min())
-            dy = (dy - dy.min()) / (dy.max() - dy.min())
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', r'invalid value encountered in (divide)')
+                dx = (dx - dx.min()) / (dx.max() - dx.min())
+                dy = (dy - dy.min()) / (dy.max() - dy.min())
         distances = pd.Series(dx**2 + dy**2)
+        distances[distances.isna()] = 0
         return df.iloc[distances.argsort().values]
 
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -2012,7 +2012,8 @@ class inspect_points(inspect_base):
         # coordinate space to ensure that distance
         # in both direction is handled the same.
         if xtype != ytype and len(dx) and len(dy):
-            with np.errstate(divide='ignore'):
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', r'invalid value encountered in (divide)')
                 dx = (dx - dx.min()) / (dx.max() - dx.min())
                 dy = (dy - dy.min()) / (dy.max() - dy.min())
         distances = pd.Series(dx**2 + dy**2)

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1442,14 +1442,25 @@ class GraphBundlingTests(ComparisonTestCase):
         direct = directly_connect_edges(self.graph)._split_edgepaths
         self.assertEqual(direct, self.graph.edgepaths)
 
+
 class InspectorTests(ComparisonTestCase):
     """
     Tests for inspector operations
     """
     def setUp(self):
         points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
-        self.pntsimg = rasterize(points, dynamic=False,
-                             x_range=(0, 1), y_range=(0, 1), width=4, height=4)
+        self.pntsimg = rasterize(
+            points, dynamic=False, height=4, width=4,
+            x_range=(0, 1), y_range=(0, 1)
+        )
+        date_pts = Points([
+            (np.datetime64('2024-09-25 11:00'), 0.3),
+            (np.datetime64('2024-09-25 11:01'), 0.7),
+            (np.datetime64('2024-09-25 11:04'), 0.99)])
+        self.datesimg = rasterize(
+            date_pts, dynamic=False, height=4, width=4,
+            x_range=(np.datetime64('2024-09-25 11:00'), np.datetime64('2024-09-25 11:04')), y_range=(0, 1)
+        )
         if spatialpandas is None:
             return
 
@@ -1463,7 +1474,6 @@ class InspectorTests(ComparisonTestCase):
 
     def tearDown(self):
         Tap.x, Tap.y = None, None
-
 
     def test_inspect_points_or_polygons(self):
         if spatialpandas is None:
@@ -1521,6 +1531,18 @@ class InspectorTests(ComparisonTestCase):
         self.assertEqual(points.streams[0].x, 0.2)
         self.assertEqual(points.streams[0].y, 0.3)
 
+    def test_points_with_dates_inspection_1px_mask(self):
+        points = inspect_points(self.datesimg, max_indicators=3, dynamic=False, pixels=1,
+                                x=np.datetime64('2024-09-25 11:01'), y=-0.1)
+        self.assertEqual(points.dimension_values('x'), np.array([]))
+        self.assertEqual(points.dimension_values('y'), np.array([]))
+
+    def test_points_with_dates_inspection_2px_mask(self):
+        points = inspect_points(self.datesimg, max_indicators=3, dynamic=False, pixels=2,
+                                x=np.datetime64('2024-09-25 11:01'), y=-0.1)
+        self.assertEqual(points.dimension_values('x'), np.array([np.datetime64('2024-09-25 11:00')]))
+        self.assertEqual(points.dimension_values('y'), np.array([0.3]))
+
     def test_polys_inspection_1px_mask_hit(self):
         if spatialpandas is None:
             raise SkipTest('Polygon inspect tests require spatialpandas')
@@ -1539,7 +1561,6 @@ class InspectorTests(ComparisonTestCase):
         data = [[6.0, 7.0, 3.0, 2.0, 7.0, 5.0, 6.0, 7.0]]
         self.assertEqual(inspector.hits.iloc[0].geometry,
                          spatialpandas.geometry.polygon.Polygon(data))
-
 
     def test_polys_inspection_1px_mask_miss(self):
         if spatialpandas is None:


### PR DESCRIPTION
A number of fixes for `inspect` operations:

- Initialize with empty x/y coordinate
- Handle undefined x/y coordinates
- Allow datetime axis
- Allow axes with different dimensions, e.g. datetime and numeric (by normalizing space before computing distances)