### PR TITLE
Add popup position and anchor

### DIFF
--- a/examples/user_guide/13-Custom_Interactivity.ipynb
+++ b/examples/user_guide/13-Custom_Interactivity.ipynb
@@ -487,6 +487,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The `popup_position` can be set to one of the following options:\n",
+    "\n",
+    "- `top_right` (the default)\n",
+    "- `top_left`\n",
+    "- `bottom_left`\n",
+    "- `bottom_right`\n",
+    "- `right`\n",
+    "- `left`\n",
+    "- `top`\n",
+    "- `bottom`\n",
+    "\n",
+    "The `popup_anchor` is automatically determined based on the `popup_position`, but can also be manually set to one of the following predefined positions:\n",
+    "\n",
+    "- `top_left`, `top_center`, `top_right`\n",
+    "- `center_left`, `center_center`, `center_right`\n",
+    "- `bottom_left`, `bottom_center`, `bottom_right`\n",
+    "- `top`, `left`, `center`, `right`, `bottom`\n",
+    "\n",
+    "Alternatively, the `popup_anchor` can be specified as a tuple, using a mix of `start`, `center`, `end`, like `(\"start\", \"center\")`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.streams.Selection1D(\n",
+    "    source=points,\n",
+    "    popup=popup_stats,\n",
+    "    popup_position=\"left\",\n",
+    "    popup_anchor=\"right\"\n",
+    ")\n",
+    "\n",
+    "points.opts(\n",
+    "    tools=[\"box_select\", \"lasso_select\", \"tap\"],\n",
+    "    active_tools=[\"lasso_select\"],\n",
+    "    size=6,\n",
+    "    color=\"black\",\n",
+    "    fill_color=None,\n",
+    "    width=500,\n",
+    "    height=500\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The contents of the `popup` can be another HoloViews object too, like the distribution of the selected points."
    ]
   },

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -625,7 +625,7 @@ class PopupMixin:
         self._popup_position = stream.popup_position
         self._panel = Panel(
             position=XY(x=np.nan, y=np.nan),
-            anchor=stream.popup_anchor or POPUP_POSITION_ANCHOR.get(self._popup_position, 'top_left'),
+            anchor=stream.popup_anchor or POPUP_POSITION_ANCHOR[self._popup_position],
             elements=[close_button],
             visible=False,
             styles={"zIndex": "1000"},
@@ -1246,7 +1246,7 @@ class Selection1DCallback(PopupMixin, Callback):
                 }
                 if (!xs || !ys) { return; }
 
-                let minX = null, maxX = null, minY = null, maxY = null;
+                let minX, maxX, minY, maxY;
 
                 for (const i of indices) {
                     const tx = xs[i];

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1247,7 +1247,7 @@ class Selection1DCallback(PopupMixin, Callback):
                     ys = source.get_column(renderer.glyph.ys.field);
                 }
 
