### PR TITLE
Apply scalebar length to subcoordinate_y range

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2443,6 +2443,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 'background_fill_color': 'white',
                 'background_fill_alpha': 0.6,
                 'length_sizing': 'adaptive',
+                'bar_length_units': 'data',
+                'bar_length': 0.8,
                 # Adding location so people can overwrite the default
                 'location': location,
             }


### PR DESCRIPTION
Fixes #6416

Enabling subcoordinate_y should now apply the scalebar length relative to the subcoordinate_y range.

<details> <summary> Code </summary>

```python
import holoviews as hv
import numpy as np
import panel as pn
pn.extension()
hv.extension("bokeh")


common_opts = dict(subcoordinate_y=True, scalebar_unit=("cm", "m"), color="lightgrey")

curves = []
for i in range(10):
    curves.append(hv.Curve(np.random.rand(1000), label=f'c{i}').opts(**common_opts, scalebar=True if i == 5 else False))

curves = hv.Overlay(curves).opts(show_legend=False)

pn.panel(curves.opts(width=800, height=600)).servable()

```

</details>


<img width="813" alt="image" src="https://github.com/user-attachments/assets/eb90c63f-de94-4719-9088-820dbcfe0b01">
