### PR TITLE
test: skip `test_render_to_png` on Linux

### DIFF
--- a/holoviews/tests/plotting/bokeh/test_renderer.py
+++ b/holoviews/tests/plotting/bokeh/test_renderer.py
@@ -1,5 +1,5 @@
+import sys
 from io import BytesIO
-from unittest import SkipTest
 
 import numpy as np
 import panel as pn
@@ -86,13 +86,12 @@ class BokehRendererTest(ComparisonTestCase):
         self.renderer.components(plot, 'html')
         self.assertEqual(plot.state.outline_line_color, '#444444')
 
+    @pytest.mark.skipif(sys.platform == "linux", reason="2025-03: Flaky test on Linux")
     def test_render_to_png(self):
+        pytest.importorskip("selenium")
         curve = Curve([])
         renderer = BokehRenderer.instance(fig='png')
-        try:
-            png, info = renderer(curve)
-        except RuntimeError:
-            raise SkipTest("Test requires selenium")
+        png, info = renderer(curve)
         self.assertIsInstance(png, bytes)
         self.assertEqual(info['file-ext'], 'png')
 

--- a/holoviews/tests/plotting/bokeh/test_renderer.py
+++ b/holoviews/tests/plotting/bokeh/test_renderer.py
@@ -86,6 +86,7 @@ class BokehRendererTest(ComparisonTestCase):
         self.renderer.components(plot, 'html')
         self.assertEqual(plot.state.outline_line_color, '#444444')
 
+    @pytest.mark.flaky(reruns=3)
     def test_render_to_png(self):
         curve = Curve([])
         renderer = BokehRenderer.instance(fig='png')

--- a/holoviews/tests/plotting/bokeh/test_renderer.py
+++ b/holoviews/tests/plotting/bokeh/test_renderer.py
@@ -86,7 +86,6 @@ class BokehRendererTest(ComparisonTestCase):
         self.renderer.components(plot, 'html')
         self.assertEqual(plot.state.outline_line_color, '#444444')
 
-    @pytest.mark.flaky(reruns=3)
     def test_render_to_png(self):
         curve = Curve([])
         renderer = BokehRenderer.instance(fig='png')

--- a/pixi.toml
+++ b/pixi.toml
@@ -133,7 +133,6 @@ spatialpandas = "*"
 streamz = ">=0.5.0"
 xarray = ">=0.10.4"
 xyzservices = "*"