-                if (!xs || !ys) {
+                if (!xs || !ys || !indices.length) {
                     return;
                 }
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1212,61 +1212,61 @@ class Selection1DCallback(PopupMixin, Callback):
             args=dict(panel=self._panel, renderer=renderer, source=source, selected=selected, popup_position=self._popup_position),
             code="""
             export default ({panel, renderer, source, selected, popup_position}, cb_obj, _) => {
-            const el = panel.elements[1];
-            if ((el && !el.visible) || !cb_obj.final) {
-                return;
-            }
-            let x, y, xs, ys;
-            let indices = selected.indices;
-            if (cb_obj.geometry.type == 'point') {
-                indices = indices.slice(-1);
-            }
-            if (renderer.glyph.x && renderer.glyph.y) {
-                xs = source.get_column(renderer.glyph.x.field);
-                ys = source.get_column(renderer.glyph.y.field);
-            } else if (renderer.glyph.right && renderer.glyph.top) {
-                xs = source.get_column(renderer.glyph.right.field);
-                ys = source.get_column(renderer.glyph.top.field);
-            } else if (renderer.glyph.x1 && renderer.glyph.y1) {
-                xs = source.get_column(renderer.glyph.x1.field);
-                ys = source.get_column(renderer.glyph.y1.field);
-            } else if (renderer.glyph.xs && renderer.glyph.ys) {
-                xs = source.get_column(renderer.glyph.xs.field);
-                ys = source.get_column(renderer.glyph.ys.field);
-            }
-            if (!xs || !ys) { return; }
+                const el = panel.elements[1];
+                if ((el && !el.visible) || !cb_obj.final) {
+                    return;
+                }
+                let x, y, xs, ys;
+                let indices = selected.indices;
+                if (cb_obj.geometry.type == 'point') {
+                    indices = indices.slice(-1);
+                }
+                if (renderer.glyph.x && renderer.glyph.y) {
+                    xs = source.get_column(renderer.glyph.x.field);
+                    ys = source.get_column(renderer.glyph.y.field);
+                } else if (renderer.glyph.right && renderer.glyph.top) {
+                    xs = source.get_column(renderer.glyph.right.field);
+                    ys = source.get_column(renderer.glyph.top.field);
+                } else if (renderer.glyph.x1 && renderer.glyph.y1) {
+                    xs = source.get_column(renderer.glyph.x1.field);
+                    ys = source.get_column(renderer.glyph.y1.field);
+                } else if (renderer.glyph.xs && renderer.glyph.ys) {
+                    xs = source.get_column(renderer.glyph.xs.field);
+                    ys = source.get_column(renderer.glyph.ys.field);
+                }
+                if (!xs || !ys) { return; }
 
-            let minX = null, maxX = null, minY = null, maxY = null;
+                let minX = null, maxX = null, minY = null, maxY = null;
 
-            for (const i of indices) {
-                const tx = xs[i];
-                const ty = ys[i];
+                for (const i of indices) {
+                    const tx = xs[i];
+                    const ty = ys[i];
 
-                if (minX === null || tx < minX) { minX = tx; }
-                if (maxX === null || tx > maxX) { maxX = tx; }
-                if (minY === null || ty < minY) { minY = ty; }
-                if (maxY === null || ty > maxY) { maxY = ty; }
-            }
-
-            if (minX !== null && maxX !== null && minY !== null && maxY !== null) {
-                if (popup_position.includes('left')) {
-                    x = minX;
-                } else if (popup_position.includes('right')) {
-                    x = maxX;
-                } else {
-                    x = (minX + maxX) / 2;
+                    if (minX === null || tx < minX) { minX = tx; }
+                    if (maxX === null || tx > maxX) { maxX = tx; }
+                    if (minY === null || ty < minY) { minY = ty; }
+                    if (maxY === null || ty > maxY) { maxY = ty; }
                 }
 
-                if (popup_position.includes('top')) {
-                    y = maxY;
-                } else if (popup_position.includes('bottom')) {
-                    y = minY;
-                } else {
-                    y = (minY + maxY) / 2;
-                }
+                if (minX !== null && maxX !== null && minY !== null && maxY !== null) {
+                    if (popup_position.includes('left')) {
+                        x = minX;
+                    } else if (popup_position.includes('right')) {
+                        x = maxX;
+                    } else {
+                        x = (minX + maxX) / 2;
+                    }
 
-                panel.position.setv({x, y});
-            }
+                    if (popup_position.includes('top')) {
+                        y = maxY;
+                    } else if (popup_position.includes('bottom')) {
+                        y = minY;
+                    } else {
+                        y = (minY + maxY) / 2;
+                    }
+
+                    panel.position.setv({x, y});
+                }
             }
             """,
         ))

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -76,10 +76,10 @@ from ...util.warnings import warn
 from .util import BOKEH_GE_3_3_0, convert_timestamp
 
 POPUP_POSITION_ANCHOR = {
-    "top_right": "top_left",
-    "top_left": "top_right",
-    "bottom_left": "bottom_right",
-    "bottom_right": "bottom_left",
+    "top_right": "bottom_left",
+    "top_left": "bottom_right",
+    "bottom_left": "top_right",
+    "bottom_right": "top_left",
     "right": "top_left",
     "left": "top_right",
     "top": "bottom",
@@ -778,7 +778,7 @@ class PopupMixin:
             position = self._get_position(event) if event else None
             if position:
                 self._panel.position = XY(**position)
-                if self.plot.comm:  # update Jupyter Notebook
+                if self.plot.comm:  # update Jupyter Notebooks
                     push_on_root(self.plot.root.ref['id'])
             return
 
@@ -1222,6 +1222,7 @@ class Selection1DCallback(PopupMixin, Callback):
             args=dict(panel=self._panel, renderer=renderer, source=source, selected=selected, popup_position=self._popup_position),
             code="""
             export default ({panel, renderer, source, selected, popup_position}, cb_obj, _) => {
+                panel.visible = false;  // Hide the popup panel so it doesn't show in previous location
                 const el = panel.elements[1];
                 if ((el && !el.visible) || !cb_obj.final) {
                     return;
@@ -1231,6 +1232,7 @@ class Selection1DCallback(PopupMixin, Callback):
                 if (cb_obj.geometry.type == 'point') {
                     indices = indices.slice(-1);
                 }
+
                 if (renderer.glyph.x && renderer.glyph.y) {
                     xs = source.get_column(renderer.glyph.x.field);
                     ys = source.get_column(renderer.glyph.y.field);
@@ -1245,23 +1247,55 @@ class Selection1DCallback(PopupMixin, Callback):
                     ys = source.get_column(renderer.glyph.ys.field);
                 }
 
-                if (!xs || !ys || indices.length == 0) {
-                    panel.visible = false;
+                if (!xs || !ys) {
                     return;
                 }
 
                 let minX, maxX, minY, maxY;
 
+                // Loop over each index in the selection and find the corresponding polygon coordinates
                 for (const i of indices) {
-                    const tx = xs[i];
-                    const ty = ys[i];
+                    let ix = xs[i];
+                    let iy = ys[i];
+                    let tx, ty;
 
+                    // Check if the values are numbers or nested arrays
+                    if (typeof ix === 'number') {
+                        tx = ix;
+                        ty = iy;
+                    } else {
+                        // Drill down into nested arrays until we find the number values
+                        while (ix.length && typeof ix[0] !== 'number') {
+                            ix = ix[0];
+                            iy = iy[0];
+                        }
+
+                        // Set tx and ty based on the popup position preferences
+                        if (popup_position.includes('left')) {
+                            tx = Math.min(...ix);
+                        } else if (popup_position.includes('right')) {
+                            tx = Math.max(...ix);
+                        } else {
+                            tx = (Math.min(...ix) + Math.max(...ix)) / 2;
+                        }
+
+                        if (popup_position.includes('top')) {
+                            ty = Math.max(...iy);
+                        } else if (popup_position.includes('bottom')) {
+                            ty = Math.min(...iy);
+                        } else {
+                            ty = (Math.min(...iy) + Math.max(...iy)) / 2;
+                        }
+                    }
+
+                    // Update the min/max values for x and y
                     if (minX === undefined || tx < minX) { minX = tx; }
                     if (maxX === undefined || tx > maxX) { maxX = tx; }
                     if (minY === undefined || ty < minY) { minY = ty; }
                     if (maxY === undefined || ty > maxY) { maxY = ty; }
                 }
 
+                // Set x and y based on popup_position preference
                 if (popup_position.includes('left')) {
                     x = minX;
                 } else if (popup_position.includes('right')) {
@@ -1278,11 +1312,12 @@ class Selection1DCallback(PopupMixin, Callback):
                     y = (minY + maxY) / 2;
                 }
 
+                // Set the popup position and make it visible
                 panel.position.setv({x, y});
+                panel.visible = true;
             }
             """,
         ))
