### PR TITLE
compat: Dask 2025.1

### DIFF
--- a/holoviews/tests/utils.py
+++ b/holoviews/tests/utils.py
@@ -8,8 +8,8 @@ from importlib.util import find_spec
 
 import param
 import pytest
-from packaging.version import Version
 
+from holoviews.core.util import _no_import_version
 from holoviews.element.comparison import ComparisonTestCase
 
 cwd = os.path.abspath(os.path.split(__file__)[0])
@@ -120,21 +120,21 @@ class LoggingComparisonTestCase(ComparisonTestCase):
 
 
 DASK_UNAVAILABLE = find_spec("dask") is None
+DASK_VERSION = _no_import_version("dask")
 
 
 @lru_cache
-def _dask_setup():
+def dask_setup():
     """
     Set-up both dask dataframes, using lru_cahce to only do it once
 
     """
-    import dask
     from datashader.data_libraries.dask import bypixel, dask_pipeline
 
     classic, expr = False, False
 
     # Removed in Dask 2025.1, and will raise AttributeError
-    if Version(dask.__version__).release < (2025, 1, 0):
+    if DASK_VERSION < (2025, 1, 0):
         import dask.dataframe as dd
 
         bypixel.pipeline.register(dd.core.DataFrame)(dask_pipeline)
@@ -164,7 +164,7 @@ def dask_switcher(*, query=False, extras=None):
     if DASK_UNAVAILABLE:
         pytest.skip("dask is not available")
 
-    classic, expr = _dask_setup()
+    classic, expr = dask_setup()
 
     if not query and not classic:
         pytest.skip("Classic DataFrame no longer supported by dask")

--- a/holoviews/tests/utils.py
+++ b/holoviews/tests/utils.py
@@ -1,12 +1,14 @@
 import logging
 import os
 import sys
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
+from functools import lru_cache
 from importlib import reload
 from importlib.util import find_spec
 
 import param
 import pytest
+from packaging.version import Version
 
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -118,25 +120,61 @@ class LoggingComparisonTestCase(ComparisonTestCase):
 
 
 DASK_UNAVAILABLE = find_spec("dask") is None
-EXPR_UNAVAILABLE = find_spec("dask_expr") is None
+
+
+@lru_cache
+def _dask_setup():
+    """
+    Set-up both dask dataframes, using lru_cahce to only do it once
+
+    """
+    import dask
+    from datashader.data_libraries.dask import bypixel, dask_pipeline
+
+    classic, expr = False, False
+
+    # Removed in Dask 2025.1, and will raise AttributeError
+    if Version(dask.__version__).release < (2025, 1, 0):
+        import dask.dataframe as dd
+
+        bypixel.pipeline.register(dd.core.DataFrame)(dask_pipeline)
+        classic = True
+    else:
+        # dask_expr import below will now fail with:
+        # cannot import name '_Frame' from 'dask.dataframe.core'
+        expr = True
+
+    with suppress(ImportError):
+        import dask_expr
+
+        bypixel.pipeline.register(dask_expr.DataFrame)(dask_pipeline)
+        expr = True
+
+    return classic, expr
 
 
 @contextmanager
-def dask_switcher(*, query=False, extras=()):
+def dask_switcher(*, query=False, extras=None):
     """
     Context manager to switch on/off dask-expr query planning.
+
     Using a context manager as it is an easy way to
     change the function to a decorator.
     """
     if DASK_UNAVAILABLE:
         pytest.skip("dask is not available")
-    if query and EXPR_UNAVAILABLE:
+
+    classic, expr = _dask_setup()
+
+    if not query and not classic:
+        pytest.skip("Classic DataFrame no longer supported by dask")
+    if query and not expr:
         pytest.skip("dask-expr is not available")
 
     import dask
 
     dask.config.set(**{"dataframe.query-planning": query})
-    for module in ("dask.dataframe", *extras):
+    for module in ("dask.dataframe", *(extras or ())):
         if module in sys.modules:
             reload(sys.modules[module])
     yield

--- a/pixi.toml
+++ b/pixi.toml
@@ -159,7 +159,6 @@ test-unit = 'pytest holoviews/tests -n logical --dist loadgroup'
 
 [feature.test-example.tasks]
 test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'
-# test-example = { cmd = 'pytest -n logical --dist loadscope --nbval-lax examples', env = { DASK_DATAFRAME__QUERY_PLANNING = "False" } }
 
 [feature.test-example.dependencies]
 nbval = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -204,7 +204,6 @@ nbsite = ">=0.8.4,<0.9.0"
 pooch = "*"
 python-kaleido = "*"
 selenium = "*"
-dask-core = "<2025.1" # Spatialpandas does not support the new dask-expr DataFrame
 
 [feature.doc.activation.env]
 DASK_DATAFRAME__QUERY_PLANNING = "False"

--- a/pixi.toml
+++ b/pixi.toml
@@ -158,7 +158,8 @@ pytest-xdist = "*"
 test-unit = 'pytest holoviews/tests -n logical --dist loadgroup'
 
 [feature.test-example.tasks]
-test-example = { cmd = 'pytest -n logical --dist loadscope --nbval-lax examples', env = { DASK_DATAFRAME__QUERY_PLANNING = "False" } }
+test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'
+# test-example = { cmd = 'pytest -n logical --dist loadscope --nbval-lax examples', env = { DASK_DATAFRAME__QUERY_PLANNING = "False" } }
 
 [feature.test-example.dependencies]
 nbval = "*"
@@ -204,6 +205,7 @@ nbsite = ">=0.8.4,<0.9.0"
 pooch = "*"
 python-kaleido = "*"
 selenium = "*"
+dask-core = "<2025.1" # Spatialpandas does not support the new dask-expr DataFrame
 
 [feature.doc.activation.env]
 DASK_DATAFRAME__QUERY_PLANNING = "False"

--- a/pixi.toml
+++ b/pixi.toml
@@ -206,7 +206,6 @@ python-kaleido = "*"
 selenium = "*"
 
 [feature.doc.activation.env]
-DASK_DATAFRAME__QUERY_PLANNING = "False"
 MOZ_HEADLESS = "1"
 MPLBACKEND = "Agg"
 PANEL_EMBED = "true"


### PR DESCRIPTION
The latest dask release dropped the classic dask dataframe, making the CI angry. 

This implements what was done in https://github.com/holoviz/datashader/pull/1390