### PR TITLE
compat: cuDF 25.02

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -190,10 +190,9 @@ NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS = "0"
 
 [feature.test-gpu.dependencies]
 cuda-version = "12.2.*"
-cudf = "24.12.*"
+cudf = "25.02.*"
 cupy = "*"
 cuspatial = "*"
-numba = "<0.61"
 librmm = { version = "*", channel = "rapidsai" }
 rmm = { version = "*", channel = "rapidsai" }
 


### PR DESCRIPTION
Bumping cudf version and remove temp. numba pin

Ran locally: 
![image](https://github.com/user-attachments/assets/27dfa895-604e-4400-9902-564619b8bd5d)