-
 
     def _get_position(self, event):
         el = self.plot.current_frame

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -641,53 +641,53 @@ class PopupMixin:
             args=dict(panel=self._panel, popup_position=self.popup_position),
             code=f"""
             export default ({{panel, popup_position}}, cb_obj, _) => {{
-            const el = panel.elements[1];
-            if ((el && !el.visible) || !cb_obj.final || ({geom_type!r} !== 'any' && cb_obj.geometry.type !== {geom_type!r})) {{
-                return;
-            }}
+                const el = panel.elements[1];
+                if ((el && !el.visible) || !cb_obj.final || ({geom_type!r} !== 'any' && cb_obj.geometry.type !== {geom_type!r})) {{
+                    return;
+                }}
 
-            let pos;
-            if (cb_obj.geometry.type === 'point') {{
-                pos = {{x: cb_obj.geometry.x, y: cb_obj.geometry.y}};
-            }} else if (cb_obj.geometry.type === 'rect') {{
-                let x, y;
-                if (popup_position.includes('left')) {{
-                    x = cb_obj.geometry.x0;
-                }} else if (popup_position.includes('right')) {{
-                    x = cb_obj.geometry.x1;
-                }} else {{
-                    x = (cb_obj.geometry.x0 + cb_obj.geometry.x1) / 2;
+                let pos;
+                if (cb_obj.geometry.type === 'point') {{
+                    pos = {{x: cb_obj.geometry.x, y: cb_obj.geometry.y}};
+                }} else if (cb_obj.geometry.type === 'rect') {{
+                    let x, y;
+                    if (popup_position.includes('left')) {{
+                        x = cb_obj.geometry.x0;
+                    }} else if (popup_position.includes('right')) {{
+                        x = cb_obj.geometry.x1;
+                    }} else {{
+                        x = (cb_obj.geometry.x0 + cb_obj.geometry.x1) / 2;
+                    }}
+                    if (popup_position.includes('top')) {{
+                        y = cb_obj.geometry.y1;
+                    }} else if (popup_position.includes('bottom')) {{
+                        y = cb_obj.geometry.y0;
+                    }} else {{
+                        y = (cb_obj.geometry.y0 + cb_obj.geometry.y1) / 2;
+                    }}
+                    pos = {{x: x, y: y}};
+                }} else if (cb_obj.geometry.type === 'poly') {{
+                    let x, y;
+                    if (popup_position.includes('left')) {{
+                        x = Math.min(...cb_obj.geometry.x);
+                    }} else if (popup_position.includes('right')) {{
+                        x = Math.max(...cb_obj.geometry.x);
+                    }} else {{
+                        x = (Math.min(...cb_obj.geometry.x) + Math.max(...cb_obj.geometry.x)) / 2;
+                    }}
+                    if (popup_position.includes('top')) {{
+                        y = Math.max(...cb_obj.geometry.y);
+                    }} else if (popup_position.includes('bottom')) {{
+                        y = Math.min(...cb_obj.geometry.y);
+                    }} else {{
+                        y = (Math.min(...cb_obj.geometry.y) + Math.max(...cb_obj.geometry.y)) / 2;
+                    }}
+                    pos = {{x: x, y: y}};
                 }}
-                if (popup_position.includes('top')) {{
-                    y = cb_obj.geometry.y1;
-                }} else if (popup_position.includes('bottom')) {{
-                    y = cb_obj.geometry.y0;
-                }} else {{
-                    y = (cb_obj.geometry.y0 + cb_obj.geometry.y1) / 2;
-                }}
-                pos = {{x: x, y: y}};
-            }} else if (cb_obj.geometry.type === 'poly') {{
-                let x, y;
-                if (popup_position.includes('left')) {{
-                    x = Math.min(...cb_obj.geometry.x);
-                }} else if (popup_position.includes('right')) {{
-                    x = Math.max(...cb_obj.geometry.x);
-                }} else {{
-                    x = (Math.min(...cb_obj.geometry.x) + Math.max(...cb_obj.geometry.x)) / 2;
-                }}
-                if (popup_position.includes('top')) {{
-                    y = Math.max(...cb_obj.geometry.y);
-                }} else if (popup_position.includes('bottom')) {{
-                    y = Math.min(...cb_obj.geometry.y);
-                }} else {{
-                    y = (Math.min(...cb_obj.geometry.y) + Math.max(...cb_obj.geometry.y)) / 2;
-                }}
-                pos = {{x: x, y: y}};
-            }}
 
-            if (pos) {{
-                panel.position.setv(pos);
-            }}
+                if (pos) {{
+                    panel.position.setv(pos);
+                }}
             }}""",
         ))
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -638,7 +638,7 @@ class PopupMixin:
         geom_type = self.geom_type
         self.plot.state.on_event('selectiongeometry', self._update_selection_event)
         self.plot.state.js_on_event('selectiongeometry', CustomJS(
-            args=dict(panel=self._panel, popup_position=self.popup_position),
+            args=dict(panel=self._panel, popup_position=self._popup_position),
             code=f"""
             export default ({{panel, popup_position}}, cb_obj, _) => {{
                 const el = panel.elements[1];

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1244,7 +1244,11 @@ class Selection1DCallback(PopupMixin, Callback):
                     xs = source.get_column(renderer.glyph.xs.field);
                     ys = source.get_column(renderer.glyph.ys.field);
                 }
-                if (!xs || !ys) { return; }
+
+                if (!xs || !ys || indices.length == 0) {
+                    panel.visible = false;
+                    return;
+                }
 
                 let minX, maxX, minY, maxY;
 
@@ -1252,31 +1256,29 @@ class Selection1DCallback(PopupMixin, Callback):
                     const tx = xs[i];
                     const ty = ys[i];
 
-                    if (minX === null || tx < minX) { minX = tx; }
-                    if (maxX === null || tx > maxX) { maxX = tx; }
-                    if (minY === null || ty < minY) { minY = ty; }
-                    if (maxY === null || ty > maxY) { maxY = ty; }
+                    if (minX === undefined || tx < minX) { minX = tx; }
+                    if (maxX === undefined || tx > maxX) { maxX = tx; }
+                    if (minY === undefined || ty < minY) { minY = ty; }
+                    if (maxY === undefined || ty > maxY) { maxY = ty; }
                 }
 
-                if (minX !== null && maxX !== null && minY !== null && maxY !== null) {
-                    if (popup_position.includes('left')) {
-                        x = minX;
-                    } else if (popup_position.includes('right')) {
-                        x = maxX;
-                    } else {
-                        x = (minX + maxX) / 2;
-                    }
-
-                    if (popup_position.includes('top')) {
-                        y = maxY;
-                    } else if (popup_position.includes('bottom')) {
-                        y = minY;
-                    } else {
-                        y = (minY + maxY) / 2;
-                    }
-
-                    panel.position.setv({x, y});
+                if (popup_position.includes('left')) {
+                    x = minX;
+                } else if (popup_position.includes('right')) {
+                    x = maxX;
+                } else {
+                    x = (minX + maxX) / 2;
                 }
+
+                if (popup_position.includes('top')) {
+                    y = maxY;
+                } else if (popup_position.includes('bottom')) {
+                    y = minY;
+                } else {
+                    y = (minY + maxY) / 2;
+                }
+
+                panel.position.setv({x, y});
             }
             """,
         ))

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1266,7 +1266,7 @@ class LinkedStream(Stream):
     supplying stream data.
     """
 
-    def __init__(self, linked=True, popup=None, popup_position=POPUP_POSITIONS[0], popup_anchor=None, **params):
+    def __init__(self, linked=True, popup=None, popup_position="top_right", popup_anchor=None, **params):
         if popup_position not in POPUP_POSITIONS:
             raise ValueError(
                 f"Invalid popup_position: {popup_position!r}; "

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -22,6 +22,17 @@ from .core.ndmapping import UniformNdMapping
 # Types supported by Pointer derived streams
 pointer_types = (Number, str, tuple)+util.datetime_types
 
+POPUP_POSITIONS = [
+    "top_right",
+    "top_left",
+    "bottom_left",
+    "bottom_right",
+    "right",
+    "left",
+    "top",
+    "bottom",
+]
+
 class _SkipTrigger: pass
 
 
@@ -1255,9 +1266,17 @@ class LinkedStream(Stream):
     supplying stream data.
     """
 
