### PR TITLE
ci: Fix check_latest_packages sorting

### DIFF
--- a/scripts/check_latest_packages.py
+++ b/scripts/check_latest_packages.py
@@ -40,10 +40,10 @@ def main(*packages):
         resp = requests.get(url, timeout=1).json()
 
         found = False
-        for vrelease, release in list(resp["releases"].items())[::-1]:
+        for vrelease in sorted(resp["releases"], key=Version, reverse=True):
             if Version(vrelease).is_devrelease or Version(vrelease).is_prerelease:
                 continue
-            for info in release:
+            for info in resp["releases"][vrelease]:
                 if not compare_versions(PY_VERSION, info['requires_python']):
                     continue
 


### PR DESCRIPTION
We need to sort so we get the latest:

Current CI:
![image](https://github.com/user-attachments/assets/a1edd34f-0648-4cc1-bb83-f3841c557e8a)

With this PR:
![image](https://github.com/user-attachments/assets/61259dd8-a4ac-48ff-93a3-5e1c51e7c5fb)
