### PR TITLE
Ensure proper cleanup of stream subscribers

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -48,7 +48,7 @@ from ..plot import (
     GenericLayoutPlot,
     GenericOverlayPlot,
 )
-from ..util import attach_streams, collate, displayable
+from ..util import attach_streams, collate, displayable, get_nested_streams
 from .links import LinkCallback
 from .util import (
     cds_column_replace,
@@ -249,12 +249,14 @@ class BokehPlot(DimensionedPlot, CallbackPlot):
             if plot.subplots:
                 plot.subplots.clear()
 
-            if isinstance(plot, GenericElementPlot):
-                for callback in plot.callbacks:
-                    streams += callback.streams
-                    callback.cleanup()
+            if not isinstance(plot, (GenericElementPlot, GenericOverlayPlot)):
+                continue
 
-            for stream in set(streams):
+            for callback in plot.callbacks:
+                streams += callback.streams
+                callback.cleanup()
+
+            for stream in get_nested_streams(plot.hmap):
                 stream._subscribers = [
                     (p, subscriber) for p, subscriber in stream._subscribers
                     if not is_param_method(subscriber) or

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -48,7 +48,7 @@ from ..plot import (
     GenericLayoutPlot,
     GenericOverlayPlot,
 )
-from ..util import attach_streams, collate, displayable, get_nested_streams
+from ..util import attach_streams, collate, displayable
 from .links import LinkCallback
 from .util import (
     cds_column_replace,
@@ -256,13 +256,12 @@ class BokehPlot(DimensionedPlot, CallbackPlot):
                 streams += callback.streams
                 callback.cleanup()
 
-            for stream in get_nested_streams(plot.hmap):
+            for stream in set(streams):
                 stream._subscribers = [
                     (p, subscriber) for p, subscriber in stream._subscribers
                     if not is_param_method(subscriber) or
                     get_method_owner(subscriber) not in plots
                 ]
-
 
     def _fontsize(self, key, label='fontsize', common=True):
         """

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -197,7 +197,7 @@ class Plot(param.Parameterized):
         for plot in plots:
             if not isinstance(plot, (GenericElementPlot, GenericOverlayPlot)):
                 continue
-            for stream in get_nested_streams(plot.hmap):
+            for stream in set(plot.streams):
                 stream._subscribers = [
                     (p, subscriber) for p, subscriber in stream._subscribers
                     if not util.is_param_method(subscriber) or

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -195,7 +195,7 @@ class Plot(param.Parameterized):
         """
         plots = self.traverse(lambda x: x, [Plot])
         for plot in plots:
-            if not isinstance(plot, (GenericCompositePlot, GenericElementPlot, GenericOverlayPlot)):
+            if not isinstance(plot, (GenericElementPlot, GenericOverlayPlot)):
                 continue
             for stream in get_nested_streams(plot.hmap):
                 stream._subscribers = [

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -197,7 +197,7 @@ class Plot(param.Parameterized):
         for plot in plots:
             if not isinstance(plot, (GenericCompositePlot, GenericElementPlot, GenericOverlayPlot)):
                 continue
-            for stream in set(plot.streams):
+            for stream in get_nested_streams(self.hmap):
                 stream._subscribers = [
                     (p, subscriber) for p, subscriber in stream._subscribers
                     if not util.is_param_method(subscriber) or

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -197,7 +197,7 @@ class Plot(param.Parameterized):
         for plot in plots:
             if not isinstance(plot, (GenericCompositePlot, GenericElementPlot, GenericOverlayPlot)):
                 continue
-            for stream in get_nested_streams(self.hmap):
+            for stream in get_nested_streams(plot.hmap):
                 stream._subscribers = [
                     (p, subscriber) for p, subscriber in stream._subscribers
                     if not util.is_param_method(subscriber) or

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -109,8 +109,8 @@ def test_layout_plot_stream_cleanup():
 
     plot = bokeh_renderer.get_plot(dmap1 + dmap2)
 
-    assert len(stream1._subscribers) == 1
-    assert len(stream2._subscribers) == 1
+    assert len(stream1._subscribers) == 2
+    assert len(stream2._subscribers) == 2
 
     plot.cleanup()
 

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -100,6 +100,24 @@ def test_element_plot_stream_cleanup():
     assert not stream._subscribers
 
 
+def test_overlay_plot_stream_cleanup():
+    stream1 = Pipe()
+    stream2 = Pipe()
+
+    dmap1 = DynamicMap(Curve, streams=[stream1])
+    dmap2 = DynamicMap(Curve, streams=[stream2])
+
+    plot = bokeh_renderer.get_plot(dmap1 * dmap2)
+
+    assert len(stream1._subscribers) == 4
+    assert len(stream2._subscribers) == 4
+
+    plot.cleanup()
+
+    assert not stream1._subscribers
+    assert not stream2._subscribers
+
+
 def test_layout_plot_stream_cleanup():
     stream1 = Pipe()
     stream2 = Pipe()

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -12,9 +12,11 @@ from param import concrete_descendents
 from holoviews import Curve
 from holoviews.core.element import Element
 from holoviews.core.options import Store
+from holoviews.core.spaces import DynamicMap
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.plotting.bokeh.callbacks import Callback
 from holoviews.plotting.bokeh.element import ElementPlot
+from holoviews.streams import Pipe
 
 bokeh_renderer = Store.renderers['bokeh']
 
@@ -80,9 +82,40 @@ class TestBokehPlot(ComparisonTestCase):
                     self.assertIn(lookup[2:-1], cds.data)
 
         # Ensure all the glyph renderers have a hover tool
-        print(renderers, hover)
         for renderer in renderers:
             self.assertTrue(any(renderer in h.renderers for h in hover))
+
+
+def test_element_plot_stream_cleanup():
+    stream = Pipe()
+
+    dmap = DynamicMap(Curve, streams=[stream])
+
+    plot = bokeh_renderer.get_plot(dmap)
+
+    assert len(stream._subscribers) == 1
+
+    plot.cleanup()
+
+    assert not stream._subscribers
+
+
+def test_layout_plot_stream_cleanup():
+    stream1 = Pipe()
+    stream2 = Pipe()
+
+    dmap1 = DynamicMap(Curve, streams=[stream1])
+    dmap2 = DynamicMap(Curve, streams=[stream2])
+
+    plot = bokeh_renderer.get_plot(dmap1 + dmap2)
+
+    assert len(stream1._subscribers) == 1
+    assert len(stream2._subscribers) == 1
+
+    plot.cleanup()
+
+    assert not stream1._subscribers
+    assert not stream2._subscribers
 
 
 def test_sync_two_plots():

--- a/holoviews/tests/plotting/plotly/test_plot.py
+++ b/holoviews/tests/plotting/plotly/test_plot.py
@@ -2,14 +2,66 @@ import plotly.graph_objs as go
 import pyviz_comms as comms
 from param import concrete_descendents
 
-from holoviews.core import Store
+from holoviews.core import DynamicMap, Store
+from holoviews.element import Curve
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.plotting.plotly.element import ElementPlot
 from holoviews.plotting.plotly.util import figure_grid
+from holoviews.streams import Pipe
 
 from .. import option_intersections
 
 plotly_renderer = Store.renderers['plotly']
+
+
+def test_element_plot_stream_cleanup():
+    stream = Pipe()
+
+    dmap = DynamicMap(Curve, streams=[stream])
+
+    plot = plotly_renderer.get_plot(dmap)
+
+    assert len(stream._subscribers) == 1
+
+    plot.cleanup()
+
+    assert not stream._subscribers
+
+
+def test_overlay_plot_stream_cleanup():
+    stream1 = Pipe()
+    stream2 = Pipe()
+
+    dmap1 = DynamicMap(Curve, streams=[stream1])
+    dmap2 = DynamicMap(Curve, streams=[stream2])
+
+    plot = plotly_renderer.get_plot(dmap1 * dmap2)
+
+    assert len(stream1._subscribers) == 4
+    assert len(stream2._subscribers) == 4
+
+    plot.cleanup()
+
+    assert not stream1._subscribers
+    assert not stream2._subscribers
+
+
+def test_layout_plot_stream_cleanup():
+    stream1 = Pipe()
+    stream2 = Pipe()
+
+    dmap1 = DynamicMap(Curve, streams=[stream1])
+    dmap2 = DynamicMap(Curve, streams=[stream2])
+
+    plot = plotly_renderer.get_plot(dmap1 + dmap2)
+
+    assert len(stream1._subscribers) == 2
+    assert len(stream2._subscribers) == 2
+
+    plot.cleanup()
+
+    assert not stream1._subscribers
+    assert not stream2._subscribers
 
 
 class TestPlotlyPlot(ComparisonTestCase):


### PR DESCRIPTION
Stream subscribers were not being properly cleaned up correctly, because we were only cleaning up linked streams. This would result in keeping references to old plots being kept around preventing garbage collection and also mean that if you reused a Stream you would continue to pointlessly update discarded plots.