### PR TITLE
compat: plotly 6.0

### DIFF
--- a/holoviews/plotting/plotly/annotation.py
+++ b/holoviews/plotting/plotly/annotation.py
@@ -2,6 +2,7 @@ import param
 
 from ...element import Tiles
 from .chart import ScatterPlot
+from .util import PLOTLY_SCATTERMAP
 
 
 class LabelPlot(ScatterPlot):
@@ -21,7 +22,7 @@ class LabelPlot(ScatterPlot):
     @classmethod
     def trace_kwargs(cls, is_geo=False, **kwargs):
         if is_geo:
-            return {'type': 'scattermapbox', 'mode': 'text'}
+            return {'type': PLOTLY_SCATTERMAP, 'mode': 'text'}
         else:
             return {'type': 'scatter', 'mode': 'text'}
 

--- a/holoviews/plotting/plotly/callbacks.py
+++ b/holoviews/plotting/plotly/callbacks.py
@@ -12,7 +12,7 @@ from ...streams import (
     SelectionXY,
     Stream,
 )
-from .util import _trace_to_subplot
+from .util import PLOTLY_MAP, PLOTLY_SCATTERMAP, _trace_to_subplot
 
 
 class PlotlyCallbackMetaClass(type):
@@ -172,10 +172,10 @@ class BoundsCallback(PlotlyCallback):
             trace_type = trace.get('type', 'scatter')
             trace_uid = trace.get('uid', None)
 
-            if _trace_to_subplot.get(trace_type, None) != ['mapbox']:
+            if _trace_to_subplot.get(trace_type, None) != [PLOTLY_MAP]:
                 continue
 
-            mapbox_ref = trace.get('subplot', 'mapbox')
+            mapbox_ref = trace.get('subplot', PLOTLY_MAP)
             if mapbox_ref in range_data:
                 lon_bounds = [range_data[mapbox_ref][0][0], range_data[mapbox_ref][1][0]]
                 lat_bounds = [range_data[mapbox_ref][0][1], range_data[mapbox_ref][1][1]]
@@ -268,13 +268,13 @@ class RangeCallback(PlotlyCallback):
         # Process traces
         event_data = {}
         for trace in traces:
-            trace_type = trace.get('type', 'scattermapbox')
+            trace_type = trace.get('type', PLOTLY_SCATTERMAP)
             trace_uid = trace.get('uid', None)
 
-            if _trace_to_subplot.get(trace_type, None) != ['mapbox']:
+            if _trace_to_subplot.get(trace_type, None) != [PLOTLY_MAP]:
                 continue
 
-            subplot_id = trace.get("subplot", "mapbox")
+            subplot_id = trace.get("subplot", PLOTLY_MAP)
             derived_prop = subplot_id + "._derived"
 
             if not property_value:

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -6,6 +6,7 @@ from ...operation import interpolate_curve
 from ..mixins import AreaMixin, BarsMixin
 from .element import ColorbarPlot, ElementPlot
 from .selection import PlotlyOverlaySelectionDisplay
+from .util import PLOTLY_SCATTERMAP
 
 
 class ChartPlot(ElementPlot):
@@ -59,7 +60,7 @@ class ScatterPlot(ChartPlot, ColorbarPlot):
     @classmethod
     def trace_kwargs(cls, is_geo=False, **kwargs):
         if is_geo:
-            return {'type': 'scattermapbox', 'mode': 'markers'}
+            return {'type': PLOTLY_SCATTERMAP, 'mode': 'markers'}
         else:
             return {'type': 'scatter', 'mode': 'markers'}
 
@@ -101,7 +102,7 @@ class CurvePlot(ChartPlot, ColorbarPlot):
     @classmethod
     def trace_kwargs(cls, is_geo=False, **kwargs):
         if is_geo:
-            return {'type': 'scattermapbox', 'mode': 'lines'}
+            return {'type': PLOTLY_SCATTERMAP, 'mode': 'lines'}
         else:
             return {'type': 'scatter', 'mode': 'lines'}
 

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -14,6 +14,7 @@ from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dim_range_key
 from .plot import PlotlyPlot
 from .util import (
+    PLOTLY_MAP,
     STYLE_ALIASES,
     get_colorscale,
     legend_trace_types,
@@ -208,8 +209,8 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
                 components[k].extend(datum_components.get(k, []))
 
             # Handle mapbox
-            if "mapbox" in datum_components:
-                components["mapbox"] = datum_components["mapbox"]
+            if PLOTLY_MAP in datum_components:
+                components[PLOTLY_MAP] = datum_components[PLOTLY_MAP]
 
         self.handles['components'] = components
 
@@ -219,8 +220,8 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
             layout.setdefault(k, [])
             layout[k].extend(components.get(k, []))
 
-        if "mapbox" in components:
-            merge_layout(layout.setdefault("mapbox", {}), components["mapbox"])
+        if PLOTLY_MAP in components:
+            merge_layout(layout.setdefault(PLOTLY_MAP, {}), components[PLOTLY_MAP])
 
         self.handles['layout'] = layout
 
@@ -534,7 +535,7 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
                     max_y_zoom = (np.log2(max_delta / y_delta) -
                                 np.log2(mapbox_tile_size / viewport_height))
                 mapbox["zoom"] = min(max_x_zoom, max_y_zoom)
-            layout["mapbox"] = mapbox
+            layout[PLOTLY_MAP] = mapbox
 
         if isinstance(self.projection, str) and self.projection == '3d':
             scene = dict(xaxis=xaxis, yaxis=yaxis)

--- a/holoviews/plotting/plotly/images.py
+++ b/holoviews/plotting/plotly/images.py
@@ -5,7 +5,7 @@ from ...core.util import VersionError
 from ...element import Tiles
 from .element import ElementPlot
 from .selection import PlotlyOverlaySelectionDisplay
-from .util import PLOTLY_SCATTERMAP
+from .util import PLOTLY_MAP, PLOTLY_SCATTERMAP
 
 
 class RGBPlot(ElementPlot):
@@ -28,8 +28,7 @@ class RGBPlot(ElementPlot):
                 'mode': 'markers',
                 'showlegend': False
             }
