### PR TITLE
compat: Param 2.3

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -855,7 +855,7 @@ class Dimensioned(LabelledData):
 
        Aliased with constant_dimensions.""")
 
-    kdims = param.List(bounds=(0, None), doc="""
+    kdims = param.List(bounds=(0, None), constant=True, doc="""
        The key dimensions defined as list of dimensions that may be
        used in indexing (and potential slicing) semantics. The order
        of the dimensions listed here determines the semantics of each
@@ -863,7 +863,7 @@ class Dimensioned(LabelledData):
 
        Aliased with key_dimensions.""")
 
-    vdims = param.List(bounds=(0, None), doc="""
+    vdims = param.List(bounds=(0, None), constant=True, doc="""
        The value dimensions defined as the list of dimensions used to
        describe the components of the data. If multiple value
        dimensions are supplied, a particular value dimension may be

--- a/holoviews/element/stats.py
+++ b/holoviews/element/stats.py
@@ -30,11 +30,13 @@ class StatisticsElement(Dataset, Element2D):
         params.update(dict(kdims=kdims, vdims=[], _validate_vdims=False))
         super().__init__(data, **params)
         if not vdims:
-            self.vdims = [Dimension('Density')]
+            with param.edit_constant(self):
+                self.vdims = [Dimension('Density')]
         elif len(vdims) > 1:
             raise ValueError(f"{type(self).__name__} expects at most one vdim.")
         else:
-            self.vdims = process_dimensions(None, vdims)['vdims']
+            with param.edit_constant(self):
+                self.vdims = process_dimensions(None, vdims)['vdims']
 
     @property
     def dataset(self):


### PR DESCRIPTION
With changes made in https://github.com/holoviz/param/pull/1017, I started to see tests/code fail locally. These test will start to fail with a new dev release of Param 2.3
```  bash
=================================================================================================================== short test summary info ===================================================================================================================
FAILED holoviews/tests/operation/test_statsoperations.py::KDEOperationTests::test_univariate_kde_flat_distribution - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/operation/test_statsoperations.py::KDEOperationTests::test_univariate_kde - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/operation/test_statsoperations.py::KDEOperationTests::test_bivariate_kde_nans - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/operation/test_statsoperations.py::KDEOperationTests::test_bivariate_kde - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/operation/test_statsoperations.py::KDEOperationTests::test_bivariate_kde_contours_filled - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/operation/test_statsoperations.py::KDEOperationTests::test_univariate_kde_nans - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/operation/test_statsoperations.py::KDEOperationTests::test_bivariate_kde_contours - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/core/data/test_daskinterface.py::DaskDatasetTest::test_dataset_extract_kdims - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/plotting/plotly/test_bivariateplot.py::TestBivariatePlot::test_bivariate_state - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/plotting/plotly/test_bivariateplot.py::TestBivariatePlot::test_bivariate_colorbar - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/plotting/plotly/test_bivariateplot.py::TestBivariatePlot::test_bivariate_ncontours - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/plotting/plotly/test_bivariateplot.py::TestBivariatePlot::test_visible - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/plotting/plotly/test_bivariateplot.py::TestBivariatePlot::test_bivariate_filled - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/core/test_datasetproperty.py::DistributionTestCase::test_distribution_dataset - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_distribution_series_constructor - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_distribution_dict_constructor - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_bivariate_array_range_vdims - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_distribution_array_constructor_custom_vdim - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_distribution_array_range_vdims - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_distribution_array_constructor - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_bivariate_array_constructor_custom_vdim - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_bivariate_array_kdim_type - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_bivariate_composite_transfer_opts_with_group - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_distribution_composite_custom_vdim - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_distribution_composite_empty_not_filled - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_distribution_composite_transfer_opts_with_group - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_bivariate_composite_empty_filled - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_distribution_array_kdim_type - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_bivariate_array_constructor - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_distribution_composite - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_bivariate_composite_filled - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_bivariate_array_vdim_type - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_distribution_array_vdim_type - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_bivariate_dict_constructor - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_bivariate_array_range_kdims - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_distribution_array_range_kdims - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_distribution_dframe_constructor - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_bivariate_dframe_constructor - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_distribution_from_image - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_distribution_composite_not_filled - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_bivariate_composite - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalElement::test_bivariate_from_points - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_distribution_composite_transfer_opts - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_bivariate_composite_transfer_opts - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_bivariate_composite_custom_vdim - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_statselements.py::TestStatisticalCompositor::test_bivariate_composite_empty_not_filled - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_selection.py::TestSelection1DExpr::test_distribution_single_inverted - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/element/test_selection.py::TestSelection1DExpr::test_distribution_single - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/core/data/test_pandasinterface.py::PandasInterfaceTests::test_dataset_extract_kdims - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/plotting/plotly/test_distributionplot.py::TestDistributionPlot::test_distribution_not_filled - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/plotting/plotly/test_distributionplot.py::TestDistributionPlot::test_distribution_filled - TypeError: Constant parameter 'vdims' cannot be modified
FAILED holoviews/tests/plotting/plotly/test_distributionplot.py::TestDistributionPlot::test_visible - TypeError: Constant parameter 'vdims' cannot be modified
```