### PR TITLE
docs: Correct doc of "allow_jedi_completion"

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -100,9 +100,7 @@ class notebook_extension(extension):
         export figures to other formats such as PDF with nbconvert.""")
 
     allow_jedi_completion = param.Boolean(default=True, doc="""
-       Whether to allow jedi tab-completion to be enabled in IPython.
-       Disabled by default because many HoloViews features rely on
-       tab-completion machinery not supported when using jedi.""")
+       Whether to allow jedi tab-completion to be enabled in IPython.""")
 
     case_sensitive_completion = param.Boolean(default=False, doc="""
        Whether to monkey patch IPython to use the correct tab-completion


### PR DESCRIPTION
PR #5701 changed the default value to `True`, enabling Jedi completion by default. This PR edits the documentation of the `allow_jedi_completion` parameter to match that change.