### PR TITLE
fix(dev): Fix failing ibis tests

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -133,7 +133,7 @@ spatialpandas = "*"
 streamz = ">=0.5.0"
 xarray = ">=0.10.4"
 xyzservices = "*"
-libsqlite = "!=3.49.*" # 2025-02; Breaks ibis test (remove dependency after problem is solved)
+libsqlite = "!=3.49.*" # 2025-02; Breaks ibis tests, https://github.com/ibis-project/ibis/issues/10865 (remove dependency after problem is solved)
 
 [feature.optional.target.unix.dependencies]
 tsdownsample = "*" # currently not available on Windows

--- a/pixi.toml
+++ b/pixi.toml
@@ -133,6 +133,7 @@ spatialpandas = "*"
 streamz = ">=0.5.0"
 xarray = ">=0.10.4"
 xyzservices = "*"
+libsqlite = "!=3.49.*" # 2025-02; Breaks ibis test (remove dependency after problem is solved)
 
 [feature.optional.target.unix.dependencies]
 tsdownsample = "*" # currently not available on Windows


### PR DESCRIPTION
This is in no way a permanent fix, but there is not a lot we can do... Have reported the issue here: https://github.com/ibis-project/ibis/issues/10865


``` python
import os

import ibis

filename = "example.db"

if os.path.exists(filename):
    os.remove(filename)

con = ibis.sqlite.connect(filename)
con.raw_sql("CREATE TABLE test (Age INTEGER)")
con.raw_sql("INSERT INTO test (Age) VALUES (10)")

table = con.table("test")
```
``` bash
mamba env create --name "tmp_ibis1" "ibis-sqlite libsqlite=3.48" # passes
mamba env create --name "tmp_ibis2" "ibis-sqlite libsqlite=3.49" # fails
```