### PR TITLE
Drop z dimension from ImageStack DataArray before shading

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -446,7 +446,11 @@ class XArrayInterface(GridInterface):
         Given a dataset object and data in the appropriate format for
         the interface, return a simple scalar.
         """
-        if not cls.packed(dataset) and len(data.data_vars) == 1:
+        if cls.packed(dataset):
+            array = data.squeeze()
+            if len(array.shape) == 0:
+                return array.item()
+        elif len(data.data_vars) == 1:
             array = data[dataset.vdims[0].name].squeeze()
             if len(array.shape) == 0:
                 return array.item()

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -93,7 +93,7 @@ class XArrayInterface(GridInterface):
         if isinstance(data, xr.DataArray):
             kdim_len = len(kdim_param.default) if kdims is None else len(kdims)
             vdim_len = len(vdim_param.default) if vdims is None else len(vdims)
-            if vdim_len > 1 and kdim_len == len(data.dims)-1 and data.shape[-1] == vdim_len:
+            if kdim_len == len(data.dims)-1 and data.shape[-1] == vdim_len:
                 packed = True
             elif vdims:
                 vdim = vdims[0]

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1348,7 +1348,7 @@ class shade(LinkableOperation):
         if self.p.clims:
             shade_opts['span'] = self.p.clims
         elif ds_version > Version('0.5.0') and self.p.cnorm != 'eq_hist':
-            shade_opts['span'] = (array.min(), array.max())
+            shade_opts['span'] = (array.min().item(), array.max().item())
 
         params = dict(get_param_values(element), kdims=kdims,
                       bounds=bounds, vdims=RGB.vdims[:],

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1291,7 +1291,7 @@ class shade(LinkableOperation):
             vdim = element.vdims
             array = element.data
             if hasattr(array, "to_array"):
-                array = array.to_array("z")
+                array = array.to_array("z").isel(z=0)
             array = array.transpose(*[kdim.name for kdim in kdims], ...)
         else:
             vdim = element.vdims[0].name

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1286,11 +1286,13 @@ class shade(LinkableOperation):
             ydensity = element.ydensity
             bounds = element.bounds
 
+        # Convert to xarray if not already
+        if element.interface.datatype != 'xarray':
+            element = element.clone(datatype=['xarray'])
+
         kdims = element.kdims
         if isinstance(element, ImageStack):
             vdim = element.vdims
-            if element.interface.datatype != 'xarray':
-                element = element.clone(datatype=['xarray'])
             array = element.data
             # If data is a Dataset it has to be converted to a
             # DataArray, either by selecting the singular value
@@ -1309,6 +1311,9 @@ class shade(LinkableOperation):
         else:
             vdim = element.vdims[0].name
             array = element.data[vdim]
+
+        # Dask is not supported by shade so materialize it
+        array = array.compute()
 
         shade_opts = dict(
             how=self.p.cnorm, min_alpha=self.p.min_alpha, alpha=self.p.alpha

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1294,7 +1294,7 @@ class shade(LinkableOperation):
         if isinstance(element, ImageStack):
             vdim = element.vdims
             array = element.data
-            # If data is a Dataset it has to be converted to a
+            # If data is a xarray Dataset it has to be converted to a
             # DataArray, either by selecting the singular value
             # dimension or by adding a z-dimension
             kdims = [kdim.name for kdim in kdims]
@@ -1306,7 +1306,7 @@ class shade(LinkableOperation):
                     # If data is 3D then we have one extra constant dimension
                     if array.ndim > 3:
                         drop = [d for d in array.dims if d not in kdims+["z"]]
-                        array = array.squeeze(drop)
+                        array = array.squeeze(dim=drop)
             array = array.transpose(*kdims, ...)
         else:
             vdim = element.vdims[0].name

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -827,6 +827,22 @@ class DatashaderCatAggregateTests(ComparisonTestCase):
         actual = img.data
         assert (expected.data.to_array("z").values == actual.T.values).all()
 
+    def test_aggregate_points_categorical_one_category(self):
+        points = Points([(0.2, 0.3, 'A'), (0.4, 0.7, 'A'), (0, 0.99, 'A')], vdims='z')
+        img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
+                        width=2, height=2, aggregator=ds.by('z', ds.count()))
+        x = np.array([0.25, 0.75])
+        y = np.array([0.25, 0.75])
+        a = np.array([[1, 2], [0, 0]])
+        xrds = xr.DataArray(
+            a,
+            dims=('x', 'y'),
+            coords={"x": x, "y": y}
+        )
+        expected = ImageStack(xrds, kdims=["x", "y"], vdims=["a"])
+        actual = img.data
+        assert (expected.data.to_array("z").values == actual.T.values).all()
+
     def test_aggregate_points_categorical_mean(self):
         points = Points([(0.2, 0.3, 'A', 0.1), (0.4, 0.7, 'B', 0.2), (0, 0.99, 'C', 0.3)], vdims=['cat', 'z'])
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),


### PR DESCRIPTION
When performing categorical rasterization with only one category the `XArrayInterface` would convert the 3D `DataArray` into a Dataset. When this 3D Dataset was then shaded we would convert the singular DataArray variable into a z-dimension, which meant we'd have two categorical variables (with the same value) and datashader would error out because it expects a 2D or 3D array.

Here we do a number of things:

- Allow the `XArrayInterface` to hold a DataArray with a singular value dimension
- Ensure that shade handles non-xarray datasets correctly (by promoting them to xarray)
- Ensure that it does not needlessly add a z-dimension if we have a singular value dimension
- Even if we have a 3D array and a multiple z-values we squeeze the DataArray to drop superfluous constant dimensions.
- Support dask array backed xarrays in shade (by materializing them)