### PR TITLE
Handle dask groupby warning

### DIFF
--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -218,8 +218,6 @@ class DaskInterface(PandasInterface):
         for coord in indices:
             if any(isinstance(c, float) and np.isnan(c) for c in coord):
                 continue
-            if len(coord) == 1:
-                coord = coord[0]
             group = group_type(groupby.get_group(coord), **group_kwargs)
             data.append((coord, group))
         if issubclass(container_type, NdMapping):

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -218,6 +218,8 @@ class DaskInterface(PandasInterface):
         for coord in indices:
             if any(isinstance(c, float) and np.isnan(c) for c in coord):
                 continue
+            if len(coord) == 1 and not util.PANDAS_GE_220:
+                coord = coord[0]
             group = group_type(groupby.get_group(coord), **group_kwargs)
             data.append((coord, group))
         if issubclass(container_type, NdMapping):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -44,6 +44,7 @@ pandas_version = Version(pd.__version__)
 
 NUMPY_GE_200 = numpy_version >= Version("2")
 PANDAS_GE_210 = pandas_version >= Version("2.1")
+PANDAS_GE_220 = pandas_version >= Version("2.2")
 
 # Types
 generator_types = (zip, range, types.GeneratorType)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ filterwarnings = [
     "ignore:datetime.datetime.utcfromtimestamp():DeprecationWarning:bokeh", # https://github.com/bokeh/bokeh/issues/13125
     "ignore:datetime.datetime.utcnow():DeprecationWarning:bokeh", # https://github.com/bokeh/bokeh/issues/13125
     # 2024-01: Pandas 2.2
-    "ignore:When grouping with a length-1 list::dask.dataframe.groupby", # https://github.com/dask/dask/issues/10572
     "ignore:\\s*Pyarrow will become a required dependency of pandas:DeprecationWarning", # Will go away by itself in Pandas 3.0
     "ignore:Passing a (SingleBlockManager|BlockManager) to (Series|GeoSeries|DataFrame|GeoDataFrame) is deprecated:DeprecationWarning", # https://github.com/holoviz/spatialpandas/issues/137
     # 2024-04


### PR DESCRIPTION
So Pandas deprecated in version 2.2.0 and with a `FutureWarning` passing a length-1 list-like name to `grouped_by.get_group()` that is not a tuple (https://github.com/pandas-dev/pandas/pull/54155).

Dask seems to call Pandas internally doing a a group-by operation followed by a `get_group()` call, so their users are also seeing this warning (https://github.com/dask/dask/issues/10572).

The change worked locally (let's see what the CI says) but I'm not sure it'll work with all the versions of Pandas and Dask supported by HoloViews.

(Sorry for the hvPlot reproducer only!)

```python
import hvplot.dask  # noqa

from hvplot.sample_data import airline_flights

flights = airline_flights.to_dask().persist()
flight_subset = flights[flights.carrier.isin(['OH', 'F9'])]
flight_subset.hvplot(x='distance', y='depdelay', by='carrier', kind='scatter', alpha=0.2, persist=True)
```

```
/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/dask/dataframe/groupby.py:270: FutureWarning: When grouping with a length-1 list-like, you will need to pass a length-1 tuple to get_group in a future version of pandas. Pass `(name,)` instead of `name` to silence this warning.
  return grouped.get_group(get_key)
/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/dask/dataframe/groupby.py:270: FutureWarning: When grouping with a length-1 list-like, you will need to pass a length-1 tuple to get_group in a future version of pandas. Pass `(name,)` instead of `name` to silence this warning.
  return grouped.get_group(get_key)
```

The full traceback when turning the warning into an error:

```
Traceback (most recent call last):
  File "/Users/mliquet/dev/hvplot/.mltmess/issue_dask_groupby.py", line 9, in <module>
    flight_subset.hvplot(x='distance', y='depdelay', by='carrier', kind='scatter', alpha=0.2, persist=True)
  File "/Users/mliquet/dev/hvplot/hvplot/plotting/core.py", line 95, in __call__
    return self._get_converter(x, y, kind, **kwds)(kind, x, y)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/hvplot/converter.py", line 1723, in __call__
    obj = method(x, y)
          ^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/hvplot/converter.py", line 2251, in scatter
    return self.chart(Scatter, x, y, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/hvplot/converter.py", line 2200, in chart
    return self.single_chart(element, x, y, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/hvplot/converter.py", line 2072, in single_chart
    Dataset(data, self.by + kdims, vdims).to(element, kdims, vdims, self.by),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/holoviews/core/data/__init__.py", line 145, in __call__
    group = selected.groupby(groupby, container_type=HoloMap,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/holoviews/core/data/__init__.py", line 196, in pipelined_fn
    result = method_fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/holoviews/core/data/__init__.py", line 1000, in groupby
    return self.interface.groupby(self, dim_names, container_type,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/holoviews/core/data/dask.py", line 223, in groupby
    group = group_type(groupby.get_group(coord), **group_kwargs)
                       ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/dask_expr/_groupby.py", line 1639, in get_group
    return new_collection(GetGroup(self.obj.expr, key, self._slice, *self.by))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/dask_expr/_collection.py", line 4799, in new_collection
    meta = expr._meta
           ^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.8/Frameworks/Python.framework/Versions/3.11/lib/python3.11/functools.py", line 1001, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/dask_expr/_expr.py", line 496, in _meta
    return self.operation(*args, **self._kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/dask_expr/_groupby.py", line 1089, in groupby_get_group
    return _groupby_get_group(df, list(by_key), get_key, columns)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/dask/dataframe/groupby.py", line 270, in _groupby_get_group
    return grouped.get_group(get_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mliquet/dev/hvplot/.venv/lib/python3.11/site-packages/pandas/core/groupby/groupby.py", line 1103, in get_group
    warnings.warn(
FutureWarning: When grouping with a length-1 list-like, you will need to pass a length-1 tuple to get_group in a future version of pandas. Pass `(name,)` instead of `name` to silence this warning.
```