-    def __init__(self, linked=True, popup=None, **params):
+    def __init__(self, linked=True, popup=None, popup_position=POPUP_POSITIONS[0], popup_anchor=None, **params):
+        if popup_position not in POPUP_POSITIONS:
+            raise ValueError(
+                f"Invalid popup_position: {popup_position!r}; "
+                f"expect one of {POPUP_POSITIONS}"
+            )
+
         super().__init__(linked=linked, **params)
         self.popup = popup
+        self.popup_position = popup_position
+        self.popup_anchor = popup_anchor
 
 
 class PointerX(LinkedStream):

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -219,8 +219,8 @@ def test_multi_axis_tap_datetime(serve_hv):
     def test():
         assert s.xs == {'x': np.datetime64('2024-01-12T13:26:44.819277')}
         assert s.xs == {'x': np.datetime64('2024-01-12T13:26:44.819277')}
-        assert 18 <= s.ys["y1"] <= 18.5
-        assert 76 <= s.ys["y2"] <= 76.5
+        assert np.isclose(s.ys["y1"], 18.2, atol=0.5)
+        assert np.isclose(s.ys["y2"], 76.5, atol=0.5)
 
     wait_until(test, page)
 

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -219,8 +219,9 @@ def test_multi_axis_tap_datetime(serve_hv):
     def test():
         assert s.xs == {'x': np.datetime64('2024-01-12T13:26:44.819277')}
         assert s.xs == {'x': np.datetime64('2024-01-12T13:26:44.819277')}
