### PR TITLE
compat: Matplotlib 3.10.0

### DIFF
--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -39,6 +39,7 @@ from ..util import COLOR_ALIASES, RGB_HEX_REGEX
 MPL_VERSION = Version(mpl.__version__).release
 MPL_GE_3_7_0 = MPL_VERSION >= (3, 7, 0)
 MPL_GE_3_9_0 = MPL_VERSION >= (3, 9, 0)
+MPL_GE_3_10_0 = MPL_VERSION >= (3, 10, 0)
 
 
 def is_color(color):


### PR DESCRIPTION
I just tested Matplotlib 3.10.0rc1 locally and saw it emitted the following warning: `vert: bool was deprecated in Matplotlib 3.10 and will be removed in 3.12. Use orientation: {'vertical', 'horizontal'} instead.`

This does the suggested change and also forces the box inside of the violin plot to follow `invert_axes`