### PR TITLE
compat: Matplotlib 3.10.1

### DIFF
--- a/holoviews/plotting/mpl/graphs.py
+++ b/holoviews/plotting/mpl/graphs.py
@@ -11,7 +11,7 @@ from ...util.transform import dim
 from ..mixins import ChordMixin, GraphMixin
 from ..util import get_directed_graph_paths, process_cmap
 from .element import ColorbarPlot
-from .util import filter_styles
+from .util import MPL_GE_3_10_1, filter_styles
 
 
 class GraphPlot(GraphMixin, ColorbarPlot):
@@ -166,6 +166,12 @@ class GraphPlot(GraphMixin, ColorbarPlot):
         xs, ys = plot_args['nodes']
         groups = [g for g in self._style_groups if g != 'node']
         node_opts = filter_styles(plot_kwargs, 'node', groups)
+        # Matplotlib 3.10.1 started emitting this UserWarning:
+        #   You passed both c and facecolor/facecolors for the markers.
+        #   c has precedence over facecolor/facecolors.
+        if MPL_GE_3_10_1 and "c" in node_opts:
+            node_opts.pop("facecolor", None)
+            node_opts.pop("facecolors", None)
         with warnings.catch_warnings():
             # scatter have a default cmap and with an empty array will emit this warning
             warnings.filterwarnings('ignore', "No data for colormapping provided via 'c'")

--- a/holoviews/plotting/mpl/graphs.py
+++ b/holoviews/plotting/mpl/graphs.py
@@ -170,7 +170,6 @@ class GraphPlot(GraphMixin, ColorbarPlot):
         #   You passed both c and facecolor/facecolors for the markers.
         #   c has precedence over facecolor/facecolors.
         if MPL_GE_3_10_1 and "c" in node_opts:
-            node_opts.pop("facecolor", None)
             node_opts.pop("facecolors", None)
         with warnings.catch_warnings():
             # scatter have a default cmap and with an empty array will emit this warning

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -40,6 +40,7 @@ MPL_VERSION = Version(mpl.__version__).release
 MPL_GE_3_7_0 = MPL_VERSION >= (3, 7, 0)
 MPL_GE_3_9_0 = MPL_VERSION >= (3, 9, 0)
 MPL_GE_3_10_0 = MPL_VERSION >= (3, 10, 0)
+MPL_GE_3_10_1 = MPL_VERSION >= (3, 10, 1)
 
 
 def is_color(color):


### PR DESCRIPTION
The failing tests because of the updated UserWarning:
``` console
FAILED holoviews/tests/plotting/matplotlib/test_graphplot.py::TestMplGraphPlot::test_graph_op_node_color_linear - holoviews.core.options.AbbreviatedException: UserWarning: You passed both c and facecolor/facecolors for the markers. c has precedence over facecolor/facecolors. This behavior may change in the future.
FAILED holoviews/tests/plotting/matplotlib/test_graphplot.py::TestMplGraphPlot::test_graph_op_node_color_categorical - holoviews.core.options.AbbreviatedException: UserWarning: You passed both c and facecolor/facecolors for the markers. c has precedence over facecolor/facecolors. This behavior may change in the future.
FAILED holoviews/tests/plotting/matplotlib/test_graphplot.py::TestMplGraphPlot::test_graph_op_node_color_linear_update - holoviews.core.options.AbbreviatedException: UserWarning: You passed both c and facecolor/facecolors for the markers. c has precedence over facecolor/facecolors. This behavior may change in the future.
FAILED holoviews/tests/plotting/matplotlib/test_graphplot.py::TestMplGraphPlot::test_plot_graph_numerically_colored_nodes - holoviews.core.options.AbbreviatedException: UserWarning: You passed both c and facecolor/facecolors for the markers. c has precedence over facecolor/facecolors. This behavior may change in the future.
FAILED holoviews/tests/plotting/matplotlib/test_graphplot.py::TestMplChordPlot::test_chord_node_color_linear_style_mapping_update - holoviews.core.options.AbbreviatedException: UserWarning: You passed both c and facecolor/facecolors for the markers. c has precedence over facecolor/facecolors. This behavior may change in the future.
FAILED holoviews/tests/plotting/matplotlib/test_graphplot.py::TestMplChordPlot::test_chord_node_color_style_mapping - holoviews.core.options.AbbreviatedException: UserWarning: You passed both c and facecolor/facecolors for the markers. c has precedence over facecolor/facecolors. This behavior may change in the future.
FAILED holoviews/tests/plotting/matplotlib/test_graphplot.py::TestMplTriMeshPlot::test_trimesh_op_node_color_categorical - holoviews.core.options.AbbreviatedException: UserWarning: You passed both c and facecolor/facecolors for the markers. c has precedence over facecolor/facecolors. This behavior may change in the future.
FAILED holoviews/tests/plotting/matplotlib/test_graphplot.py::TestMplTriMeshPlot::test_trimesh_op_node_color_linear - holoviews.core.options.AbbreviatedException: UserWarning: You passed both c and facecolor/facecolors for the markers. c has precedence over facecolor/facecolors. This behavior may change in the future.
```

As far as I can see, we have relied on the behavior of `c` taking precedence over `facecolor`/`facecolors`, so here we just remove the values from the node options.