### PR TITLE
fix: add legend to distribution mpl backend

### DIFF
--- a/holoviews/element/stats.py
+++ b/holoviews/element/stats.py
@@ -34,8 +34,7 @@ class StatisticsElement(Dataset, Element2D):
         elif len(vdims) > 1:
             raise ValueError(f"{type(self).__name__} expects at most one vdim.")
         else:
-            with param.edit_constant(self):
-                self.vdims = process_dimensions(None, vdims)['vdims']
+            self.vdims = process_dimensions(None, vdims)['vdims']
 
     @property
     def dataset(self):

--- a/holoviews/element/stats.py
+++ b/holoviews/element/stats.py
@@ -34,7 +34,8 @@ class StatisticsElement(Dataset, Element2D):
         elif len(vdims) > 1:
             raise ValueError(f"{type(self).__name__} expects at most one vdim.")
         else:
-            self.vdims = process_dimensions(None, vdims)['vdims']
+            with param.edit_constant(self):
+                self.vdims = process_dimensions(None, vdims)['vdims']
 
     @property
     def dataset(self):

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -312,4 +312,5 @@ options.Sankey = Options('style', edge_color='grey', node_edgecolors='black',
 # Statistics
 options.Distribution = Options('style', facecolor=Cycle(), edgecolor='black',
                                alpha=0.5)
+options.Distribution = Options('plot', show_legend=True)
 options.Violin = Options('style', facecolors=Cycle(), showextrema=False, alpha=0.7)

--- a/holoviews/tests/plotting/matplotlib/test_distribution.py
+++ b/holoviews/tests/plotting/matplotlib/test_distribution.py
@@ -1,0 +1,14 @@
+import pytest
+
+import holoviews as hv
+
+
+@pytest.mark.usefixtures("mpl_backend")
+def test_distribution_legend(rng):
+    normal = rng.normal(1000)
+    binary = rng.integers(0, 2, 1000)
+    df = {"normal": normal, "binary": binary}
+
+    ds = hv.Dataset(df, kdims=["binary"], vdims=["normal"])
+    plot = ds.to(hv.Distribution, "normal").overlay("binary")
+    assert "legend" in hv.renderer("matplotlib").get_plot(plot).handles


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/5686

Having a legend aligns the Distribution with the Matplotlib backend and how the Bokeh backend works. 

``` python
import holoviews as hv
import numpy as np
import pandas as pd

hv.extension("matplotlib")

# example data
normal1 = np.random.randn(1000)
normal2 = np.random.randn(1000)
binary = np.random.randint(0, 2, 1000)
df = pd.DataFrame({"normal1": normal1, "normal2": normal2, "binary": binary})

ds = hv.Dataset(df, kdims=["binary"], vdims=["normal1", "normal2"])
ds.to(hv.Distribution, "normal1", "normal2").overlay("binary")
```