### PR TITLE
ci: Don't check numpy for latest version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -188,7 +188,8 @@ jobs:
           environments: ${{ matrix.environment }}
       - name: Check packages latest version
         run: |
-          pixi run -e ${{ matrix.environment }} check-latest-packages numpy pandas bokeh panel param
+          # pixi run -e ${{ matrix.environment }} check-latest-packages numpy pandas bokeh panel param
+          pixi run -e ${{ matrix.environment }} check-latest-packages pandas bokeh panel param
       - name: Test Unit
         run: |
           pixi run -e ${{ matrix.environment }} test-unit


### PR DESCRIPTION
Currently numpy 2.2.3 is on Conda-Forge and not pypi, have asked about this upstream.