-        assert np.isclose(s.ys["y1"], 18.2, atol=0.5)
-        assert np.isclose(s.ys["y2"], 76.5, atol=0.5)
+        assert len(s.ys) == 2
+        assert np.isclose(s.ys["y1"], 18.130705394191)
+        assert np.isclose(s.ys["y2"], 76.551867219917)
 
     wait_until(test, page)
 
@@ -293,11 +294,6 @@ def test_stream_subcoordinate_y_range(serve_hv, points):
 @pytest.mark.usefixtures("bokeh_backend")
 @skip_popup
 class TestPopup:
-    @pytest.fixture
-    def points(self):
-        rng = np.random.default_rng(10)
-        return hv.Points(rng.normal(size=(1000, 2)))
-
     def _select_points_based_on_tool(self, tool, page, plot):
         """Helper method to perform point selection based on tool type."""
         box = plot.bounding_box()

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -192,7 +192,7 @@ def test_multi_axis_tap(serve_hv):
 
     def test():
         assert s.xs == {'x': 11.560240963855422}
-        assert s.ys == {'y1': 18.642857142857146, 'y2': 78.71428571428572}
+        assert s.ys == {'y1': 18, 'y2': 78.71428571428572}
 
     wait_until(test, page)
 
@@ -324,9 +324,9 @@ def test_stream_popup_polygons_tap(serve_hv, popup_position):
 ])
 def test_stream_popup_polygons_selection1d(serve_hv, popup_position):
     def popup_form(name):
