### PR TITLE
docs: add gallery intro with link to examples.holoviz.org

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -81,6 +81,11 @@ nbsite_gallery_conf = {
 if os.environ.get('HV_DOC_GALLERY') not in ('False', 'false', '0'):
     nbsite_gallery_conf['galleries']['gallery'] = {
         'title': 'Gallery',
+        'intro': (
+            'Also visit the `Examples HoloViz Gallery <https://examples.holoviz.org>`_ to '
+            'discover a curated collection of domain-specific narrative examples using '
+            'HoloViews and various HoloViz projects.'
+        ),
         'sections': [
             {'path': 'apps', 'title': 'Applications', 'skip': True},
             'demos'


### PR DESCRIPTION
Need to run a dev site build to see how this looks.

EDIT - Not too bad:
![image](https://github.com/user-attachments/assets/31bcfedb-a251-45b9-bc86-b5e7ca16f928)
