### PR TITLE
fix: regression in get_value_array

### DIFF
--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -643,9 +643,7 @@ def get_value_array(data, dimension, expanded, keep_index, geom_col,
     is_scalars = [isscalar(value) for value in column]
     all_scalar = all(is_scalars)
     if all_scalar and not expanded:
-        scal_unique = column.unique()
-        # .unique() on categorical dtype doesn't return a np array
-        return scal_unique if isinstance(scal_unique, np.ndarray) else scal_unique.to_numpy()
+        return np.asarray(column)
     arrays, scalars = [], []
     for i, geom in enumerate(data[geom_col]):
         val = column.iloc[i]

--- a/holoviews/tests/core/data/test_spatialpandas.py
+++ b/holoviews/tests/core/data/test_spatialpandas.py
@@ -4,6 +4,7 @@ Tests for the spatialpandas interface.
 from unittest import SkipTest
 
 import numpy as np
+import pandas as pd
 
 try:
     import spatialpandas
@@ -24,12 +25,14 @@ try:
 except ImportError:
     dd = None
 
+from holoviews import Dimension
 from holoviews.core.data import (
     DaskSpatialPandasInterface,
     Dataset,
     SpatialPandasInterface,
 )
 from holoviews.core.data.interface import DataError
+from holoviews.core.data.spatialpandas import get_value_array
 from holoviews.element import Path, Points, Polygons
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -301,3 +304,14 @@ class DaskSpatialPandasTest(GeomTests, RoundTripTests):
 
     def test_sort_by_value(self):
         raise SkipTest("Not supported")
+
+
+
+def test_regression_get_value_array():
+    # See: https://github.com/holoviz/holoviews/pull/6519
+    df = pd.DataFrame(
+        {"Longitude": [0, 1, 2], "Latitude": [0, 1, 2], "Sensor": ["S1", "S2", "S1"]}
+    )
+    result = get_value_array(df, Dimension("Sensor"), False, None, None, None)
+
+    np.testing.assert_array_equal(df.Sensor, result)


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/6516

The performance improvement done in https://github.com/holoviz/holoviews/pull/6470 introduced a bug. The bug came when trying to bypass the for loop, which was done with a `.unique` call of the dataset. This bug caused the following regression. In short, when using dim-expression, the sensor's output would now be two-sized lengths instead of three-sized lengths like the rest of the data, resulting in an error when converting to Bokeh valid data.  

This PR replaces the unique call with a conversion to a numpy array, keeping the data size. 


``` python
import geopandas as gpd
import geoviews as gv
import pandas as pd

import holoviews as hv

hv.extension("bokeh")

df = pd.DataFrame(
    {"Longitude": [0, 1, 2], "Latitude": [0, 1, 2], "Sensor": ["S1", "S2", "S1"]}
)
gdf = gpd.GeoDataFrame(df, geometry=gpd.points_from_xy(df["Longitude"], df["Latitude"]))

gv.Points(gdf).opts(line_color=hv.dim("Sensor").categorize(["red", "blue", "yellow"]))

```
