### PR TITLE
perf: faster spatialpandas unique scalar values

### DIFF
--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -624,7 +624,6 @@ def get_value_array(data, dimension, expanded, keep_index, geom_col,
     all_scalar = True
     arrays, scalars = [], []
     for i, geom in enumerate(data[geom_col]):
-        length = 1 if is_points else geom_length(geom)
         val = column.iloc[i]
         scalar = isscalar(val)
         if scalar:
@@ -637,6 +636,7 @@ def get_value_array(data, dimension, expanded, keep_index, geom_col,
         if not expanded or not scalar:
             arrays.append(val)
         elif scalar:
+            length = 1 if is_points else geom_length(geom)
             arrays.append(np.full(length, val))
         if expanded and not is_points and not i == (len(data[geom_col])-1):
             arrays.append(np.array([np.nan]))

--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -624,7 +624,9 @@ def get_value_array(data, dimension, expanded, keep_index, geom_col,
     is_scalars = [isscalar(value) for value in column]
     all_scalar = all(is_scalars)
     if all_scalar and not expanded:
-        return column.unique()
+        scal_unique = column.unique()
+        # .unique() on categorical dtype doesn't return a np array
+        return scal_unique if isinstance(scal_unique, np.ndarray) else scal_unique.to_numpy()
     arrays, scalars = [], []
     for i, geom in enumerate(data[geom_col]):
         val = column.iloc[i]

--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -621,17 +621,19 @@ def get_value_array(data, dimension, expanded, keep_index, geom_col,
     column = data[dimension.name]
     if keep_index:
         return column
-    all_scalar = True
+    is_scalars = [isscalar(value) for value in column]
+    all_scalar = all(is_scalars)
+    if all_scalar and not expanded:
+        return column.unique()
     arrays, scalars = [], []
     for i, geom in enumerate(data[geom_col]):
         val = column.iloc[i]
-        scalar = isscalar(val)
+        scalar = is_scalars[i]
         if scalar:
             val = np.array([val])
         if not scalar and len(unique_array(val)) == 1:
             val = val[:1]
             scalar = True
-        all_scalar &= scalar
         scalars.append(scalar)
         if not expanded or not scalar:
             arrays.append(val)

--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -616,6 +616,8 @@ def get_value_array(data, dimension, expanded, keep_index, geom_col,
     Returns:
         An array containing the values along a dimension
     """
+    if not len(data):
+        return np.array([])
     column = data[dimension.name]
     if keep_index:
         return column
@@ -639,8 +641,6 @@ def get_value_array(data, dimension, expanded, keep_index, geom_col,
         if expanded and not is_points and not i == (len(data[geom_col])-1):
             arrays.append(np.array([np.nan]))
 
-    if not len(data):
-        return np.array([])
     if expanded:
         return np.concatenate(arrays) if len(arrays) > 1 else arrays[0]
     elif (all_scalar and arrays):


### PR DESCRIPTION
While working on modernizing the NYC Buildings example (https://github.com/holoviz-topics/examples/pull/386), I noticed that the creation of a HoloViews object (not the rendering) was very slow, the code below took  ~35 seconds to run on my machine.

```python
import time
import spatialpandas as spd
import spatialpandas.io
import hvplot.pandas # noqa

sdf = spd.io.read_parquet('/Users/mliquet/dev/examples/nyc_buildings/data/nyc_buildings.parq')
cats = ['unknown'] + list(sdf['type'].value_counts().iloc[:10].index.values)
sdf['type'] = sdf['type'].replace({None: 'unknown'})
sdf = sdf[sdf['type'].isin(cats)]
sdf['type'] = sdf['type'].astype('category')
sdf = sdf.build_sindex()

start = time.perf_counter()
print("Create object")
p = sdf.hvplot.polygons(rasterize=True, groupby='type', aggregator='any', width=600, height=500)
print(f"Obj creation time: {time.perf_counter() - start}")
```

The new code differs quite a bit from the old one, that was pure HoloViews. Note that the NYC Buildings example uses a DaskSpatialPandas object, I saw the problem was also present for a standard SpatialPandas object.

```python
cats = ['unknown'] + list(sdf['type'].value_counts().iloc[:10].index.values)
polys = hv.Polygons(sdf, vdims='type')
hmap  = hv.HoloMap(OrderedDict([(cat, polys.select(type=cat)) for cat in cats]), 'Type', sort=False)
rasterize(hmap, aggregator='any').opts(width=600, height=500)
```

The main difference is that, internally, hvPlot creates a dynamic HoloViews `groupby` operation. This operation calls the `values` method of the interface, and it turns out that this is very slow for the spatialpandas one, since AFAIU, it has to deal with collecting the values that may be associated with every node of a geometry. This code is in `get_value_array` that loops through every row of the dataset, and every node of the geometry, and creates intermediate numpy arrays that are finally combined based on how the function is called.

This PR implements a couple of optimizations, the main one being in https://github.com/holoviz/holoviews/commit/3fc8935ebbb9772bf5c68296c0b02d9ad51c6f96 that skips the loop entirely if all the values in the targeted column are scalar and if the function should return unique values (`expanded=False`, `expanded=True` is a bit more difficult o deal with as the values must be separated with `np.nan`, and not the scope of this PR). With this change, the timing went down to 0.4s, about 90x faster.