### PR TITLE
enh(bokeh): Inspect timeseries

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1375,7 +1375,7 @@ class shade(LinkableOperation):
         array = array.compute()
 
         if array.shape[-1] == 1:
-            array = array.squeeze()
+            array = array[..., 0]
 
         shade_opts = dict(
             how=self.p.cnorm, min_alpha=self.p.min_alpha, alpha=self.p.alpha

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1374,6 +1374,9 @@ class shade(LinkableOperation):
         # Dask is not supported by shade so materialize it
         array = array.compute()
 
+        if array.shape[-1] == 1:
+            array = array.squeeze()
+
         shade_opts = dict(
             how=self.p.cnorm, min_alpha=self.p.min_alpha, alpha=self.p.alpha
         )


### PR DESCRIPTION
Disabling the `overlay_aggregate` fastpath when we have a `selector`. A bit of formatting in the `applies` as it was pretty complicated already. 

<details>
<summary>Code</summary>


``` python
import itertools

import datashader as ds
import numpy as np
import pandas as pd
import panel as pn

import holoviews as hv
from holoviews.operation.datashader import datashade, dynspread, rasterize

hv.extension("bokeh")

num = 10000
seed = np.random.default_rng(1)


def y(val):
    y = seed.normal(0, 1, num).cumsum()
    if val == 1:
        y[num // 2 : num // 2 + num // 10] = np.nan
    return y + val * 100  # No overlap


dists = [
    pd.DataFrame(
        {
            "x": np.arange(num),
            "y": y(val),
            "val": val,
            "cat": cat,
        }
    )
    for val, cat in [
        (0, "c0"),
        (1, "c1"),
    ]
]

df = pd.concat(dists, ignore_index=True)
curves = hv.Curve(df).groupby("cat").opts(tools=["hover"])
overlay = curves.overlay()


def dynspread_datashade(*args, **kwargs):
    return dynspread(datashade(*args, **kwargs))


def dynspread_rasterize(*args, **kwargs):
    return dynspread(rasterize(*args, **kwargs))


def rasterize_linewidth(*args, **kwargs):
    return rasterize(*args, **dict(kwargs, line_width=10))


def datashade_linewidth(*args, **kwargs):
    return datashade(*args, **dict(kwargs, line_width=10))


ops = (
    rasterize,
    dynspread_rasterize,
    rasterize_linewidth,
    datashade,
    dynspread_datashade,
    datashade_linewidth,
)
aggs = (ds.count(self_intersect=False), ds.by("cat", ds.count(self_intersect=False)))
sels = (None, ds.min("val"))
combinations = itertools.product(ops, aggs, sels)
plots = []
for op, agg, sel in combinations:
    title = f"{op.__name__.replace('_','+')}(agg={type(agg).__name__}, sel={type(sel).__name__ if sel else None})"
    plot = op(overlay, aggregator=agg, selector=sel).opts(
        tools=["hover"], title=title, width=400, height=400
    )
    plots.append(plot)

pn.panel(hv.Layout(plots).cols(4).opts(shared_axes=False)).servable()
```

</details>


![image](https://github.com/user-attachments/assets/7f597145-2a1c-41e6-9bc7-1e6439c66a7f)

