### PR TITLE
fix: Histogram error with datatype `dask.array` and backend Matplotlib

### DIFF
--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -369,6 +369,8 @@ class HistogramPlot(ColorbarPlot):
         xlim = hist.range(0)
         ylim = hist.range(1)
         is_datetime = isdatetime(edges)
+        if hasattr(edges, "compute"):
+            edges = edges.compute()
         if is_datetime:
             edges = np.array([dt64_to_dt(e) if isinstance(e, np.datetime64) else e for e in edges])
             edges = date2num(edges)

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -603,7 +603,7 @@ class OperationTests(ComparisonTestCase):
             "carrier": ["A", "A", "A", "A", "B", "B", "B", "B", "B"],
             "depdelay": [127.0, 3.0, -3.0, 19.0, 264.0, -6.0, 1.0, 2.0, 83.0],
         }
-        flights = dd.from_pandas(pd.DataFrame(data))
+        flights = dd.from_pandas(pd.DataFrame(data), npartitions=2)
 
         by = "carrier"
         ds = Dataset(flights, by)

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -4,7 +4,6 @@ from unittest import SkipTest, skipIf
 
 import numpy as np
 import pandas as pd
-import panel as pn
 import pytest
 
 try:
@@ -611,7 +610,7 @@ class OperationTests(ComparisonTestCase):
         hists = histogram(ds_grouped, dimension="depdelay")
 
         # Should not error
-        pn.panel(hists).get_root()
+        renderer("matplotlib").get_plot(hists)
 
     def test_interpolate_curve_pre(self):
         interpolated = interpolate_curve(Curve([0, 0.5, 1]), interpolation='steps-pre')

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -4,6 +4,7 @@ from unittest import SkipTest, skipIf
 
 import numpy as np
 import pandas as pd
+import panel as pn
 import pytest
 
 try:
@@ -592,6 +593,25 @@ class OperationTests(ComparisonTestCase):
                             mean_weighted=True, normed=True)
         hist = Histogram(([1.,  4., 7.5], [0, 3, 6, 9]), vdims=['y'])
         self.assertEqual(op_hist, hist)
+
+    @pytest.mark.usefixtures("mpl_backend")
+    def test_histogram_dask_array_mpl(self):
+        # Regression test for https://github.com/holoviz/holoviews/issues/5111
+        dd = pytest.importorskip("dask.dataframe")
+
+        data = {
+            "carrier": ["A", "A", "A", "A", "B", "B", "B", "B", "B"],
+            "depdelay": [127.0, 3.0, -3.0, 19.0, 264.0, -6.0, 1.0, 2.0, 83.0],
+        }
+        flights = dd.from_pandas(pd.DataFrame(data))
+
+        by = "carrier"
+        ds = Dataset(flights, by)
+        ds_grouped = ds.groupby(by)
+        hists = histogram(ds_grouped, dimension="depdelay")
+
+        # Should not error
+        pn.panel(hists).get_root()
 
     def test_interpolate_curve_pre(self):
         interpolated = interpolate_curve(Curve([0, 0.5, 1]), interpolation='steps-pre')


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/5111

We call compute on edges if it is a `dask.array`, so it doesn't error later down the pipeline. A similar thing is done in the Bokeh backend:

https://github.com/holoviz/holoviews/blob/ea8e8057d6213843fcd1d9a9a3fc39e3bafd841e/holoviews/plotting/bokeh/chart.py#L444-L445