### PR TITLE
fix(dev): Fix failing gpu test related to numba

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -194,6 +194,7 @@ cuda-version = "12.2.*"
 cudf = "24.12.*"
 cupy = "*"
 cuspatial = "*"
+numba = "<0.61"
 librmm = { version = "*", channel = "rapidsai" }
 rmm = { version = "*", channel = "rapidsai" }
 


### PR DESCRIPTION
I just ran the gpu test locally and saw this error. 

![image](https://github.com/user-attachments/assets/171e623c-7d61-4c44-869e-3ae409d2322d)

Will likely be fixed in the next cuspatial release. 