### PR TITLE
fix(dev): Avoid checking out CRLF in shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# The "shellcheck" pre-commit hook requires shell scripts to end lines with LF
+# regardless of git's "core.autocrlf" setting.
+*.sh text eol=lf


### PR DESCRIPTION
This PR resolves issue #6482 by instructing *git* to check out "*.sh" files with LF line endings.

A shell script previously checked out with CRLF endings will need its endings changed by other means for linting to pass.