### PR TITLE
enh(dev): Don't force holoviews to be installed for test-example and docs-build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,6 +13,9 @@ authors = 'HoloViz developers'
 copyright = '2005 ' + authors
 description = 'Stop plotting your data - annotate your data and let it visualize itself.'
 
+# Setting this to not error out if no install is done
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
 import holoviews
 version = release = base_version(holoviews.__version__)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,9 @@ copyright = '2005 ' + authors
 description = 'Stop plotting your data - annotate your data and let it visualize itself.'
 
 # Setting this to not error out if no install is done
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+root_path = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, root_path)
+os.environ["PYTHONPATH"] = root_path
 
 import holoviews
 version = release = base_version(holoviews.__version__)

--- a/doc/developer_guide/index.md
+++ b/doc/developer_guide/index.md
@@ -95,6 +95,14 @@ pixi run download-data
 
 All available tasks can be found by running `pixi task list`, the following sections will give a brief introduction to the most common tasks.
 
+For setting up a complete development you can run:
+
+```bash
+pixi run setup-dev
+```
+
+This will run the `install` and `download-data` tasks, among other tasks deemed necessary for a development environment.
+
 ### Syncing Git tags with upstream repository
 
 If you are working from a forked repository of HoloViews, you will need to sync the tags with the upstream repo.

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -7,14 +7,12 @@ import bokeh
 import pandas as pd
 from packaging.version import Version
 
+# Setting this to not error out if no install is done.
+os.environ["PYTHONPATH"] = os.path.dirname(os.path.dirname(__file__))
+
 system = platform.system()
 py_version = sys.version_info[:2]
 PANDAS_GE_2_0_0 = Version(pd.__version__).release >= (2, 0, 0)
-
-# Having "OMP_NUM_THREADS"=1, set as an environment variable, can be needed
-# to avoid crashing when running tests with pytest-xdist on Windows.
-# This is set in the .github/workflows/test.yaml file.
-# https://github.com/holoviz/holoviews/pull/5720
 
 collect_ignore_glob = [
     # Needs selenium, phantomjs, firefox, and geckodriver to save a png picture

--- a/pixi.toml
+++ b/pixi.toml
@@ -141,6 +141,7 @@ setuptools_scm = "*"
 
 [feature.dev.tasks]
 lab = 'jupyter lab'
+setup-dev = { depends-on = ["install", "download-data", "lint-install"] }
 
 # =============================================
 # =================== TESTS ===================


### PR DESCRIPTION
Right now, if we want to `pixi run test-example` and `pixi run docs-build`, it will fail because 'HoloViews' is not installed, and for new developers give a weird error message like `holoviews is not installed`. It is stated in the docs that you need to run `pixi run install` before doing anything, but people forget or don't read the docs. 

I can't currently think of a reason why this should be done, as holoviews is doing anything weird as installing/downloading doing the build step.