-            return dict(mapbox=dict(layers=[layer]),
-                        traces=[dummy_trace])
+            return {PLOTLY_MAP: dict(layers=[layer]), 'traces': [dummy_trace]}
         else:
             image = dict(datum, **options)
             # Create a dummy invisible scatter trace for this image.

--- a/holoviews/plotting/plotly/images.py
+++ b/holoviews/plotting/plotly/images.py
@@ -5,6 +5,7 @@ from ...core.util import VersionError
 from ...element import Tiles
 from .element import ElementPlot
 from .selection import PlotlyOverlaySelectionDisplay
+from .util import PLOTLY_SCATTERMAP
 
 
 class RGBPlot(ElementPlot):
@@ -21,7 +22,7 @@ class RGBPlot(ElementPlot):
         if is_geo:
             layer = dict(datum, **options)
             dummy_trace = {
-                'type': 'scattermapbox',
+                'type': PLOTLY_SCATTERMAP,
                 'lat': [None],
                 'lon': [None],
                 'mode': 'markers',

--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -9,7 +9,11 @@ from ...core import HoloMap
 from ...core.options import Store
 from ..renderer import HTML_TAGS, MIME_TYPES, Renderer
 from .callbacks import callbacks
-from .util import clean_internal_figure_properties
+from .util import (
+    PLOTLY_GE_6_0_0,
+    _convert_numpy_in_fig_dict,
+    clean_internal_figure_properties,
+)
 
 with param.logging_level('CRITICAL'):
     import plotly.graph_objs as go
@@ -67,7 +71,7 @@ class PlotlyRenderer(Renderer):
     _render_with_panel = True
 
     @bothmethod
-    def get_plot_state(self_or_cls, obj, doc=None, renderer=None, **kwargs):
+    def get_plot_state(self_or_cls, obj, doc=None, renderer=None, numpy_convert=False, **kwargs):
         """
         Given a HoloViews Viewable return a corresponding figure dictionary.
         Allows cleaning the dictionary of any internal properties that were added
@@ -85,6 +89,10 @@ class PlotlyRenderer(Renderer):
 
         # Remove template
         fig_dict.get('layout', {}).pop('template', None)
+
+        if numpy_convert and PLOTLY_GE_6_0_0:
+            return _convert_numpy_in_fig_dict(fig_dict)
+
         return fig_dict
 
     def _figure_data(self, plot, fmt, as_script=False, **kwargs):

--- a/holoviews/plotting/plotly/shapes.py
+++ b/holoviews/plotting/plotly/shapes.py
@@ -4,6 +4,7 @@ import param
 from ...element import HLine, HSpan, Tiles, VLine, VSpan
 from ..mixins import GeomMixin
 from .element import ElementPlot
+from .util import PLOTLY_SCATTERMAP
 
 
 class ShapePlot(ElementPlot):
@@ -17,7 +18,7 @@ class ShapePlot(ElementPlot):
     def init_graph(self, datum, options, index=0, is_geo=False, **kwargs):
         if is_geo:
             trace = {
-                'type': 'scattermapbox',
+                'type': PLOTLY_SCATTERMAP,
                 'mode': 'lines',
                 'showlegend': False,
                 'hoverinfo': 'skip',

--- a/holoviews/plotting/plotly/tiles.py
+++ b/holoviews/plotting/plotly/tiles.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from holoviews.element.tiles import _ATTRIBUTIONS
 from holoviews.plotting.plotly import ElementPlot
-from holoviews.plotting.plotly.util import STYLE_ALIASES
+from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP, STYLE_ALIASES
 
 
 class TilePlot(ElementPlot):
@@ -12,11 +12,11 @@ class TilePlot(ElementPlot):
 
     @classmethod
     def trace_kwargs(cls, **kwargs):
-        return {'type': 'scattermapbox'}
+        return {'type': PLOTLY_SCATTERMAP}
 
     def get_data(self, element, ranges, style, **kwargs):
         return [{
-            "type": "scattermapbox", "lat": [], "lon": [], "subplot": "mapbox",
+            "type": PLOTLY_SCATTERMAP, "lat": [], "lon": [], "subplot": PLOTLY_MAP,
             "showlegend": False,
         }]
 
@@ -65,7 +65,7 @@ class TilePlot(ElementPlot):
         return extents
 
     def init_graph(self, datum, options, index=0, **kwargs):
-        return {'traces': [datum], "mapbox": options}
+        return {'traces': [datum], PLOTLY_MAP: options}
 
     def generate_plot(self, key, ranges, element=None, is_geo=False):
         """

--- a/holoviews/plotting/plotly/tiles.py
+++ b/holoviews/plotting/plotly/tiles.py
@@ -2,7 +2,12 @@ import numpy as np
 
 from holoviews.element.tiles import _ATTRIBUTIONS
 from holoviews.plotting.plotly import ElementPlot
-from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP, STYLE_ALIASES
+from holoviews.plotting.plotly.util import (
+    PLOTLY_GE_6_0_0,
+    PLOTLY_MAP,
+    PLOTLY_SCATTERMAP,
+    STYLE_ALIASES,
+)
 
 
 class TilePlot(ElementPlot):
@@ -21,9 +26,12 @@ class TilePlot(ElementPlot):
         }]
 
     def graph_options(self, element, ranges, style, **kwargs):
+        if PLOTLY_GE_6_0_0 and "mapboxstyle" in style:
+            raise ValueError("'mapboxstyle' no longer supported with Plotly 6.0 use 'mapstyle'")
+
         style = dict(style)
         opts = dict(
-            style=style.pop("mapboxstyle", style.pop("mapstyle", "white-bg")),
+            style=style.pop("mapstyle", "white-bg"),
             accesstoken=style.pop("accesstoken", None),
         )
         # Extract URL and lower case wildcard characters for mapbox