-        return f"# {name}"
+        return "# selection"
 
-    points = hv.Polygons([(0, 0), (0, 1), (1, 1), (1, 0)]).opts(tools=["tap"])
+    points = hv.Polygons([(0, 0), (0, 1), (1, 1), (1, 0)]).opts(tools=["tap"], padding=1)
     hv.streams.Selection1D(source=points, popup=popup_form("Tap"), popup_position=popup_position)
 
     page = serve_hv(points)
@@ -570,6 +570,8 @@ def test_stream_popup_position_selection1d(serve_hv, points, tool, popup_positio
         page.mouse.move(end_x, end_y)
         page.mouse.up()
     elif tool == "tap":
+        mid_x, mid_y = box['x'] + 1, box['y'] + 1
+        page.mouse.move(mid_x, mid_y)
         hv_plot.click()
 
     # Wait for popup to show
@@ -630,7 +632,7 @@ def test_stream_popup_anchor_selection1d(serve_hv, points):
 
 
 @skip_popup
-@pytest.mark.parametrize("tool, tool_type", [("box_select", BoundsXY), ("lasso_select", Lasso), ("tap", Tap)])
+@pytest.mark.parametrize("tool, tool_type", [("box_select", BoundsXY), ("lasso_select", Lasso)])
 @pytest.mark.parametrize("popup_position", [
     "top_right", "top_left", "bottom_left", "bottom_right",
     "right", "left", "top", "bottom"
@@ -673,6 +675,7 @@ def test_stream_popup_position_streams(serve_hv, points, tool, tool_type, popup_
 
     locator = page.locator("#selection")
     popup_box = locator.bounding_box()
+    expect(locator).to_have_count(1)
 
     distance_to_left = abs(popup_box['x'] - box['x'])
     distance_to_right = abs((popup_box['x'] + popup_box['width']) - (box['x'] + box['width']))
@@ -730,6 +733,7 @@ def test_stream_popup_anchor_streams(serve_hv, points, tool, tool_type):
 
     locator = page.locator("#selection")
     popup_box = locator.bounding_box()
+    expect(locator).to_have_count(1)
 
     distance_to_left = abs(popup_box['x'] - box['x'])
     distance_to_right = abs((popup_box['x'] + popup_box['width']) - (box['x'] + box['width']))

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -192,7 +192,9 @@ def test_multi_axis_tap(serve_hv):
 
     def test():
         assert s.xs == {'x': 11.560240963855422}
-        assert s.ys == {'y1': 18.642857142857146, 'y2': np.float64(78.71428571428572)}
+        assert len(s.ys) == 2
+        assert np.isclose(s.ys["y1"], 18.642857142857146)
+        assert np.isclose(s.ys["y2"], 78.71428571428572)
 
     wait_until(test, page)
 
@@ -293,7 +295,7 @@ def test_stream_popup_polygons_tap(serve_hv, popup_position):
     expect(hv_plot).to_have_count(1)
 
     # Wait for popup to show
-    wait_until(lambda: expect(page.locator("#selection")).to_have_count(1), page)
+    expect(page.locator("#selection")).to_have_count(1)
     locator = page.locator("#selection")
     expect(locator).to_have_count(1)
 

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -543,7 +543,8 @@ def test_stream_popup_selection1d_box_select_right(serve_hv, points):
     expect(locator).not_to_have_text("lasso\n0")
 
     popup = locator.bounding_box()
-    assert popup['x'] + popup["width"] > mid_x  # Should be towards the right
+    assert popup['x'] > mid_x  # Should be towards the right
+    assert popup['y'] > mid_y  # Should be towards the top
 
 
 @skip_popup
@@ -581,6 +582,7 @@ def test_stream_popup_selection1d_box_select_left(serve_hv, points):
 
     popup = locator.bounding_box()
     assert popup['x'] < mid_x  # Should be towards the left
+    assert popup['y'] > mid_y  # Should be towards the top
 
 
 @pytest.mark.usefixtures("bokeh_backend")

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -219,8 +219,8 @@ def test_multi_axis_tap_datetime(serve_hv):
     def test():
         assert s.xs == {'x': np.datetime64('2024-01-12T13:26:44.819277')}
         assert s.xs == {'x': np.datetime64('2024-01-12T13:26:44.819277')}
-        assert np.isclose(s.ys["y1"], 18)
-        assert np.isclose(s.ys["y2"], 76)
+        assert 18 <= s.ys["y1"] <= 18.5
+        assert 76 <= s.ys["y2"] <= 76.5
 
     wait_until(test, page)
 

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -509,6 +509,80 @@ def test_stream_popup_selection1d_lasso_select(serve_hv, points):
     expect(locator).not_to_have_text("lasso\n0")
 
 
+@skip_popup
+@pytest.mark.usefixtures("bokeh_backend")
+def test_stream_popup_selection1d_box_select_right(serve_hv, points):
+    def popup_form(index):
+        if index:
+            return f"# lasso\n{len(index)}"
+
+    hv.streams.Selection1D(source=points, popup=popup_form, popup_position="right", popup_anchor="left")
+    points.opts(tools=["box_select"], active_tools=["box_select"])
+
+    page = serve_hv(points)
+    hv_plot = page.locator('.bk-events')
+    expect(hv_plot).to_have_count(1)
+
+    box = hv_plot.bounding_box()
+    start_x, start_y = box['x'] + 10, box['y'] + box['height'] - 10
+    mid_x, mid_y = box['x'], box['y']
+    end_x, end_y = box['x'], box['y']
+
+    # Perform lasso selection
+    page.mouse.move(start_x, start_y)
+    hv_plot.click()
+    page.mouse.down()
+    page.mouse.move(mid_x, mid_y)
+    page.mouse.move(end_x, end_y)
+    page.mouse.up()
+
+    # Wait for popup to show
+    wait_until(lambda: expect(page.locator("#lasso")).to_have_count(1), page)
+    locator = page.locator("#lasso")
+    expect(locator).to_have_count(1)
+    expect(locator).not_to_have_text("lasso\n0")
+
+    popup = locator.bounding_box()
+    assert popup['x'] + popup["width"] > mid_x  # Should be towards the right
+
+
+@skip_popup
+@pytest.mark.usefixtures("bokeh_backend")
+def test_stream_popup_selection1d_box_select_left(serve_hv, points):
+    def popup_form(index):
+        if index:
+            return f"# lasso\n{len(index)}"
+
+    hv.streams.Selection1D(source=points, popup=popup_form, popup_position="left", popup_anchor="right")
+    points.opts(tools=["box_select"], active_tools=["box_select"])
+
+    page = serve_hv(points)
+    hv_plot = page.locator('.bk-events')
+    expect(hv_plot).to_have_count(1)
+
+    box = hv_plot.bounding_box()
+    start_x, start_y = box['x'] + 10, box['y'] + box['height'] - 10
+    mid_x, mid_y = box['x'], box['y']
+    end_x, end_y = box['x'], box['y']
+
+    # Perform lasso selection
+    page.mouse.move(start_x, start_y)
+    hv_plot.click()
+    page.mouse.down()
+    page.mouse.move(mid_x, mid_y)
+    page.mouse.move(end_x, end_y)
+    page.mouse.up()
+
+    # Wait for popup to show
+    wait_until(lambda: expect(page.locator("#lasso")).to_have_count(1), page)
+    locator = page.locator("#lasso")
+    expect(locator).to_have_count(1)
+    expect(locator).not_to_have_text("lasso\n0")
+
+    popup = locator.bounding_box()
+    assert popup['x'] < mid_x  # Should be towards the left
+
+
 @pytest.mark.usefixtures("bokeh_backend")
 def test_stream_subcoordinate_y_range(serve_hv, points):
     def cb(x_range, y_range):

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -674,8 +674,8 @@ def test_stream_popup_position_streams(serve_hv, points, tool, tool_type, popup_
         hv_plot.click()
 
     locator = page.locator("#selection")
-    popup_box = locator.bounding_box()
     expect(locator).to_have_count(1)
+    popup_box = locator.bounding_box()
 
     distance_to_left = abs(popup_box['x'] - box['x'])
     distance_to_right = abs((popup_box['x'] + popup_box['width']) - (box['x'] + box['width']))
@@ -732,8 +732,8 @@ def test_stream_popup_anchor_streams(serve_hv, points, tool, tool_type):
         hv_plot.click()
 
     locator = page.locator("#selection")
-    popup_box = locator.bounding_box()
     expect(locator).to_have_count(1)
+    popup_box = locator.bounding_box()
 
     distance_to_left = abs(popup_box['x'] - box['x'])
     distance_to_right = abs((popup_box['x'] + popup_box['width']) - (box['x'] + box['width']))

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -192,7 +192,7 @@ def test_multi_axis_tap(serve_hv):
 
     def test():
         assert s.xs == {'x': 11.560240963855422}
-        assert s.ys == {'y1': 18, 'y2': 78.71428571428572}
+        assert s.ys == {'y1': 18.642857142857146, 'y2': np.float64(78.71428571428572)}
 
     wait_until(test, page)
 


### PR DESCRIPTION
Closes https://github.com/holoviz/holoviews/issues/6266

<img width="816" alt="image" src="https://github.com/user-attachments/assets/6d56adc4-2172-451a-8b95-4d9c573c705d">

```python
import numpy as np
import holoviews as hv

hv.extension("bokeh")


def popup_stats(index):
    if not index:
        return
    return points.iloc[index].dframe().describe()


points = hv.Points(np.random.randn(1000, 2))

hv.streams.Selection1D(
    source=points,
    popup=popup_stats,
    popup_position="right"
)

points.opts(
    tools=["xbox_select"],
    active_tools=["xbox_select"],
    size=6,
    color="black",
    fill_color=None,
    width=500,
    height=500
)
```




```python
import numpy as np
import holoviews as hv

hv.extension("bokeh")


def popup_stats(index):
    if not index:
        return
    return points.iloc[index].dframe().describe()


points = hv.Points(np.random.randn(1000, 2))

hv.streams.BoundsXY(source=points, popup="Used Box Select", popup_position="top_right")
hv.streams.Lasso(source=points, popup="Used Lasso Select", popup_position="bottom_right")
hv.streams.Tap(source=points, popup="Used Tap")

points.opts(
    tools=["box_select", "lasso_select", "tap"],
    active_tools=["lasso_select"],
    size=6,
    color="black",
    fill_color=None,
    width=500,
    height=500
)
```

<img width="839" alt="image" src="https://github.com/user-attachments/assets/25fc423e-f0a9-490a-9c12-3da8c8221256">
