### PR TITLE
Fix bar width for small xdiff

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -931,7 +931,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
                 if is_dt:
                     width *= xdiff.astype('timedelta64[ms]').astype(np.int64)
                 else:
-                    width /= xdiff
+                    width = width * xdiff if np.min(xdiff) < 1 else width / xdiff
                 width = np.min(width)
         else:
             grouped = element.groupby(group_dim, group_type=Dataset,

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -397,4 +397,4 @@ class TestBarPlot(TestBokehPlot):
         dic = {"ratio": [0.82, 1.11, 3, 6], "count": [1, 2, 1, 3]}
         bars = Bars(dic, kdims=["ratio"], vdims=["count"])
         plot = bokeh_renderer.get_plot(bars)
-        assert np.isclose(plot.handles["glyph"].width, 0.23200000000000012)
+        assert np.isclose(plot.handles["glyph"].width, 0.232)

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -391,3 +391,10 @@ class TestBarPlot(TestBokehPlot):
         bars = Bars(df, kdims=["a", "b"], vdims=["c"]).opts(stacked=True)
         plot = bokeh_renderer.get_plot(bars)
         assert plot.handles["glyph"].width == 0.8
+
+    def test_bar_narrow_non_monotonous_xvals(self):
+        # Tests regression: https://github.com/holoviz/hvplot/issues/1450
+        dic = {"ratio": [0.82, 1.11, 3, 6], "count": [1, 2, 1, 3]}
+        bars = Bars(dic, kdims=["ratio"], vdims=["count"])
+        plot = bokeh_renderer.get_plot(bars)
+        assert np.isclose(plot.handles["glyph"].width, 0.23200000000000012)


### PR DESCRIPTION
Closes https://github.com/holoviz/hvplot/issues/1450
```python
import holoviews as hv
hv.extension("bokeh")
# import hvplot.polars
# import hvplot.pandas
import polars as pl

dic = {"ratio": [0.82, 1.11, 3, 6],
       "count": [1, 2, 1, 3]}

hv.Bars(dic, kdims="ratio", vdims="count")
```
<img width="882" alt="image" src="https://github.com/user-attachments/assets/ce62dfc3-3c47-4963-9820-2ca959c63909">
<img width="870" alt="image" src="https://github.com/user-attachments/assets/53a8fec8-48b4-4690-bf70-7dc117ffed3a">
<img width="1273" alt="image" src="https://github.com/user-attachments/assets/3b8d8aac-d7a1-4157-9c7f-673e5d5461b7">
