### PR TITLE
docs: Fix failing docs-build

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -209,7 +209,7 @@ nbsite = ">=0.8.4,<0.9.0"
 pooch = "*"
 python-kaleido = "*"
 selenium = "*"
-sphinx = "<8.2" # Currently not building
+sphinx = "<8.2" # Currently not building, https://github.com/holoviz/holoviews/pull/6514
 
 [feature.doc.activation.env]
 MOZ_HEADLESS = "1"

--- a/pixi.toml
+++ b/pixi.toml
@@ -209,6 +209,7 @@ nbsite = ">=0.8.4,<0.9.0"
 pooch = "*"
 python-kaleido = "*"
 selenium = "*"
+sphinx = "<8.2" # Currently not building
 
 [feature.doc.activation.env]
 MOZ_HEADLESS = "1"


### PR DESCRIPTION
It looks like the last release of Sphinx broke the docs build...

![image](https://github.com/user-attachments/assets/06a65ef1-0615-4cb7-b780-14b6adb8eb29)


``` python-traceback
INFO: Writing evaluated notebook to /Users/runner/work/holoviews/holoviews/doc/gallery/demos/bokeh/area_chart.ipynb
Traceback (most recent call last):
  File "/Users/runner/work/holoviews/holoviews/.pixi/envs/docs/bin/nbsite", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/runner/work/holoviews/holoviews/.pixi/envs/docs/lib/python3.11/site-packages/nbsite/__main__.py", line 63, in main
    return args.func(args) if hasattr(args,'func') else parser.error("must supply command to run")
           ^^^^^^^^^^^^^^^
  File "/Users/runner/work/holoviews/holoviews/.pixi/envs/docs/lib/python3.11/site-packages/nbsite/__main__.py", line 18, in <lambda>
    parser.set_defaults(func=lambda args: fn( **{k: getattr(args,k) for k in vars(args) if k!='func'} ))
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/holoviews/holoviews/.pixi/envs/docs/lib/python3.11/site-packages/nbsite/cmd.py", line 110, in build
    app.build()
  File "/Users/runner/work/holoviews/holoviews/.pixi/envs/docs/lib/python3.11/site-packages/sphinx/application.py", line 426, in build
    self.builder.build_update()
  File "/Users/runner/work/holoviews/holoviews/.pixi/envs/docs/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 375, in build_update
    self.build(
  File "/Users/runner/work/holoviews/holoviews/.pixi/envs/docs/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 403, in build
    updated_docnames = set(self.read())
                           ^^^^^^^^^^^
  File "/Users/runner/work/holoviews/holoviews/.pixi/envs/docs/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 517, in read
    self._read_parallel(docnames, nproc=self.app.parallel)
  File "/Users/runner/work/holoviews/holoviews/.pixi/envs/docs/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 618, in _read_parallel
    tasks.join()
  File "/Users/runner/work/holoviews/holoviews/.pixi/envs/docs/lib/python3.11/site-packages/sphinx/util/parallel.py", line 117, in join
    if not self._join_one():
           ^^^^^^^^^^^^^^^^
  File "/Users/runner/work/holoviews/holoviews/.pixi/envs/docs/lib/python3.11/site-packages/sphinx/util/parallel.py", line 137, in _join_one
    raise SphinxParallelError(*result)
sphinx.errors.SphinxParallelError: AttributeError: 'str' object has no attribute 'parent'
[IPKernelApp] WARNING | Parent appears to have exited, shutting down.
[IPKernelApp] WARNING | Parent appears to have exited, shutting down.

```

https://github.com/holoviz/holoviews/actions/runs/13417498532/job/37483492920

Running `pixi update` on the last lock file which worked returned this:

``` bash
Environment: docs
  ~ C mistune                  3.1.1 pyhd8ed1ab_0      ->  3.1.2 pyhd8ed1ab_0
  ~ C narwhals                 1.26.0 pyhd8ed1ab_0     ->  1.27.1 pyhd8ed1ab_0
  + C roman-numerals-py        3.0.0 pyhd8ed1ab_0
  ~ C spatialpandas            0.5.0rc0 py_0           ->  0.5.0 py_0
  ~ C sphinx                   8.1.3 pyhd8ed1ab_1      ->  8.2.0 pyhd8ed1ab_0
  ~ C tifffile                 2025.1.10 pyhd8ed1ab_0  ->  2025.2.18 pyhd8ed1ab_0
  ~ C trio-websocket           0.12.0 pyh29332c3_0     ->  0.12.1 pyh29332c3_0
Platform: docs:win-64
  ~ C libiconv                 1.17 hcfcfb64_2         ->  1.18 h135ad9c_0
  ~ C libpng                   1.6.46 had7236b_0       ->  1.6.47 had7236b_0
  ~ C libxml2                  2.13.5 he286e8c_1       ->  2.13.6 he286e8c_0
  ~ C scikit-image             0.25.1 py311hcf9f919_0  ->  0.25.2 py311hcf9f919_0
Platform: docs:osx-64
  ~ C libiconv                 1.17 hd75f5a5_2         ->  1.18 h4b5e92a_0
  ~ C libpng                   1.6.46 h3c4a55f_0       ->  1.6.47 h3c4a55f_0
  ~ C libxml2                  2.13.5 hebb159f_1       ->  2.13.6 hebb159f_0
  ~ C scikit-image             0.25.1 py311hcf53e2f_0  ->  0.25.2 py311hcf53e2f_0
Platform: docs:osx-arm64
  ~ C libiconv                 1.17 h0d3ecfb_2         ->  1.18 hfe07756_0
  ~ C libpng                   1.6.46 h3783ad8_0       ->  1.6.47 h3783ad8_0
  ~ C libxml2                  2.13.5 h178c5d8_1       ->  2.13.6 h178c5d8_0
  ~ C scikit-image             0.25.1 py311hca32420_0  ->  0.25.2 py311hca32420_0
Platform: docs:linux-64
  ~ C level-zero               1.20.5 h84d6215_0       ->  1.20.6 h84d6215_0
  ~ C libiconv                 1.17 hd590300_2         ->  1.18 h4ce23a2_0
  ~ C libpng                   1.6.46 h943b412_0       ->  1.6.47 h943b412_0
  ~ C libxml2                  2.13.5 h8d12d68_1       ->  2.13.6 h8d12d68_0
  ~ C scikit-image             0.25.1 py311h7db5c69_0  ->  0.25.2 py311h7db5c69_0
  ~ C wayland-protocols        1.40 hd8ed1ab_0         ->  1.41 hd8ed1ab_0
```