### PR TITLE
docs: Typo correction in Composing Elements notebook 

### DIFF
--- a/examples/user_guide/02-Composing_Elements.ipynb
+++ b/examples/user_guide/02-Composing_Elements.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "Instantly viewable HoloViews objects include elements (discussed already) and containers (collections of elements or other containers).  Here we'll introduce two types of containers for collecting viewable objects, each typically created from the existing objects using a convenient operator syntax:\n",
     "\n",
-    "   1. ** [``Layout``](../reference/containers/bokeh/Layout.ipynb) (``+``):** A collection of any HoloViews objects to be displayed side by side. \n",
+    "   1. **[``Layout``](../reference/containers/bokeh/Layout.ipynb) (``+``):** A collection of HoloViews objects to be displayed side by side.\n",
     "   2. **[``Overlay``](../reference/containers/bokeh/Overlay.ipynb) (``*``):** A collection of HoloViews objects to be displayed overlaid on one another with the same axes.\n",
     "\n",
     "The Layout and Overlay containers allow you to mix types in any combination, and have an ordering but no numerical or categorical key dimension with which to index the objects.  In contrast, the [Dimensioned containers](./05-Dimensioned_Containers.ipynb) discussed later, such as [``HoloMap``](../reference/containers/bokeh/HoloMap.ipynb) , [``GridSpace``](../reference/containers/bokeh/GridSpace.ipynb), [``NdOverlay``](../reference/containers/bokeh/NdOverlay.ipynb), and [``NdLayout``](../reference/containers/bokeh/NdLayout.ipynb), do not allow mixed types, and each item has an associated numerical or categorical index (key).\n",


### PR DESCRIPTION
While reading the [Composing Elements](https://holoviews.org/user_guide/Composing_Elements.html) user guide notebook, I noticed a small typo with the bold text and a minor inconsistency with phrasing (the addition of "any" for `Layout`) 


<img width="854" alt="image" src="https://github.com/user-attachments/assets/3a5ac04b-976b-49cf-83aa-4e8041416642" />

I've updated the syntax here and and updated the phrasing. 