### PR TITLE
enh: Add Scalebar support for subcoordinate_y plots

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -54,6 +54,7 @@ from ...core.overlay import CompositeOverlay, NdOverlay
 from ...element import Annotation, Contours, Graph, Path, Tiles, VectorField
 from ...streams import Buffer, PlotSize, RangeXY
 from ...util.transform import dim
+from ...util.warnings import warn
 from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import color_intervals, dim_axis_label, dim_range_key, process_cmap
 from .plot import BokehPlot
@@ -2419,7 +2420,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if not bokeh34:
             raise RuntimeError("Scalebar requires Bokeh >= 3.4.0")
         elif not bokeh36 and self._subcoord_overlaid:
-            raise RuntimeError("Scalebar with subcoordinate_y requires Bokeh >= 3.6.0")
+            warn("Scalebar with subcoordinate_y requires Bokeh >= 3.6.0", RuntimeWarning)
 
         from bokeh.models import Metric, ScaleBar
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2112,7 +2112,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self._postprocess_hover(renderer, source)
 
         if self.scalebar:
-            self._draw_scalebar(plot)
+            self._draw_scalebar(plot=plot, renderer=renderer)
 
         zooms_subcoordy = self.handles.get('zooms_subcoordy')
         if zooms_subcoordy is not None:
@@ -2402,7 +2402,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         return any(self.lookup_options(frame, 'norm').options.get('framewise')
                    for frame in current_frames)
 
-    def _draw_scalebar(self, plot):
+    def _draw_scalebar(self, *, plot, renderer):
         """Draw scalebar on the plot
 
         This will draw a scalebar on the plot. See the documentation for
@@ -2429,7 +2429,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             base_unit = unit
 
         if self._subcoord_overlaid:
-            srange = plot.renderers[-1].coordinates.y_source
+            srange = renderer.coordinates.y_source
             orientation = "vertical"
             # Integer is used for the location as `major_label_overrides` overrides the
             # label with {0: labelA, 1: labelB}

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2440,19 +2440,20 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 'background_fill_color': 'white',
                 'background_fill_alpha': 0.6,
                 'length_sizing': 'adaptive',
+                # Adding location so people can overwrite the default
+                'location': location,
             }
         else:
             srange = plot.x_range if self.scalebar_range == "x" else plot.y_range
             orientation = "horizontal" if self.scalebar_range == "x" else "vertical"
             location = self.scalebar_location or "bottom_right"
-            default_scalebar_opts = {"background_fill_alpha": 0.8}
+            default_scalebar_opts = {"background_fill_alpha": 0.8, "location": location}
 
         scale_bar = ScaleBar(
             range=srange,
             orientation=orientation,
             unit=unit,
             dimensional=Metric(base_unit=base_unit),
-            location=location,
             label=self.scalebar_label,
             **dict(default_scalebar_opts, **self.scalebar_opts),
         )

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -219,7 +219,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         doc="""
             Location anchor for positioning scale bar.
 
-            Default to 'bottom_right', except if subcoordinate_y is True then it will default to 'left'.
+            Default to 'bottom_right', except if subcoordinate_y is True then it will default to 'right'.
 
             The scalebar_location is only used if scalebar is True.""")
 
@@ -2433,22 +2433,19 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             orientation = "vertical"
             # Integer is used for the location as `major_label_overrides` overrides the
             # label with {0: labelA, 1: labelB}
-            location = (self.scalebar_location or "left", len(plot.renderers) - 1)
-            _default_scalebar_opts = {
-                "label_location": "right",
-                "background_fill_color": None,
-                "border_line_color": None,
-                "bar_length": 0.8,
-                "bar_length_units": "data",
-                "margin": 10,
-                "padding": 0,
-                "length_sizing": "exact",
+            location = (self.scalebar_location or "right", len(plot.renderers) - 1)
+            default_scalebar_opts = {
+                'bar_line_width': 3,
+                'label_location': 'left',
+                'background_fill_color': 'white',
+                'background_fill_alpha': 0.6,
+                'length_sizing': 'adaptive',
             }
         else:
             srange = plot.x_range if self.scalebar_range == "x" else plot.y_range
             orientation = "horizontal" if self.scalebar_range == "x" else "vertical"
             location = self.scalebar_location or "bottom_right"
-            _default_scalebar_opts = {"background_fill_alpha": 0.8}
+            default_scalebar_opts = {"background_fill_alpha": 0.8}
 
         scale_bar = ScaleBar(
             range=srange,
@@ -2457,7 +2454,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             dimensional=Metric(base_unit=base_unit),
             location=location,
             label=self.scalebar_label,
-            **dict(_default_scalebar_opts, **self.scalebar_opts),
+            **dict(default_scalebar_opts, **self.scalebar_opts),
         )
         self.handles['scalebar'] = scale_bar
         plot.add_layout(scale_bar)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2416,7 +2416,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         if not bokeh34:
             raise RuntimeError("Scalebar requires Bokeh >= 3.4.0")
-        elif not bokeh36 and self.subcoordinate_y:
+        elif not bokeh36 and self._subcoord_overlaid:
             raise RuntimeError("Scalebar with subcoordinate_y requires Bokeh >= 3.6.0")
 
         from bokeh.models import Metric, ScaleBar
@@ -2428,7 +2428,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             base_unit = unit
 
-        if self.subcoordinate_y:
+        if self._subcoord_overlaid:
             srange = plot.renderers[-1].coordinates.y_source
             orientation = "vertical"
             # Integer is used for the location as `major_label_overrides` overrides the

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -67,6 +67,7 @@ bokeh32 = bokeh_version >= Version("3.2")
 bokeh33 = bokeh_version >= Version("3.3")
 bokeh34 = bokeh_version >= Version("3.4")
 bokeh35 = bokeh_version >= Version("3.5")
+bokeh36 = bokeh_version >= Version("3.6")
 
 TOOL_TYPES = {
     'pan': tools.PanTool,


### PR DESCRIPTION
Resolves #6292

Example:

``` python
import holoviews as hv
import numpy as np
hv.extension("bokeh")

common_opts = dict(subcoordinate_y=True, scalebar=True, scalebar_unit=('cm', 'm'),)

c1 = hv.Curve(np.random.rand(1000), label='c1').opts(color='lightblue',  scalebar_location="left", **common_opts)
c2 = hv.Curve(np.random.rand(1000), label='c2').opts(color='indianred', scalebar_location="right", **common_opts)
c3 = hv.Curve(np.random.rand(1000), label='c3').opts(color='plum', scalebar_location="left", **common_opts)
c4 = hv.Curve(np.random.rand(1000), label='c4').opts(color='palegreen', scalebar_location="right", **common_opts)

curves = hv.Overlay(c1 * c2 * c3 * c4).opts(show_legend=False)
curves.opts(width=800, height=600)
```

![image](https://github.com/user-attachments/assets/cd7a656d-c7d8-4eee-b20b-8033fe1ed41a)