--- a/holoviews/plotting/plotly/tiles.py
+++ b/holoviews/plotting/plotly/tiles.py
@@ -8,10 +8,19 @@ from holoviews.plotting.plotly.util import (
     PLOTLY_SCATTERMAP,
     STYLE_ALIASES,
 )
+from holoviews.util.warnings import warn
 
 
 class TilePlot(ElementPlot):
-    style_opts = ['min_zoom', 'max_zoom', "alpha", "accesstoken", "mapboxstyle", "mapstyle"]
+    style_opts = [
+        "min_zoom",
+        "max_zoom",
+        "alpha",
+        "mapstyle",
+        # Only needed for Plotly <6
+        "accesstoken",
+        "mapboxstyle",
+    ]
 
     _supports_geo = True
 
@@ -26,10 +35,13 @@ class TilePlot(ElementPlot):
         }]
 
     def graph_options(self, element, ranges, style, **kwargs):
-        if PLOTLY_GE_6_0_0 and "mapboxstyle" in style:
-            raise ValueError("'mapboxstyle' no longer supported with Plotly 6.0 use 'mapstyle'")
-
         style = dict(style)
+        if PLOTLY_GE_6_0_0 and (mapboxstyle := style.pop("mapboxstyle", None)):
+            warn("'mapboxstyle' no longer supported with Plotly 6.0 use 'mapstyle' instead", category=UserWarning)
+            style["mapstyle"] = mapboxstyle
+        if PLOTLY_GE_6_0_0 and style.pop("accesstoken", None):
+            warn("'accesstoken' no longer needed with Plotly 6.0", category=UserWarning)
+
         opts = dict(
             style=style.pop("mapstyle", "white-bg"),
             accesstoken=style.pop("accesstoken", None),

--- a/holoviews/plotting/plotly/tiles.py
+++ b/holoviews/plotting/plotly/tiles.py
@@ -6,7 +6,7 @@ from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP, STYLE_
 
 
 class TilePlot(ElementPlot):
-    style_opts = ['min_zoom', 'max_zoom', "alpha", "accesstoken", "mapboxstyle"]
+    style_opts = ['min_zoom', 'max_zoom', "alpha", "accesstoken", "mapboxstyle", "mapstyle"]
 
     _supports_geo = True
 
@@ -23,7 +23,7 @@ class TilePlot(ElementPlot):
     def graph_options(self, element, ranges, style, **kwargs):
         style = dict(style)
         opts = dict(
-            style=style.pop("mapboxstyle", "white-bg"),
+            style=style.pop("mapboxstyle", style.pop("mapstyle", "white-bg")),
             accesstoken=style.pop("accesstoken", None),
         )
         # Extract URL and lower case wildcard characters for mapbox

--- a/holoviews/plotting/plotly/util.py
+++ b/holoviews/plotting/plotly/util.py
@@ -1,11 +1,16 @@
+import base64
 import copy
 import re
 
 import numpy as np
-from plotly import colors
+from packaging.version import Version
+from plotly import __version__, colors
 
 from ...core.util import isfinite, max_range
 from ..util import color_intervals, process_cmap
+
+PLOTLY_VERSION = Version(__version__).release
+PLOTLY_GE_6_0_0 = PLOTLY_VERSION >= (6, 0, 0)
 
 # Constants
 # ---------
@@ -911,3 +916,17 @@ def clean_internal_figure_properties(fig):
         elif isinstance(val, (list, tuple)) and val and isinstance(val[0], dict):
             for el in val:
                 clean_internal_figure_properties(el)
+
+
+def _convert_numpy_in_fig_dict(fig_dict):
+    if isinstance(fig_dict, dict):
+        if fig_dict.keys() == {"dtype", "bdata"}:
+            return np.frombuffer(base64.b64decode(fig_dict["bdata"]), dtype=fig_dict["dtype"])
+        elif fig_dict.keys() == {"dtype", "bdata", "shape"}:
+            shape = list(map(int, fig_dict["shape"].split(",")))
+            return np.frombuffer(base64.b64decode(fig_dict["bdata"]), dtype=fig_dict["dtype"]).reshape(shape)
+        return {key: _convert_numpy_in_fig_dict(value) for key, value in fig_dict.items()}
+    elif isinstance(fig_dict, list):
+        return [_convert_numpy_in_fig_dict(item) for item in fig_dict]
+    else:
+        return fig_dict

--- a/holoviews/plotting/plotly/util.py
+++ b/holoviews/plotting/plotly/util.py
@@ -11,6 +11,8 @@ from ..util import color_intervals, process_cmap
 
 PLOTLY_VERSION = Version(__version__).release
 PLOTLY_GE_6_0_0 = PLOTLY_VERSION >= (6, 0, 0)
+PLOTLY_SCATTERMAP = "scattermap" if PLOTLY_GE_6_0_0 else "scattermapbox"
+PLOTLY_MAP = "map" if PLOTLY_GE_6_0_0 else "mapbox"
 
 # Constants
 # ---------
@@ -28,7 +30,7 @@ _domain_trace_types = {'parcoords', 'pie', 'table', 'sankey', 'parcats'}
 # Each of these subplot types has a `domain` property with `x`/`y` properties.
 # Note that this set does not contain `xaxis`/`yaxis` because these behave a
 # little differently.
-_subplot_types = {'scene', 'geo', 'polar', 'ternary', 'mapbox'}
+_subplot_types = {'scene', 'geo', 'polar', 'ternary', PLOTLY_MAP}
 
 # For most subplot types, a trace is associated with a particular subplot
 # using a trace property with a name that matches the subplot type. For
@@ -39,7 +41,7 @@ _subplot_types = {'scene', 'geo', 'polar', 'ternary', 'mapbox'}
 # the trace property is just named `subplot`.  For example setting
 # the `scatterpolar.subplot` property to `polar3` associates the scatterpolar
 # trace with the third polar subplot in the figure
-_subplot_prop_named_subplot = {'polar', 'ternary', 'mapbox'}
+_subplot_prop_named_subplot = {'polar', 'ternary', PLOTLY_MAP}
 
 # Mapping from trace type to subplot type(s).
 _trace_to_subplot = {
@@ -82,7 +84,7 @@ _trace_to_subplot = {
     'scatterternary': ['ternary'],
 
     # mapbox
-    'scattermapbox': ['mapbox']
+    PLOTLY_SCATTERMAP: [PLOTLY_MAP],
 }
 
 # trace types that support legends
@@ -102,7 +104,7 @@ legend_trace_types = {
     'scattergl',
     'splom',
     'pointcloud',
-    'scattermapbox',
+    PLOTLY_SCATTERMAP,
     'scattercarpet',
     'contourcarpet',
     'ohlc',

--- a/holoviews/tests/plotting/plotly/test_callbacks.py
+++ b/holoviews/tests/plotting/plotly/test_callbacks.py
@@ -14,6 +14,7 @@ from holoviews.plotting.plotly.callbacks import (
     RangeYCallback,
     Selection1DCallback,
 )
+from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP
 from holoviews.streams import (
     BoundsX,
     BoundsXY,
@@ -95,9 +96,9 @@ class TestCallbacks(TestCase):
 
         self.mapbox_fig_dict = go.Figure({
             'data': [
-                {'type': 'scattermapbox', 'uid': 'first', 'subplot': 'mapbox'},
-                {'type': 'scattermapbox', 'uid': 'second', 'subplot': 'mapbox2'},
-                {'type': 'scattermapbox', 'uid': 'third', 'subplot': 'mapbox3'}
+                {'type': PLOTLY_SCATTERMAP, 'uid': 'first', 'subplot': PLOTLY_MAP},
+                {'type': PLOTLY_SCATTERMAP, 'uid': 'second', 'subplot': PLOTLY_MAP + '2'},
+                {'type': PLOTLY_SCATTERMAP, 'uid': 'third', 'subplot': PLOTLY_MAP + '3'}
             ],
             'layout': {
                 'title': {'text': 'Figure Title'},
@@ -211,8 +212,8 @@ class TestCallbacks(TestCase):
 
     def testMapboxRangeXYCallbackEventData(self):
         relayout_data = {
-            'mapbox._derived': {"coordinates": self.mapbox_coords1},
-            'mapbox3._derived': {"coordinates": self.mapbox_coords2}
+            f'{PLOTLY_MAP}._derived': {"coordinates": self.mapbox_coords1},
+            f'{PLOTLY_MAP}3._derived': {"coordinates": self.mapbox_coords2}
         }
 
         event_data = RangeXYCallback.get_event_data_from_property_update(
@@ -226,8 +227,8 @@ class TestCallbacks(TestCase):
 
     def testMapboxRangeXCallbackEventData(self):
         relayout_data = {
-            'mapbox._derived': {"coordinates": self.mapbox_coords1},
-            'mapbox3._derived': {"coordinates": self.mapbox_coords2}
+            f'{PLOTLY_MAP}._derived': {"coordinates": self.mapbox_coords1},
+            f'{PLOTLY_MAP}3._derived': {"coordinates": self.mapbox_coords2}
         }
 
         event_data = RangeXCallback.get_event_data_from_property_update(
@@ -241,8 +242,8 @@ class TestCallbacks(TestCase):
 
     def testMapboxRangeYCallbackEventData(self):
         relayout_data = {
-            'mapbox._derived': {"coordinates": self.mapbox_coords1},
-            'mapbox3._derived': {"coordinates": self.mapbox_coords2}
+            f'{PLOTLY_MAP}._derived': {"coordinates": self.mapbox_coords1},
+            f'{PLOTLY_MAP}3._derived': {"coordinates": self.mapbox_coords2}
         }
 
         event_data = RangeYCallback.get_event_data_from_property_update(
@@ -387,7 +388,7 @@ class TestCallbacks(TestCase):
         })
 
     def testMapboxBoundsXYCallbackEventData(self):
-        selected_data = {"range": {'mapbox2': [
+        selected_data = {"range": {f'{PLOTLY_MAP}2': [
             [self.lon_range1[0], self.lat_range1[0]],
             [self.lon_range1[1], self.lat_range1[1]]
         ]}}
@@ -406,7 +407,7 @@ class TestCallbacks(TestCase):
         })
 
     def testMapboxBoundsXCallbackEventData(self):
-        selected_data = {"range": {'mapbox': [
+        selected_data = {"range": {f'{PLOTLY_MAP}': [
             [self.lon_range1[0], self.lat_range1[0]],
             [self.lon_range1[1], self.lat_range1[1]]
         ]}}
@@ -424,7 +425,7 @@ class TestCallbacks(TestCase):
         })
 
     def testMapboxBoundsYCallbackEventData(self):
-        selected_data = {"range": {'mapbox3': [
+        selected_data = {"range": {f'{PLOTLY_MAP}3': [
             [self.lon_range1[0], self.lat_range1[0]],
             [self.lon_range1[1], self.lat_range1[1]]
         ]}}

--- a/holoviews/tests/plotting/plotly/test_curveplot.py
+++ b/holoviews/tests/plotting/plotly/test_curveplot.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from holoviews.element import Curve, Tiles
+from holoviews.plotting.plotly.util import PLOTLY_MAP
 
 from .test_plot import TestPlotlyPlot
 
@@ -86,7 +87,7 @@ class TestMapboxCurvePlot(TestPlotlyPlot):
         self.assertEqual(state['data'][1]['lat'], self.lats)
         self.assertEqual(state['data'][1]['mode'], 'lines')
         self.assertEqual(
-            state['layout']['mapbox']['center'], {
+            state['layout'][PLOTLY_MAP]['center'], {
                 'lat': self.lat_center, 'lon': self.lon_center
             }
         )

--- a/holoviews/tests/plotting/plotly/test_dynamic.py
+++ b/holoviews/tests/plotting/plotly/test_dynamic.py
@@ -6,6 +6,7 @@ from bokeh.document import Document
 from pyviz_comms import Comm
 
 import holoviews as hv
+from holoviews.plotting.plotly.util import _convert_numpy_in_fig_dict
 from holoviews.streams import (
     BoundsXY,
     RangeXY,
@@ -44,7 +45,7 @@ class TestDynamicMap(TestPlotlyPlot):
         _, plotly_pane = next(iter(dmap_pane._plots.values()))
 
         # Check initial data
-        data = plotly_pane.object['data']
+        data = _convert_numpy_in_fig_dict(plotly_pane.object['data'])
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['type'], 'scatter')
         np.testing.assert_equal(data[0]['y'], ys)
@@ -57,7 +58,7 @@ class TestDynamicMap(TestPlotlyPlot):
         scale_stream.event(scale=2.0)
 
         # Check that figure object was updated
-        data = plotly_pane.object['data']
+        data = _convert_numpy_in_fig_dict(plotly_pane.object['data'])
         np.testing.assert_equal(data[0]['y'], ys * 2.0)
 
         # Check that object callback was triggered

--- a/holoviews/tests/plotting/plotly/test_labelplot.py
+++ b/holoviews/tests/plotting/plotly/test_labelplot.py
@@ -3,6 +3,7 @@ import numpy as np
 from holoviews.core.options import Cycle
 from holoviews.core.spaces import HoloMap
 from holoviews.element import Labels, Tiles
+from holoviews.plotting.plotly.util import PLOTLY_MAP
 
 from .test_plot import TestPlotlyPlot
 
@@ -86,7 +87,7 @@ class TestMapboxLabelsPlot(TestPlotlyPlot):
         self.assertEqual(state['data'][1]['text'], ['A', 'B', 'C'])
         self.assertEqual(state['data'][1]['mode'], 'text')
         self.assertEqual(
-            state['layout']['mapbox']['center'], {
+            state['layout'][PLOTLY_MAP]['center'], {
                 'lat': self.lat_center, 'lon': self.lon_center
             }
         )

--- a/holoviews/tests/plotting/plotly/test_plot.py
+++ b/holoviews/tests/plotting/plotly/test_plot.py
@@ -83,7 +83,7 @@ class TestPlotlyPlot(ComparisonTestCase):
             plot.padding = padding
 
     def _get_plot_state(self, element):
-        fig_dict = plotly_renderer.get_plot_state(element)
+        fig_dict = plotly_renderer.get_plot_state(element, numpy_convert=True)
         return fig_dict
 
     def assert_property_values(self, obj, props):

--- a/holoviews/tests/plotting/plotly/test_rgb.py
+++ b/holoviews/tests/plotting/plotly/test_rgb.py
@@ -3,6 +3,7 @@ import PIL.Image
 import plotly.graph_objs as go
 
 from holoviews.element import RGB, Tiles
+from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP
 
 from .test_plot import TestPlotlyPlot, plotly_renderer
 
@@ -276,13 +277,13 @@ class TestMapboxRGBPlot(TestPlotlyPlot):
 
         fig_dict = plotly_renderer.get_plot_state(rgb)
         # Check dummy trace
-        self.assertEqual(fig_dict["data"][1]["type"], "scattermapbox")
+        self.assertEqual(fig_dict["data"][1]["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(fig_dict["data"][1]["lon"], [None])
         self.assertEqual(fig_dict["data"][1]["lat"], [None])
         self.assertEqual(fig_dict["data"][1]["showlegend"], False)
 
         # Check mapbox subplot
-        subplot = fig_dict["layout"]["mapbox"]
+        subplot = fig_dict["layout"][PLOTLY_MAP]
         self.assertEqual(subplot["style"], "white-bg")
         self.assertEqual(
             subplot['center'], {'lat': self.lat_center, 'lon': self.lon_center}

--- a/holoviews/tests/plotting/plotly/test_rgb.py
+++ b/holoviews/tests/plotting/plotly/test_rgb.py
@@ -1,11 +1,9 @@
 import numpy as np
 import PIL.Image
 import plotly.graph_objs as go
-import pytest
 
 from holoviews.element import RGB, Tiles
 from holoviews.plotting.plotly.util import (
-    PLOTLY_GE_6_0_0,
     PLOTLY_MAP,
     PLOTLY_SCATTERMAP,
 )
@@ -271,7 +269,6 @@ class TestMapboxRGBPlot(TestPlotlyPlot):
         self.lon_center, self.lat_center = self.lon_centers[0], self.lat_centers[0]
         self.lons, self.lats = Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
 
-    @pytest.mark.skipif(PLOTLY_GE_6_0_0, reason="Fails on Plotly 6.0")
     def test_rgb(self):
         rgb_data = np.random.rand(10, 10, 3)
         rgb = Tiles("") * RGB(
@@ -296,7 +293,7 @@ class TestMapboxRGBPlot(TestPlotlyPlot):
         )
 
         # Check rgb layer
-        layers = fig_dict["layout"]["mapbox"]["layers"]
+        layers = fig_dict["layout"][PLOTLY_MAP]["layers"]
         self.assertEqual(len(layers), 1)
         rgb_layer = layers[0]
         self.assertEqual(rgb_layer["below"], "traces")

--- a/holoviews/tests/plotting/plotly/test_rgb.py
+++ b/holoviews/tests/plotting/plotly/test_rgb.py
@@ -1,9 +1,14 @@
 import numpy as np
 import PIL.Image
 import plotly.graph_objs as go
+import pytest
 
 from holoviews.element import RGB, Tiles
-from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP
+from holoviews.plotting.plotly.util import (
+    PLOTLY_GE_6_0_0,
+    PLOTLY_MAP,
+    PLOTLY_SCATTERMAP,
+)
 
 from .test_plot import TestPlotlyPlot, plotly_renderer
 
@@ -266,6 +271,7 @@ class TestMapboxRGBPlot(TestPlotlyPlot):
         self.lon_center, self.lat_center = self.lon_centers[0], self.lat_centers[0]
         self.lons, self.lats = Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
 
+    @pytest.mark.skipif(PLOTLY_GE_6_0_0, reason="Fails on Plotly 6.0")
     def test_rgb(self):
         rgb_data = np.random.rand(10, 10, 3)
         rgb = Tiles("") * RGB(

--- a/holoviews/tests/plotting/plotly/test_scatterplot.py
+++ b/holoviews/tests/plotting/plotly/test_scatterplot.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from holoviews.element import Scatter, Tiles
+from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP
 
 from .test_plot import TestPlotlyPlot
 
@@ -82,12 +83,12 @@ class TestMapboxScatterPlot(TestPlotlyPlot):
 
         scatter = Tiles('') * Scatter((xs, ys)).redim.range(x=x_range, y=y_range)
         state = self._get_plot_state(scatter)
-        self.assertEqual(state['data'][1]['type'], 'scattermapbox')
+        self.assertEqual(state['data'][1]['type'], PLOTLY_SCATTERMAP)
         self.assertEqual(state['data'][1]['lon'], lons)
         self.assertEqual(state['data'][1]['lat'], lats)
         self.assertEqual(state['data'][1]['mode'], 'markers')
         self.assertEqual(
-            state['layout']['mapbox']['center'], {'lat': lat_center, 'lon': lon_center}
+            state['layout'][PLOTLY_MAP]['center'], {'lat': lat_center, 'lon': lon_center}
         )
 
         # There xaxis and yaxis should not be in the layout

--- a/holoviews/tests/plotting/plotly/test_shapeplots.py
+++ b/holoviews/tests/plotting/plotly/test_shapeplots.py
@@ -10,6 +10,7 @@ from holoviews.element import (
     Tiles,
     VLine,
 )
+from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP
 
 from .test_plot import TestPlotlyPlot
 
@@ -160,7 +161,7 @@ class TestMapboxPathShape(TestMapboxShape):
         )
 
         state = self._get_plot_state(path)
-        self.assertEqual(state["data"][1]["type"], "scattermapbox")
+        self.assertEqual(state["data"][1]["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(state["data"][1]["mode"], "lines")
         self.assertEqual(state["data"][1]["lon"], np.array([
             self.lon_range[i] for i in (0, 1, 0, 0)
@@ -171,7 +172,7 @@ class TestMapboxPathShape(TestMapboxShape):
         self.assertEqual(state["data"][1]["showlegend"], False)
         self.assertEqual(state["data"][1]["line"]["color"], default_shape_color)
         self.assertEqual(
-            state['layout']['mapbox']['center'], {
+            state['layout'][PLOTLY_MAP]['center'], {
                 'lat': self.lat_center, 'lon': self.lon_center
             }
         )
@@ -221,7 +222,7 @@ class TestMapboxBounds(TestMapboxShape):
         )
 
         state = self._get_plot_state(bounds)
-        self.assertEqual(state["data"][1]["type"], "scattermapbox")
+        self.assertEqual(state["data"][1]["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(state["data"][1]["mode"], "lines")
         self.assertEqual(state["data"][1]["lon"], np.array([
             self.lon_range[i] for i in (0, 0, 1, 1, 0)
@@ -232,7 +233,7 @@ class TestMapboxBounds(TestMapboxShape):
         self.assertEqual(state["data"][1]["showlegend"], False)
         self.assertEqual(state["data"][1]["line"]["color"], default_shape_color)
         self.assertEqual(
-            state['layout']['mapbox']['center'], {
+            state['layout'][PLOTLY_MAP]['center'], {
                 'lat': self.lat_center, 'lon': self.lon_center
             }
         )
@@ -247,10 +248,10 @@ class TestMapboxBounds(TestMapboxShape):
                   Tiles("") * bounds3 + Tiles("") * bounds4).cols(2)
 
         state = self._get_plot_state(layout)
-        self.assertEqual(state['data'][1]["subplot"], "mapbox")
-        self.assertEqual(state['data'][3]["subplot"], "mapbox2")
-        self.assertEqual(state['data'][5]["subplot"], "mapbox3")
-        self.assertEqual(state['data'][7]["subplot"], "mapbox4")
+        self.assertEqual(state['data'][1]["subplot"], PLOTLY_MAP)
+        self.assertEqual(state['data'][3]["subplot"], PLOTLY_MAP + "2")
+        self.assertEqual(state['data'][5]["subplot"], PLOTLY_MAP + "3")
+        self.assertEqual(state['data'][7]["subplot"], PLOTLY_MAP + "4")
         self.assertNotIn("xaxis", state['layout'])
         self.assertNotIn("yaxis", state['layout'])
 
@@ -299,7 +300,7 @@ class TestMapboxBox(TestMapboxShape):
         lon_box_range, lat_box_range = Tiles.easting_northing_to_lon_lat(x_box_range, y_box_range)
 
         state = self._get_plot_state(box)
-        self.assertEqual(state["data"][1]["type"], "scattermapbox")
+        self.assertEqual(state["data"][1]["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(state["data"][1]["mode"], "lines")
         self.assertEqual(state["data"][1]["showlegend"], False)
         self.assertEqual(state["data"][1]["line"]["color"], default_shape_color)
@@ -311,7 +312,7 @@ class TestMapboxBox(TestMapboxShape):
         ]))
 
         self.assertEqual(
-            state['layout']['mapbox']['center'], {
+            state['layout'][PLOTLY_MAP]['center'], {
                 'lat': self.lat_center, 'lon': self.lon_center
             }
         )
@@ -344,7 +345,7 @@ class TestMapboxRectangles(TestMapboxShape):
         )
 
         state = self._get_plot_state(rectangles)
-        self.assertEqual(state["data"][1]["type"], "scattermapbox")
+        self.assertEqual(state["data"][1]["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(state["data"][1]["mode"], "lines")
         self.assertEqual(state["data"][1]["showlegend"], False)
         self.assertEqual(state["data"][1]["line"]["color"], default_shape_color)
@@ -358,7 +359,7 @@ class TestMapboxRectangles(TestMapboxShape):
         ]))
 
         self.assertEqual(
-            state['layout']['mapbox']['center'], {
+            state['layout'][PLOTLY_MAP]['center'], {
                 'lat': self.lat_center, 'lon': self.lon_center
             }
         )
@@ -391,7 +392,7 @@ class TestMapboxSegments(TestMapboxShape):
         )
 
         state = self._get_plot_state(rectangles)
-        self.assertEqual(state["data"][1]["type"], "scattermapbox")
+        self.assertEqual(state["data"][1]["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(state["data"][1]["mode"], "lines")
         self.assertEqual(state["data"][1]["showlegend"], False)
         self.assertEqual(state["data"][1]["line"]["color"], default_shape_color)
@@ -405,7 +406,7 @@ class TestMapboxSegments(TestMapboxShape):
         ]))
 
         self.assertEqual(
-            state['layout']['mapbox']['center'], {
+            state['layout'][PLOTLY_MAP]['center'], {
                 'lat': self.lat_center, 'lon': self.lon_center
             }
         )

--- a/holoviews/tests/plotting/plotly/test_tiles.py
+++ b/holoviews/tests/plotting/plotly/test_tiles.py
@@ -61,18 +61,17 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         layers = fig_dict["layout"][PLOTLY_MAP].get("layers", [])
         self.assertEqual(len(layers), 0)
 
-    @pytest.mark.skipif(PLOTLY_GE_6_0_0, reason="Fails on Plotly 6.0")
     def test_styled_mapbox_tiles(self):
-        tiles = Tiles().opts(mapboxstyle="dark", accesstoken="token-str").redim.range(
-            x=self.x_range, y=self.y_range
-        )
+        opts = dict(mapstyle="dark") if PLOTLY_GE_6_0_0 else dict(mapboxstyle="dark", accesstoken="token-str")
+        tiles = Tiles().opts(**opts).redim.range(x=self.x_range, y=self.y_range)
 
         fig_dict = plotly_renderer.get_plot_state(tiles)
 
         # Check mapbox subplot
         subplot = fig_dict["layout"][PLOTLY_MAP]
         self.assertEqual(subplot["style"], "dark")
-        self.assertEqual(subplot["accesstoken"], "token-str")
+        if not PLOTLY_GE_6_0_0:
+            self.assertEqual(subplot["accesstoken"], "token-str")
         self.assertEqual(
             subplot['center'], {'lat': self.lat_center, 'lon': self.lon_center}
         )
@@ -127,10 +126,10 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         self.assertEqual(layer["maxzoom"], osm.max_zoom)
         self.assertEqual(layer["sourceattribution"], osm.html_attribution)
 
-    @pytest.mark.skipif(PLOTLY_GE_6_0_0, reason="Fails on Plotly 6.0")
     def test_overlay(self):
         # Base layer is mapbox vector layer
-        tiles = Tiles("").opts(mapboxstyle="dark", accesstoken="token-str")
+        opts = dict(mapstyle="dark") if PLOTLY_GE_6_0_0 else dict(mapboxstyle="dark", accesstoken="token-str")
+        tiles = Tiles("").opts(**opts)
 
         # Raster tile layer
         stamen_raster = StamenTerrain().opts(alpha=0.7)
@@ -176,7 +175,8 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         self.assertFalse(dummy_trace["showlegend"])
 
         self.assertEqual(subplot["style"], "dark")
-        self.assertEqual(subplot["accesstoken"], "token-str")
+        if not PLOTLY_GE_6_0_0:
+            self.assertEqual(subplot["accesstoken"], "token-str")
         self.assertEqual(
             subplot['center'], {'lat': self.lat_center, 'lon': self.lon_center}
         )

--- a/holoviews/tests/plotting/plotly/test_tiles.py
+++ b/holoviews/tests/plotting/plotly/test_tiles.py
@@ -3,6 +3,7 @@ import pytest
 
 from holoviews.element import RGB, Bounds, Points, Tiles
 from holoviews.element.tiles import _ATTRIBUTIONS, StamenTerrain
+from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP
 
 from .test_plot import TestPlotlyPlot, plotly_renderer
 
@@ -35,13 +36,13 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         # Check dummy trace
         self.assertEqual(len(fig_dict["data"]), 1)
         dummy_trace = fig_dict["data"][0]
-        self.assertEqual(dummy_trace["type"], "scattermapbox")
+        self.assertEqual(dummy_trace["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(dummy_trace["lon"], [])
         self.assertEqual(dummy_trace["lat"], [])
         self.assertEqual(dummy_trace["showlegend"], False)
 
         # Check mapbox subplot
-        subplot = fig_dict["layout"]["mapbox"]
+        subplot = fig_dict["layout"][PLOTLY_MAP]
         self.assertEqual(subplot["style"], "white-bg")
         self.assertEqual(
             subplot['center'], {'lat': self.lat_center, 'lon': self.lon_center}
@@ -53,7 +54,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
 
         # Check no layers are introduced when an empty tile server string is
         # passed
-        layers = fig_dict["layout"]["mapbox"].get("layers", [])
+        layers = fig_dict["layout"][PLOTLY_MAP].get("layers", [])
         self.assertEqual(len(layers), 0)
 
     def test_styled_mapbox_tiles(self):
@@ -64,7 +65,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         fig_dict = plotly_renderer.get_plot_state(tiles)
 
         # Check mapbox subplot
-        subplot = fig_dict["layout"]["mapbox"]
+        subplot = fig_dict["layout"][PLOTLY_MAP]
         self.assertEqual(subplot["style"], "dark")
         self.assertEqual(subplot["accesstoken"], "token-str")
         self.assertEqual(
@@ -81,20 +82,20 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         # Check dummy trace
         self.assertEqual(len(fig_dict["data"]), 1)
         dummy_trace = fig_dict["data"][0]
-        self.assertEqual(dummy_trace["type"], "scattermapbox")
+        self.assertEqual(dummy_trace["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(dummy_trace["lon"], [])
         self.assertEqual(dummy_trace["lat"], [])
         self.assertEqual(dummy_trace["showlegend"], False)
 
         # Check mapbox subplot
-        subplot = fig_dict["layout"]["mapbox"]
+        subplot = fig_dict["layout"][PLOTLY_MAP]
         self.assertEqual(subplot["style"], "white-bg")
         self.assertEqual(
             subplot['center'], {'lat': self.lat_center, 'lon': self.lon_center}
         )
 
         # Check for raster layer
-        layers = fig_dict["layout"]["mapbox"].get("layers", [])
+        layers = fig_dict["layout"][PLOTLY_MAP].get("layers", [])
         self.assertEqual(len(layers), 1)
         layer = layers[0]
         self.assertEqual(layer["source"][0].lower(), tiles.data.lower())
@@ -114,7 +115,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
 
         fig_dict = plotly_renderer.get_plot_state(tiles)
         # Check mapbox subplot
-        layers = fig_dict["layout"]["mapbox"].get("layers", [])
+        layers = fig_dict["layout"][PLOTLY_MAP].get("layers", [])
         self.assertEqual(len(layers), 1)
         layer = layers[0]
         self.assertEqual(layer["source"][0].lower(), osm.build_url(scale_factor="@2x"))
@@ -155,7 +156,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
 
         # Check number of traces and layers
         traces = fig_dict["data"]
-        subplot = fig_dict["layout"]["mapbox"]
+        subplot = fig_dict["layout"][PLOTLY_MAP]
         layers = subplot["layers"]
 
         self.assertEqual(len(traces), 5)
@@ -163,7 +164,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
 
         # Check vector layer
         dummy_trace = traces[0]
-        self.assertEqual(dummy_trace["type"], "scattermapbox")
+        self.assertEqual(dummy_trace["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(dummy_trace["lon"], [])
         self.assertEqual(dummy_trace["lat"], [])
         self.assertFalse(dummy_trace["showlegend"])
@@ -177,7 +178,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         # Check raster layer
         dummy_trace = traces[1]
         raster_layer = layers[0]
-        self.assertEqual(dummy_trace["type"], "scattermapbox")
+        self.assertEqual(dummy_trace["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(dummy_trace["lon"], [])
         self.assertEqual(dummy_trace["lat"], [])
         self.assertFalse(dummy_trace["showlegend"])
@@ -191,7 +192,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         # Check RGB layer
         dummy_trace = traces[2]
         rgb_layer = layers[1]
-        self.assertEqual(dummy_trace["type"], "scattermapbox")
+        self.assertEqual(dummy_trace["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(dummy_trace["lon"], [None])
         self.assertEqual(dummy_trace["lat"], [None])
         self.assertFalse(dummy_trace["showlegend"])
@@ -210,7 +211,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
 
         # Check Points layer
         points_trace = traces[3]
-        self.assertEqual(points_trace["type"], "scattermapbox")
+        self.assertEqual(points_trace["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(points_trace["lon"], np.array([0, self.lon_range[1]]))
         self.assertEqual(points_trace["lat"], np.array([0, self.lat_range[1]]))
         self.assertEqual(points_trace["mode"], "markers")
@@ -218,7 +219,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
 
         # Check Bounds layer
         bounds_trace = traces[4]
-        self.assertEqual(bounds_trace["type"], "scattermapbox")
+        self.assertEqual(bounds_trace["type"], PLOTLY_SCATTERMAP)
         self.assertEqual(bounds_trace["lon"], np.array([
             self.lon_range[0], self.lon_range[0], 0, 0, self.lon_range[0]
         ]))

--- a/holoviews/tests/plotting/plotly/test_tiles.py
+++ b/holoviews/tests/plotting/plotly/test_tiles.py
@@ -3,7 +3,11 @@ import pytest
 
 from holoviews.element import RGB, Bounds, Points, Tiles
 from holoviews.element.tiles import _ATTRIBUTIONS, StamenTerrain
-from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP
+from holoviews.plotting.plotly.util import (
+    PLOTLY_GE_6_0_0,
+    PLOTLY_MAP,
+    PLOTLY_SCATTERMAP,
+)
 
 from .test_plot import TestPlotlyPlot, plotly_renderer
 
@@ -57,6 +61,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         layers = fig_dict["layout"][PLOTLY_MAP].get("layers", [])
         self.assertEqual(len(layers), 0)
 
+    @pytest.mark.skipif(PLOTLY_GE_6_0_0, reason="Fails on Plotly 6.0")
     def test_styled_mapbox_tiles(self):
         tiles = Tiles().opts(mapboxstyle="dark", accesstoken="token-str").redim.range(
             x=self.x_range, y=self.y_range

--- a/holoviews/tests/plotting/plotly/test_tiles.py
+++ b/holoviews/tests/plotting/plotly/test_tiles.py
@@ -127,6 +127,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         self.assertEqual(layer["maxzoom"], osm.max_zoom)
         self.assertEqual(layer["sourceattribution"], osm.html_attribution)
 
+    @pytest.mark.skipif(PLOTLY_GE_6_0_0, reason="Fails on Plotly 6.0")
     def test_overlay(self):
         # Base layer is mapbox vector layer
         tiles = Tiles("").opts(mapboxstyle="dark", accesstoken="token-str")

--- a/holoviews/tests/plotting/plotly/test_tiles.py
+++ b/holoviews/tests/plotting/plotly/test_tiles.py
@@ -151,7 +151,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         )
 
         # Render to plotly figure dictionary
-        fig_dict = plotly_renderer.get_plot_state(overlay)
+        fig_dict = plotly_renderer.get_plot_state(overlay, numpy_convert=True)
 
         # Check number of traces and layers
         traces = fig_dict["data"]


### PR DESCRIPTION
Two big things with the plotly 6.0 release

1. The `fig_dict` no longer outputs numpy arrays but a special dict with information to create it. I have made a util for this.
2. `scattermapbox` is deprecated for `scattermap`, and by that logic, `mapbox` is deprecated for `map`, emits this warning: `*scattermapbox* is deprecated! Use *scattermap* instead. Learn more at: https://plotly.com/python/mapbox-to-maplibre/`. `accesstoken` is not needed for the new implementation and will give an error. 
