### PR TITLE
Lock closed issues/prs

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -1,0 +1,31 @@
+name: "Lock Threads"
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+      # - cron: "0 0 * * 2"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          issue-inactive-days: "100"
+          pr-inactive-days: "100"
+          issue-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          pr-comment: >
+            This pull request has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.


### PR DESCRIPTION
Same as the one used on Lumen https://github.com/holoviz/lumen/blob/main/.github/workflows/lock.yaml

For now, it is set to run every hour, every day, until the backlog is completed, at which point I will change it to run each Tuesday night. 