-urllib3 = "<2.3"
 pyzmq = "!=26.3.0"
 
 [feature.optional.target.unix.dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -134,6 +134,7 @@ streamz = ">=0.5.0"
 xarray = ">=0.10.4"
 xyzservices = "*"
 urllib3 = "<2.3"
+pyzmq = "!=26.3.0"
 
 [feature.optional.target.unix.dependencies]
 tsdownsample = "*" # currently not available on Windows

--- a/pixi.toml
+++ b/pixi.toml
@@ -133,6 +133,7 @@ spatialpandas = "*"
 streamz = ">=0.5.0"
 xarray = ">=0.10.4"
 xyzservices = "*"
+urllib3 = "<2.3"
 
 [feature.optional.target.unix.dependencies]
 tsdownsample = "*" # currently not available on Windows

--- a/pixi.toml
+++ b/pixi.toml
@@ -133,7 +133,6 @@ spatialpandas = "*"
 streamz = ">=0.5.0"
 xarray = ">=0.10.4"
 xyzservices = "*"
-pyzmq = "!=26.3.0"
 
 [feature.optional.target.unix.dependencies]
 tsdownsample = "*" # currently not available on Windows


### PR DESCRIPTION
Not sure why this test suddenly became flaky on Linux, both seen on 3.9 and 3.13:

https://github.com/holoviz/holoviews/actions/runs/13828811445/job/38689244841
![image](https://github.com/user-attachments/assets/a2395b86-581b-4341-af1b-918f295a2731)

https://github.com/holoviz/holoviews/actions/runs/13828793793/job/38688471911
![image](https://github.com/user-attachments/assets/0f725f50-cce2-4e9a-908f-12f116800cc6)

``` yaml
❯ holoviz artifact-test holoviews 3725 3738 --arch linux-64
                          Difference in packages on 'holoviews' for env 'test-310' on arch 'linux-64'
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Package                 ┃ Good run (#3725)                                ┃ Bad run (#3738)                                 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ attrs                   │ attrs-25.1.0-pyh71513ae_0.conda                 │ attrs-25.2.0-pyh71513ae_0.conda                 │
│ cairo                   │ cairo-1.18.2-h3394656_1.conda                   │ cairo-1.18.4-h3394656_0.conda                   │
│ ffmpeg                  │ ffmpeg-7.1.1-gpl_ha1cb39d_700.conda             │ ffmpeg-7.1.1-gpl_h24e5c1d_701.conda             │
│ fsspec                  │ fsspec-2025.2.0-pyhd8ed1ab_0.conda              │ fsspec-2025.3.0-pyhd8ed1ab_0.conda              │
│ gtk3                    │ gtk3-3.24.43-h021d004_3.conda                   │ gtk3-3.24.43-h021d004_4.conda                   │
│ ipython                 │ ipython-8.33.0-pyh907856f_0.conda               │ ipython-8.34.0-pyh907856f_0.conda               │
│ level-zero              │ level-zero-1.21.1-h84d6215_0.conda              │ level-zero-1.21.2-h84d6215_0.conda              │
│ libarrow                │ libarrow-19.0.1-hfa2a6e7_0_cpu.conda            │ libarrow-19.0.1-hee35a22_2_cpu.conda            │
│ libarrow-acero          │ libarrow-acero-19.0.1-hcb10f89_0_cpu.conda      │ libarrow-acero-19.0.1-hcb10f89_2_cpu.conda      │
│ libarrow-dataset        │ libarrow-dataset-19.0.1-hcb10f89_0_cpu.conda    │ libarrow-dataset-19.0.1-hcb10f89_2_cpu.conda    │
│ libarrow-substrait      │ libarrow-substrait-19.0.1-h08228c5_0_cpu.conda  │ libarrow-substrait-19.0.1-h08228c5_2_cpu.conda  │
│ libavif16               │ libavif16-1.2.0-hf3231e4_0.conda                │ libavif16-1.2.0-h63b8bd6_1.conda                │
│ libcap                  │ libcap-2.71-h39aace5_0.conda                    │ libcap-2.75-h39aace5_0.conda                    │
│ libgoogle-cloud         │ libgoogle-cloud-2.35.0-h2b5623c_0.conda         │ libgoogle-cloud-2.36.0-h2b5623c_0.conda         │
│ libgoogle-cloud-storage │ libgoogle-cloud-storage-2.35.0-h0121fbd_0.conda │ libgoogle-cloud-storage-2.36.0-h0121fbd_0.conda │
│ libparquet              │ libparquet-19.0.1-h081d1f1_0_cpu.conda          │ libparquet-19.0.1-h081d1f1_2_cpu.conda          │
│ libsystemd0             │ libsystemd0-257.3-h3dc2cb9_0.conda              │ libsystemd0-257.4-h4e0b6ca_1.conda              │
│ libudev1                │ libudev1-257.3-h9a4d06a_0.conda                 │ libudev1-257.4-hbe16f8c_1.conda                 │
│ libusb                  │ libusb-1.0.27-h520f47e_100.conda                │ libusb-1.0.27-hb9d3cd8_101.conda                │
│ libxkbcommon            │ libxkbcommon-1.8.0-hc4a0caf_0.conda             │ libxkbcommon-1.8.1-hc4a0caf_0.conda             │
│ narwhals                │ narwhals-1.29.1-pyhd8ed1ab_0.conda              │ narwhals-1.30.0-pyhd8ed1ab_0.conda              │
│ orc                     │ orc-2.0.3-h12ee42a_2.conda                      │ orc-2.1.1-h2271f48_0.conda                      │
│ panel                   │ panel-1.6.2a2-py_0.tar.bz2                      │ panel-1.6.2a3-py_0.tar.bz2                      │
│ pango                   │ pango-1.56.1-h861ebed_0.conda                   │ pango-1.56.2-h861ebed_0.conda                   │
│ pyzmq                   │ pyzmq-26.2.1-py310h71f11fc_0.conda              │ pyzmq-26.3.0-py310h71f11fc_0.conda              │
│ svt-av1                 │ svt-av1-3.0.0-h5888daf_0.conda                  │ svt-av1-3.0.1-h5888daf_0.conda                  │
└─────────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────┘
                          Difference in packages on 'holoviews' for env 'test-311' on arch 'linux-64'
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Package                 ┃ Good run (#3725)                                ┃ Bad run (#3738)                                 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ attrs                   │ attrs-25.1.0-pyh71513ae_0.conda                 │ attrs-25.2.0-pyh71513ae_0.conda                 │
│ cairo                   │ cairo-1.18.2-h3394656_1.conda                   │ cairo-1.18.4-h3394656_0.conda                   │
│ ffmpeg                  │ ffmpeg-7.1.1-gpl_ha1cb39d_700.conda             │ ffmpeg-7.1.1-gpl_h24e5c1d_701.conda             │
│ fsspec                  │ fsspec-2025.2.0-pyhd8ed1ab_0.conda              │ fsspec-2025.3.0-pyhd8ed1ab_0.conda              │
│ gtk3                    │ gtk3-3.24.43-h021d004_3.conda                   │ gtk3-3.24.43-h021d004_4.conda                   │
│ ipython                 │ ipython-9.0.0-pyhfb0248b_1.conda                │ ipython-9.0.2-pyhfb0248b_0.conda                │
│ level-zero              │ level-zero-1.21.1-h84d6215_0.conda              │ level-zero-1.21.2-h84d6215_0.conda              │
│ libarrow                │ libarrow-19.0.1-hfa2a6e7_0_cpu.conda            │ libarrow-19.0.1-hee35a22_2_cpu.conda            │
│ libarrow-acero          │ libarrow-acero-19.0.1-hcb10f89_0_cpu.conda      │ libarrow-acero-19.0.1-hcb10f89_2_cpu.conda      │
│ libarrow-dataset        │ libarrow-dataset-19.0.1-hcb10f89_0_cpu.conda    │ libarrow-dataset-19.0.1-hcb10f89_2_cpu.conda    │
│ libarrow-substrait      │ libarrow-substrait-19.0.1-h08228c5_0_cpu.conda  │ libarrow-substrait-19.0.1-h08228c5_2_cpu.conda  │
│ libavif16               │ libavif16-1.2.0-hf3231e4_0.conda                │ libavif16-1.2.0-h63b8bd6_1.conda                │
│ libcap                  │ libcap-2.71-h39aace5_0.conda                    │ libcap-2.75-h39aace5_0.conda                    │
│ libgoogle-cloud         │ libgoogle-cloud-2.35.0-h2b5623c_0.conda         │ libgoogle-cloud-2.36.0-h2b5623c_0.conda         │
│ libgoogle-cloud-storage │ libgoogle-cloud-storage-2.35.0-h0121fbd_0.conda │ libgoogle-cloud-storage-2.36.0-h0121fbd_0.conda │
│ libparquet              │ libparquet-19.0.1-h081d1f1_0_cpu.conda          │ libparquet-19.0.1-h081d1f1_2_cpu.conda          │
│ libsystemd0             │ libsystemd0-257.3-h3dc2cb9_0.conda              │ libsystemd0-257.4-h4e0b6ca_1.conda              │
│ libudev1                │ libudev1-257.3-h9a4d06a_0.conda                 │ libudev1-257.4-hbe16f8c_1.conda                 │
│ libusb                  │ libusb-1.0.27-h520f47e_100.conda                │ libusb-1.0.27-hb9d3cd8_101.conda                │
│ libxkbcommon            │ libxkbcommon-1.8.0-hc4a0caf_0.conda             │ libxkbcommon-1.8.1-hc4a0caf_0.conda             │
│ narwhals                │ narwhals-1.29.1-pyhd8ed1ab_0.conda              │ narwhals-1.30.0-pyhd8ed1ab_0.conda              │
│ orc                     │ orc-2.0.3-h12ee42a_2.conda                      │ orc-2.1.1-h2271f48_0.conda                      │
│ panel                   │ panel-1.6.2a2-py_0.tar.bz2                      │ panel-1.6.2a3-py_0.tar.bz2                      │
│ pango                   │ pango-1.56.1-h861ebed_0.conda                   │ pango-1.56.2-h861ebed_0.conda                   │
│ pyzmq                   │ pyzmq-26.2.1-py311h7deb3e3_0.conda              │ pyzmq-26.3.0-py311h7deb3e3_0.conda              │
│ svt-av1                 │ svt-av1-3.0.0-h5888daf_0.conda                  │ svt-av1-3.0.1-h5888daf_0.conda                  │
└─────────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────┘
                          Difference in packages on 'holoviews' for env 'test-312' on arch 'linux-64'
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Package                 ┃ Good run (#3725)                                ┃ Bad run (#3738)                                 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ attrs                   │ attrs-25.1.0-pyh71513ae_0.conda                 │ attrs-25.2.0-pyh71513ae_0.conda                 │
│ cairo                   │ cairo-1.18.2-h3394656_1.conda                   │ cairo-1.18.4-h3394656_0.conda                   │
│ ffmpeg                  │ ffmpeg-7.1.1-gpl_ha1cb39d_700.conda             │ ffmpeg-7.1.1-gpl_h24e5c1d_701.conda             │
│ fsspec                  │ fsspec-2025.2.0-pyhd8ed1ab_0.conda              │ fsspec-2025.3.0-pyhd8ed1ab_0.conda              │
│ gtk3                    │ gtk3-3.24.43-h021d004_3.conda                   │ gtk3-3.24.43-h021d004_4.conda                   │
│ ipython                 │ ipython-9.0.0-pyhfb0248b_1.conda                │ ipython-9.0.2-pyhfb0248b_0.conda                │
│ level-zero              │ level-zero-1.21.1-h84d6215_0.conda              │ level-zero-1.21.2-h84d6215_0.conda              │
│ libarrow                │ libarrow-19.0.1-hfa2a6e7_0_cpu.conda            │ libarrow-19.0.1-hee35a22_2_cpu.conda            │
│ libarrow-acero          │ libarrow-acero-19.0.1-hcb10f89_0_cpu.conda      │ libarrow-acero-19.0.1-hcb10f89_2_cpu.conda      │
│ libarrow-dataset        │ libarrow-dataset-19.0.1-hcb10f89_0_cpu.conda    │ libarrow-dataset-19.0.1-hcb10f89_2_cpu.conda    │
│ libarrow-substrait      │ libarrow-substrait-19.0.1-h08228c5_0_cpu.conda  │ libarrow-substrait-19.0.1-h08228c5_2_cpu.conda  │
│ libavif16               │ libavif16-1.2.0-hf3231e4_0.conda                │ libavif16-1.2.0-h63b8bd6_1.conda                │
│ libcap                  │ libcap-2.71-h39aace5_0.conda                    │ libcap-2.75-h39aace5_0.conda                    │
│ libgoogle-cloud         │ libgoogle-cloud-2.35.0-h2b5623c_0.conda         │ libgoogle-cloud-2.36.0-h2b5623c_0.conda         │
│ libgoogle-cloud-storage │ libgoogle-cloud-storage-2.35.0-h0121fbd_0.conda │ libgoogle-cloud-storage-2.36.0-h0121fbd_0.conda │
│ libparquet              │ libparquet-19.0.1-h081d1f1_0_cpu.conda          │ libparquet-19.0.1-h081d1f1_2_cpu.conda          │
│ libsystemd0             │ libsystemd0-257.3-h3dc2cb9_0.conda              │ libsystemd0-257.4-h4e0b6ca_1.conda              │
│ libudev1                │ libudev1-257.3-h9a4d06a_0.conda                 │ libudev1-257.4-hbe16f8c_1.conda                 │
│ libusb                  │ libusb-1.0.27-h520f47e_100.conda                │ libusb-1.0.27-hb9d3cd8_101.conda                │
│ libxkbcommon            │ libxkbcommon-1.8.0-hc4a0caf_0.conda             │ libxkbcommon-1.8.1-hc4a0caf_0.conda             │
│ narwhals                │ narwhals-1.29.1-pyhd8ed1ab_0.conda              │ narwhals-1.30.0-pyhd8ed1ab_0.conda              │
│ orc                     │ orc-2.0.3-h12ee42a_2.conda                      │ orc-2.1.1-h2271f48_0.conda                      │
│ panel                   │ panel-1.6.2a2-py_0.tar.bz2                      │ panel-1.6.2a3-py_0.tar.bz2                      │
│ pango                   │ pango-1.56.1-h861ebed_0.conda                   │ pango-1.56.2-h861ebed_0.conda                   │
│ pyzmq                   │ pyzmq-26.2.1-py312hbf22597_0.conda              │ pyzmq-26.3.0-py312hbf22597_0.conda              │
│ svt-av1                 │ svt-av1-3.0.0-h5888daf_0.conda                  │ svt-av1-3.0.1-h5888daf_0.conda                  │
│ urllib3                 │ urllib3-2.3.0-pyhd8ed1ab_0.conda                │ urllib3-2.2.2-pyhd8ed1ab_0.conda                │
│ zstandard               │ zstandard-0.23.0-py312hef9b889_1.conda          │ -                                               │
│ zstd                    │ zstd-1.5.6-ha6fb4c9_0.conda                     │ zstd-1.5.7-hb8e6e7a_1.conda                     │
└─────────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────┘
                          Difference in packages on 'holoviews' for env 'test-313' on arch 'linux-64'
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Package                 ┃ Good run (#3725)                                ┃ Bad run (#3738)                                 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ attrs                   │ attrs-25.1.0-pyh71513ae_0.conda                 │ attrs-25.2.0-pyh71513ae_0.conda                 │
│ cairo                   │ cairo-1.18.2-h3394656_1.conda                   │ cairo-1.18.4-h3394656_0.conda                   │
│ ffmpeg                  │ ffmpeg-7.1.1-gpl_ha1cb39d_700.conda             │ ffmpeg-7.1.1-gpl_h24e5c1d_701.conda             │
│ fsspec                  │ fsspec-2025.2.0-pyhd8ed1ab_0.conda              │ fsspec-2025.3.0-pyhd8ed1ab_0.conda              │
│ gtk3                    │ gtk3-3.24.43-h021d004_3.conda                   │ gtk3-3.24.43-h021d004_4.conda                   │
│ ipython                 │ ipython-9.0.0-pyhfb0248b_1.conda                │ ipython-9.0.2-pyhfb0248b_0.conda                │
│ level-zero              │ level-zero-1.21.1-h84d6215_0.conda              │ level-zero-1.21.2-h84d6215_0.conda              │
│ libarrow                │ libarrow-19.0.1-hfa2a6e7_0_cpu.conda            │ libarrow-19.0.1-hee35a22_2_cpu.conda            │
│ libarrow-acero          │ libarrow-acero-19.0.1-hcb10f89_0_cpu.conda      │ libarrow-acero-19.0.1-hcb10f89_2_cpu.conda      │
│ libarrow-dataset        │ libarrow-dataset-19.0.1-hcb10f89_0_cpu.conda    │ libarrow-dataset-19.0.1-hcb10f89_2_cpu.conda    │
│ libarrow-substrait      │ libarrow-substrait-19.0.1-h08228c5_0_cpu.conda  │ libarrow-substrait-19.0.1-h08228c5_2_cpu.conda  │
│ libavif16               │ libavif16-1.2.0-hf3231e4_0.conda                │ libavif16-1.2.0-h63b8bd6_1.conda                │
│ libcap                  │ libcap-2.71-h39aace5_0.conda                    │ libcap-2.75-h39aace5_0.conda                    │
│ libgoogle-cloud         │ libgoogle-cloud-2.35.0-h2b5623c_0.conda         │ libgoogle-cloud-2.36.0-h2b5623c_0.conda         │
│ libgoogle-cloud-storage │ libgoogle-cloud-storage-2.35.0-h0121fbd_0.conda │ libgoogle-cloud-storage-2.36.0-h0121fbd_0.conda │
│ libparquet              │ libparquet-19.0.1-h081d1f1_0_cpu.conda          │ libparquet-19.0.1-h081d1f1_2_cpu.conda          │
│ libsystemd0             │ libsystemd0-257.3-h3dc2cb9_0.conda              │ libsystemd0-257.4-h4e0b6ca_1.conda              │
│ libudev1                │ libudev1-257.3-h9a4d06a_0.conda                 │ libudev1-257.4-hbe16f8c_1.conda                 │
│ libusb                  │ libusb-1.0.27-h520f47e_100.conda                │ libusb-1.0.27-hb9d3cd8_101.conda                │
│ libxkbcommon            │ libxkbcommon-1.8.0-hc4a0caf_0.conda             │ libxkbcommon-1.8.1-hc4a0caf_0.conda             │
│ narwhals                │ narwhals-1.29.1-pyhd8ed1ab_0.conda              │ narwhals-1.30.0-pyhd8ed1ab_0.conda              │
│ orc                     │ orc-2.0.3-h12ee42a_2.conda                      │ orc-2.1.1-h2271f48_0.conda                      │
│ panel                   │ panel-1.6.2a2-py_0.tar.bz2                      │ panel-1.6.2a3-py_0.tar.bz2                      │
│ pango                   │ pango-1.56.1-h861ebed_0.conda                   │ pango-1.56.2-h861ebed_0.conda                   │
│ pyzmq                   │ pyzmq-26.2.1-py313h8e95178_0.conda              │ pyzmq-26.3.0-py313h8e95178_0.conda              │
│ svt-av1                 │ svt-av1-3.0.0-h5888daf_0.conda                  │ svt-av1-3.0.1-h5888daf_0.conda                  │
│ urllib3                 │ urllib3-2.3.0-pyhd8ed1ab_0.conda                │ urllib3-2.2.2-pyhd8ed1ab_0.conda                │
│ zstandard               │ zstandard-0.23.0-py313h80202fe_1.conda          │ -                                               │
│ zstd                    │ zstd-1.5.6-ha6fb4c9_0.conda                     │ zstd-1.5.7-hb8e6e7a_1.conda                     │
└─────────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────┘
                          Difference in packages on 'holoviews' for env 'test-39' on arch 'linux-64'
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Package                 ┃ Good run (#3725)                                ┃ Bad run (#3738)                                 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ attrs                   │ attrs-25.1.0-pyh71513ae_0.conda                 │ attrs-25.2.0-pyh71513ae_0.conda                 │
│ cairo                   │ cairo-1.18.2-h3394656_1.conda                   │ cairo-1.18.4-h3394656_0.conda                   │
│ ffmpeg                  │ ffmpeg-7.1.1-gpl_ha1cb39d_700.conda             │ ffmpeg-7.1.1-gpl_h24e5c1d_701.conda             │
│ fsspec                  │ fsspec-2025.2.0-pyhd8ed1ab_0.conda              │ fsspec-2025.3.0-pyhd8ed1ab_0.conda              │
│ gtk3                    │ gtk3-3.24.43-h021d004_3.conda                   │ gtk3-3.24.43-h021d004_4.conda                   │
│ level-zero              │ level-zero-1.21.1-h84d6215_0.conda              │ level-zero-1.21.2-h84d6215_0.conda              │
│ libarrow                │ libarrow-19.0.1-hfa2a6e7_0_cpu.conda            │ libarrow-19.0.1-hee35a22_2_cpu.conda            │
│ libarrow-acero          │ libarrow-acero-19.0.1-hcb10f89_0_cpu.conda      │ libarrow-acero-19.0.1-hcb10f89_2_cpu.conda      │
│ libarrow-dataset        │ libarrow-dataset-19.0.1-hcb10f89_0_cpu.conda    │ libarrow-dataset-19.0.1-hcb10f89_2_cpu.conda    │
│ libarrow-substrait      │ libarrow-substrait-19.0.1-h08228c5_0_cpu.conda  │ libarrow-substrait-19.0.1-h08228c5_2_cpu.conda  │
│ libavif16               │ libavif16-1.2.0-hf3231e4_0.conda                │ libavif16-1.2.0-h63b8bd6_1.conda                │
│ libcap                  │ libcap-2.71-h39aace5_0.conda                    │ libcap-2.75-h39aace5_0.conda                    │
│ libgoogle-cloud         │ libgoogle-cloud-2.35.0-h2b5623c_0.conda         │ libgoogle-cloud-2.36.0-h2b5623c_0.conda         │
│ libgoogle-cloud-storage │ libgoogle-cloud-storage-2.35.0-h0121fbd_0.conda │ libgoogle-cloud-storage-2.36.0-h0121fbd_0.conda │
│ libparquet              │ libparquet-19.0.1-h081d1f1_0_cpu.conda          │ libparquet-19.0.1-h081d1f1_2_cpu.conda          │
│ libsystemd0             │ libsystemd0-257.3-h3dc2cb9_0.conda              │ libsystemd0-257.4-h4e0b6ca_1.conda              │
│ libudev1                │ libudev1-257.3-h9a4d06a_0.conda                 │ libudev1-257.4-hbe16f8c_1.conda                 │
│ libusb                  │ libusb-1.0.27-h520f47e_100.conda                │ libusb-1.0.27-hb9d3cd8_101.conda                │
│ libxkbcommon            │ libxkbcommon-1.8.0-hc4a0caf_0.conda             │ libxkbcommon-1.8.1-hc4a0caf_0.conda             │
│ narwhals                │ narwhals-1.29.1-pyhd8ed1ab_0.conda              │ narwhals-1.30.0-pyhd8ed1ab_0.conda              │
│ orc                     │ orc-2.0.3-h12ee42a_2.conda                      │ orc-2.1.1-h2271f48_0.conda                      │
│ pango                   │ pango-1.56.1-h861ebed_0.conda                   │ pango-1.56.2-h861ebed_0.conda                   │
│ pyzmq                   │ pyzmq-26.2.1-py39h4e4fb57_0.conda               │ pyzmq-26.3.0-py39h4e4fb57_0.conda               │
│ svt-av1                 │ svt-av1-3.0.0-h5888daf_0.conda                  │ svt-av1-3.0.1-h5888daf_0.conda                  │
└─────────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────┘
        Difference in packages on 'holoviews' for env 'test-core' on arch 'linux-64'
┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Package         ┃ Good run (#3725)                   ┃ Bad run (#3738)                    ┃
┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ narwhals        │ narwhals-1.29.1-pyhd8ed1ab_0.conda │ narwhals-1.30.0-pyhd8ed1ab_0.conda │
│ panel           │ panel-1.6.2a2-py_0.tar.bz2         │ panel-1.6.2a3-py_0.tar.bz2         │
└─────────────────┴────────────────────────────────────┴────────────────────────────────────┘
                          Difference in packages on 'holoviews' for env 'test-gpu' on arch 'linux-64'
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Package                 ┃ Good run (#3725)                                ┃ Bad run (#3738)                                 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ attrs                   │ attrs-25.1.0-pyh71513ae_0.conda                 │ attrs-25.2.0-pyh71513ae_0.conda                 │
│ cairo                   │ cairo-1.18.2-h3394656_1.conda                   │ cairo-1.18.4-h3394656_0.conda                   │
│ ffmpeg                  │ ffmpeg-7.1.1-gpl_ha1cb39d_700.conda             │ ffmpeg-7.1.1-gpl_h24e5c1d_701.conda             │
│ fmt                     │ fmt-11.1.4-h07f6e7f_0.conda                     │ fmt-11.0.2-h434a139_0.conda                     │
│ fsspec                  │ fsspec-2025.2.0-pyhd8ed1ab_0.conda              │ fsspec-2025.3.0-pyhd8ed1ab_0.conda              │
│ gtk3                    │ gtk3-3.24.43-h021d004_3.conda                   │ gtk3-3.24.43-h021d004_4.conda                   │
│ ipython                 │ ipython-9.0.0-pyhfb0248b_1.conda                │ ipython-9.0.2-pyhfb0248b_0.conda                │
│ level-zero              │ level-zero-1.21.1-h84d6215_0.conda              │ level-zero-1.21.2-h84d6215_0.conda              │
│ libarrow                │ libarrow-19.0.1-hfa2a6e7_0_cpu.conda            │ libarrow-19.0.1-hee35a22_2_cpu.conda            │
│ libarrow-acero          │ libarrow-acero-19.0.1-hcb10f89_0_cpu.conda      │ libarrow-acero-19.0.1-hcb10f89_2_cpu.conda      │
│ libarrow-dataset        │ libarrow-dataset-19.0.1-hcb10f89_0_cpu.conda    │ libarrow-dataset-19.0.1-hcb10f89_2_cpu.conda    │
│ libarrow-substrait      │ libarrow-substrait-19.0.1-h08228c5_0_cpu.conda  │ libarrow-substrait-19.0.1-h08228c5_2_cpu.conda  │
│ libavif16               │ libavif16-1.2.0-hf3231e4_0.conda                │ libavif16-1.2.0-h63b8bd6_1.conda                │
│ libcap                  │ libcap-2.71-h39aace5_0.conda                    │ libcap-2.75-h39aace5_0.conda                    │
│ libgoogle-cloud         │ libgoogle-cloud-2.35.0-h2b5623c_0.conda         │ libgoogle-cloud-2.36.0-h2b5623c_0.conda         │
│ libgoogle-cloud-storage │ libgoogle-cloud-storage-2.35.0-h0121fbd_0.conda │ libgoogle-cloud-storage-2.36.0-h0121fbd_0.conda │
│ libparquet              │ libparquet-19.0.1-h081d1f1_0_cpu.conda          │ libparquet-19.0.1-h081d1f1_2_cpu.conda          │
│ libsystemd0             │ libsystemd0-257.3-h3dc2cb9_0.conda              │ libsystemd0-257.4-h4e0b6ca_1.conda              │
│ libudev1                │ libudev1-257.3-h9a4d06a_0.conda                 │ libudev1-257.4-hbe16f8c_1.conda                 │
│ libusb                  │ libusb-1.0.27-h520f47e_100.conda                │ libusb-1.0.27-hb9d3cd8_101.conda                │
│ libxkbcommon            │ libxkbcommon-1.8.0-hc4a0caf_0.conda             │ libxkbcommon-1.8.1-hc4a0caf_0.conda             │
│ narwhals                │ narwhals-1.29.1-pyhd8ed1ab_0.conda              │ narwhals-1.30.0-pyhd8ed1ab_0.conda              │
│ orc                     │ orc-2.0.3-h12ee42a_2.conda                      │ orc-2.1.1-h2271f48_0.conda                      │
│ panel                   │ panel-1.6.2a2-py_0.tar.bz2                      │ panel-1.6.2a3-py_0.tar.bz2                      │
│ pango                   │ pango-1.56.1-h861ebed_0.conda                   │ pango-1.56.2-h861ebed_0.conda                   │
│ pynvjitlink             │ pynvjitlink-0.5.0-py312hf640dd1_0.conda         │ pynvjitlink-0.5.2-py312hf640dd1_0.conda         │
│ pyzmq                   │ pyzmq-26.2.1-py312hbf22597_0.conda              │ pyzmq-26.3.0-py312hbf22597_0.conda              │
│ svt-av1                 │ svt-av1-3.0.0-h5888daf_0.conda                  │ svt-av1-3.0.1-h5888daf_0.conda                  │
└─────────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────┘
                          Difference in packages on 'holoviews' for env 'test-ui' on arch 'linux-64'
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Package                 ┃ Good run (#3725)                                ┃ Bad run (#3738)                                 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ attrs                   │ attrs-25.1.0-pyh71513ae_0.conda                 │ attrs-25.2.0-pyh71513ae_0.conda                 │
│ cairo                   │ cairo-1.18.2-h3394656_1.conda                   │ cairo-1.18.4-h3394656_0.conda                   │
│ ffmpeg                  │ ffmpeg-7.1.1-gpl_ha1cb39d_700.conda             │ ffmpeg-7.1.1-gpl_h24e5c1d_701.conda             │
│ fsspec                  │ fsspec-2025.2.0-pyhd8ed1ab_0.conda              │ fsspec-2025.3.0-pyhd8ed1ab_0.conda              │
│ gtk3                    │ gtk3-3.24.43-h021d004_3.conda                   │ gtk3-3.24.43-h021d004_4.conda                   │
│ ipython                 │ ipython-9.0.0-pyhfb0248b_1.conda                │ ipython-9.0.2-pyhfb0248b_0.conda                │
│ level-zero              │ level-zero-1.21.1-h84d6215_0.conda              │ level-zero-1.21.2-h84d6215_0.conda              │
│ libarrow                │ libarrow-19.0.1-hfa2a6e7_0_cpu.conda            │ libarrow-19.0.1-hee35a22_2_cpu.conda            │
│ libarrow-acero          │ libarrow-acero-19.0.1-hcb10f89_0_cpu.conda      │ libarrow-acero-19.0.1-hcb10f89_2_cpu.conda      │
│ libarrow-dataset        │ libarrow-dataset-19.0.1-hcb10f89_0_cpu.conda    │ libarrow-dataset-19.0.1-hcb10f89_2_cpu.conda    │
│ libarrow-substrait      │ libarrow-substrait-19.0.1-h08228c5_0_cpu.conda  │ libarrow-substrait-19.0.1-h08228c5_2_cpu.conda  │
│ libavif16               │ libavif16-1.2.0-hf3231e4_0.conda                │ libavif16-1.2.0-h63b8bd6_1.conda                │
│ libcap                  │ libcap-2.71-h39aace5_0.conda                    │ libcap-2.75-h39aace5_0.conda                    │
│ libgoogle-cloud         │ libgoogle-cloud-2.35.0-h2b5623c_0.conda         │ libgoogle-cloud-2.36.0-h2b5623c_0.conda         │
│ libgoogle-cloud-storage │ libgoogle-cloud-storage-2.35.0-h0121fbd_0.conda │ libgoogle-cloud-storage-2.36.0-h0121fbd_0.conda │
│ libparquet              │ libparquet-19.0.1-h081d1f1_0_cpu.conda          │ libparquet-19.0.1-h081d1f1_2_cpu.conda          │
│ libsystemd0             │ libsystemd0-257.3-h3dc2cb9_0.conda              │ libsystemd0-257.4-h4e0b6ca_1.conda              │
│ libudev1                │ libudev1-257.3-h9a4d06a_0.conda                 │ libudev1-257.4-hbe16f8c_1.conda                 │
│ libusb                  │ libusb-1.0.27-h520f47e_100.conda                │ libusb-1.0.27-hb9d3cd8_101.conda                │
│ libxkbcommon            │ libxkbcommon-1.8.0-hc4a0caf_0.conda             │ libxkbcommon-1.8.1-hc4a0caf_0.conda             │
│ narwhals                │ narwhals-1.29.1-pyhd8ed1ab_0.conda              │ narwhals-1.30.0-pyhd8ed1ab_0.conda              │
│ orc                     │ orc-2.0.3-h12ee42a_2.conda                      │ orc-2.1.1-h2271f48_0.conda                      │
│ panel                   │ panel-1.6.2a2-py_0.tar.bz2                      │ panel-1.6.2a3-py_0.tar.bz2                      │
│ pango                   │ pango-1.56.1-h861ebed_0.conda                   │ pango-1.56.2-h861ebed_0.conda                   │
│ pyzmq                   │ pyzmq-26.2.1-py312hbf22597_0.conda              │ pyzmq-26.3.0-py312hbf22597_0.conda              │
│ svt-av1                 │ svt-av1-3.0.0-h5888daf_0.conda                  │ svt-av1-3.0.1-h5888daf_0.conda                  │
│ urllib3                 │ urllib3-2.3.0-pyhd8ed1ab_0.conda                │ urllib3-2.2.2-pyhd8ed1ab_0.conda                │
│ zstandard               │ zstandard-0.23.0-py312hef9b889_1.conda          │ -                                               │
│ zstd                    │ zstd-1.5.6-ha6fb4c9_0.conda                     │ zstd-1.5.7-hb8e6e7a_1.conda                     │
└─────────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────┘
```