### PR TITLE
fix: heatmap aggregation when kdims are in a Pandas multi-index

### DIFF
--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -216,7 +216,6 @@ class categorical_aggregate2d(Operation):
         if not all(c in obj.data.index.names for c in index_cols):
             df = df.set_index(index_cols)
         df = df.groupby(index_cols, **groupby_kwargs).first()
-        # df = obj.data.set_index(index_cols).groupby(index_cols, **groupby_kwargs).first()
         label = 'unique' if len(df) == len(obj) else 'non-unique'
         levels = self._get_coords(obj)
         index = pd.MultiIndex.from_product(levels, names=df.index.names)

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -213,7 +213,7 @@ class categorical_aggregate2d(Operation):
         if PANDAS_GE_2_1_0:
             groupby_kwargs["observed"] = False
         df = obj.data
-        if not all(c in obj.data.index.names for c in index_cols):
+        if not all(c in df.index.names for c in index_cols):
             df = df.set_index(index_cols)
         df = df.groupby(index_cols, **groupby_kwargs).first()
         label = 'unique' if len(df) == len(obj) else 'non-unique'

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -212,7 +212,11 @@ class categorical_aggregate2d(Operation):
         groupby_kwargs = {"sort": False}
         if PANDAS_GE_2_1_0:
             groupby_kwargs["observed"] = False
-        df = obj.data.set_index(index_cols).groupby(index_cols, **groupby_kwargs).first()
+        df = obj.data
+        if not all(c in obj.data.index.names for c in index_cols):
+            df = df.set_index(index_cols)
+        df = df.groupby(index_cols, **groupby_kwargs).first()
+        # df = obj.data.set_index(index_cols).groupby(index_cols, **groupby_kwargs).first()
         label = 'unique' if len(df) == len(obj) else 'non-unique'
         levels = self._get_coords(obj)
         index = pd.MultiIndex.from_product(levels, names=df.index.names)

--- a/holoviews/tests/plotting/bokeh/test_heatmapplot.py
+++ b/holoviews/tests/plotting/bokeh/test_heatmapplot.py
@@ -156,3 +156,15 @@ class TestHeatMapPlot(TestBokehPlot):
         np.testing.assert_array_equal(data["X"], df["X"])
         np.testing.assert_array_equal(data["Y"], df["Y"])
         np.testing.assert_array_equal(data["zvalues"], df["Z"])
+
+    def test_heatmap_pandas_multiindex(self):
+        df = pd.DataFrame(
+            data={'C': [5, 2, -1, 5]},
+            index=pd.MultiIndex.from_product([(0, 1), (0, 1)], names=['A', 'B']),
+        )
+        hm = HeatMap(df, ['A', 'B'], 'C')
+        plot = bokeh_renderer.get_plot(hm)
+        data = plot.handles["cds"].data
+        np.testing.assert_array_equal(data['A'], df.index.get_level_values('A'))
+        np.testing.assert_array_equal(data['B'], df.index.get_level_values('B'))
+        np.testing.assert_array_equal(data['zvalues'], df['C'])


### PR DESCRIPTION
The optimizations recently done in HoloViews and hvPlot to avoid unnecessary Pandas copies have exposed this bug reported first on hvPlot's issue tracker https://github.com/holoviz/hvplot/issues/1467.

```python
import xarray as xr
import pandas as pd
import holoviews as hv
hv.extension('bokeh')

da = xr.DataArray([[0.5, 0.2], [-0.1, 0.5]], dims=["A", "B"], name="C")
df = da.to_dataframe()
heatmap = hv.HeatMap(df, ['A', 'B'], ['C'])
hv.render(heatmap)
```

Error: `KeyError: "None of ['A', 'B'] are in the columns"`.


closes https://github.com/holoviz/hvplot/issues/1467
