### PR TITLE
compat: Dask 2024.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,8 @@ filterwarnings = [
     "ignore: Jitify is performing a one-time only warm::cupy", # OK,
     # 2024-10
     "ignore::ResourceWarning",
+    # 2024-11
+    "ignore:The legacy Dask DataFrame implementation is deprecated:FutureWarning", # https://github.com/holoviz/spatialpandas/issues/146
 ]
 
 [tool.coverage]


### PR DESCRIPTION
More verbose logging of the lack of use of dask-expr. Tracked in https://github.com/holoviz/spatialpandas/issues/146.

(Also explicit tests which runs the legacy implementation)