### PR TITLE
fix: multi_y give weird error if single element

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -919,7 +919,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         axis_specs = {'x': {}, 'y': {}}
         axis_specs['x']['x'] = (*self._axis_props(plots, subplots, element, ranges, pos=0), self.xaxis, {})
-        if self.multi_y:
+        if self.multi_y and self.subplots:
             if not BOKEH_GE_3_2_0:
                 self.param.warning('Independent axis zooming for multi_y=True only supported for Bokeh >=3.2')
             yaxes, extra_axis_specs = self._create_extra_axes(plots, subplots, element, ranges)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -919,7 +919,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         axis_specs = {'x': {}, 'y': {}}
         axis_specs['x']['x'] = (*self._axis_props(plots, subplots, element, ranges, pos=0), self.xaxis, {})
-        if self.multi_y and self.subplots:
+        if self.multi_y and subplots:
             if not BOKEH_GE_3_2_0:
                 self.param.warning('Independent axis zooming for multi_y=True only supported for Bokeh >=3.2')
             yaxes, extra_axis_specs = self._create_extra_axes(plots, subplots, element, ranges)

--- a/holoviews/tests/plotting/bokeh/test_multiaxis.py
+++ b/holoviews/tests/plotting/bokeh/test_multiaxis.py
@@ -306,3 +306,10 @@ class TestCurveTwinAxes(LoggingComparisonTestCase, TestBokehPlot):
         assert plot.state.yaxis[0].axis_label_text_font_size == '15pt'
         assert plot.state.yaxis[1].axis_label == 'A'
         assert plot.state.yaxis[1].axis_label_text_font_size == '13pt'
+
+    def test_multi_y_on_curve(self):
+        # Regression test for https://github.com/holoviz/holoviews/issues/6322
+        overlay = Curve(range(10), vdims='A').opts(multi_y=True)
+
+        # Should not error
+        bokeh_renderer.get_plot(overlay)

--- a/holoviews/tests/plotting/bokeh/test_multiaxis.py
+++ b/holoviews/tests/plotting/bokeh/test_multiaxis.py
@@ -308,7 +308,7 @@ class TestCurveTwinAxes(LoggingComparisonTestCase, TestBokehPlot):
         assert plot.state.yaxis[1].axis_label_text_font_size == '13pt'
 
     def test_multi_y_on_curve(self):
-        # Regression test for https://github.com/holoviz/holoviews/issues/6322
+        # Test for https://github.com/holoviz/holoviews/issues/6322
         overlay = Curve(range(10), vdims='A').opts(multi_y=True)
 
         # Should not error


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/6322

If `self.subplots` is falsy we just treat it as a "normal". 