### PR TITLE
compat!: Drop Python 3.9

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,7 +83,7 @@ jobs:
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
-              "environment": ["test-39", "test-313"]
+              "environment": ["test-310", "test-313"]
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'full' option
@@ -91,7 +91,7 @@ jobs:
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
-              "environment": ["test-39", "test-310", "test-311", "test-312", "test-313"]
+              "environment": ["test-310", "test-311", "test-312", "test-313"]
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'downstream' option

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -307,7 +307,7 @@ class Annotator(PaneBase):
 
     @property
     def tables(self):
-        return list(zip(self.editor._names, self.editor))
+        return list(zip(self.editor._names, self.editor, strict=None))
 
     @property
     def selected(self):

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -366,7 +366,7 @@ class Redim(metaclass=AccessorPipelineMeta):
         """
         filtered = []
         for key, value in dmap.data.items():
-            if not any(kd.values and v not in kd.values for kd, v in zip(kdims, key)):
+            if not any(kd.values and v not in kd.values for kd, v in zip(kdims, key, strict=None)):
                 filtered.append((key, value))
         return filtered
 
@@ -439,7 +439,7 @@ class Redim(metaclass=AccessorPipelineMeta):
 
         kdims = self.replace_dimensions(obj.kdims, dimensions)
         vdims = self.replace_dimensions(obj.vdims, dimensions)
-        zipped_dims = zip(obj.kdims+obj.vdims, kdims+vdims)
+        zipped_dims = zip(obj.kdims+obj.vdims, kdims+vdims, strict=None)
         renames = {pk.name: nk for pk, nk in zipped_dims if pk.name != nk.name}
 
         if self.mode == 'dataset':

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -475,7 +475,7 @@ class Dataset(Element, metaclass=PipelineMeta):
         if xs.dtype.kind in 'SO':
             raise NotImplementedError("Closest only supported for numeric types")
         idxs = [np.argmin(np.abs(xs-coord)) for coord in coords]
-        return [type(s)(xs[idx]) for s, idx in zip(coords, idxs)]
+        return [type(s)(xs[idx]) for s, idx in zip(coords, idxs, strict=None)]
 
 
     def sort(self, by=None, reverse=False):
@@ -739,13 +739,13 @@ class Dataset(Element, metaclass=PipelineMeta):
         if len(slices) == 1 and slices[0] in self.dimensions():
             return self.dimension_values(slices[0])
         elif len(slices) == self.ndims+1 and slices[self.ndims] in self.dimensions():
-            selection = dict(zip(self.dimensions('key', label=True), slices))
+            selection = dict(zip(self.dimensions('key', label=True), slices, strict=None))
             value_select = slices[self.ndims]
         elif len(slices) == self.ndims+1 and isinstance(slices[self.ndims],
                                                         (Dimension,str)):
             raise IndexError(f"{slices[self.ndims]!r} is not an available value dimension")
         else:
-            selection = dict(zip(self.dimensions(label=True), slices))
+            selection = dict(zip(self.dimensions(label=True), slices, strict=None))
         data = self.select(**selection)
         if value_select:
             if data.shape[0] == 1:
@@ -821,7 +821,7 @@ class Dataset(Element, metaclass=PipelineMeta):
                 ysamples = [(ly+uy)/2.0 for ly,uy in pairwise(yedges)]
 
                 Y,X = np.meshgrid(ysamples, xsamples)
-                linsamples = list(zip(X.flat, Y.flat))
+                linsamples = list(zip(X.flat, Y.flat, strict=None))
             else:
                 raise NotImplementedError("Regular sampling not implemented "
                                           "for elements with more than two dimensions.")
@@ -833,7 +833,7 @@ class Dataset(Element, metaclass=PipelineMeta):
         from ...element import Curve, Table
         datatype = ['dataframe', 'dictionary', 'dask', 'ibis', 'cuDF']
         if len(samples) == 1:
-            sel = {kd.name: s for kd, s in zip(self.kdims, samples[0])}
+            sel = {kd.name: s for kd, s in zip(self.kdims, samples[0], strict=None)}
             dims = [kd for kd, v in sel.items() if not np.isscalar(v)]
             selection = self.select(**sel)
 
@@ -1042,7 +1042,7 @@ class Dataset(Element, metaclass=PipelineMeta):
             group_kwargs = dict(core_util.get_param_values(self), kdims=kdims)
             group_kwargs.update(kwargs)
             def load_subset(*args):
-                constraint = dict(zip(dim_names, args))
+                constraint = dict(zip(dim_names, args, strict=None))
                 group = self.select(**constraint)
                 if np.isscalar(group):
                     return group_type(([group],), group=self.group,
@@ -1105,7 +1105,7 @@ class Dataset(Element, metaclass=PipelineMeta):
             if len(signature) == 1:
                 new_data[signature[0]] = applied
             else:
-                for s, vals in zip(signature, applied):
+                for s, vals in zip(signature, applied, strict=None):
                     new_data[s] = vals
 
         new_dims = []

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -2,6 +2,7 @@ import copy
 import types
 from contextlib import contextmanager
 from functools import wraps
+from itertools import pairwise
 
 import numpy as np
 import param
@@ -805,7 +806,7 @@ class Dataset(Element, metaclass=PipelineMeta):
                 xlim = self.range(0)
                 lower, upper = (xlim[0], xlim[1]) if bounds is None else bounds
                 edges = np.linspace(lower, upper, samples+1)
-                linsamples = [(l+u)/2.0 for l,u in zip(edges[:-1], edges[1:])]
+                linsamples = [(l+u)/2.0 for l,u in pairwise(edges)]
             elif self.ndims == 2:
                 (rows, cols) = samples
                 if bounds:
@@ -816,8 +817,8 @@ class Dataset(Element, metaclass=PipelineMeta):
 
                 xedges = np.linspace(l, r, cols+1)
                 yedges = np.linspace(b, t, rows+1)
-                xsamples = [(lx+ux)/2.0 for lx,ux in zip(xedges[:-1], xedges[1:])]
-                ysamples = [(ly+uy)/2.0 for ly,uy in zip(yedges[:-1], yedges[1:])]
+                xsamples = [(lx+ux)/2.0 for lx,ux in pairwise(xedges)]
+                ysamples = [(ly+uy)/2.0 for ly,uy in pairwise(yedges)]
 
                 Y,X = np.meshgrid(ysamples, xsamples)
                 linsamples = list(zip(X.flat, Y.flat))

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -36,7 +36,7 @@ class ArrayInterface(Interface):
         elif isinstance(data, dict) and not all(d in data for d in dimensions):
             dict_data = sorted(data.items())
             dataset = zip(*((util.wrap_tuple(k)+util.wrap_tuple(v))
-                            for k, v in dict_data))
+                            for k, v in dict_data), strict=None)
             data = np.column_stack(list(dataset))
         elif isinstance(data, tuple):
             data = [d if isinstance(d, np.ndarray) else np.asarray(d) for d in data]

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -288,7 +288,7 @@ class cuDFInterface(PandasInterface):
             if not hasattr(grouped, agg):
                 raise ValueError(f'{agg} aggregation is not supported on cudf DataFrame.')
             numeric_cols = [
-                c for c, d in zip(reindexed.columns, reindexed.dtypes, strict=None)
+                c for c, d in zip(reindexed.columns, reindexed.dtypes, strict=True)
                 if is_numeric_dtype(d) and c not in cols
             ]
             df = getattr(grouped[numeric_cols], agg)().reset_index()
@@ -299,12 +299,12 @@ class cuDFInterface(PandasInterface):
                 raise ValueError(f'{agg} aggregation is not supported on cudf DataFrame.')
             agg = getattr(reindexed, agg)()
             try:
-                data = {col: [v] for col, v in zip(agg.index.values_host, agg.to_numpy(), strict=None)}
+                data = {col: [v] for col, v in zip(agg.index.values_host, agg.to_numpy(), strict=True)}
             except Exception:
                 # Give FutureWarning: 'The to_array method will be removed in a future cuDF release.
                 # Consider using `to_numpy` instead.'
                 # Seen in cudf=21.12.01
-                data = {col: [v] for col, v in zip(agg.index.values_host, agg.to_array(), strict=None)}
+                data = {col: [v] for col, v in zip(agg.index.values_host, agg.to_array(), strict=True)}
             df = pd.DataFrame(data, columns=list(agg.index.values_host))
 
         dropped = []

--- a/holoviews/core/data/cudf.py
+++ b/holoviews/core/data/cudf.py
@@ -167,7 +167,7 @@ class cuDFInterface(PandasInterface):
         # Iterate over the unique entries applying selection masks
         grouped_data = []
         for unique_key in util.unique_iterator(keys):
-            group_data = dataset.select(**dict(zip(dimensions, unique_key)))
+            group_data = dataset.select(**dict(zip(dimensions, unique_key, strict=None)))
             if not len(group_data):
                 continue
             group_data = group_type(group_data, **group_kwargs)
@@ -288,7 +288,7 @@ class cuDFInterface(PandasInterface):
             if not hasattr(grouped, agg):
                 raise ValueError(f'{agg} aggregation is not supported on cudf DataFrame.')
             numeric_cols = [
-                c for c, d in zip(reindexed.columns, reindexed.dtypes)
+                c for c, d in zip(reindexed.columns, reindexed.dtypes, strict=None)
                 if is_numeric_dtype(d) and c not in cols
             ]
             df = getattr(grouped[numeric_cols], agg)().reset_index()
@@ -299,12 +299,12 @@ class cuDFInterface(PandasInterface):
                 raise ValueError(f'{agg} aggregation is not supported on cudf DataFrame.')
             agg = getattr(reindexed, agg)()
             try:
-                data = {col: [v] for col, v in zip(agg.index.values_host, agg.to_numpy())}
+                data = {col: [v] for col, v in zip(agg.index.values_host, agg.to_numpy(), strict=None)}
             except Exception:
                 # Give FutureWarning: 'The to_array method will be removed in a future cuDF release.
                 # Consider using `to_numpy` instead.'
                 # Seen in cudf=21.12.01
-                data = {col: [v] for col, v in zip(agg.index.values_host, agg.to_array())}
+                data = {col: [v] for col, v in zip(agg.index.values_host, agg.to_array(), strict=None)}
             df = pd.DataFrame(data, columns=list(agg.index.values_host))
 
         dropped = []

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -234,7 +234,7 @@ class DaskInterface(PandasInterface):
         cols = [d.name for d in dataset.kdims if d in dimensions]
         vdims = dataset.dimensions('value', label='name')
         dtypes = data.dtypes
-        numeric = [c for c, dtype in zip(dtypes.index, dtypes.values)
+        numeric = [c for c, dtype in zip(dtypes.index, dtypes.values, strict=None)
                    if dtype.kind in 'iufc' and c in vdims]
         reindexed = data[cols+numeric]
 
@@ -282,7 +282,7 @@ class DaskInterface(PandasInterface):
         mask = None
         for sample in samples:
             if np.isscalar(sample): sample = [sample]
-            for c, v in zip(dims, sample):
+            for c, v in zip(dims, sample, strict=None):
                 dim_mask = data[c]==v
                 if mask is None:
                     mask = dim_mask

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -40,7 +40,7 @@ class DictInterface(Interface):
             not all(c in d for d in data for c in dimensions)):
             raise ValueError('DictInterface could not find specified dimensions in the data.')
         elif isinstance(data, tuple):
-            data = {d: v for d, v in zip(dimensions, data)}
+            data = {d: v for d, v in zip(dimensions, data, strict=None)}
         elif util.is_dataframe(data) and all(d in data for d in dimensions):
             data = {d: data[d] for d in dimensions}
         elif isinstance(data, np.ndarray):
@@ -60,13 +60,13 @@ class DictInterface(Interface):
         elif (isinstance(data, list) and isinstance(data[0], tuple) and len(data[0]) == 2
               and any(isinstance(v, tuple) for v in data[0])):
             dict_data = zip(*((util.wrap_tuple(k)+util.wrap_tuple(v))
-                              for k, v in data))
-            data = {k: np.array(v) for k, v in zip(dimensions, dict_data)}
+                              for k, v in data), strict=None)
+            data = {k: np.array(v) for k, v in zip(dimensions, dict_data, strict=None)}
         # Ensure that interface does not consume data of other types
         # with an iterator interface
         elif not any(isinstance(data, tuple(t for t in interface.types if t is not None))
                      for interface in cls.interfaces.values()):
-            data = {k: v for k, v in zip(dimensions, zip(*data))}
+            data = {k: v for k, v in zip(dimensions, zip(*data, strict=None), strict=None)}
         elif (isinstance(data, dict) and not any(isinstance(v, np.ndarray) for v in data.values()) and not
               any(d in data or any(d in k for k in data if isinstance(k, tuple)) for d in dimensions)):
             # For data where both keys and values are dimension values
@@ -78,8 +78,8 @@ class DictInterface(Interface):
                                  "per dimension or a mapping between key and value dimension "
                                  "values.")
             dict_data = zip(*((util.wrap_tuple(k)+util.wrap_tuple(v))
-                              for k, v in dict_data))
-            data = {k: np.array(v) for k, v in zip(dimensions, dict_data)}
+                              for k, v in dict_data), strict=None)
+            data = {k: np.array(v) for k, v in zip(dimensions, dict_data, strict=None)}
 
         if not isinstance(data, cls.types):
             raise ValueError("DictInterface interface couldn't convert data.""")
@@ -210,7 +210,7 @@ class DictInterface(Interface):
         for key, ds in datasets:
             for k, vals in ds.data.items():
                 columns[k].append(np.atleast_1d(vals))
-            for d, k in zip(dimensions, key):
+            for d, k in zip(dimensions, key, strict=None):
                 columns[d.name].append(np.full(len(ds), k))
 
         template = datasets[0][1]
@@ -303,7 +303,7 @@ class DictInterface(Interface):
         # Iterate over the unique entries applying selection masks
         grouped_data = []
         for unique_key in util.unique_iterator(keys):
-            mask = cls.select_mask(dataset, dict(zip(dimensions, unique_key)))
+            mask = cls.select_mask(dataset, dict(zip(dimensions, unique_key, strict=None)))
             group_data = dict((d.name, dataset.data[d.name] if isscalar(dataset.data[d.name])
                                        else dataset.data[d.name][mask])
                                       for d in kdims+vdims)
@@ -365,7 +365,7 @@ class DictInterface(Interface):
         dropped = []
         for key, group in groups:
             key = key if isinstance(key, tuple) else (key,)
-            for kdim, val in zip(kdims, key):
+            for kdim, val in zip(kdims, key, strict=None):
                 aggregated[kdim].append(val)
             for vdim, arr in group.items():
                 if vdim in dataset.vdims:

--- a/holoviews/core/data/ibis.py
+++ b/holoviews/core/data/ibis.py
@@ -167,7 +167,7 @@ class IbisInterface(Interface):
             # sort_by will be removed in Ibis 5.0
             hist_bins = binned.value_counts().sort_by('bucket').execute()
         metric_name = 'bucket_count' if IBIS_GE_5_0_0 else 'count'
-        for b, v in zip(hist_bins['bucket'], hist_bins[metric_name]):
+        for b, v in zip(hist_bins['bucket'], hist_bins[metric_name], strict=None):
             if np.isnan(b):
                 continue
             hist[int(b)] = v

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -33,7 +33,7 @@ class ImageInterface(GridInterface):
         kwargs = {}
         dimensions = [dimension_name(d) for d in kdims + vdims]
         if isinstance(data, tuple):
-            data = dict(zip(dimensions, data))
+            data = dict(zip(dimensions, data, strict=None))
         if isinstance(data, dict):
             xs, ys = np.asarray(data[kdims[0].name]), np.asarray(data[kdims[1].name])
             xvalid = util.validate_regular_sampling(xs, eltype.rtol or util.config.image_rtol)
@@ -280,9 +280,9 @@ class ImageInterface(GridInterface):
                        for i in range(dataset.data.shape[abs(didx-1)])]
             data = np.flipud(dataset.data)
             groups = [(c, group_type((xvals, data[s]), **group_kwargs))
-                       for s, c in zip(samples, coords)]
+                       for s, c in zip(samples, coords, strict=None)]
         else:
-            data = zip(*[dataset.dimension_values(i) for i in range(len(dataset.dimensions()))])
+            data = zip(*[dataset.dimension_values(i) for i in range(len(dataset.dimensions()))], strict=None)
             groups = [(g[:dataset.ndims], group_type([g[dataset.ndims:]], **group_kwargs))
                       for g in data]
 
@@ -318,7 +318,7 @@ class ImageInterface(GridInterface):
             if len(dataset.vdims) == 1:
                 return (data if np.isscalar(data) else data[0], [])
             else:
-                return ({vd.name: np.array([v]) for vd, v in zip(dataset.vdims, data)}, [])
+                return ({vd.name: np.array([v]) for vd, v in zip(dataset.vdims, data, strict=None)}, [])
         elif len(axes) == 1:
             return ({kdims[0]: cls.values(dataset, axes[0], expanded=False),
                     dataset.vdims[0].name: data[::-1] if axes[0] else data}, [])

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -437,7 +437,7 @@ class Interface(param.Parameterized):
         new_type = new_type or Dataset
         if isinstance(datasets, NdMapping):
             dimensions = datasets.kdims
-            keys, datasets = zip(*datasets.data.items(), strict=None)
+            keys, datasets = zip(*datasets.data.items(), strict=True)
         elif isinstance(datasets, list) and all(not isinstance(v, tuple) for v in datasets):
             # Allow concatenating list of datasets (by declaring no dimensions and keys)
             dimensions, keys = [], [()]*len(datasets)

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -437,7 +437,7 @@ class Interface(param.Parameterized):
         new_type = new_type or Dataset
         if isinstance(datasets, NdMapping):
             dimensions = datasets.kdims
-            keys, datasets = zip(*datasets.data.items())
+            keys, datasets = zip(*datasets.data.items(), strict=None)
         elif isinstance(datasets, list) and all(not isinstance(v, tuple) for v in datasets):
             # Allow concatenating list of datasets (by declaring no dimensions and keys)
             dimensions, keys = [], [()]*len(datasets)
@@ -462,7 +462,7 @@ class Interface(param.Parameterized):
 
         datasets = template.interface.cast(datasets, datatype)
         template = datasets[0]
-        data = list(zip(keys, datasets)) if keys else datasets
+        data = list(zip(keys, datasets, strict=None)) if keys else datasets
         concat_data = template.interface.concat(data, dimensions, vdims=template.vdims)
         return template.clone(concat_data, kdims=dimensions+template.kdims, new_type=new_type)
 

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -225,7 +225,7 @@ class MultiInterface(Interface):
         if not dataset.data:
             return dataset.data
         elif selection_mask is not None:
-            return [d for b, d in zip(selection_mask, dataset.data) if b]
+            return [d for b, d in zip(selection_mask, dataset.data, strict=None) if b]
         ds = cls._inner_dataset_template(dataset)
         skipped = (Polygons._hole_key,)
         if hasattr(ds.interface, 'geo_column'):
@@ -288,8 +288,8 @@ class MultiInterface(Interface):
         keys = (tuple(vals[i] for vals in values) for i in range(len(vals)))
         grouped_data = []
         for unique_key in util.unique_iterator(keys):
-            mask = ds.interface.select_mask(ds, dict(zip(dimensions, unique_key)))
-            selection = [data for data, m in zip(dataset.data, mask) if m]
+            mask = ds.interface.select_mask(ds, dict(zip(dimensions, unique_key, strict=None)))
+            selection = [data for data, m in zip(dataset.data, mask, strict=None) if m]
             group_data = group_type(selection, **group_kwargs)
             grouped_data.append((unique_key, group_data))
 
@@ -435,7 +435,7 @@ class MultiInterface(Interface):
             return np.concatenate(values) if values else np.array([])
         else:
             array = np.empty(len(values), dtype=object)
-            array[:] = [a[0] if s else a for s, a in zip(scalars, values)]
+            array[:] = [a[0] if s else a for s, a in zip(scalars, values, strict=None)]
             return array
 
     @classmethod
@@ -494,7 +494,7 @@ class MultiInterface(Interface):
         new_data = []
         template = cls._inner_dataset_template(dataset)
         array_type = template.interface.datatype == 'array'
-        for d, v in zip(dataset.data, values):
+        for d, v in zip(dataset.data, values, strict=None):
             template.data = d
             if array_type:
                 ds = template.clone(template.columns())
@@ -574,9 +574,9 @@ def ensure_ring(geom, values=None):
     breaks = np.where(np.isnan(geom.astype('float')).sum(axis=1))[0]
     starts = [0, *(breaks + 1)]
     ends = [*(breaks - 1), len(geom) - 1]
-    zipped = zip(geom[starts], geom[ends], ends, values[starts])
+    zipped = zip(geom[starts], geom[ends], ends, values[starts], strict=None)
     unpacked = tuple(zip(*[(v, i+1) for s, e, i, v in zipped
-                     if (s!=e).any()]))
+                     if (s!=e).any()], strict=None))
     if not unpacked:
         return values
     inserts, inds = unpacked

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -105,8 +105,8 @@ class PandasInterface(Interface, PandasAPI):
                                     "per dimension or a mapping between key and value dimension "
                                     "values.")
                 column_data = zip(*((util.wrap_tuple(k)+util.wrap_tuple(v))
-                                    for k, v in column_data))
-                data = dict(((c, col) for c, col in zip(columns, column_data)))
+                                    for k, v in column_data), strict=None)
+                data = dict(((c, col) for c, col in zip(columns, column_data, strict=None)))
             elif isinstance(data, np.ndarray):
                 if data.ndim == 1:
                     if eltype._auto_indexable_1d and len(kdims)+len(vdims)>1:
@@ -126,7 +126,7 @@ class PandasInterface(Interface, PandasAPI):
                                     f'at least {min_dims} columns but found only {len(data)} columns.')
                 elif not cls.expanded(data):
                     raise ValueError('PandasInterface expects data to be of uniform shape.')
-                data = pd.DataFrame(dict(zip(columns, data)), columns=columns)
+                data = pd.DataFrame(dict(zip(columns, data, strict=None)), columns=columns)
             elif ((isinstance(data, dict) and any(c not in data for c in columns)) or
                   (isinstance(data, list) and any(isinstance(d, dict) and c not in d for d in data for c in columns))):
                 raise ValueError('PandasInterface could not find specified dimensions in the data.')
@@ -227,7 +227,7 @@ class PandasInterface(Interface, PandasAPI):
         dataframes = []
         for key, ds in datasets:
             data = ds.data.copy()
-            for d, k in zip(dimensions, key):
+            for d, k in zip(dimensions, key, strict=None):
                 data[d.name] = k
             dataframes.append(data)
         return cls.concat_fn(dataframes)
@@ -290,7 +290,7 @@ class PandasInterface(Interface, PandasAPI):
                 ]
             else:
                 numeric_cols = [
-                    c for c, d in zip(reindexed.columns, reindexed.dtypes)
+                    c for c, d in zip(reindexed.columns, reindexed.dtypes, strict=None)
                     if is_numeric_dtype(d) and c not in cols
                 ]
             groupby_kwargs = {"sort": False}
@@ -300,7 +300,7 @@ class PandasInterface(Interface, PandasAPI):
             df = grouped[numeric_cols].aggregate(fn, **kwargs).reset_index()
         else:
             agg = reindexed.apply(fn, **kwargs)
-            data = {col: [v] for col, v in zip(agg.index, agg.values)}
+            data = {col: [v] for col, v in zip(agg.index, agg.values, strict=None)}
             df = pd.DataFrame(data, columns=list(agg.index))
 
         dropped = []

--- a/holoviews/core/data/spatialpandas.py
+++ b/holoviews/core/data/spatialpandas.py
@@ -668,7 +668,7 @@ def get_value_array(data, dimension, expanded, keep_index, geom_col,
         return np.array([a[0] for a in arrays])
     else:
         array = np.empty(len(arrays), dtype=object)
-        array[:] = [a[0] if s else a for s, a in zip(scalars, arrays)]
+        array[:] = [a[0] if s else a for s, a in zip(scalars, arrays, strict=None)]
         return array
 
 
@@ -803,7 +803,7 @@ def to_spatialpandas(data, xdim, ydim, columns=None, geom='point'):
             array_type = single_array
 
     converted = defaultdict(list)
-    for geom_data, arrays, holes in zip(data, geom_arrays, hole_arrays):
+    for geom_data, arrays, holes in zip(data, geom_arrays, hole_arrays, strict=None):
         parts = []
         for i, g in enumerate(arrays):
             if i != (len(arrays)-1):

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -64,7 +64,7 @@ class XArrayInterface(GridInterface):
             array = dataset.data[dataset.vdims[0].name]
         if not gridded:
             return (np.prod(array.shape, dtype=np.intp), len(dataset.dimensions()))
-        shape_map = dict(zip(array.dims, array.shape))
+        shape_map = dict(zip(array.dims, array.shape, strict=None))
         return tuple(shape_map.get(kd.name, np.nan) for kd in dataset.kdims[::-1])
 
     @classmethod
@@ -167,10 +167,10 @@ class XArrayInterface(GridInterface):
                 if (len(data) != len(dimensions) and len(data) == (ndims+1) and
                     len(data[-1].shape) == (ndims+1)):
                     value_array = data[-1]
-                    data = {d: v for d, v in zip(dimensions, data[:-1])}
+                    data = {d: v for d, v in zip(dimensions, data[:-1], strict=None)}
                     packed = True
                 else:
-                    data = {d: v for d, v in zip(dimensions, data)}
+                    data = {d: v for d, v in zip(dimensions, data, strict=None)}
             elif isinstance(data, (list, np.ndarray)) and len(data) == 0:
                 dimensions = [d.name for d in kdims + vdims]
                 data = {d: np.array([]) for d in dimensions[:ndims]}
@@ -345,9 +345,9 @@ class XArrayInterface(GridInterface):
                 data.append((k, group_type(v, **group_kwargs)))
         else:
             unique_iters = [cls.values(dataset, d, False) for d in group_by]
-            indexes = zip(*util.cartesian_product(unique_iters))
+            indexes = zip(*util.cartesian_product(unique_iters), strict=None)
             for k in indexes:
-                sel = dataset.data.sel(**dict(zip(group_by, k)))
+                sel = dataset.data.sel(**dict(zip(group_by, k, strict=None)))
                 if drop_dim:
                     sel = sel.to_dataframe().reset_index()
                 data.append((k, group_type(sel, **group_kwargs)))
@@ -461,7 +461,7 @@ class XArrayInterface(GridInterface):
         kdims = [d for d in dataset.kdims[::-1]]
         adjusted_indices = []
         slice_dims = []
-        for kd, ind in zip(kdims, indices):
+        for kd, ind in zip(kdims, indices, strict=None):
             if cls.irregular(dataset, kd):
                 coords = [c for c in dataset.data.coords if c not in dataset.data.dims]
                 dim = dataset.data[kd.name].dims[coords.index(kd.name)]
@@ -489,7 +489,7 @@ class XArrayInterface(GridInterface):
                 ind = np.where(ind)[0]
             adjusted_indices.append(ind)
 
-        isel = dict(zip(slice_dims, adjusted_indices))
+        isel = dict(zip(slice_dims, adjusted_indices, strict=None))
         all_scalar = all(map(np.isscalar, indices))
         if all_scalar and len(indices) == len(kdims) and len(dataset.vdims) == 1:
             return dataset.data[dataset.vdims[0].name].isel(**isel).values.item()
@@ -656,7 +656,7 @@ class XArrayInterface(GridInterface):
         if samples is None:
             samples = []
         names = [kd.name for kd in dataset.kdims]
-        samples = [dataset.data.sel(**{k: [v] for k, v in zip(names, s)}).to_dataframe().reset_index()
+        samples = [dataset.data.sel(**{k: [v] for k, v in zip(names, s, strict=None)}).to_dataframe().reset_index()
                    for s in samples]
         return pd.concat(samples)
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -649,7 +649,7 @@ class LabelledData(param.Parameterized):
         specification = (self.__class__.__name__, self.group, self.label)
         split_spec = tuple(spec.split('.')) if not isinstance(spec, tuple) else spec
         split_spec, nocompare = zip(*((None, True) if s == '*' or s is None else (s, False)
-                                    for s in split_spec))
+                                    for s in split_spec), strict=None)
         if all(nocompare): return True
         match_fn = itemgetter(*(idx for idx, nc in enumerate(nocompare) if not nc))
         self_spec = match_fn(split_spec)
@@ -657,7 +657,7 @@ class LabelledData(param.Parameterized):
         if unescaped_match: return True
         sanitizers = [util.sanitize_identifier, util.group_sanitizer, util.label_sanitizer]
         identifier_specification = tuple(fn(ident, escape=False)
-                                         for ident, fn in zip(specification, sanitizers))
+                                         for ident, fn in zip(specification, sanitizers, strict=None))
         identifier_match = match_fn(identifier_specification[:len(split_spec)]) == self_spec
         return identifier_match
 

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -450,15 +450,15 @@ class Collator(NdMapping):
             if isinstance(data, AttrTree):
                 data = data.filter(self.filters)
             if len(self.vdims) and self.value_transform:
-                vargs = dict(zip(self.dimensions('value', label=True), data))
+                vargs = dict(zip(self.dimensions('value', label=True), data, strict=None))
                 data = self.value_transform(vargs)
             if not isinstance(data, Dimensioned):
                 raise ValueError("Collator values must be Dimensioned objects "
                                  "before collation.")
 
-            varying_keys = [(d, k) for d, k in zip(self.kdims, key) if not self.drop_constant or
+            varying_keys = [(d, k) for d, k in zip(self.kdims, key, strict=None) if not self.drop_constant or
                             (d not in constant_dims and d not in self.drop)]
-            constant_keys = {d: k for d, k in zip(self.kdims, key) if d in constant_dims
+            constant_keys = {d: k for d, k in zip(self.kdims, key, strict=None) if d in constant_dims
                              and d not in self.drop and self.drop_constant}
             if varying_keys or constant_keys:
                 data = self._add_dimensions(data, varying_keys, constant_keys)
@@ -504,7 +504,7 @@ class Collator(NdMapping):
                     new_item = new_item.add_dimension(dim, 0, val)
         elif isinstance(item, self._nest_order[self.merge_type]):
             if dim_vals:
-                dimensions, key = zip(*dim_vals)
+                dimensions, key = zip(*dim_vals, strict=None)
                 new_item = self.merge_type({key: item}, kdims=list(dimensions),
                                            cdims=constant_keys)
             else:

--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -379,7 +379,7 @@ class Pickler(Exporter):
                 entries = [f'{group_sanitizer(obj.group, False)}.{label_sanitizer(obj.label, False)}']
                 components = [obj]
 
-            for component, entry in zip(components, entries):
+            for component, entry in zip(components, entries, strict=None):
                 f.writestr(entry,
                            Store.dumps(component, protocol=self_or_cls.protocol))
             f.writestr('metadata',
@@ -640,7 +640,7 @@ class FileArchive(Archive):
         if formatter is None: return []
         try:
             parse = list(string.Formatter().parse(formatter))
-            return {f for f in list(zip(*parse))[1] if f is not None}
+            return {f for f in list(zip(*parse, strict=None))[1] if f is not None}
         except Exception as e:
             raise SyntaxError(f"Could not parse formatter {formatter!r}") from e
 
@@ -889,7 +889,7 @@ class FileArchive(Archive):
 
         fnames = [self._truncate_name(*k, maxlen=maxlen) for k in self._files]
         max_len = max([len(f) for f in fnames])
-        for name,v in zip(fnames, self._files.values()):
+        for name,v in zip(fnames, self._files.values(), strict=None):
             mime_type = v[1].get('mime_type', 'no mime type')
             lines.append(f'{name.ljust(max_len)} : {mime_type}')
         print('\n'.join(lines))

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -107,7 +107,7 @@ class AdjointLayout(Layoutable, Dimensioned):
             if wrong_pos:
                 raise Exception('Wrong AdjointLayout positions provided.')
         elif isinstance(data, list):
-            data = dict(zip(self.layout_order, data))
+            data = dict(zip(self.layout_order, data, strict=None))
         else:
             data = {}
 

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -164,9 +164,9 @@ class MultiDimensionalMapping(Dimensioned):
         self._item_check(dim_vals, data)
 
         # Apply dimension types
-        dim_types = zip([kd.type for kd in self.kdims], dim_vals)
+        dim_types = zip([kd.type for kd in self.kdims], dim_vals, strict=None)
         dim_vals = tuple(v if None in [t, v] else t(v) for t, v in dim_types)
-        valid_vals = zip(self.kdims, dim_vals)
+        valid_vals = zip(self.kdims, dim_vals, strict=None)
 
         for dim, val in valid_vals:
             if dim.values and val is not None and val not in dim.values:
@@ -190,7 +190,7 @@ class MultiDimensionalMapping(Dimensioned):
 
         """
         typed_key = ()
-        for dim, key in zip(self.kdims, keys):
+        for dim, key in zip(self.kdims, keys, strict=None):
             key_type = dim.type
             if key_type is None:
                 typed_key += (key,)
@@ -369,7 +369,7 @@ class MultiDimensionalMapping(Dimensioned):
                                 "as existing keys.")
 
         items = {}
-        for dval, (key, val) in zip(dim_val, self.data.items()):
+        for dval, (key, val) in zip(dim_val, self.data.items(), strict=None):
             if vdim:
                 new_val = list(val)
                 new_val.insert(dim_pos, dval)
@@ -469,7 +469,7 @@ class MultiDimensionalMapping(Dimensioned):
 
         keys = [tuple(k[i] for i in indices) for k in self.data.keys()]
         reindexed_items = dict(
-            (k, v) for (k, v) in zip(keys, self.data.values()))
+            (k, v) for (k, v) in zip(keys, self.data.values(), strict=None))
         reduced_dims = {d.name for d in self.kdims}.difference(kdims)
         dimensions = [self.get_dimension(d) for d in kdims
                       if d not in reduced_dims]
@@ -574,7 +574,7 @@ class MultiDimensionalMapping(Dimensioned):
         """Returns all elements as a list in (key,value) format.
 
         """
-        return list(zip(list(self.keys()), list(self.values())))
+        return list(zip(list(self.keys()), list(self.values()), strict=None))
 
 
     def get(self, key, default=None):
@@ -660,7 +660,7 @@ class NdMapping(MultiDimensionalMapping):
         if isinstance(indexslice, np.ndarray) and indexslice.dtype.kind == 'b':
             if not len(indexslice) == len(self):
                 raise IndexError("Boolean index must match length of sliced object")
-            selection = zip(indexslice, self.data.items())
+            selection = zip(indexslice, self.data.items(), strict=None)
             return self.clone([item for c, item in selection if c])
         elif isinstance(indexslice, tuple) and indexslice == () and not self.kdims:
             return self.data[()]
@@ -679,7 +679,7 @@ class NdMapping(MultiDimensionalMapping):
         else:
             conditions = self._generate_conditions(map_slice)
             items = self.data.items()
-            for cidx, (condition, dim) in enumerate(zip(conditions, self.kdims)):
+            for cidx, (condition, dim) in enumerate(zip(conditions, self.kdims, strict=None)):
                 values = dim.values
                 items = [(k, v) for k, v in items
                          if condition(values.index(k[cidx])
@@ -732,7 +732,7 @@ class NdMapping(MultiDimensionalMapping):
 
         """
         conditions = []
-        for dim, dim_slice in zip(self.kdims, map_slice):
+        for dim, dim_slice in zip(self.kdims, map_slice, strict=None):
             if isinstance(dim_slice, slice):
                 start, stop = dim_slice.start, dim_slice.stop
                 if dim.values:
@@ -935,7 +935,7 @@ class UniformNdMapping(NdMapping):
                 keys, maps = self._split_overlays()
                 group_data = group.type(dict([
                     (key, ndmap.collapse(function=function, spreadfn=spreadfn, **kwargs))
-                    for key, ndmap in zip(keys, maps)
+                    for key, ndmap in zip(keys, maps, strict=None)
                 ]))
             else:
                 raise ValueError(

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -962,7 +962,7 @@ class Compositor(param.Parameterized):
             if isinstance(overlay, Overlay):
                 result = [result]
             else:
-                result = list(zip(sliced.keys(), [result]))
+                result = list(zip(sliced.keys(), [result], strict=None))
             processed[applicable_op] += [el for r in result for el in r.traverse(lambda x: x, [Element])]
             overlay = overlay.clone(values[:start]+result+values[stop:])
 
@@ -984,7 +984,7 @@ class Compositor(param.Parameterized):
 
         # Apply compositors
         clone = holomap.clone(shared_data=False)
-        data = zip(ranges[1], holomap.data.values()) if ranges else holomap.data.items()
+        data = zip(ranges[1], holomap.data.values(), strict=None) if ranges else holomap.data.items()
         for key, overlay in data:
             clone[key] = cls.collapse_element(overlay, ranges, mode)
         return clone
@@ -1058,7 +1058,7 @@ class Compositor(param.Parameterized):
 
         """
         level = 0
-        for spec, el in zip(self._pattern_spec, overlay_items):
+        for spec, el in zip(self._pattern_spec, overlay_items, strict=None):
             if spec[0] != type(el).__name__:
                 return None
             level += 1      # Types match

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -184,7 +184,7 @@ class InfoPrinter:
         if isinstance(obj, type): return ''
 
         targets = obj.traverse(cls.get_target)
-        elements, containers = zip(*targets)
+        elements, containers = zip(*targets, strict=None)
         element_set = {el for el in elements if el is not None}
         container_set = {c for c in containers if c is not None}
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -179,7 +179,7 @@ class HoloMap(Layoutable, UniformNdMapping, Overlayable):
         the dimension labels.
 
         """
-        return [tuple(zip([d.name for d in self.kdims], [k] if self.ndims == 1 else k))
+        return [tuple(zip([d.name for d in self.kdims], [k] if self.ndims == 1 else k, strict=None))
                 for k in self.keys()]
 
     def _dynamic_mul(self, dimensions, other, keys):
@@ -206,7 +206,7 @@ class HoloMap(Layoutable, UniformNdMapping, Overlayable):
             streams = map_obj.streams
 
         def dynamic_mul(*key, **kwargs):
-            key_map = {d.name: k for d, k in zip(dimensions, key)}
+            key_map = {d.name: k for d, k in zip(dimensions, key, strict=None)}
             layers = []
             try:
                 self_el = self.select(HoloMap, **key_map) if self.kdims else self[()]
@@ -612,7 +612,7 @@ class Callable(param.Parameterized):
             # Missing information on positional argument names, cannot promote to keywords
             pass
         elif len(args) != 0: # Turn positional arguments into keyword arguments
-            pos_kwargs = {k:v for k,v in zip(self.argspec.args, args)}
+            pos_kwargs = {k:v for k,v in zip(self.argspec.args, args, strict=None)}
             ignored = range(len(self.argspec.args),len(args))
             if ignored:
                 self.param.warning('Ignoring extra positional argument {}'.format(', '.join(f'{i}' for i in ignored)))
@@ -1039,7 +1039,7 @@ class DynamicMap(HoloMap):
             kwargs = {}
             args = args + tuple([s.contents for s in self.streams])
         elif self._posarg_keys:
-            kwargs = dict(flattened, **dict(zip(self._posarg_keys, args)))
+            kwargs = dict(flattened, **dict(zip(self._posarg_keys, args, strict=None)))
             args = ()
         else:
             kwargs = dict(flattened)
@@ -1642,8 +1642,8 @@ class DynamicMap(HoloMap):
             def outer_fn(*outer_key, **dynkwargs):
                 if inner_dynamic:
                     def inner_fn(*inner_key, **dynkwargs):
-                        outer_vals = zip(outer_kdims, util.wrap_tuple(outer_key))
-                        inner_vals = zip(inner_kdims, util.wrap_tuple(inner_key))
+                        outer_vals = zip(outer_kdims, util.wrap_tuple(outer_key), strict=None)
+                        inner_vals = zip(inner_kdims, util.wrap_tuple(inner_key), strict=None)
                         inner_sel = [(k.name, v) for k, v in inner_vals]
                         outer_sel = [(k.name, v) for k, v in outer_vals]
                         return self.select(**dict(inner_sel+outer_sel))
@@ -1651,7 +1651,7 @@ class DynamicMap(HoloMap):
                 else:
                     dim_vals = [(d.name, d.values) for d in inner_kdims]
                     dim_vals += [(d.name, [v]) for d, v in
-                                   zip(outer_kdims, util.wrap_tuple(outer_key))]
+                                   zip(outer_kdims, util.wrap_tuple(outer_key), strict=None)]
                     with item_check(False):
                         selected = HoloMap(self.select(**dict(dim_vals)))
                         return group_type(selected.reindex(inner_kdims))
@@ -1664,10 +1664,10 @@ class DynamicMap(HoloMap):
                                                 for d in dimensions])
             groups = []
             for outer in outer_product:
-                outer_vals = [(d.name, [o]) for d, o in zip(outer_kdims, outer)]
+                outer_vals = [(d.name, [o]) for d, o in zip(outer_kdims, outer, strict=None)]
                 if inner_dynamic or not inner_kdims:
                     def inner_fn(outer_vals, *key, **dynkwargs):
-                        inner_dims = zip(inner_kdims, util.wrap_tuple(key))
+                        inner_dims = zip(inner_kdims, util.wrap_tuple(key), strict=None)
                         inner_vals = [(d.name, k) for d, k in inner_dims]
                         return self.select(**dict(outer_vals+inner_vals)).last
                     if inner_kdims or self.streams:

--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -13,7 +13,7 @@ from .util import merge_dimensions
 
 def create_ndkey(length, indexes, values):
     key = [None] * length
-    for i, v in zip(indexes, values):
+    for i, v in zip(indexes, values, strict=None):
         key[i] = v
     return tuple(key)
 
@@ -47,7 +47,7 @@ def unique_dimkeys(obj, default_dim='Frame'):
                                        list(x.data.keys())), (HoloMap,))
     if not key_dims:
         return [Dimension(default_dim)], [(0,)]
-    dim_groups, keys = zip(*sorted(key_dims, key=lambda x: -len(x[0])))
+    dim_groups, keys = zip(*sorted(key_dims, key=lambda x: -len(x[0])), strict=None)
     dgroups = [frozenset(d.name for d in dg) for dg in dim_groups]
     subset = all(g1 <= g2 or g1 >= g2 for g1 in dgroups for g2 in dgroups)
     # Find unique keys
@@ -64,7 +64,7 @@ def unique_dimkeys(obj, default_dim='Frame'):
         dim_keys = {}
         for dims, keys in key_dims:
             for key in keys:
-                for d, k in zip(dims, key):
+                for d, k in zip(dims, key, strict=None):
                     dim_keys[d.name] = k
         if dim_keys:
             keys = [tuple(dim_keys.get(dim.name) for dim in dimensions)]
@@ -74,13 +74,13 @@ def unique_dimkeys(obj, default_dim='Frame'):
 
     ndims = len(all_dims)
     unique_keys = []
-    for group, subkeys in zip(dim_groups, keys):
+    for group, subkeys in zip(dim_groups, keys, strict=None):
         dim_idxs = [all_dims.index(dim) for dim in group]
         for key in subkeys:
             padded_key = create_ndkey(ndims, dim_idxs, key)
             matches = [item for item in unique_keys
                        if padded_key == tuple(k if k is None else i
-                                              for i, k in zip(item, padded_key))]
+                                              for i, k in zip(item, padded_key, strict=None))]
             if not matches:
                 unique_keys.append(padded_key)
 
@@ -117,8 +117,8 @@ def hierarchical(keys):
     ndims = len(keys[0])
     if ndims <= 1:
         return True
-    dim_vals = list(zip(*keys))
-    combinations = (zip(*dim_vals[i:i+2])
+    dim_vals = list(zip(*keys, strict=None))
+    combinations = (zip(*dim_vals[i:i+2], strict=None)
                     for i in range(ndims-1))
     hierarchies = []
     for combination in combinations:

--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -166,7 +166,7 @@ class AttrTree:
                 del self.data[path]
             else:
                 items = [(key, v) for key, v in self.data.items()
-                         if not all(k==p for k, p in zip(key, path))]
+                         if not all(k==p for k, p in zip(key, path, strict=None))]
                 self.data = dict(items)
         else:
             self.data[path] = val

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1183,18 +1183,18 @@ def unique_iterator(seq):
             yield item
 
 
-def lzip(*args):
+def lzip(*args, strict=None):
     """Zip function that returns a list.
 
     """
-    return list(zip(*args, strict=None))
+    return list(zip(*args, strict=strict))
 
 
-def unique_zip(*args):
+def unique_zip(*args, strict=None):
     """Returns a unique list of zipped values.
 
     """
-    return list(unique_iterator(zip(*args, strict=None)))
+    return list(unique_iterator(zip(*args, strict=strict)))
 
 
 def unique_array(arr):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -956,7 +956,7 @@ def find_minmax(lims, olims):
 
     """
     try:
-        limzip = zip(list(lims), list(olims), [np.nanmin, np.nanmax])
+        limzip = zip(list(lims), list(olims), [np.nanmin, np.nanmax], strict=None)
         limits = tuple([float(fn([l, ol])) for l, ol, fn in limzip])
     except Exception:
         limits = (np.nan, np.nan)
@@ -1109,7 +1109,7 @@ def max_extents(extents, zrange=False):
     else:
         num = 4
         inds = [(0, 2), (1, 3)]
-    arr = list(zip(*extents)) if extents else []
+    arr = list(zip(*extents, strict=None)) if extents else []
     extents = [np.nan] * num
     if len(arr) == 0:
         return extents
@@ -1187,14 +1187,14 @@ def lzip(*args):
     """Zip function that returns a list.
 
     """
-    return list(zip(*args))
+    return list(zip(*args, strict=None))
 
 
 def unique_zip(*args):
     """Returns a unique list of zipped values.
 
     """
-    return list(unique_iterator(zip(*args)))
+    return list(unique_iterator(zip(*args, strict=None)))
 
 
 def unique_array(arr):
@@ -1471,7 +1471,7 @@ def layer_sort(hmap):
       if len(okeys) == 1 and okeys[0] not in orderings:
          orderings[okeys[0]] = []
       else:
-         orderings.update({k: [] if k == v else [v] for k, v in zip(okeys[1:], okeys)})
+         orderings.update({k: [] if k == v else [v] for k, v in zip(okeys[1:], okeys, strict=None)})
    return [i for g in sort_topologically(orderings) for i in sorted(g)]
 
 
@@ -1693,7 +1693,7 @@ def disable_constant(parameterized):
     try:
         yield
     finally:
-        for (p, const) in zip(params, constants):
+        for (p, const) in zip(params, constants, strict=None):
             p.constant = const
 
 
@@ -1854,7 +1854,7 @@ def drop_streams(streams, kdims, keys):
     """
     stream_params = stream_parameters(streams)
     inds, dims = zip(*[(ind, kdim) for ind, kdim in enumerate(kdims)
-                       if kdim not in stream_params])
+                       if kdim not in stream_params], strict=None)
     get = operator.itemgetter(*inds) # itemgetter used for performance
     keys = (get(k) for k in keys)
     return dims, ([wrap_tuple(k) for k in keys] if len(inds) == 1 else list(keys))
@@ -1905,7 +1905,7 @@ def get_path(item):
             path = path[:1]
     else:
         path = (item.group, item.label) if item.label else (item.group,)
-    return tuple(capitalize(fn(p)) for (p, fn) in zip(path, sanitizers))
+    return tuple(capitalize(fn(p)) for (p, fn) in zip(path, sanitizers, strict=None))
 
 
 def make_path_unique(path, counts, new):
@@ -2017,7 +2017,7 @@ def cross_index(values, index):
         indexes.append(index//p)
         index -= indexes[-1] * p
     indexes.append(index)
-    return tuple(v[i] for v, i in zip(values, indexes))
+    return tuple(v[i] for v, i in zip(values, indexes, strict=None))
 
 
 def arglexsort(arrays):

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -266,7 +266,7 @@ class Area(Curve):
             #   Creating a Groupby object with a length-1 list-like level parameter
             #   will yield indexes as tuples in a future version.
             levels = levels[0]
-        for (key, sdf), element_vdims in zip(df.groupby(level=levels, sort=False), vdims):
+        for (key, sdf), element_vdims in zip(df.groupby(level=levels, sort=False), vdims, strict=None):
             vdim = element_vdims[0]
             sdf = sdf.droplevel(levels).reindex(index=df.index.unique(-1), fill_value=0)
             if baseline is None:

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -239,7 +239,7 @@ class Comparison(ComparisonInterface):
     def compare_lists(cls, l1, l2, msg=None):
         try:
             cls.assertEqual(len(l1), len(l2))
-            for v1, v2 in zip(l1, l2):
+            for v1, v2 in zip(l1, l2, strict=None):
                 cls.assertEqual(v1, v2)
         except AssertionError as e:
             raise AssertionError(msg or f'{l1!r} != {l2!r}') from e
@@ -249,7 +249,7 @@ class Comparison(ComparisonInterface):
     def compare_tuples(cls, t1, t2, msg=None):
         try:
             cls.assertEqual(len(t1), len(t2))
-            for i1, i2 in zip(t1, t2):
+            for i1, i2 in zip(t1, t2, strict=None):
                 cls.assertEqual(i1, i2)
         except AssertionError as e:
             raise AssertionError(msg or f'{t1!r} != {t2!r}') from e
@@ -282,7 +282,7 @@ class Comparison(ComparisonInterface):
         lbrt1 = el1.bounds.lbrt()
         lbrt2 = el2.bounds.lbrt()
         try:
-            for v1, v2 in zip(lbrt1, lbrt2):
+            for v1, v2 in zip(lbrt1, lbrt2, strict=None):
                 if isinstance(v1, datetime_types):
                     v1 = dt_to_int(v1)
                 if isinstance(v2, datetime_types):
@@ -332,7 +332,7 @@ class Comparison(ComparisonInterface):
     def compare_dimension_lists(cls, dlist1, dlist2, msg='Dimension lists'):
         if len(dlist1) != len(dlist2):
             raise cls.failureException(f'{msg} mismatched')
-        for d1, d2 in zip(dlist1, dlist2):
+        for d1, d2 in zip(dlist1, dlist2, strict=None):
             cls.assertEqual(d1, d2)
 
     @classmethod
@@ -359,7 +359,7 @@ class Comparison(ComparisonInterface):
             raise cls.failureException(f"{msg} have mismatched path counts.")
         if el1.keys() != el2.keys():
             raise cls.failureException(f"{msg} have mismatched paths.")
-        for element1, element2 in zip(el1.values(),  el2.values()):
+        for element1, element2 in zip(el1.values(),  el2.values(), strict=None):
             cls.assertEqual(element1, element2)
 
     @classmethod
@@ -395,7 +395,7 @@ class Comparison(ComparisonInterface):
                                        + f"In first, not second {diff1}. "
                                        + f"In second, not first: {diff2}.")
 
-        for element1, element2 in zip(el1, el2):
+        for element1, element2 in zip(el1, el2, strict=None):
             cls.assertEqual(element1, element2)
 
     @classmethod
@@ -420,7 +420,7 @@ class Comparison(ComparisonInterface):
         if set(el1.keys()) != set(el2.keys()):
             raise cls.failureException("Layouts have different keys.")
 
-        for element1, element2 in zip(el1, el2):
+        for element1, element2 in zip(el1, el2, strict=None):
             cls.assertEqual(element1,element2)
 
 
@@ -430,13 +430,13 @@ class Comparison(ComparisonInterface):
         if len(el1) != len(el2):
             raise cls.failureException("NdOverlays have different lengths.")
 
-        for (layer1, layer2) in zip(el1, el2):
+        for (layer1, layer2) in zip(el1, el2, strict=None):
             cls.assertEqual(layer1, layer2)
 
     @classmethod
     def compare_adjointlayouts(cls, el1, el2, msg=None):
         cls.compare_dimensioned(el1, el2)
-        for element1, element2 in zip(el1, el1):
+        for element1, element2 in zip(el1, el1, strict=None):
             cls.assertEqual(element1, element2)
 
 
@@ -493,7 +493,7 @@ class Comparison(ComparisonInterface):
         paths2 = el2.split()
         if len(paths1) != len(paths2):
             raise cls.failureException(f"{msg} objects do not have a matching number of paths.")
-        for p1, p2 in zip(paths1, paths2):
+        for p1, p2 in zip(paths1, paths2, strict=None):
             cls.compare_dataset(p1, p2, f'{msg} data')
 
     @classmethod
@@ -745,7 +745,7 @@ class Comparison(ComparisonInterface):
         if len(el1) != len(el2):
             raise cls.failureException(f"{name}s have different depths.")
 
-        for element1, element2 in zip(el1, el2):
+        for element1, element2 in zip(el1, el2, strict=None):
             cls.assertEqual(element1, element2)
 
     @classmethod

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -60,7 +60,7 @@ class layout_nodes(Operation):
             graph = nx.from_edgelist(edges)
             if 'weight' in self.p.kwargs:
                 weight = self.p.kwargs['weight']
-                for (s, t), w in zip(edges, element[weight]):
+                for (s, t), w in zip(edges, element[weight], strict=None):
                     graph.edges[s, t][weight] = w
             positions = self.p.layout(graph, **self.p.kwargs)
             nodes = [(*pos, idx) for idx, pos in sorted(positions.items())]
@@ -168,7 +168,7 @@ class Graph(Dataset, Element2D):
         nodes = self.nodes.clone(datatype=['pandas', 'dictionary'])
         if isinstance(node_info, self.node_type):
             nodes = nodes.redim(**dict(zip(nodes.dimensions('key', label=True),
-                                           node_info.kdims)))
+                                           node_info.kdims, strict=None)))
 
         if not node_info.kdims and len(node_info) != len(nodes):
             raise ValueError("The supplied node data does not match "
@@ -204,7 +204,7 @@ class Graph(Dataset, Element2D):
         if self._edgepaths is None:
             return
         mismatch = []
-        for kd1, kd2 in zip(self.nodes.kdims, self.edgepaths.kdims):
+        for kd1, kd2 in zip(self.nodes.kdims, self.edgepaths.kdims, strict=None):
             if kd1 != kd2:
                 mismatch.append(f'{kd1} != {kd2}')
         if mismatch:
@@ -432,8 +432,8 @@ class Graph(Dataset, Element2D):
         if nodes:
             node_columns = nodes.columns()
             idx_dim = nodes.kdims[0].name
-            info_cols, values = zip(*((k, v) for k, v in node_columns.items() if k != idx_dim))
-            node_info = {i: vals for i, vals in zip(node_columns[idx_dim], zip(*values))}
+            info_cols, values = zip(*((k, v) for k, v in node_columns.items() if k != idx_dim), strict=None)
+            node_info = {i: vals for i, vals in zip(node_columns[idx_dim], zip(*values, strict=None), strict=None)}
         else:
             info_cols = []
             node_info = None
@@ -661,7 +661,7 @@ class layout_chords(Operation):
 
         # Compute connectivity matrix
         matrix = np.zeros((len(nodes), len(nodes)))
-        for s, t, v in zip(src_idx, tgt_idx, values):
+        for s, t, v in zip(src_idx, tgt_idx, values, strict=None):
             matrix[s, t] += v
 
         # Compute weighted angular slice for each connection
@@ -684,7 +684,7 @@ class layout_chords(Operation):
             n_conn = weights_of_areas[i]
             p0, p1 = points[i], points[i+1]
             angles = np.linspace(p0, p1, int(n_conn))
-            coords = list(zip(np.cos(angles), np.sin(angles)))
+            coords = list(zip(np.cos(angles), np.sin(angles), strict=None))
             all_areas.append(coords)
 
         # Draw each chord by interpolating quadratic splines

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -188,7 +188,7 @@ class Dendrogram(Path):
         return super().__new__(cls)
 
     def __init__(self, x, y=None, kdims=None, vdims=None, **params):
-        data = x if y is None else zip(x, y)  # strict=True
+        data = x if y is None else zip(x, y, strict=True)
         super().__init__(data, kdims=kdims, vdims=vdims, **params)
 
 

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -73,7 +73,7 @@ class Path(SelectionPolyExpr, Geometry):
             paths = []
             for path in data:
                 if path.kdims != kdims:
-                    redim = {okd.name: nkd for okd, nkd in zip(path.kdims, kdims)}
+                    redim = {okd.name: nkd for okd, nkd in zip(path.kdims, kdims, strict=None)}
                     path = path.redim(**redim)
                 if path.interface.multi and isinstance(path.data, list):
                     paths += path.data
@@ -464,7 +464,7 @@ class Ellipse(BaseShape):
         #create points
         ellipse = np.array(
             list(zip(half_width*np.sin(angles),
-                     half_height*np.cos(angles))))
+                     half_height*np.cos(angles), strict=None)))
         #rotate ellipse and add offset
         rot = np.array([[np.cos(self.orientation), -np.sin(self.orientation)],
                [np.sin(self.orientation), np.cos(self.orientation)]])

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -114,7 +114,7 @@ class Raster(Element2D):
             samples = []
         if isinstance(samples, tuple):
             X, Y = samples
-            samples = zip(X, Y)
+            samples = zip(X, Y, strict=None)
 
         params = dict(self.param.values(onlychanged=True),
                       vdims=self.vdims)
@@ -122,7 +122,7 @@ class Raster(Element2D):
             if not len(samples):
                 samples = zip(*[c if isinstance(c, list) else [c] for _, c in
                                sorted([(self.get_dimension_index(k), v) for k, v in
-                                       sample_values.items()])])
+                                       sample_values.items()])], strict=None)
             table_data = [(*c, self._zdata[self._coord2matrix(c)])
                           for c in samples]
             params['kdims'] = self.kdims
@@ -149,7 +149,7 @@ class Raster(Element2D):
             x_vals = self.dimension_values(other_dimension[0].name, False)
             ydata = self._zdata[tuple(sample[::-1])]
             if hasattr(self, 'bounds') and sample_ind == 0: ydata = ydata[::-1]
-            data = list(zip(x_vals, ydata))
+            data = list(zip(x_vals, ydata, strict=None))
             params['kdims'] = other_dimension
             return Curve(data, **params)
 
@@ -175,7 +175,7 @@ class Raster(Element2D):
             reduced = function(self._zdata, axis=oidx)
             if oidx and hasattr(self, 'bounds'):
                 reduced = reduced[::-1]
-            data = zip(x_vals, reduced)
+            data = zip(x_vals, reduced, strict=None)
             params = dict(dict(self.param.values(onlychanged=True)),
                           kdims=other_dimension, vdims=self.vdims)
             params.pop('bounds', None)
@@ -371,7 +371,7 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
             bounds = data_bounds
 
         not_close = False
-        for r, c in zip(bounds, self.bounds.lbrt()):
+        for r, c in zip(bounds, self.bounds.lbrt(), strict=None):
             if isinstance(r, util.datetime_types):
                 r = util.dt_to_int(r)
             if isinstance(c, util.datetime_types):
@@ -481,7 +481,7 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
                         raise ValueError("Length of samples must match")
                     elif len(coords):
                         coords = [(t[abs(idx-1)], c) if idx else (c, t[abs(idx-1)])
-                                  for c, t in zip(v, coords)]
+                                  for c, t in zip(v, coords, strict=None)]
                 getter.append(idx)
         else:
             getter = [0, 1]
@@ -687,7 +687,7 @@ class RGB(Image):
             ranges = [im.vdims[0].range for im in images]
             if any(None in r for r in ranges):
                 raise ValueError("Ranges must be defined on all the value dimensions of all the Images")
-            arrays = [(im.data - r[0]) / (r[1] - r[0]) for r,im in zip(ranges, images)]
+            arrays = [(im.data - r[0]) / (r[1] - r[0]) for r,im in zip(ranges, images, strict=None)]
             data = np.dstack(arrays)
         if vdims is None:
             # Need to make a deepcopy of the value so the RGB.default is not shared across instances

--- a/holoviews/element/sankey.py
+++ b/holoviews/element/sankey.py
@@ -84,16 +84,16 @@ class _layout_sankey(Operation):
         node_map = {}
         if element.nodes.vdims:
             values = zip(*(element.nodes.dimension_values(d)
-                           for d in element.nodes.vdims))
+                           for d in element.nodes.vdims), strict=None)
         else:
             values = cycle([tuple()])
-        for idx, vals in zip(element.nodes.dimension_values(index), values):
+        for idx, vals in zip(element.nodes.dimension_values(index), values, strict=None):
             node = {'index': idx, 'sourceLinks': [], 'targetLinks': [], 'values': vals}
             graph['nodes'].append(node)
             node_map[idx] = node
 
         links = [element.dimension_values(d) for d in element.dimensions()[:3]]
-        for i, (src, tgt, value) in enumerate(zip(*links)):
+        for i, (src, tgt, value) in enumerate(zip(*links, strict=None)):
             source, target = node_map[src], node_map[tgt]
             link = dict(index=i, source=source, target=target, value=value)
             graph['links'].append(link)

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -175,7 +175,7 @@ def _mask_spatialpandas(masked_xvals, masked_yvals, geometry):
 
 def _mask_shapely(masked_xvals, masked_yvals, geometry):
     from shapely.geometry import Point, Polygon
-    points = (Point(x, y) for x, y in zip(masked_xvals, masked_yvals))
+    points = (Point(x, y) for x, y in zip(masked_xvals, masked_yvals, strict=None))
     poly = Polygon(geometry)
     return np.array([poly.contains(p) for p in points], dtype=bool)
 
@@ -190,7 +190,7 @@ def spatial_geom_select(x0vals, y0vals, x1vals, y1vals, geometry):
     try:
         from shapely.geometry import Polygon, box
         boxes = (box(x0, y0, x1, y1) for x0, y0, x1, y1 in
-                 zip(x0vals, y0vals, x1vals, y1vals))
+                 zip(x0vals, y0vals, x1vals, y1vals, strict=None))
         poly = Polygon(geometry)
         return np.array([poly.contains(p) for p in boxes])
     except ImportError:
@@ -200,7 +200,7 @@ def spatial_geom_select(x0vals, y0vals, x1vals, y1vals, geometry):
 def spatial_poly_select(xvals, yvals, geometry):
     try:
         from shapely.geometry import Polygon
-        boxes = (Polygon(np.column_stack([xs, ys])) for xs, ys in zip(xvals, yvals))
+        boxes = (Polygon(np.column_stack([xs, ys])) for xs, ys in zip(xvals, yvals, strict=None))
         poly = Polygon(geometry)
         return np.array([poly.contains(p) for p in boxes])
     except ImportError:
@@ -211,7 +211,7 @@ def spatial_bounds_select(xvals, yvals, bounds):
     x0, y0, x1, y1 = bounds
     return np.array([((x0<=np.nanmin(xs)) & (y0<=np.nanmin(ys)) &
                       (x1>=np.nanmax(xs)) & (y1>=np.nanmax(ys)))
-                     for xs, ys in zip(xvals, yvals)])
+                     for xs, ys in zip(xvals, yvals, strict=None)])
 
 
 class Selection2DExpr(SelectionIndexExpr):

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -158,7 +158,7 @@ class categorical_aggregate2d(Operation):
             if len(vals) == 1:
                 orderings[vals[0]] = [vals[0]]
             else:
-                for p1, p2 in zip(vals[:-1], vals[1:]):
+                for p1, p2 in itertools.pairwise(vals):
                     orderings[p1] = [p2]
             if sort:
                 if vals.dtype.kind in ('i', 'f'):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -306,7 +306,7 @@ class aggregate(LineAggregationOperation):
                 dims = (x, y)
                 df = PandasInterface.as_dframe(element)
                 if isinstance(obj, NdOverlay):
-                    df = df.assign(**dict(zip(obj.dimensions('key', True), key)))
+                    df = df.assign(**dict(zip(obj.dimensions('key', True), key, strict=None)))
                 paths.append(df)
             if element is None:
                 dims = None
@@ -1056,7 +1056,7 @@ class trimesh_rasterize(aggregate):
                     "DataFrames.")
             simplices = element.dframe(simplex_dims)
             verts = element.nodes.dframe(vert_dims)
-        for c, dtype in zip(simplices.columns[:3], simplices.dtypes):
+        for c, dtype in zip(simplices.columns[:3], simplices.dtypes, strict=None):
             if dtype.kind != 'i':
                 simplices[c] = simplices[c].astype('int')
         mesh = mesh(verts, simplices)
@@ -1130,7 +1130,7 @@ class trimesh_rasterize(aggregate):
         cvs = ds.Canvas(plot_width=width, plot_height=height,
                         x_range=x_range, y_range=y_range)
         if wireframe:
-            rename_dict = {k: v for k, v in zip("xy", (x.name, y.name)) if k != v}
+            rename_dict = {k: v for k, v in zip("xy", (x.name, y.name), strict=None) if k != v}
             agg = cvs.line(segments, x=['x0', 'x1', 'x2', 'x0'],
                            y=['y0', 'y1', 'y2', 'y0'], axis=1,
                            agg=agg).rename(rename_dict)
@@ -1395,7 +1395,7 @@ class shade(LinkableOperation):
                 shade_opts['color_key'] = self.p.color_key
             elif isinstance(self.p.color_key, Iterable):
                 shade_opts['color_key'] = [c for _, c in
-                                           zip(range(categories), self.p.color_key)]
+                                           zip(range(categories), self.p.color_key, strict=None)]
             else:
                 colors = [self.p.color_key(s) for s in np.linspace(0, 1, categories)]
                 shade_opts['color_key'] = map(self.rgb2hex, colors)
@@ -1506,7 +1506,7 @@ class geometry_rasterize(LineAggregationOperation):
             agg = cvs.line(data, **agg_kwargs)
         elif isinstance(element, Points):
             agg = cvs.points(data, **agg_kwargs)
-        rename_dict = {k: v for k, v in zip("xy", (xdim.name, ydim.name)) if k != v}
+        rename_dict = {k: v for k, v in zip("xy", (xdim.name, ydim.name), strict=None) if k != v}
         agg = agg.rename(rename_dict)
 
         if agg.ndim == 2:
@@ -1870,8 +1870,8 @@ class _connect_edges(Operation):
 
     def _process(self, element, key=None):
         index = element.nodes.kdims[2].name
-        rename_edges = {d.name: v for d, v in zip(element.kdims[:2], ['source', 'target'])}
-        rename_nodes = {d.name: v for d, v in zip(element.nodes.kdims[:2], ['x', 'y'])}
+        rename_edges = {d.name: v for d, v in zip(element.kdims[:2], ['source', 'target'], strict=None)}
+        rename_nodes = {d.name: v for d, v in zip(element.nodes.kdims[:2], ['x', 'y'], strict=None)}
         position_df = element.nodes.redim(**rename_nodes).dframe([0, 1, 2]).set_index(index)
         edges_df = element.redim(**rename_edges).dframe([0, 1])
         paths = self._bundle(position_df, edges_df)

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -347,7 +347,7 @@ class image_overlay(Operation):
         """Return the strength of the match (None if no match)
 
         """
-        spec_dict = dict(zip(['type', 'group', 'label'], spec.split('.')))
+        spec_dict = dict(zip(['type', 'group', 'label'], spec.split('.'), strict=None))
         if not isinstance(el, Image) or spec_dict['type'] != 'Image':
             raise NotImplementedError("Only Image currently supported")
 
@@ -391,9 +391,9 @@ class image_overlay(Operation):
 
         completed = []
         strongest = ordering[np.argmax(strengths)]
-        for el, spec in zip(ordering, specs):
+        for el, spec in zip(ordering, specs, strict=None):
             if el is None:
-                spec_dict = dict(zip(['type', 'group', 'label'], spec.split('.')))
+                spec_dict = dict(zip(['type', 'group', 'label'], spec.split('.'), strict=None))
                 el = Image(np.ones(strongest.data.shape) * self.p.fill,
                             group=spec_dict.get('group','Image'),
                             label=spec_dict.get('label',''))
@@ -606,7 +606,7 @@ class contours(Operation):
 
             data = tuple(
                 date2num(d) if is_datetime else d
-                for d, is_datetime in zip(data, data_is_datetime)
+                for d, is_datetime in zip(data, data_is_datetime, strict=None)
             )
 
         xdim, ydim = element.dimensions('key', label=True)
@@ -1045,7 +1045,7 @@ class interpolate_curve(Operation):
         steps[1::2] = steps[0:-2:2]
 
         val_arrays = []
-        for v, s in zip(values, value_steps):
+        for v, s in zip(values, value_steps, strict=None):
             s[0::2] = v
             s[1::2] = s[2::2]
             val_arrays.append(s)
@@ -1061,7 +1061,7 @@ class interpolate_curve(Operation):
         steps[0], steps[-1] = x[0], x[-1]
 
         val_arrays = []
-        for v, s in zip(values, value_steps):
+        for v, s in zip(values, value_steps, strict=None):
             s[0::2] = v
             s[1::2] = s[0::2]
             val_arrays.append(s)
@@ -1077,7 +1077,7 @@ class interpolate_curve(Operation):
         steps[1::2] = steps[2::2]
 
         val_arrays = []
-        for v, s in zip(values, value_steps):
+        for v, s in zip(values, value_steps, strict=None):
             s[0::2] = v
             s[1::2] = s[0:-2:2]
             val_arrays.append(s)

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -4,6 +4,7 @@ examples.
 """
 import warnings
 from functools import partial
+from itertools import pairwise
 
 import numpy as np
 import param
@@ -670,7 +671,7 @@ class contours(Operation):
         paths = []
         if self.p.filled:
             empty = np.array([[np.nan, np.nan]])
-            for lower_level, upper_level in zip(levels[:-1], levels[1:]):
+            for lower_level, upper_level in pairwise(levels):
                 filled = cont_gen.filled(lower_level, upper_level)
                 # Only have to consider last index 0 as we are using contourpy without chunking
                 if (points := filled[0][0]) is None:
@@ -685,7 +686,7 @@ class contours(Operation):
                 outer_offsets = filled[2][0]
 
                 # Loop through exterior polygon boundaries.
-                for jstart, jend in zip(outer_offsets[:-1], outer_offsets[1:]):
+                for jstart, jend in pairwise(outer_offsets):
                     if exteriors:
                         exteriors.append(empty)
                     exteriors.append(points[offsets[jstart]:offsets[jstart + 1]])

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -58,7 +58,7 @@ class _SyntheticAnnotationPlot(ColorbarPlot):
         data = element.columns(element.kdims)
         self._get_hover_data(data, element)
         default = self._element_default[self.invert_axes].kdims
-        mapping = {str(d): str(k) for d, k in zip(default, element.kdims)}
+        mapping = {str(d): str(k) for d, k in zip(default, element.kdims, strict=None)}
         return data, mapping, style
 
     def initialize_plot(self, ranges=None, plot=None, plots=None, source=None):
@@ -68,7 +68,7 @@ class _SyntheticAnnotationPlot(ColorbarPlot):
             return figure
         labels = [self.xlabel or "x", self.ylabel or "y"]
         labels = labels[::-1] if self.invert_axes else labels
-        for ax, label in zip(figure.axis, labels):
+        for ax, label in zip(figure.axis, labels, strict=None):
             ax.axis_label = label
         return figure
 
@@ -147,7 +147,7 @@ class TextPlot(ElementPlot, AnnotationPlot):
     def get_batched_data(self, element, ranges=None):
         data = defaultdict(list)
         zorders = self._updated_zorders(element)
-        for (_key, el), zorder in zip(element.data.items(), zorders):
+        for (_key, el), zorder in zip(element.data.items(), zorders, strict=None):
             style = self.lookup_options(element.last, 'style')
             style = style.max_cycles(len(self.ordering))[zorder]
             eldata, elmapping, style = self.get_data(el, ranges, style)
@@ -361,7 +361,7 @@ class SplinePlot(ElementPlot, AnnotationPlot):
             if len(vs) != 4:
                 skipped = len(vs) > 1
                 continue
-            for x, y, xl, yl in zip(vs[:, 0], vs[:, 1], data_attrs[::2], data_attrs[1::2]):
+            for x, y, xl, yl in zip(vs[:, 0], vs[:, 1], data_attrs[::2], data_attrs[1::2], strict=None):
                 data[xl].append(x)
                 data[yl].append(y)
         if skipped:
@@ -369,7 +369,7 @@ class SplinePlot(ElementPlot, AnnotationPlot):
                 'Bokeh SplinePlot only support cubic splines, unsupported '
                 'splines were skipped during plotting.')
         data = {da: data[da] for da in data_attrs}
-        return (data, dict(zip(data_attrs, data_attrs)), style)
+        return (data, dict(zip(data_attrs, data_attrs, strict=None)), style)
 
 
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1636,7 +1636,7 @@ class BoxEditCallback(GlyphDrawCallback):
         element = self.plot.current_frame
 
         l, b, r, t =  [], [], [], []
-        for x, y in zip(data['xs'], data['ys']):
+        for x, y in zip(data['xs'], data['ys'], strict=None):
             x0, x1 = (np.nanmin(x), np.nanmax(x))
             y0, y1 = (np.nanmin(y), np.nanmax(y))
             l.append(x0)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -140,7 +140,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
         # Angles need special handling since they are tied to the
         # marker in certain cases
         has_angles = False
-        for (key, el), zorder in zip(element.data.items(), zorders):
+        for (key, el), zorder in zip(element.data.items(), zorders, strict=None):
             el_opts = self.lookup_options(el, 'plot').options
             self.param.update(**{k: v for k, v in el_opts.items()
                                     if k not in OverlayPlot._propagate_options})
@@ -172,7 +172,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
                 data['__angle'].append(np.zeros(len(v)))
 
             if 'hover' in self.handles:
-                for d, k in zip(element.dimensions(), key):
+                for d, k in zip(element.dimensions(), key, strict=None):
                     sanitized = dimension_sanitizer(d.name)
                     data[sanitized].append([k]*nvals)
 
@@ -389,7 +389,7 @@ class CurvePlot(ElementPlot):
         data = defaultdict(list)
 
         zorders = self._updated_zorders(overlay)
-        for (key, el), zorder in zip(overlay.data.items(), zorders):
+        for (key, el), zorder in zip(overlay.data.items(), zorders, strict=None):
             el_opts = self.lookup_options(el, 'plot').options
             self.param.update(**{k: v for k, v in el_opts.items()
                                     if k not in OverlayPlot._propagate_options})
@@ -411,7 +411,7 @@ class CurvePlot(ElementPlot):
             for k, v in sdata.items():
                 data[k].append(v[0])
 
-            for d, k in zip(overlay.kdims, key):
+            for d, k in zip(overlay.kdims, key, strict=None):
                 sanitized = dimension_sanitizer(d.name)
                 data[sanitized].append(k)
         data = {opt: vals for opt, vals in data.items()
@@ -623,7 +623,7 @@ class SpreadPlot(ElementPlot):
         lower = np.split(lower, split)
         upper = np.split(upper, split)
         band_x, band_y = [], []
-        for i, (x, l, u) in enumerate(zip(xvals, lower, upper)):
+        for i, (x, l, u) in enumerate(zip(xvals, lower, upper, strict=None)):
             if i:
                 x, l, u = x[1:], l[1:], u[1:]
             if not len(x):
@@ -834,7 +834,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
 
         """
         bottoms, tops = [], []
-        for x, y in zip(xvals, yvals):
+        for x, y in zip(xvals, yvals, strict=None):
             baseline = baselines[x][sign]
             if sign == 'positive':
                 bottom = baseline

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -849,7 +849,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         ax_specs, yaxes, dimensions = {}, {}, {}
         subcoordinate_axes = 0
-        for el, (sp_key, sp) in zip(element, self.subplots.items()):
+        for el, (sp_key, sp) in zip(element, self.subplots.items(), strict=None):
             ax_dims = sp._get_axis_dims(el)[:2]
             if sp.invert_axes:
                 ax_dims[::-1]
@@ -861,7 +861,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 if opts.get('subcoordinate_y') is None:
                     continue
                 if sp.overlay_dims:
-                    ax_name = ', '.join(d.pprint_value(k) for d, k in zip(element.kdims, sp_key))
+                    ax_name = ', '.join(d.pprint_value(k) for d, k in zip(element.kdims, sp_key, strict=None))
                 else:
                     ax_name = el.label
                 subcoordinate_axes += 1
@@ -1173,7 +1173,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             elif not self.drawn:
                 ticks, labels = [], []
                 idx = 0
-                for el, (sp_key, sp) in zip(self.current_frame, self.subplots.items()):
+                for el, (sp_key, sp) in zip(self.current_frame, self.subplots.items(), strict=None):
                     if not sp.subcoordinate_y:
                         continue
                     ycenter = idx if isinstance(sp.subcoordinate_y, bool) else 0.5 * sum(sp.subcoordinate_y)
@@ -1182,10 +1182,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     if el.label or not self.current_frame.kdims:
                         labels.append(el.label)
                     else:
-                        labels.append(', '.join(d.pprint_value(k) for d, k in zip(self.current_frame.kdims, sp_key)))
+                        labels.append(', '.join(d.pprint_value(k) for d, k in zip(self.current_frame.kdims, sp_key, strict=None)))
                 axis_props['ticker'] = FixedTicker(ticks=ticks)
                 if labels is not None:
-                    axis_props['major_label_overrides'] = dict(zip(ticks, labels))
+                    axis_props['major_label_overrides'] = dict(zip(ticks, labels, strict=None))
         formatter = self.xformatter if axis == 'x' else self.yformatter
         if formatter:
             formatter = wrap_formatter(formatter, axis)
@@ -1246,7 +1246,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         el = el[0] if el else element
         dimensions = self._get_axis_dims(el)
         props = {axis: self._axis_properties(axis, key, plot, dim)
-                 for axis, dim in zip(['x', 'y'], dimensions)}
+                 for axis, dim in zip(['x', 'y'], dimensions, strict=None)}
         xlabel, ylabel, zlabel = self._get_axis_labels(dimensions)
         if self.invert_axes:
             xlabel, ylabel = ylabel, xlabel
@@ -3281,7 +3281,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
         if 'zooms_subcoordy' in subplot.handles and 'zooms_subcoordy' in self.handles:
             for subplot_zoom, overlay_zoom in zip(
                 subplot.handles['zooms_subcoordy'].values(),
-                self.handles['zooms_subcoordy'].values(),
+                self.handles['zooms_subcoordy'].values(), strict=None,
             ):
                 renderers = list(util.unique_iterator(overlay_zoom.renderers + subplot_zoom.renderers))
                 overlay_zoom.renderers = renderers

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -187,11 +187,11 @@ class GraphPlot(GraphMixin, CompositeElementPlot, ColorbarPlot, LegendPlot):
             node_indices = {v: i for i, v in enumerate(nodes)}
             index = np.array([node_indices[n] for n in nodes], dtype=np.int32)
             layout = {node_indices[k]: (y, x) if self.invert_axes else (x, y)
-                      for k, (x, y) in zip(nodes, node_positions)}
+                      for k, (x, y) in zip(nodes, node_positions, strict=None)}
         else:
             index = nodes.astype(np.int32)
             layout = {k: (y, x) if self.invert_axes else (x, y)
-                      for k, (x, y) in zip(index, node_positions)}
+                      for k, (x, y) in zip(index, node_positions, strict=None)}
 
         point_data = {'index': index}
 

--- a/holoviews/plotting/bokeh/heatmap.py
+++ b/holoviews/plotting/bokeh/heatmap.py
@@ -262,7 +262,7 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
         if reverse:
             bins = bins[::-1]
 
-        return dict(zip(order, bins))
+        return dict(zip(order, bins, strict=None))
 
     @staticmethod
     def _get_bounds(mapper, values):
@@ -380,7 +380,7 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
         values = [(text, ((end - start) / 2) + start)
                   for text, (start, end) in mapping.items()]
 
-        labels, radiant = zip(*values)
+        labels, radiant = zip(*values, strict=None)
         radiant = np.array(radiant)
 
         y_coord = np.sin(radiant) * self.max_radius + self.max_radius
@@ -401,7 +401,7 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
         mapping = self._compute_tick_mapping("radius", order_ann, bins_ann)
         values = [(label, radius[0]) for label, radius in mapping.items()]
 
-        labels, radius = zip(*values)
+        labels, radius = zip(*values, strict=None)
         radius = np.array(radius)
 
         y_coord = np.sin(np.deg2rad(self.yrotation)) * radius + self.max_radius
@@ -447,8 +447,8 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
         x_start = np.cos(angles) * inner + self.max_radius
         x_end = np.cos(angles) * outer + self.max_radius
 
-        xs = zip(x_start, x_end)
-        ys = zip(y_start, y_end)
+        xs = zip(x_start, x_end, strict=None)
+        ys = zip(y_start, y_end, strict=None)
 
         return dict(xs=list(xs), ys=list(ys))
 

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -134,8 +134,8 @@ class PathPlot(LegendPlot, ColorbarPlot):
             cols = path.columns(path.kdims)
             xs, ys = (cols[kd.name] for kd in element.kdims)
             alen = len(xs)
-            xpaths += [xs[s1:s2+1] for (s1, s2) in zip(range(alen-1), range(1, alen+1))]
-            ypaths += [ys[s1:s2+1] for (s1, s2) in zip(range(alen-1), range(1, alen+1))]
+            xpaths += [xs[s1:s2+1] for (s1, s2) in zip(range(alen-1), range(1, alen+1), strict=None)]
+            ypaths += [ys[s1:s2+1] for (s1, s2) in zip(range(alen-1), range(1, alen+1), strict=None)]
             if not hover:
                 continue
             for vd in element.vdims:
@@ -157,13 +157,13 @@ class PathPlot(LegendPlot, ColorbarPlot):
         data = defaultdict(list)
 
         zorders = self._updated_zorders(element)
-        for (key, el), zorder in zip(element.data.items(), zorders):
+        for (key, el), zorder in zip(element.data.items(), zorders, strict=None):
             el_opts = self.lookup_options(el, 'plot').options
             self.param.update(**{k: v for k, v in el_opts.items()
                                     if k not in OverlayPlot._propagate_options})
             style = self.lookup_options(el, 'style')
             style = style.max_cycles(len(self.ordering))[zorder]
-            self.overlay_dims = dict(zip(element.kdims, key))
+            self.overlay_dims = dict(zip(element.kdims, key, strict=None))
             eldata, elmapping, style = self.get_data(el, ranges, style)
             for k, eld in eldata.items():
                 data[k].extend(eld)

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -425,7 +425,7 @@ class CompositePlot(BokehPlot):
 
     def _stream_update(self, **kwargs):
         contents = [k for s in self.streams for k in s.contents]
-        key = tuple(None if d in contents else k for d, k in zip(self.dimensions, self.current_key))
+        key = tuple(None if d in contents else k for d, k in zip(self.dimensions, self.current_key, strict=None))
         key = wrap_tuple_streams(key, self.dimensions, self.streams)
         self._get_title_div(key)
 
@@ -777,7 +777,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             # to create the correct subaxes for all plots in the layout
             layout_key, _ = layout_items.get((r, c), (None, None))
             if isinstance(layout, NdLayout) and layout_key:
-                layout_dimensions = dict(zip(layout_dimensions, layout_key))
+                layout_dimensions = dict(zip(layout_dimensions, layout_key, strict=None))
 
             # Generate the axes and create the subplots with the appropriate
             # axis objects, handling any Empty objects.

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -91,7 +91,7 @@ class ServerHoverMixin:
         def on_change(attr, old, new):
             if np.isinf(new).all():
                 return
-            data_sel = self._hover_data.sel(**dict(zip(self._hover_data.coords, new)), method="nearest").to_dict()
+            data_sel = self._hover_data.sel(**dict(zip(self._hover_data.coords, new, strict=None)), method="nearest").to_dict()
             # TODO: When ValueOf support formatter remove the rounding
             # https://github.com/bokeh/bokeh/issues/14123
             data_coords = {dim: round(data_sel['coords'][dim]['data'], 3) for dim in coords}
@@ -360,7 +360,7 @@ class ImageStackPlot(RasterPlot):
                     "The supplied cmap dictionary must have the same "
                     f"value dimensions as the element. Missing: '{missing_str}'"
                 )
-            keys, values = zip(*dict_cmap.items())
+            keys, values = zip(*dict_cmap.items(), strict=None)
             style["cmap"] = list(values)
             indices = [keys.index(vd.name) for vd in vdims]
 
@@ -483,7 +483,7 @@ class QuadMeshPlot(ColorbarPlot):
             XS, YS = [], []
             mask = []
             xc, yc = [], []
-            for xs, ys, zval in zip(X, Y, zvals):
+            for xs, ys, zval in zip(X, Y, zvals, strict=None):
                 xs, ys = xs[:-1], ys[:-1]
                 if isfinite(zval) and all(isfinite(xs)) and all(isfinite(ys)):
                     XS.append(list(xs))
@@ -537,7 +537,7 @@ class QuadMeshPlot(ColorbarPlot):
         hover_vals = [element.dimension_values(hover_dim, flat=False)
                       for hover_dim in hover_dims]
         hover_data = {}
-        for hdim, hvals in zip(hover_dims, hover_vals):
+        for hdim, hvals in zip(hover_dims, hover_vals, strict=None):
             hdat = hvals.T.flatten() if transpose else hvals.flatten()
             hover_data[dimension_sanitizer(hdim.name)] = hdat[mask]
         return hover_data

--- a/holoviews/plotting/bokeh/sankey.py
+++ b/holoviews/plotting/bokeh/sankey.py
@@ -220,7 +220,7 @@ class SankeyPlot(GraphPlot):
         src, tgt = (dimension_sanitizer(kd.name) for kd in element.kdims[:2])
         if src == 'start': src += '_values'
         if tgt == 'end':   tgt += '_values'
-        lookup = dict(zip(*(element.nodes.dimension_values(d) for d in (2, lidx))))
+        lookup = dict(zip(*(element.nodes.dimension_values(d) for d in (2, lidx)), strict=None))
         src_vals = data['patches_1'][src]
         tgt_vals = data['patches_1'][tgt]
         data['patches_1'][src] = [lookup.get(v, v) for v in src_vals]

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -126,7 +126,7 @@ class BoxWhiskerPlot(MultiDistributionMixin, CompositeElementPlot, ColorbarPlot,
             factors = [key for key in element.groupby(element.kdims).data.keys()]
             if element.ndims > 1:
                 factors = sorted(factors)
-            factors = [tuple(d.pprint_value(k) for d, k in zip(element.kdims, key))
+            factors = [tuple(d.pprint_value(k) for d, k in zip(element.kdims, key, strict=None))
                        for key in factors]
             factors = [f[0] if len(f) == 1 else f for f in factors]
             xfactors, yfactors = factors, []
@@ -213,7 +213,7 @@ class BoxWhiskerPlot(MultiDistributionMixin, CompositeElementPlot, ColorbarPlot,
         for key, g in groups.items():
             # Compute group label
             if element.kdims:
-                label = tuple(d.pprint_value(v) for d, v in zip(element.kdims, key))
+                label = tuple(d.pprint_value(v) for d, v in zip(element.kdims, key, strict=None))
                 if len(label) == 1:
                     label = label[0]
             else:
@@ -255,10 +255,10 @@ class BoxWhiskerPlot(MultiDistributionMixin, CompositeElementPlot, ColorbarPlot,
                 out_data['index'] += [label]*len(outliers)
                 out_data[vdim] += list(outliers)
                 if hover:
-                    for kd, k in zip(element.kdims, wrap_tuple(key)):
+                    for kd, k in zip(element.kdims, wrap_tuple(key), strict=None):
                         out_data[dimension_sanitizer(kd.name)] += [k]*len(outliers)
             if hover:
-                for kd, k in zip(element.kdims, wrap_tuple(key)):
+                for kd, k in zip(element.kdims, wrap_tuple(key), strict=None):
                     kd_name = dimension_sanitizer(kd.name)
                     if kd_name in r1_data:
                         r1_data[kd_name].append(k)
@@ -383,7 +383,7 @@ class ViolinPlot(BoxWhiskerPlot):
             factors = [key for key in element.groupby(kdims).data.keys()]
             if element.ndims > 1:
                 factors = sorted(factors)
-            factors = [tuple(d.pprint_value(k) for d, k in zip(kdims, key))
+            factors = [tuple(d.pprint_value(k) for d, k in zip(kdims, key, strict=None))
                        for key in factors]
             factors = [f[0] if len(f) == 1 else f for f in factors]
             xfactors, yfactors = factors, []
@@ -547,7 +547,7 @@ class ViolinPlot(BoxWhiskerPlot):
         for key, g in groups.items():
             key = decode_bytes(key)
             if element.kdims:
-                key = tuple(d.pprint_value(k) for d, k in zip(element.kdims, key))
+                key = tuple(d.pprint_value(k) for d, k in zip(element.kdims, key, strict=None))
             kde, line, segs, bars, scatter = self._kde_data(
                 element, g, key, split_dim, split_cats, **kwargs
             )

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -190,7 +190,7 @@ def compute_plot_size(plot):
             w_agg, h_agg = (np.max, np.max)
         else:
             w_agg, h_agg = (np.max, np.sum)
-        widths, heights = zip(*[compute_plot_size(child) for child in plot.children])
+        widths, heights = zip(*[compute_plot_size(child) for child in plot.children], strict=None)
         return w_agg(widths), h_agg(heights)
     elif isinstance(plot, figure):
         if plot.width:
@@ -707,7 +707,7 @@ def pad_plots(plots):
         widths.append(row_widths)
 
     plots = [[Column(p, width=w) if isinstance(p, (DataTable, Tabs)) else p
-              for p, w in zip(row, ws)] for row, ws in zip(plots, widths)]
+              for p, w in zip(row, ws, strict=None)] for row, ws in zip(plots, widths, strict=None)]
     return plots
 
 
@@ -745,7 +745,7 @@ def get_tab_title(key, frame, overlay):
         title = ' '.join(title)
     else:
         title = ' | '.join([d.pprint_value_string(k) for d, k in
-                            zip(overlay.kdims, key)])
+                            zip(overlay.kdims, key, strict=None)])
     return title
 
 
@@ -1068,14 +1068,14 @@ def multi_polygons_data(element):
     xs, ys = (element.dimension_values(kd, expanded=False) for kd in element.kdims)
     holes = element.holes()
     xsh, ysh = [], []
-    for x, y, multi_hole in zip(xs, ys, holes):
+    for x, y, multi_hole in zip(xs, ys, holes, strict=None):
         xhs = [[h[:, 0] for h in hole] for hole in multi_hole]
         yhs = [[h[:, 1] for h in hole] for hole in multi_hole]
         array = np.column_stack([x, y])
         splits = np.where(np.isnan(array[:, :2].astype('float')).sum(axis=1))[0]
         arrays = np.split(array, splits+1) if len(splits) else [array]
         multi_xs, multi_ys = [], []
-        for i, (path, hx, hy) in enumerate(zip(arrays, xhs, yhs)):
+        for i, (path, hx, hy) in enumerate(zip(arrays, xhs, yhs, strict=None)):
             if i != (len(arrays)-1):
                 path = path[:-1]
             multi_xs.append([path[:, 0], *hx])
@@ -1096,8 +1096,8 @@ def match_dim_specs(specs1, specs2):
     """
     if (specs1 is None or specs2 is None) or (len(specs1) != len(specs2)):
         return False
-    for spec1, spec2 in zip(specs1, specs2):
-        for s1, s2 in zip(spec1, spec2):
+    for spec1, spec2 in zip(specs1, specs2, strict=None):
+        for s1, s2 in zip(spec1, spec2, strict=None):
             if s1 is None or s2 is None:
                 continue
             if s1 != s2:
@@ -1223,7 +1223,7 @@ def get_ticker_axis_props(ticker):
         axis_props['ticker'] = BasicTicker(desired_num_ticks=ticker)
     elif isinstance(ticker, (tuple, list)):
         if all(isinstance(t, tuple) for t in ticker):
-            ticks, labels = zip(*ticker)
+            ticks, labels = zip(*ticker, strict=None)
             # Ensure floats which are integers are serialized as ints
             # because in JS the lookup fails otherwise
             ticks = [int(t) if isinstance(t, float) and t.is_integer() else t
@@ -1236,5 +1236,5 @@ def get_ticker_axis_props(ticker):
             ticks = [util.dt_to_int(tick, 'ms') for tick in ticks]
         axis_props['ticker'] = FixedTicker(ticks=ticks)
         if labels is not None:
-            axis_props['major_label_overrides'] = dict(zip(ticks, labels))
+            axis_props['major_label_overrides'] = dict(zip(ticks, labels, strict=None))
     return axis_props

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -17,7 +17,7 @@ class GeomMixin:
         # loop over start and end points of segments
         # simultaneously in each dimension
         for kdim0, kdim1 in zip([kdims[i].label for i in range(2)],
-                                [kdims[i].label for i in range(2,4)]):
+                                [kdims[i].label for i in range(2,4)], strict=None):
             new_range = {}
             for kdim in [kdim0, kdim1]:
                 # for good measure, update ranges for both start and end kdim

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -240,7 +240,7 @@ class LabelsPlot(ColorbarPlot):
         vectorized = {k: v for k, v in plot_kwargs.items() if isinstance(v, np.ndarray)}
 
         texts = []
-        for i, item in enumerate(zip(*plot_args)):
+        for i, item in enumerate(zip(*plot_args, strict=None)):
             x, y, text = item[:3]
             if len(item) == 4 and cmap is not None:
                 color = item[3]
@@ -324,7 +324,7 @@ class _SyntheticAnnotationPlot(AnnotationPlot):
         else:
             size = len(self.hmap.last.kdims)
             first_keys = list(positions)[:size]
-            values = zip(*[positions[n] for n in first_keys])
+            values = zip(*[positions[n] for n in first_keys], strict=None)
         fn = getattr(axis, self._methods[self.invert_axes])
         return [fn(*val, **opts) for val in values]
 

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -410,7 +410,7 @@ class HistogramPlot(ColorbarPlot):
         and limits.
 
         """
-        axis_settings = dict(zip(self.axis_settings, [None, None, (None if self.overlaid else ticks)]))
+        axis_settings = dict(zip(self.axis_settings, [None, None, (None if self.overlaid else ticks)], strict=None))
         return axis_settings
 
     def _update_plot(self, key, hist, bars, lims, ranges):
@@ -425,7 +425,7 @@ class HistogramPlot(ColorbarPlot):
         allow updating of further artists.
 
         """
-        plot_vals = zip(self.handles['artist'], edges, hvals, widths)
+        plot_vals = zip(self.handles['artist'], edges, hvals, widths, strict=None)
         for bar, edge, height, width in plot_vals:
             if self.invert_axes:
                 bar.set_y(edge)
@@ -534,7 +534,7 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
         lower_bound = main_range[0]
         colors = np.array(element.dimension_values(dim))
         colors = (colors - lower_bound) / (cmap_range)
-        for c, bar in zip(colors, bars):
+        for c, bar in zip(colors, bars, strict=None):
             bar.set_facecolor(cmap(c))
             bar.set_clip_on(False)
 
@@ -916,7 +916,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         alignments = None
         ticks = xticks or yticks
         if ticks is not None:
-            ticks, labels, alignments = zip(*sorted(ticks, key=lambda x: x[0]))
+            ticks, labels, alignments = zip(*sorted(ticks, key=lambda x: x[0]), strict=None)
             ticks = (list(ticks), list(labels))
         if xticks:
             xticks = ticks
@@ -925,10 +925,10 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         super()._finalize_ticks(axis, element, xticks, yticks, zticks)
         if alignments:
             if xticks:
-                for t, y in zip(axis.get_xticklabels(), alignments):
+                for t, y in zip(axis.get_xticklabels(), alignments, strict=None):
                     t.set_y(y)
             elif yticks:
-                for t, x in zip(axis.get_yticklabels(), alignments):
+                for t, x in zip(axis.get_yticklabels(), alignments, strict=None):
                     t.set_x(x)
 
     def _create_bars(self, axis, element, ranges, style):
@@ -1117,7 +1117,7 @@ class SpikesPlot(SpikesMixin, PathPlot, ColorbarPlot):
         if ndims > 1 and 'spike_length' not in opts:
             data = element.columns([0, 1])
             xs, ys = data[dimensions[0]], data[dimensions[1]]
-            data = [[(x, pos), (x, pos+y)] for x, y in zip(xs, ys)]
+            data = [[(x, pos), (x, pos+y)] for x, y in zip(xs, ys, strict=None)]
         else:
             xs = element.array([0])
             height = self.spike_length
@@ -1129,7 +1129,7 @@ class SpikesPlot(SpikesMixin, PathPlot, ColorbarPlot):
         dims = element.dimensions()
         clean_spikes = []
         for spike in data:
-            xs, ys = zip(*spike)
+            xs, ys = zip(*spike, strict=None)
             cols = []
             for i, vs in enumerate((xs, ys)):
                 vs = np.array(vs)

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -244,7 +244,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             axes_str += 'z'
             axes_list.append(axis.zaxis)
 
-        for ax, ax_obj in zip(axes_str, axes_list):
+        for ax, ax_obj in zip(axes_str, axes_list, strict=None):
             tick_fontsize = self._fontsize(f'{ax}ticks','labelsize',common=False)
             if tick_fontsize: ax_obj.set_tick_params(**tick_fontsize)
 
@@ -487,7 +487,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         elif isinstance(ticks, (list, tuple)):
             labels = None
             if all(isinstance(t, tuple) for t in ticks):
-                ticks, labels = zip(*ticks)
+                ticks, labels = zip(*ticks, strict=None)
             axis.set_ticks(ticks)
             if labels:
                 axis.set_ticklabels(labels)
@@ -560,7 +560,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         element = self.hmap.last
         ax = self.handles['axis']
         key = list(self.hmap.data.keys())[-1]
-        dim_map = dict(zip((d.name for d in self.hmap.kdims), key))
+        dim_map = dict(zip((d.name for d in self.hmap.kdims), key, strict=None))
         key = tuple(dim_map.get(d.name, None) for d in self.dimensions)
         ranges = self.compute_ranges(self.hmap, key, ranges)
         self.current_ranges = ranges
@@ -823,10 +823,10 @@ class ColorbarPlot(ElementPlot):
             cbar.ax.yaxis.set_major_locator(locator)
         elif isinstance(self.cbar_ticks, list):
             if all(isinstance(t, tuple) for t in self.cbar_ticks):
-                ticks, labels = zip(*self.cbar_ticks)
+                ticks, labels = zip(*self.cbar_ticks, strict=None)
             else:
                 ticks, labels = zip(*[(t, dim.pprint_value(t))
-                                        for t in self.cbar_ticks])
+                                        for t in self.cbar_ticks], strict=None)
             cbar.set_ticks(ticks)
             cbar.set_ticklabels(labels)
 
@@ -1154,17 +1154,17 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
                 legend_plot = True
             elif isinstance(overlay, NdOverlay):
                 label = ','.join([dim.pprint_value(k, print_unit=True)
-                                  for k, dim in zip(key, dimensions)])
+                                  for k, dim in zip(key, dimensions, strict=None)])
                 if handle:
                     legend_data.append((handle, label))
             elif isinstance(subplot, OverlayPlot):
                 legend_data += subplot.handles.get('legend_data', {}).items()
             elif element.label and handle:
                 legend_data.append((handle, labels.get(element.label, element.label)))
-        all_handles, all_labels = list(zip(*legend_data)) if legend_data else ([], [])
+        all_handles, all_labels = list(zip(*legend_data, strict=None)) if legend_data else ([], [])
         data = {}
         used_labels = []
-        for handle, label in zip(all_handles, all_labels):
+        for handle, label in zip(all_handles, all_labels, strict=None):
             # Ensure that artists with multiple handles are supported
             if isinstance(handle, list): handle = tuple(handle)
             handle = tuple(h for h in handle if not isinstance(h, (AxesImage, list)))

--- a/holoviews/plotting/mpl/geometry.py
+++ b/holoviews/plotting/mpl/geometry.py
@@ -35,7 +35,7 @@ class SegmentPlot(GeomMixin, ColorbarPlot):
         inds = (1, 0, 3, 2) if self.invert_axes else (0, 1, 2, 3)
         dims = element.dimensions()
         data = [[(x0, y0), (x1, y1)] for x0, y0, x1, y1
-                in zip(*(element.dimension_values(d) for d in inds))]
+                in zip(*(element.dimension_values(d) for d in inds), strict=None)]
         with abbreviated_exception():
             style = self._apply_transforms(element, ranges, style)
         return (data,), style, {'dimensions': dims}
@@ -73,7 +73,7 @@ class RectanglesPlot(GeomMixin, ColorbarPlot):
 
         dims = element.dimensions()
         data = [Rectangle((x0, y0), x1, y1) for (x0, y0, x1, y1)
-                in zip(x0s, y0s, x1s-x0s, y1s-y0s)]
+                in zip(x0s, y0s, x1s-x0s, y1s-y0s, strict=None)]
 
         with abbreviated_exception():
             style = self._apply_transforms(element, ranges, style)

--- a/holoviews/plotting/mpl/graphs.py
+++ b/holoviews/plotting/mpl/graphs.py
@@ -333,7 +333,7 @@ class ChordPlot(ChordMixin, GraphPlot):
         if 'text' in plot_args:
             fontsize = plot_kwargs.get('text_font_size', 8)
             labels = []
-            for (x, y, l, a) in zip(*plot_args['text']):
+            for (x, y, l, a) in zip(*plot_args['text'], strict=None):
                 label = ax.annotate(l, xy=(x, y), xycoords='data', rotation=a,
                                     horizontalalignment='left', fontsize=fontsize,
                                     verticalalignment='center', rotation_mode='anchor')
@@ -369,7 +369,7 @@ class ChordPlot(ChordMixin, GraphPlot):
             return
         labels = []
         fontsize = style.get('text_font_size', 8)
-        for (x, y, l, a) in zip(*data['text']):
+        for (x, y, l, a) in zip(*data['text'], strict=None):
             label = ax.annotate(l, xy=(x, y), xycoords='data', rotation=a,
                                 horizontalalignment='left', fontsize=fontsize,
                                 verticalalignment='center', rotation_mode='anchor')

--- a/holoviews/plotting/mpl/heatmap.py
+++ b/holoviews/plotting/mpl/heatmap.py
@@ -86,7 +86,7 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
         ypos = yvals[:-1] + np.diff(yvals)/2.
         plot_coords = product(xpos, ypos)
         annotations = {}
-        for plot_coord, v in zip(plot_coords, vals):
+        for plot_coord, v in zip(plot_coords, vals, strict=None):
             text = '-' if is_nan(v) else val_dim.pprint_value(v)
             annotations[plot_coord] = text
         return annotations
@@ -105,7 +105,7 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
             if not xfactors:
                 xfactors = element.gridded.dimension_values(xdim, False)
             xlabels = [xdim.pprint_value(k) for k in xfactors]
-            xticks = list(zip(xpos, xlabels))
+            xticks = list(zip(xpos, xlabels, strict=None))
 
         yticks = opts.get('yticks')
         if yticks is None:
@@ -113,7 +113,7 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
             if not yfactors:
                 yfactors = element.gridded.dimension_values(ydim, False)
             ylabels = [ydim.pprint_value(k) for k in yfactors]
-            yticks = list(zip(ypos, ylabels))
+            yticks = list(zip(ypos, ylabels, strict=None))
         return xticks, yticks
 
 
@@ -258,7 +258,7 @@ class RadialHeatMapPlot(ColorbarPlot):
         bounds = np.linspace(start, end, size + 1)
         if reverse:
             bounds = bounds[::-1]
-        mapping = list(zip(bounds[:-1]%(np.pi*2), order))
+        mapping = list(zip(bounds[:-1]%(np.pi*2), order, strict=None))
         return mapping
 
     @staticmethod
@@ -290,7 +290,7 @@ class RadialHeatMapPlot(ColorbarPlot):
             ticks = ticks[::nth_mark]
         elif isinstance(ticker, (tuple, list)):
             nth_mark = max([np.ceil(len(ticks) / len(ticker)).astype(int), 1])
-            ticks = [(v, tl) for (v, l), tl in zip(ticks[::nth_mark], ticker)]
+            ticks = [(v, tl) for (v, l), tl in zip(ticks[::nth_mark], ticker, strict=None)]
         elif ticker:
             ticks = list(ticker)
         else:

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -67,7 +67,7 @@ class PathPlot(ColorbarPlot):
                 paths.append(arr)
                 continue
             length = len(xarr)
-            for (s1, s2) in zip(range(length-1), range(1, length+1)):
+            for (s1, s2) in zip(range(length-1), range(1, length+1), strict=None):
                 if cdim:
                     cvals.append(path[cdim.name])
                 paths.append(arr[s1:s2+1])
@@ -149,7 +149,7 @@ class ContourPlot(PathPlot):
         if len(paths) != len(array):
             # If there are multi-geometries the list of scalar values
             # will not match the list of paths and has to be expanded
-            array = np.array([v for v, sps in zip(array, subpaths)
+            array = np.array([v for v, sps in zip(array, subpaths, strict=None)
                               for _ in range(len(sps))])
 
         if array.dtype.kind not in 'uif':

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -311,7 +311,7 @@ class CompositePlot(GenericCompositePlot, MPLPlot):
 
     def _stream_update(self, **kwargs):
         contents = [k for s in self.streams for k in s.contents]
-        key = tuple(None if d in contents else k for d, k in zip(self.dimensions, self.current_key))
+        key = tuple(None if d in contents else k for d, k in zip(self.dimensions, self.current_key, strict=None))
         key = wrap_tuple_streams(key, self.dimensions, self.streams)
         self._update_title(key)
 
@@ -551,7 +551,7 @@ class GridPlot(CompositePlot):
             layout_axis.set_position(self.position)
         layout_axis.patch.set_visible(False)
 
-        for ax, ax_obj in zip(['x', 'y'], [layout_axis.xaxis, layout_axis.yaxis]):
+        for ax, ax_obj in zip(['x', 'y'], [layout_axis.xaxis, layout_axis.yaxis], strict=None):
             tick_fontsize = self._fontsize(f'{ax}ticks','labelsize', common=False)
             if tick_fontsize: ax_obj.set_tick_params(**tick_fontsize)
 
@@ -570,7 +570,7 @@ class GridPlot(CompositePlot):
             dim2_keys = [0]
             layout_axis.get_yaxis().set_visible(False)
         else:
-            dim1_keys, dim2_keys = zip(*keys)
+            dim1_keys, dim2_keys = zip(*keys, strict=None)
             layout_axis.set_ylabel(dims[1].pprint_label)
             layout_axis.set_aspect(float(self.rows)/self.cols)
 
@@ -675,7 +675,7 @@ class AdjointLayoutPlot(MPLPlot, GenericAdjointLayoutPlot):
         self.view_positions = self.layout_dict[self.layout_type]
 
         # The supplied (axes, view) objects as indexed by position
-        self.subaxes = {pos: ax for ax, pos in zip(subaxes, self.view_positions)}
+        self.subaxes = {pos: ax for ax, pos in zip(subaxes, self.view_positions, strict=None)}
         super().__init__(subplots=subplots, **params)
 
     @mpl_rc_context
@@ -970,7 +970,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
 
             layout_key, _ = layout_items.get((r, c), (None, None))
             if isinstance(layout, NdLayout) and layout_key:
-                layout_dimensions = dict(zip(layout_dimensions, layout_key))
+                layout_dimensions = dict(zip(layout_dimensions, layout_key, strict=None))
 
             # Generate the axes and create the subplots with the appropriate
             # axis objects, handling any Empty objects.
@@ -988,10 +988,10 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
             else:
                 layout_count += 1
             subaxes = [plt.subplot(self.gs[ind], projection=proj)
-                       for ind, proj in zip(gsinds, projs)]
+                       for ind, proj in zip(gsinds, projs, strict=None)]
             subplot_data = self._create_subplots(obj, positions,
                                                  layout_dimensions, frame_ranges,
-                                                 dict(zip(positions, subaxes)),
+                                                 dict(zip(positions, subaxes, strict=None)),
                                                  num=0 if empty else layout_count)
             subplots, adjoint_layout, _ = subplot_data
             layout_axes[(r, c)] = subaxes

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -273,7 +273,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
         self.overlaid = False
         self.hmap = layout
         if layout.ndims > 1:
-            xkeys, ykeys = zip(*layout.keys())
+            xkeys, ykeys = zip(*layout.keys(), strict=None)
         else:
             xkeys = layout.keys()
             ykeys = [None]
@@ -322,7 +322,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
                     vmap = self.layout.get((xkey, ykey), None)
                 else:
                     vmap = self.layout.get(xkey, None)
-                pane = vmap.select(**{d.name: val for d, val in zip(self.dimensions, key)
+                pane = vmap.select(**{d.name: val for d, val in zip(self.dimensions, key, strict=None)
                                     if d in vmap.kdims})
                 pane = vmap.last.values()[-1] if issubclass(vmap.type, CompositeOverlay) else vmap.last
                 data = get_raster_array(pane) if pane else None

--- a/holoviews/plotting/mpl/stats.py
+++ b/holoviews/plotting/mpl/stats.py
@@ -72,7 +72,7 @@ class BoxPlot(MultiDistributionMixin, ChartPlot):
         data, labels = [], []
         for key, group in groups:
             if element.kdims:
-                label = ','.join([d.pprint_value(v) for d, v in zip(element.kdims, key)])
+                label = ','.join([d.pprint_value(v) for d, v in zip(element.kdims, key, strict=None)])
             else:
                 label = key
             d = group[group.vdims[0]]
@@ -184,7 +184,7 @@ class ViolinPlot(BoxPlot):
                              medianprops={'color': 'white'}, widths=0.1,
                              **invert_axes, **labels)
             artists.update(box)
-        for body, color in zip(artists['bodies'], facecolors):
+        for body, color in zip(artists['bodies'], facecolors, strict=None):
             body.set_facecolors(color)
             body.set_edgecolors(edgecolors)
             body.set_alpha(alpha)
@@ -205,7 +205,7 @@ class ViolinPlot(BoxPlot):
         elstyle = self.lookup_options(element, 'style')
         for i, (key, group) in enumerate(groups):
             if element.kdims:
-                label = ','.join([d.pprint_value(v) for d, v in zip(element.kdims, key)])
+                label = ','.join([d.pprint_value(v) for d, v in zip(element.kdims, key, strict=None)])
             else:
                 label = key
             d = group[group.vdims[0]]

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -204,7 +204,7 @@ def unpack_adjoints(ratios):
 
 def normalize_ratios(ratios):
     normalized = {}
-    for i, v in enumerate(zip(*ratios.values())):
+    for i, v in enumerate(zip(*ratios.values(), strict=None)):
         arr = np.array(v)
         normalized[i] = arr/float(np.nanmax(arr))
     return normalized

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -232,7 +232,7 @@ class Plot(param.Parameterized):
                            if any(c in self.dimensions for c in stream.contents)]
             stream_params = stream_parameters(dim_streams)
             key = tuple(None if d in stream_params else k
-                        for d, k in zip(self.dimensions, key))
+                        for d, k in zip(self.dimensions, key, strict=None))
             stream_key = util.wrap_tuple_streams(key, self.dimensions, self.streams)
 
 
@@ -493,14 +493,14 @@ class DimensionedPlot(Plot):
 
         """
         if self.layout_dimensions is not None:
-            dimensions, key = zip(*self.layout_dimensions.items())
+            dimensions, key = zip(*self.layout_dimensions.items(), strict=None)
         elif not self.dynamic and (not self.uniform or len(self) == 1) or self.subplot:
             return ''
         else:
             key = key if isinstance(key, tuple) else (key,)
             dimensions = self.dimensions
         dimension_labels = [dim.pprint_value_string(k) for dim, k in
-                            zip(dimensions, key)]
+                            zip(dimensions, key, strict=None)]
         groups = [', '.join(dimension_labels[i*group_size:(i+1)*group_size])
                   for i in range(len(dimension_labels))]
         return util.bytes_to_unicode(separator.join(g for g in groups if g))
@@ -862,7 +862,7 @@ class DimensionedPlot(Plot):
                 # Filter out ranges of updated elements and append new ranges
                 merged = {}
                 for g, drange in dranges['values'].items():
-                    filtered = [r for i, r in zip(ids, values.get(g, [])) if i not in prev_ids]
+                    filtered = [r for i, r in zip(ids, values.get(g, []), strict=None) if i not in prev_ids]
                     filtered += drange
                     merged[g] = filtered
                 prev_ranges[d] = cls._merge_group_ranges(merged)
@@ -1324,7 +1324,7 @@ class GenericElementPlot(DimensionedPlot):
             return self.current_frame
 
         cached = self.current_key is None and not any(s._triggering for s in self.streams)
-        key_map = dict(zip([d.name for d in self.dimensions], key))
+        key_map = dict(zip([d.name for d in self.dimensions], key, strict=None))
         frame = get_plot_frame(self.hmap, key_map, cached)
         traverse_setter(self, '_force', False)
 
@@ -1510,7 +1510,7 @@ class GenericElementPlot(DimensionedPlot):
             )
         else:
             max_extent = []
-            for l1, l2 in zip(range_extents, extents):
+            for l1, l2 in zip(range_extents, extents, strict=None):
                 if isfinite(l2):
                     max_extent.append(l2)
                 else:
@@ -1790,7 +1790,7 @@ class GenericOverlayPlot(GenericElementPlot):
             dim_inds = [dimensions.index(d) for d in holomap.kdims]
             sliced_keys = [tuple(k[i] for i in dim_inds) for k in keys]
             frame_ranges = dict([(slckey, self.compute_ranges(holomap, key, ranges[key]))
-                                        for key, slckey in zip(keys, sliced_keys) if slckey in holomap.data.keys()])
+                                        for key, slckey in zip(keys, sliced_keys, strict=None) if slckey in holomap.data.keys()])
         else:
             mapwise_ranges = self.compute_ranges(holomap, None, None)
             frame_ranges = dict([(key, self.compute_ranges(holomap, key, mapwise_ranges))
@@ -1822,7 +1822,7 @@ class GenericOverlayPlot(GenericElementPlot):
 
         if isinstance(self.hmap, DynamicMap):
             dmap_streams = [streams+get_nested_streams(layer) for layer, streams in
-                            zip(*split_dmap_overlay(self.hmap))]
+                            zip(*split_dmap_overlay(self.hmap), strict=None)]
         else:
             dmap_streams = [None]*len(keys)
 
@@ -1833,7 +1833,7 @@ class GenericOverlayPlot(GenericElementPlot):
             self.map_lengths[group_fn(m)[:length]] += 1
 
         subplots = {}
-        for (key, vmap, streams) in zip(keys, vmaps, dmap_streams):
+        for (key, vmap, streams) in zip(keys, vmaps, dmap_streams, strict=None):
             if streams:
                 streams = list(unique_iterator(streams))
             subplot = self._create_subplot(key, vmap, streams, ranges)
@@ -1863,7 +1863,7 @@ class GenericOverlayPlot(GenericElementPlot):
         else:
             if not isinstance(key, tuple): key = (key,)
             style_key = group_fn(obj) + key
-            opts['overlay_dims'] = dict(zip(self.hmap.last.kdims, key))
+            opts['overlay_dims'] = dict(zip(self.hmap.last.kdims, key, strict=None))
 
         if self.batched:
             vtype = type(obj.last.last)
@@ -1985,7 +1985,7 @@ class GenericOverlayPlot(GenericElementPlot):
         subplot.cyclic_index = cyclic_index
         if subplot.overlay_dims:
             odim_key = util.wrap_tuple(spec[-1])
-            new_dims = zip(subplot.overlay_dims, odim_key)
+            new_dims = zip(subplot.overlay_dims, odim_key, strict=None)
             subplot.overlay_dims = dict(new_dims)
 
     def _get_subplot_extents(self, overlay, ranges, range_type, dimension=None):
@@ -2122,7 +2122,7 @@ class GenericCompositePlot(DimensionedPlot):
         else:
             self.current_key = key
 
-        key_map = dict(zip([d.name for d in self.dimensions], key))
+        key_map = dict(zip([d.name for d in self.dimensions], key, strict=None))
         for path, item in self.layout.items():
             frame = get_nested_plot_frame(item, key_map, cached)
             if frame is not None:

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -557,7 +557,7 @@ def to_dash(
         store_data.setdefault("kdims", {})
         for i, kdim in zip(
                 range(num_figs * 2, num_figs * 2 + len(all_kdims)),
-                all_kdims
+                all_kdims, strict=None
         ):
             if kdim not in store_data["kdims"] or store_data["kdims"][kdim] != args[i]:
                 store_data["kdims"][kdim] = args[i]

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -565,7 +565,7 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
         axis_props = {}
         if isinstance(ticker, (tuple, list)):
             if all(isinstance(t, tuple) for t in ticker):
-                ticks, labels = zip(*ticker)
+                ticks, labels = zip(*ticker, strict=None)
                 labels = [l if isinstance(l, str) else str(l)
                               for l in labels]
                 axis_props['tickvals'] = ticks

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -109,7 +109,7 @@ class LayoutPlot(PlotlyPlot, GenericLayoutPlot):
             # to create the correct subaxes for all plots in the layout
             layout_key, _ = layout_items.get((r, c), (None, None))
             if isinstance(layout, NdLayout) and layout_key:
-                layout_dimensions = dict(zip(layout_dimensions, layout_key))
+                layout_dimensions = dict(zip(layout_dimensions, layout_key, strict=None))
 
             # Generate the axes and create the subplots with the appropriate
             # axis objects, handling any Empty objects.

--- a/holoviews/plotting/plotly/shapes.py
+++ b/holoviews/plotting/plotly/shapes.py
@@ -37,7 +37,7 @@ class ShapePlot(ElementPlot):
     @staticmethod
     def build_path(xs, ys, closed=True):
         line_tos = ''.join([f'L{x} {y}'
-                            for x, y in zip(xs[1:], ys[1:])])
+                            for x, y in zip(xs[1:], ys[1:], strict=None)])
         path = f'M{xs[0]} {ys[0]}{line_tos}'
 
         if closed:
@@ -64,15 +64,15 @@ class BoxShapePlot(GeomMixin, ShapePlot):
                 lon_chunks, lat_chunks = zip(*[
                     ([lon0, lon0, lon1, lon1, lon0, np.nan],
                      [lat0, lat1, lat1, lat0, lat0, np.nan])
-                    for (lon0, lat0, lon1, lat1) in zip(lon0s, lat0s, lon1s, lat1s)
-                ])
+                    for (lon0, lat0, lon1, lat1) in zip(lon0s, lat0s, lon1s, lat1s, strict=None)
+                ], strict=None)
 
                 lon = np.concatenate(lon_chunks)
                 lat = np.concatenate(lat_chunks)
             return [{"lat": lat, "lon": lon}]
         else:
             return [dict(x0=x0, x1=x1, y0=y0, y1=y1, xref='x', yref='y')
-                    for (x0, y0, x1, y1) in zip(x0s, y0s, x1s, y1s)]
+                    for (x0, y0, x1, y1) in zip(x0s, y0s, x1s, y1s, strict=None)]
 
 
 class SegmentShapePlot(GeomMixin, ShapePlot):
@@ -92,15 +92,15 @@ class SegmentShapePlot(GeomMixin, ShapePlot):
                 lon_chunks, lat_chunks = zip(*[
                     ([lon0, lon1, np.nan],
                      [lat0, lat1, np.nan])
-                    for (lon0, lat0, lon1, lat1) in zip(lon0s, lat0s, lon1s, lat1s)
-                ])
+                    for (lon0, lat0, lon1, lat1) in zip(lon0s, lat0s, lon1s, lat1s, strict=None)
+                ], strict=None)
 
                 lon = np.concatenate(lon_chunks)
                 lat = np.concatenate(lat_chunks)
             return [{"lat": lat, "lon": lon}]
         else:
             return [dict(x0=x0, x1=x1, y0=y0, y1=y1, xref='x', yref='y')
-                    for (x0, y0, x1, y1) in zip(x0s, y0s, x1s, y1s)]
+                    for (x0, y0, x1, y1) in zip(x0s, y0s, x1s, y1s, strict=None)]
 
 
 class PathShapePlot(ShapePlot):

--- a/holoviews/plotting/plotly/stats.py
+++ b/holoviews/plotting/plotly/stats.py
@@ -89,7 +89,7 @@ class MultiDistributionPlot(MultiDistributionMixin, ElementPlot):
             if element.kdims:
                 if isinstance(key, str):
                     key = (key,)
-                label = ','.join([d.pprint_value(v) for d, v in zip(element.kdims, key)])
+                label = ','.join([d.pprint_value(v) for d, v in zip(element.kdims, key, strict=None)])
             else:
                 label = key
             data = {axis: group.dimension_values(group.vdims[0]), 'name': label}

--- a/holoviews/plotting/plotly/util.py
+++ b/holoviews/plotting/plotly/util.py
@@ -728,8 +728,8 @@ def figure_grid(figures_grid,
 
     output_figure = {'data': [], 'layout': {}}
 
-    for r, (fig_row, row_domain) in enumerate(zip(figures_grid, row_domains)):
-        for c, (fig, column_domain) in enumerate(zip(fig_row, column_domains)):
+    for r, (fig_row, row_domain) in enumerate(zip(figures_grid, row_domains, strict=None)):
+        for c, (fig, column_domain) in enumerate(zip(fig_row, column_domains, strict=None)):
             if fig:
                 fig = copy.deepcopy(fig)
 

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -235,7 +235,7 @@ class Renderer(Exporter):
                                                    **plot_opts)
             defaults = [kd.default for kd in plot.dimensions]
             init_key = tuple(v if d is None else d for v, d in
-                             zip(plot.keys[0], defaults))
+                             zip(plot.keys[0], defaults, strict=None))
             plot.update(init_key)
         else:
             plot = obj

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -335,7 +335,7 @@ def get_nested_plot_frame(obj, key_map, cached=False):
 
     # Ensure that DynamicMaps in the cloned frame have
     # identical callback inputs to allow memoization to work
-    for it1, it2 in zip(obj.traverse(lambda x: x), clone.traverse(lambda x: x)):
+    for it1, it2 in zip(obj.traverse(lambda x: x), clone.traverse(lambda x: x), strict=None):
         if isinstance(it1, DynamicMap):
             with disable_constant(it2.callback):
                 it2.callback.inputs = it1.callback.inputs
@@ -518,7 +518,7 @@ def initialize_unbounded(obj, dimensions, key):
     """Initializes any DynamicMaps in unbounded mode.
 
     """
-    select = dict(zip([d.name for d in dimensions], key))
+    select = dict(zip([d.name for d in dimensions], key, strict=None))
     try:
         obj.select(selection_specs=[DynamicMap], **select)
     except KeyError:
@@ -1004,7 +1004,7 @@ def color_intervals(colors, levels, clip=None, N=255):
     cmin, cmax = min(levels), max(levels)
     interval = cmax-cmin
     cmap = []
-    for intv, c in zip(intervals, colors):
+    for intv, c in zip(intervals, colors, strict=None):
         cmap += [c]*round(N*(intv/interval))
     if clip is not None:
         clmin, clmax = clip

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -676,7 +676,7 @@ class ColorListSelectionDisplay(SelectionDisplay):
 
             color_inds = np.zeros(n, dtype='int8')
 
-            for i, expr in zip(range(1, len(clrs)), selection_exprs):
+            for i, expr in zip(range(1, len(clrs)), selection_exprs, strict=None):
                 if not expr:
                     color_inds[:] = i
                 else:

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1895,7 +1895,7 @@ class BoxEdit(CDSStream):
             data = tuple(data[d] for d in dims)
             return source.clone(data, id=None)
         paths = []
-        for i, (x0, x1, y0, y1) in enumerate(zip(data['x0'], data['x1'], data['y0'], data['y1'])):
+        for i, (x0, x1, y0, y1) in enumerate(zip(data['x0'], data['x1'], data['y0'], data['y1'], strict=None)):
             xs = [x0, x0, x1, x1]
             ys = [y0, y1, y1, y0]
             if isinstance(source, Polygons):

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -466,35 +466,35 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_simple_zip_init(self):
-        dataset = Dataset(zip(self.xs, self.ys), kdims=['x'], vdims=['y'])
+        dataset = Dataset(zip(self.xs, self.ys, strict=None), kdims=['x'], vdims=['y'])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_simple_zip_init_alias(self):
-        dataset = Dataset(zip(self.xs, self.ys), kdims=[('x', 'X')], vdims=[('y', 'Y')])
+        dataset = Dataset(zip(self.xs, self.ys, strict=None), kdims=[('x', 'X')], vdims=[('y', 'Y')])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_zip_init(self):
         dataset = Dataset(zip(self.gender, self.age,
-                              self.weight, self.height),
+                              self.weight, self.height, strict=None),
                           kdims=self.kdims, vdims=self.vdims)
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_zip_init_alias(self):
         dataset = self.alias_table.clone(zip(self.gender, self.age,
-                                             self.weight, self.height))
+                                             self.weight, self.height, strict=None))
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_odict_init(self):
-        dataset = Dataset(dict(zip(self.xs, self.ys)), kdims=['A'], vdims=['B'])
+        dataset = Dataset(dict(zip(self.xs, self.ys, strict=None)), kdims=['A'], vdims=['B'])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_odict_init_alias(self):
-        dataset = Dataset(dict(zip(self.xs, self.ys)),
+        dataset = Dataset(dict(zip(self.xs, self.ys, strict=None)),
                           kdims=[('a', 'A')], vdims=[('b', 'B')])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_dict_init(self):
-        dataset = Dataset(dict(zip(self.xs, self.ys)), kdims=['A'], vdims=['B'])
+        dataset = Dataset(dict(zip(self.xs, self.ys, strict=None)), kdims=['A'], vdims=['B'])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_range_with_dimension_range(self):

--- a/holoviews/tests/core/data/test_multiinterface.py
+++ b/holoviews/tests/core/data/test_multiinterface.py
@@ -245,7 +245,7 @@ class GeomTests(ComparisonTestCase):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
         mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         self.assertIs(mds.interface, self.interface)
-        for arr1, arr2 in zip(mds.split(datatype='array'), arrays):
+        for arr1, arr2 in zip(mds.split(datatype='array'), arrays, strict=None):
             self.assertEqual(arr1, arr2)
 
     def test_split_empty(self):

--- a/holoviews/tests/core/test_collation.py
+++ b/holoviews/tests/core/test_collation.py
@@ -16,7 +16,7 @@ class TestCollation(ComparisonTestCase):
         Bs = list(range(100))
         coords = itertools.product(*(range(n) for n in [alphas, betas, deltas]))
         mus=np.random.rand(alphas, betas, 100, 10)
-        self.phase_boundaries = {(a, b, d): Curve(zip(Bs, mus[a, b, :, i]*a+b))
+        self.phase_boundaries = {(a, b, d): Curve(zip(Bs, mus[a, b, :, i]*a+b, strict=None))
                                  for i in range(10) for a, b, d in coords}
         self.dimensions = ['alpha', 'beta', 'delta']
         self.nesting_hmap = HoloMap(self.phase_boundaries, kdims=self.dimensions)

--- a/holoviews/tests/core/test_layers.py
+++ b/holoviews/tests/core/test_layers.py
@@ -26,7 +26,7 @@ class OverlayTest(CompositeTest):
     def test_overlay_iter(self):
         views = [self.view1, self.view2, self.view3]
         overlay = NdOverlay(list(enumerate(views)))
-        for el, v in zip(overlay, views):
+        for el, v in zip(overlay, views, strict=None):
             self.assertEqual(el, v)
 
     def test_overlay_iterable(self):

--- a/holoviews/tests/core/test_layouts.py
+++ b/holoviews/tests/core/test_layouts.py
@@ -65,7 +65,7 @@ class AdjointLayoutTest(CompositeTest):
 
     def test_adjointlayout_iter(self):
         layout = self.view3 << self.view2 << self.view1
-        for el, view in zip(layout, [self.view3, self.view2, self.view1]):
+        for el, view in zip(layout, [self.view3, self.view2, self.view1], strict=None):
             self.assertEqual(el, view)
 
     def test_adjointlayout_add_operator(self):
@@ -217,25 +217,25 @@ class GridTest(CompositeTest):
     def test_grid_init(self):
         vals = [self.view1, self.view2, self.view3, self.view2]
         keys = [(0,0), (0,1), (1,0), (1,1)]
-        grid = GridSpace(zip(keys, vals))
+        grid = GridSpace(zip(keys, vals, strict=None))
         self.assertEqual(grid.shape, (2,2))
 
     def test_grid_index_snap(self):
         vals = [self.view1, self.view2, self.view3, self.view2]
         keys = [(0,0), (0,1), (1,0), (1,1)]
-        grid = GridSpace(zip(keys, vals))
+        grid = GridSpace(zip(keys, vals, strict=None))
         self.assertEqual(grid[0.1, 0.1], self.view1)
 
     def test_grid_index_strings(self):
         vals = [self.view1, self.view2, self.view3, self.view2]
         keys = [('A', 0), ('B', 1), ('C', 0), ('D', 1)]
-        grid = GridSpace(zip(keys, vals))
+        grid = GridSpace(zip(keys, vals, strict=None))
         self.assertEqual(grid['B', 1], self.view2)
 
     def test_grid_index_one_axis(self):
         vals = [self.view1, self.view2, self.view3, self.view2]
         keys = [('A', 0), ('B', 1), ('C', 0), ('D', 1)]
-        grid = GridSpace(zip(keys, vals))
+        grid = GridSpace(zip(keys, vals, strict=None))
         self.assertEqual(grid[:, 0], GridSpace([(('A', 0), self.view1), (('C', 0), self.view3)]))
 
     def test_gridspace_overlay_element(self):

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -58,7 +58,7 @@ class TestStoreOptsMethod(ComparisonTestCase):
         """
         The new style introduced in #73
         """
-        data = [zip(range(10),range(10)), zip(range(5),range(5))]
+        data = [zip(range(10),range(10), strict=None), zip(range(5),range(5), strict=None)]
         o = Overlay([Curve(c) for c in data]).opts(
             {'Curve.Curve': {'show_grid': False, 'color':'k'}}
         )
@@ -76,7 +76,7 @@ class TestStoreOptsMethod(ComparisonTestCase):
         """
         Complete specification style.
         """
-        data = [zip(range(10),range(10)), zip(range(5),range(5))]
+        data = [zip(range(10),range(10), strict=None), zip(range(5),range(5), strict=None)]
         o = Overlay([Curve(c) for c in data]).opts(
             {'Curve.Curve': {'show_grid':True, 'color':'b'}})
 

--- a/holoviews/tests/element/test_elementconstructors.py
+++ b/holoviews/tests/element/test_elementconstructors.py
@@ -65,7 +65,7 @@ class ElementConstructorTest(ComparisonTestCase):
         self.assertEqual(failed_elements, [])
 
     def test_chart_zipconstruct(self):
-        self.assertEqual(Curve(zip(self.xs, self.sin)), self.curve)
+        self.assertEqual(Curve(zip(self.xs, self.sin, strict=None)), self.curve)
 
     def test_chart_tuple_construct(self):
         self.assertEqual(Curve((self.xs, self.sin)), self.curve)
@@ -77,10 +77,10 @@ class ElementConstructorTest(ComparisonTestCase):
         self.assertEqual(Path([(self.xs, self.sin), (self.xs, self.cos)]), self.path)
 
     def test_path_ziplist_construct(self):
-        self.assertEqual(Path([list(zip(self.xs, self.sin)), list(zip(self.xs, self.cos))]), self.path)
+        self.assertEqual(Path([list(zip(self.xs, self.sin, strict=None)), list(zip(self.xs, self.cos, strict=None))]), self.path)
 
     def test_hist_zip_construct(self):
-        self.assertEqual(Histogram(list(zip(self.hxs, self.sin))), self.histogram)
+        self.assertEqual(Histogram(list(zip(self.hxs, self.sin, strict=None))), self.histogram)
 
     def test_hist_array_construct(self):
         self.assertEqual(Histogram(np.column_stack((self.hxs, self.sin))), self.histogram)

--- a/holoviews/tests/element/test_ellipsis.py
+++ b/holoviews/tests/element/test_ellipsis.py
@@ -57,7 +57,7 @@ class TestEllipsisTable(ComparisonTestCase):
     def setUp(self):
         keys =   [('M',10), ('M',16), ('F',12)]
         values = [(15, 0.8), (18, 0.6), (10, 0.8)]
-        self.table =hv.Table(zip(keys,values),
+        self.table =hv.Table(zip(keys,values, strict=None),
                              kdims = ['Gender', 'Age'],
                              vdims=['Weight', 'Height'])
         super().setUp()

--- a/holoviews/tests/element/test_graphelement.py
+++ b/holoviews/tests/element/test_graphelement.py
@@ -38,7 +38,7 @@ class GraphTests(ComparisonTestCase):
         segments = connect_edges(self.graph)
         paths = []
         nodes = np.column_stack(self.nodes)
-        for start, end in zip(nodes[self.source], nodes[self.target]):
+        for start, end in zip(nodes[self.source], nodes[self.target], strict=None):
             paths.append(np.array([start[:2], end[:2]]))
         self.assertEqual(segments, paths)
 
@@ -69,7 +69,7 @@ class GraphTests(ComparisonTestCase):
         segments = connect_edges_pd(self.graph)
         paths = []
         nodes = np.column_stack(self.nodes)
-        for start, end in zip(nodes[self.source], nodes[self.target]):
+        for start, end in zip(nodes[self.source], nodes[self.target], strict=None):
             paths.append(np.array([start[:2], end[:2]]))
         self.assertEqual(segments, paths)
 
@@ -89,32 +89,32 @@ class GraphTests(ComparisonTestCase):
 
     def test_select_by_node_in_edges_selection_mode(self):
         graph = Graph(((self.source, self.target),))
-        selection = Graph(([(1, 0), (2, 0)], list(zip(*self.nodes))[0:3]))
+        selection = Graph(([(1, 0), (2, 0)], list(zip(*self.nodes, strict=None))[0:3]))
         self.assertEqual(graph.select(index=(1, 3)), selection)
 
     def test_select_by_node_in_nodes_selection_mode(self):
         graph = Graph(((self.source, self.source+1), self.nodes))
-        selection = Graph(([(1, 2)], list(zip(*self.nodes))[1:3]))
+        selection = Graph(([(1, 2)], list(zip(*self.nodes, strict=None))[1:3]))
         self.assertEqual(graph.select(index=(1, 3), selection_mode='nodes'), selection)
 
     def test_select_by_source(self):
         graph = Graph(((self.source, self.target),))
-        selection = Graph(([(0,0), (1, 0)], list(zip(*self.nodes))[:2]))
+        selection = Graph(([(0,0), (1, 0)], list(zip(*self.nodes, strict=None))[:2]))
         self.assertEqual(graph.select(start=(0, 2)), selection)
 
     def test_select_by_target(self):
         graph = Graph(((self.source, self.target),))
-        selection = Graph(([(0,0), (1, 0)], list(zip(*self.nodes))[:2]))
+        selection = Graph(([(0,0), (1, 0)], list(zip(*self.nodes, strict=None))[:2]))
         self.assertEqual(graph.select(start=(0, 2)), selection)
 
     def test_select_by_source_and_target(self):
         graph = Graph(((self.source, self.source+1), self.nodes))
-        selection = Graph(([(0,1)], list(zip(*self.nodes))[:2]))
+        selection = Graph(([(0,1)], list(zip(*self.nodes, strict=None))[:2]))
         self.assertEqual(graph.select(start=(0, 3), end=1), selection)
 
     def test_select_by_edge_data(self):
         graph = Graph(((self.target, self.source, self.edge_info),), vdims=['info'])
-        selection = Graph(([(0, 0, 0), (0, 1, 1)], list(zip(*self.nodes))[:2]), vdims=['info'])
+        selection = Graph(([(0, 0, 0), (0, 1, 1)], list(zip(*self.nodes, strict=None))[:2]), vdims=['info'])
         self.assertEqual(graph.select(info=(0, 2)), selection)
 
     def test_graph_node_range(self):
@@ -258,7 +258,7 @@ class TriMeshTests(ComparisonTestCase):
         self.assertEqual(trimesh.nodes.array(), np.empty((0, 3)))
 
     def test_trimesh_constructor_tuple_nodes(self):
-        nodes = tuple(zip(*self.nodes))[:2]
+        nodes = tuple(zip(*self.nodes, strict=None))[:2]
         trimesh = TriMesh((self.simplices, nodes))
         self.assertEqual(trimesh.array(), np.array(self.simplices))
         self.assertEqual(trimesh.nodes.array([0, 1]), np.array(nodes).T)
@@ -283,7 +283,7 @@ class TriMeshTests(ComparisonTestCase):
         trimesh = TriMesh((self.simplices, self.nodes))
         paths = [np.array([(0, 0), (0.5, 1), (1, 0), (0, 0), (np.nan, np.nan),
                  (0.5, 1), (1, 0), (1.5, 1), (0.5, 1)])]
-        for p1, p2 in zip(trimesh.edgepaths.split(datatype='array'), paths):
+        for p1, p2 in zip(trimesh.edgepaths.split(datatype='array'), paths, strict=None):
             self.assertEqual(p1, p2)
 
     def test_trimesh_select(self):

--- a/holoviews/tests/element/test_raster.py
+++ b/holoviews/tests/element/test_raster.py
@@ -64,7 +64,7 @@ class TestRGB(ComparisonTestCase):
     def test_not_using_class_variables_vdims(self):
         init_vdims = RGB(self.rgb_array).vdims
         cls_vdims = RGB.vdims
-        for i, c in zip(init_vdims, cls_vdims):
+        for i, c in zip(init_vdims, cls_vdims, strict=None):
             assert i is not c
             assert i == c
 
@@ -89,7 +89,7 @@ class TestHSV(ComparisonTestCase):
     def test_not_using_class_variables_vdims(self):
             init_vdims = HSV(self.hsv_array).vdims
             cls_vdims = HSV.vdims
-            for i, c in zip(init_vdims, cls_vdims):
+            for i, c in zip(init_vdims, cls_vdims, strict=None):
                 assert i is not c
                 assert i == c
 

--- a/holoviews/tests/plotting/bokeh/test_areaplot.py
+++ b/holoviews/tests/plotting/bokeh/test_areaplot.py
@@ -159,5 +159,5 @@ class TestAreaPlot(LoggingComparisonTestCase, TestBokehPlot):
         overlay = Overlay([Area(df, kdims='x', vdims=col, label=col) for col in ['y_1', 'y_2', 'y_3']])
         plot = Area.stack(overlay)
         baselines = [np.array([0, 0, 0]), np.array([1., 2., 3.]), np.array([7., 6., 5.])]
-        for n, baseline in zip(plot.data, baselines):
+        for n, baseline in zip(plot.data, baselines, strict=None):
             self.assertEqual(plot.data[n].data.Baseline.to_numpy(), baseline)

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -282,7 +282,7 @@ class TestBarPlot(TestBokehPlot):
         colors = ['blue', 'red']
         overlay = NdOverlay({color: Bars(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Bars', fill_color='Color')
         plot = bokeh_renderer.get_plot(overlay)
-        for subplot, color in zip(plot.subplots.values(),  colors):
+        for subplot, color in zip(plot.subplots.values(),  colors, strict=None):
             self.assertEqual(subplot.handles['glyph'].fill_color, color)
 
     def test_bars_color_index_color_clash(self):

--- a/holoviews/tests/plotting/bokeh/test_curveplot.py
+++ b/holoviews/tests/plotting/bokeh/test_curveplot.py
@@ -51,7 +51,7 @@ class TestCurvePlot(TestBokehPlot):
                         for i in range(3)})
         colors = palette[3].values
         plot = bokeh_renderer.get_plot(hmap)
-        for subp, color in zip(plot.subplots.values(), colors):
+        for subp, color in zip(plot.subplots.values(), colors, strict=None):
             color = color if isinstance(color, str) else rgb2hex(color)
             self.assertEqual(subp.handles['glyph'].line_color, color)
 
@@ -361,7 +361,7 @@ class TestCurvePlot(TestBokehPlot):
                              for i, color in enumerate(colors)},
                             'color').opts('Curve', color='color')
         plot = bokeh_renderer.get_plot(overlay)
-        for subplot, color in zip(plot.subplots.values(), colors):
+        for subplot, color in zip(plot.subplots.values(), colors, strict=None):
             style = dict(subplot.style[subplot.cyclic_index])
             style = subplot._apply_transforms(subplot.current_frame, {}, {}, style)
             self.assertEqual(style['color'], color)

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -904,7 +904,7 @@ class TestScalebarPlot:
         scalebars = [next(sb) if e else None for e in enabled]
         assert sum(map(bool, scalebars)) == sum(enabled)
 
-        for coordinate, scalebar, idx in zip(coordinates, scalebars, "123"):
+        for coordinate, scalebar, idx in zip(coordinates, scalebars, "123", strict=None):
             assert coordinate.y_source.name == f"c{idx}"
             if scalebar is None:
                 continue

--- a/holoviews/tests/plotting/bokeh/test_histogramplot.py
+++ b/holoviews/tests/plotting/bokeh/test_histogramplot.py
@@ -259,5 +259,5 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         colors = ['blue', 'red']
         overlay = NdOverlay({color: Histogram(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Histogram', fill_color='Color')
         plot = bokeh_renderer.get_plot(overlay)
-        for subplot, color in zip(plot.subplots.values(),  colors):
+        for subplot, color in zip(plot.subplots.values(),  colors, strict=None):
             self.assertEqual(subplot.handles['glyph'].fill_color, color)

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -208,7 +208,7 @@ class TestLinkCallbacks(TestBokehPlot):
     def test_data_link_nan(self):
         arr = np.random.rand(3, 5)
         arr[0, 0] = np.nan
-        data = {k: v for k, v in zip(['x', 'y', 'z'], arr)}
+        data = {k: v for k, v in zip(['x', 'y', 'z'], arr, strict=None)}
         a = Scatter(data, 'x', 'z')
         b = Scatter(data, 'x', 'y')
         DataLink(a, b)

--- a/holoviews/tests/plotting/bokeh/test_overlayplot.py
+++ b/holoviews/tests/plotting/bokeh/test_overlayplot.py
@@ -194,7 +194,7 @@ class TestOverlayPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(x_range.factors, ['A', 'B', 'C', 'D', 'E'])
         self.assertIsInstance(y_range, Range1d)
         error_plot = plot.subplots[('ErrorBars', 'I')]
-        for xs, factor in zip(error_plot.handles['source'].data['base'], factors):
+        for xs, factor in zip(error_plot.handles['source'].data['base'], factors, strict=None):
             self.assertEqual(factor, xs)
 
     def test_overlay_categorical_two_level(self):

--- a/holoviews/tests/plotting/bokeh/test_pathplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pathplot.py
@@ -167,7 +167,7 @@ class TestPathPlot(TestBokehPlot):
         colors = ["#FF0000", "#00FF00", "#0000FF"]
         levels=[0,1,2,3]
 
-        path = Path(data, vdims="cat").opts(color="cat", cmap=dict(zip(levels, colors)), line_width=4, show_legend=True)
+        path = Path(data, vdims="cat").opts(color="cat", cmap=dict(zip(levels, colors, strict=None)), line_width=4, show_legend=True)
         plot = bokeh_renderer.get_plot(path)
         item = plot.state.legend[0].items[0]
         legend = {'field': 'color_str__'}
@@ -184,7 +184,7 @@ class TestPathPlot(TestBokehPlot):
         colors = ["#FF0000", "#00FF00", "#0000FF"]
         levels=[0,1,2,3]
 
-        path = Path(data, vdims="cat").opts(color="cat", cmap=dict(zip(levels, colors)), line_width=4, show_legend=True, legend_labels={0: 'A', 1: 'B', 2: 'C'})
+        path = Path(data, vdims="cat").opts(color="cat", cmap=dict(zip(levels, colors, strict=None)), line_width=4, show_legend=True, legend_labels={0: 'A', 1: 'B', 2: 'C'})
         plot = bokeh_renderer.get_plot(path)
         cds = plot.handles['cds']
         item = plot.state.legend[0].items[0]
@@ -561,7 +561,7 @@ class TestDendrogramPlot(TestBokehPlot):
         assert len(source.data['ys']) == 0
 
     def test_plot(self):
-        dendrogram = Dendrogram(zip(self.x, self.y))
+        dendrogram = Dendrogram(zip(self.x, self.y, strict=None))
         plot = bokeh_renderer.get_plot(dendrogram)
         source = plot.handles['source']
         assert len(source.data['xs']) == 4
@@ -576,7 +576,7 @@ class TestDendrogramPlot(TestBokehPlot):
 
     def test_plot_equals_path_zip(self):
         dendrogram = Dendrogram(self.x, self.y)
-        path = Path(zip(self.x, self.y))
+        path = Path(zip(self.x, self.y, strict=None))
         dendro_plot = bokeh_renderer.get_plot(dendrogram)
         dendro_source = dendro_plot.handles['source']
         path_plot = bokeh_renderer.get_plot(path)
@@ -617,7 +617,7 @@ class TestDendrogramPlot(TestBokehPlot):
 
     def test_1_adjoint_plot_2_kdims(self):
         dendrogram = Dendrogram(self.x, self.y)
-        main = Path(zip(self.x, self.y))
+        main = Path(zip(self.x, self.y, strict=None))
         adjoint = main << dendrogram
         top, main, right = self.get_childrens(adjoint)
         assert top is None

--- a/holoviews/tests/plotting/bokeh/test_pointplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pointplot.py
@@ -501,7 +501,7 @@ class TestPointPlot(TestBokehPlot):
         markers = ['circle', 'triangle']
         overlay = NdOverlay({marker: Points(np.arange(i)) for i, marker in enumerate(markers)}, 'Marker').opts('Points', marker='Marker')
         plot = bokeh_renderer.get_plot(overlay)
-        for subplot, glyph_type, marker in zip(plot.subplots.values(), [Scatter, Scatter], markers):
+        for subplot, glyph_type, marker in zip(plot.subplots.values(), [Scatter, Scatter], markers, strict=None):
             self.assertIsInstance(subplot.handles['glyph'], glyph_type)
             self.assertEqual(subplot.handles['glyph'].marker, marker)
 

--- a/holoviews/tests/plotting/bokeh/test_radialheatmap.py
+++ b/holoviews/tests/plotting/bokeh/test_radialheatmap.py
@@ -18,7 +18,7 @@ class BokehRadialHeatMapPlotTests(TestBokehPlot):
         x = [f"Seg {idx}" for idx in range(2)]
         y = [f"Ann {idx}" for idx in range(2)]
         self.z = list(range(4))
-        self.x, self.y = zip(*product(x, y))
+        self.x, self.y = zip(*product(x, y), strict=None)
 
         self.ann_bins = {"o1": np.array([0.5, 0.75]),
                          "o2": np.array([0.75, 1])}
@@ -229,7 +229,7 @@ class BokehRadialHeatMapPlotTests(TestBokehPlot):
         cmp_mark_data = self.plot._get_xmarks_data(["o1"], self.seg_bins)
 
         for sub_list in ["xs", "ys"]:
-            test_pairs = zip(test_mark_data[sub_list], cmp_mark_data[sub_list])
+            test_pairs = zip(test_mark_data[sub_list], cmp_mark_data[sub_list], strict=None)
             for test_value, cmp_value in test_pairs:
                 self.assertEqual(np.array(test_value), np.array(cmp_value))
 

--- a/holoviews/tests/plotting/bokeh/test_spikesplot.py
+++ b/holoviews/tests/plotting/bokeh/test_spikesplot.py
@@ -227,7 +227,7 @@ class TestSpikesPlot(TestBokehPlot):
         colors = ['blue', 'red']
         overlay = NdOverlay({color: Spikes(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Spikes', color='Color')
         plot = bokeh_renderer.get_plot(overlay)
-        for subplot, color in zip(plot.subplots.values(),  colors):
+        for subplot, color in zip(plot.subplots.values(),  colors, strict=None):
             self.assertEqual(subplot.handles['glyph'].line_color, color)
 
     def test_spikes_color_index_color_clash(self):

--- a/holoviews/tests/plotting/bokeh/test_subcoordy.py
+++ b/holoviews/tests/plotting/bokeh/test_subcoordy.py
@@ -382,7 +382,7 @@ class TestSubcoordinateY(TestBokehPlot):
         zoom_tools = [tool for tool in plot.state.tools if isinstance(tool, WheelZoomTool)]
         assert zoom_tools == plot.handles['zooms_subcoordy']['wheel_zoom']
         assert len(zoom_tools) == len(groups)
-        for zoom_tool, group in zip(zoom_tools, reversed(groups)):
+        for zoom_tool, group in zip(zoom_tools, reversed(groups), strict=None):
             assert len(zoom_tool.renderers) == 2
             assert len(set(zoom_tool.renderers)) == 2
             assert zoom_tool.dimensions == 'height'

--- a/holoviews/tests/plotting/bokeh/test_tabular.py
+++ b/holoviews/tests/plotting/bokeh/test_tabular.py
@@ -37,7 +37,7 @@ class TestBokehTablePlot(ComparisonTestCase):
         dims = table.dimensions()
         formatters = (NumberFormatter, NumberFormatter, StringFormatter)
         editors = (IntEditor, NumberEditor, StringEditor)
-        for dim, fmt, edit, column in zip(dims, formatters, editors, plot.state.columns):
+        for dim, fmt, edit, column in zip(dims, formatters, editors, plot.state.columns, strict=None):
             self.assertEqual(column.title, dim.pprint_label)
             self.assertIsInstance(column.formatter, fmt)
             self.assertIsInstance(column.editor, edit)

--- a/holoviews/tests/plotting/matplotlib/test_annotationplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_annotationplot.py
@@ -23,7 +23,7 @@ class TestHVLinesPlot(TestMPLPlot):
 
         sources = plot.handles["annotations"]
         assert len(sources) == 4
-        for source, val in zip(sources, hlines.data["y"]):
+        for source, val in zip(sources, hlines.data["y"], strict=None):
             assert source.get_data() == ([0, 1], [val, val])
 
     def test_hlines_array(self):
@@ -39,7 +39,7 @@ class TestHVLinesPlot(TestMPLPlot):
 
         sources = plot.handles["annotations"]
         assert len(sources) == 4
-        for source, val in zip(sources, hlines.data):
+        for source, val in zip(sources, hlines.data, strict=None):
             assert source.get_data() == ([0, 1], [val, val])
 
     def test_hlines_plot_invert_axes(self):
@@ -57,7 +57,7 @@ class TestHVLinesPlot(TestMPLPlot):
 
         sources = plot.handles["annotations"]
         assert len(sources) == 4
-        for source, val in zip(sources, hlines.data["y"]):
+        for source, val in zip(sources, hlines.data["y"], strict=None):
             assert source.get_data() == ([val, val], [0, 1])
 
     def test_hlines_nondefault_kdim(self):
@@ -73,7 +73,7 @@ class TestHVLinesPlot(TestMPLPlot):
 
         sources = plot.handles["annotations"]
         assert len(sources) == 4
-        for source, val in zip(sources, hlines.data["other"]):
+        for source, val in zip(sources, hlines.data["other"], strict=None):
             assert source.get_data() == ([0, 1], [val, val])
 
     def test_vlines_plot(self):
@@ -91,7 +91,7 @@ class TestHVLinesPlot(TestMPLPlot):
 
         sources = plot.handles["annotations"]
         assert len(sources) == 4
-        for source, val in zip(sources, vlines.data["x"]):
+        for source, val in zip(sources, vlines.data["x"], strict=None):
             assert source.get_data() == ([val, val], [0, 1])
 
     def test_vlines_plot_invert_axes(self):
@@ -109,7 +109,7 @@ class TestHVLinesPlot(TestMPLPlot):
 
         sources = plot.handles["annotations"]
         assert len(sources) == 4
-        for source, val in zip(sources, vlines.data["x"]):
+        for source, val in zip(sources, vlines.data["x"], strict=None):
             assert source.get_data() == ([0, 1], [val, val])
 
     def test_vlines_nondefault_kdim(self):
@@ -125,7 +125,7 @@ class TestHVLinesPlot(TestMPLPlot):
 
         sources = plot.handles["annotations"]
         assert len(sources) == 4
-        for source, val in zip(sources, vlines.data["other"]):
+        for source, val in zip(sources, vlines.data["other"], strict=None):
             assert source.get_data() == ([val, val], [0, 1])
 
     def test_vlines_hlines_overlay(self):
@@ -146,10 +146,10 @@ class TestHVLinesPlot(TestMPLPlot):
         assert np.allclose(ylim, (0, 5.5))
 
         sources = plot.handles["fig"].axes[0].get_children()
-        for source, val in zip(sources[:4], hlines.data["y"]):
+        for source, val in zip(sources[:4], hlines.data["y"], strict=None):
             assert source.get_data() == ([0, 1], [val, val])
 
-        for source, val in zip(sources[4:], vlines.data["x"]):
+        for source, val in zip(sources[4:], vlines.data["x"], strict=None):
             assert source.get_data() == ([val, val], [0, 1])
 
 
@@ -189,7 +189,7 @@ class TestHVSpansPlot(TestMPLPlot):
 
         sources = plot.handles["annotations"]
         assert len(sources) == 3
-        for source, v0, v1 in zip(sources, hspans.data["y0"], hspans.data["y1"]):
+        for source, v0, v1 in zip(sources, hspans.data["y0"], hspans.data["y1"], strict=None):
             self._hspans_check(source, v0, v1)
 
     def test_hspans_inverse_plot(self):
@@ -208,7 +208,7 @@ class TestHVSpansPlot(TestMPLPlot):
 
         sources = plot.handles["annotations"]
         assert len(sources) == 3
-        for source, v0, v1 in zip(sources, hspans.data["y0"], hspans.data["y1"]):
+        for source, v0, v1 in zip(sources, hspans.data["y0"], hspans.data["y1"], strict=None):
             self._vspans_check(source, v0, v1)
 
     def test_dynamicmap_overlay_hspans(self):
@@ -242,7 +242,7 @@ class TestHVSpansPlot(TestMPLPlot):
         sources = plot.handles["annotations"]
         assert len(sources) == 3
         for source, v0, v1 in zip(
-            sources, hspans.data["other0"], hspans.data["other1"]
+            sources, hspans.data["other0"], hspans.data["other1"], strict=None
         ):
             self._hspans_check(source, v0, v1)
 
@@ -262,7 +262,7 @@ class TestHVSpansPlot(TestMPLPlot):
 
         sources = plot.handles["annotations"]
         assert len(sources) == 3
-        for source, v0, v1 in zip(sources, vspans.data["x0"], vspans.data["x1"]):
+        for source, v0, v1 in zip(sources, vspans.data["x0"], vspans.data["x1"], strict=None):
             self._vspans_check(source, v0, v1)
 
     def test_vspans_inverse_plot(self):
@@ -281,7 +281,7 @@ class TestHVSpansPlot(TestMPLPlot):
 
         sources = plot.handles["annotations"]
         assert len(sources) == 3
-        for source, v0, v1 in zip(sources, vspans.data["x0"], vspans.data["x1"]):
+        for source, v0, v1 in zip(sources, vspans.data["x0"], vspans.data["x1"], strict=None):
             self._hspans_check(source, v0, v1)
 
     def test_vspans_nondefault_kdims(self):
@@ -300,7 +300,7 @@ class TestHVSpansPlot(TestMPLPlot):
         sources = plot.handles["annotations"]
         assert len(sources) == 3
         for source, v0, v1 in zip(
-            sources, vspans.data["other0"], vspans.data["other1"]
+            sources, vspans.data["other0"], vspans.data["other1"], strict=None
         ):
             self._vspans_check(source, v0, v1)
 
@@ -323,10 +323,10 @@ class TestHVSpansPlot(TestMPLPlot):
         assert np.allclose(ylim, (0, 6.5))
 
         sources = plot.handles["fig"].axes[0].get_children()
-        for source, v0, v1 in zip(sources[:3], hspans.data["y0"], hspans.data["y1"]):
+        for source, v0, v1 in zip(sources[:3], hspans.data["y0"], hspans.data["y1"], strict=None):
             self._hspans_check(source, v0, v1)
 
-        for source, v0, v1 in zip(sources[3:6], vspans.data["x0"], vspans.data["x1"]):
+        for source, v0, v1 in zip(sources[3:6], vspans.data["x0"], vspans.data["x1"], strict=None):
             self._vspans_check(source, v0, v1)
 
     def test_dynamicmap_overlay_vspans(self):

--- a/holoviews/tests/plotting/matplotlib/test_areaplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_areaplot.py
@@ -105,5 +105,5 @@ class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
         overlay = Overlay([Area(df, kdims='x', vdims=col, label=col) for col in ['y_1', 'y_2', 'y_3']])
         plot = Area.stack(overlay)
         baselines = [np.array([0, 0, 0]), np.array([1., 2., 3.]), np.array([7., 6., 5.])]
-        for n, baseline in zip(plot.data, baselines):
+        for n, baseline in zip(plot.data, baselines, strict=None):
             self.assertEqual(plot.data[n].data.Baseline.to_numpy(), baseline)

--- a/holoviews/tests/plotting/matplotlib/test_curveplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_curveplot.py
@@ -161,7 +161,7 @@ class TestCurvePlot(TestMPLPlot):
                              for i, color in enumerate(colors)},
                             'color').opts('Curve', color='color')
         plot = mpl_renderer.get_plot(overlay)
-        for subplot, color in zip(plot.subplots.values(), colors):
+        for subplot, color in zip(plot.subplots.values(), colors, strict=None):
             style = dict(subplot.style[subplot.cyclic_index])
             style = subplot._apply_transforms(subplot.current_frame, {}, style)
             self.assertEqual(style['color'], color)

--- a/holoviews/tests/plotting/matplotlib/test_histogramplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_histogramplot.py
@@ -112,7 +112,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         plot = mpl_renderer.get_plot(histogram)
         artist = plot.handles['artist']
         children = artist.get_children()
-        for c, w in zip(children, ['#000000', '#FF0000', '#00FF00']):
+        for c, w in zip(children, ['#000000', '#FF0000', '#00FF00'], strict=None):
             self.assertEqual(c.get_facecolor(), (*(c / 255.0 for c in hex2rgb(w)), 1))
 
     def test_histogram_linear_color_op(self):
@@ -152,7 +152,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         plot = mpl_renderer.get_plot(histogram)
         artist = plot.handles['artist']
         children = artist.get_children()
-        for c, w in zip(children, np.array([1, 4, 8])):
+        for c, w in zip(children, np.array([1, 4, 8]), strict=None):
             self.assertEqual(c.get_linewidth(), w)
 
     def test_op_ndoverlay_value(self):
@@ -163,7 +163,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
                              )
         plot = mpl_renderer.get_plot(overlay)
         colors = [(0, 0, 1, 1), (1, 0, 0, 1)]
-        for subplot, color in zip(plot.subplots.values(),  colors):
+        for subplot, color in zip(plot.subplots.values(),  colors, strict=None):
             children = subplot.handles['artist'].get_children()
             for c in children:
                 self.assertEqual(c.get_facecolor(), color)

--- a/holoviews/tests/plotting/matplotlib/test_layoutplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_layoutplot.py
@@ -35,7 +35,7 @@ class TestLayoutPlot(LoggingComparisonTestCase, TestMPLPlot):
         positions = [(0, 0), (0, 1), (1, 0), (2, 0), (3, 0)]
         self.assertEqual(sorted(plot.subplots.keys()), positions)
         nums = [1, 5, 2, 3, 4]
-        for pos, num in zip(positions, nums):
+        for pos, num in zip(positions, nums, strict=None):
             adjoint = plot.subplots[pos]
             if 'main' in adjoint.subplots:
                 self.assertEqual(adjoint.subplots['main'].layout_num, num)

--- a/holoviews/tests/plotting/matplotlib/test_pointplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pointplot.py
@@ -312,7 +312,7 @@ class TestPointPlot(TestMPLPlot):
                              for i, marker in enumerate(markers)},
                             'Marker').opts('Points', marker='Marker')
         plot = mpl_renderer.get_plot(overlay)
-        for subplot, marker in zip(plot.subplots.values(), markers):
+        for subplot, marker in zip(plot.subplots.values(), markers, strict=None):
             style = dict(subplot.style[subplot.cyclic_index])
             style = subplot._apply_transforms(subplot.current_frame, {}, style)
             self.assertEqual(style['marker'], marker)

--- a/holoviews/tests/plotting/matplotlib/test_radialheatmap.py
+++ b/holoviews/tests/plotting/matplotlib/test_radialheatmap.py
@@ -22,7 +22,7 @@ class RadialHeatMapPlotTests(TestMPLPlot):
         x = [f"Seg {idx}" for idx in range(2)]
         y = [f"Ann {idx}" for idx in range(2)]
         self.z = list(range(4))
-        self.x, self.y = zip(*product(x, y))
+        self.x, self.y = zip(*product(x, y), strict=None)
 
         self.wedge_data = [((0.5, 0.5), 0.125, 0.375, 180.0, 360.0),
                            ((0.5, 0.5), 0.125, 0.375,   0.0, 180.0),
@@ -48,7 +48,7 @@ class RadialHeatMapPlotTests(TestMPLPlot):
         plot = mpl_renderer.get_plot(self.element)
         data, style, ticks = plot.get_data(self.element, {'z': {'combined': (0, 3)}}, {})
         wedges = data['annular']
-        for wedge, wdata in zip(wedges, self.wedge_data):
+        for wedge, wdata in zip(wedges, self.wedge_data, strict=None):
             self.assertEqual((wedge.center, wedge.width, wedge.r,
                               wedge.theta1, wedge.theta2), wdata)
         self.assertEqual(ticks['xticks'], self.xticks)
@@ -68,7 +68,7 @@ class RadialHeatMapPlotTests(TestMPLPlot):
         plot = mpl_renderer.get_plot(self.element.opts(ymarks=4))
         data, style, ticks = plot.get_data(self.element, {'z': {'combined': (0, 3)}}, {})
         yseparators = data['yseparator']
-        for circle, r in zip(yseparators, [0.25, 0.375]):
+        for circle, r in zip(yseparators, [0.25, 0.375], strict=None):
             self.assertEqual(circle.radius, r)
 
     def test_heatmap_holomap(self):

--- a/holoviews/tests/plotting/matplotlib/test_spikeplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_spikeplot.py
@@ -186,7 +186,7 @@ class TestSpikesPlot(TestMPLPlot):
                              )
         plot = mpl_renderer.get_plot(overlay)
         colors = [(0, 0, 1, 1), (1, 0, 0, 1)]
-        for subplot, color in zip(plot.subplots.values(),  colors):
+        for subplot, color in zip(plot.subplots.values(),  colors, strict=None):
             children = subplot.handles['artist'].get_children()
             for c in children:
                 self.assertEqual(c.get_facecolor(), color)

--- a/holoviews/tests/plotting/matplotlib/test_violinplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_violinplot.py
@@ -27,7 +27,7 @@ class TestMPLViolinPlot(TestMPLPlot):
         p1, p2 = plot.subplots.values()
         self.assertEqual(p1.handles['boxes'][0].get_path().vertices,
                          p2.handles['boxes'][0].get_path().vertices)
-        for b1, b2 in zip(p1.handles['bodies'][0].get_paths(), p2.handles['bodies'][0].get_paths()):
+        for b1, b2 in zip(p1.handles['bodies'][0].get_paths(), p2.handles['bodies'][0].get_paths(), strict=None):
             self.assertEqual(b1.vertices, b2.vertices)
 
     def test_violin_multi(self):

--- a/holoviews/tests/plotting/plotly/test_areaplot.py
+++ b/holoviews/tests/plotting/plotly/test_areaplot.py
@@ -62,5 +62,5 @@ class TestAreaPlot(TestPlotlyPlot):
         overlay = Overlay([Area(df, kdims='x', vdims=col, label=col) for col in ['y_1', 'y_2', 'y_3']])
         plot = Area.stack(overlay)
         baselines = [np.array([0, 0, 0]), np.array([1., 2., 3.]), np.array([7., 6., 5.])]
-        for n, baseline in zip(plot.data, baselines):
+        for n, baseline in zip(plot.data, baselines, strict=None):
             self.assertEqual(plot.data[n].data.Baseline.to_numpy(), baseline)

--- a/holoviews/tests/plotting/plotly/test_callbacks.py
+++ b/holoviews/tests/plotting/plotly/test_callbacks.py
@@ -290,7 +290,7 @@ class TestCallbacks(TestCase):
         for xystream, xstream, ystream in zip(
                 xystreamss[0] + xystreamss[1],
                 xstreamss[0] + xstreamss[1],
-                ystreamss[0] + ystreamss[1],
+                ystreamss[0] + ystreamss[1], strict=None,
         ):
             assert xystream.x_range == (1, 4)
             assert xystream.y_range == (-1, 5)
@@ -301,7 +301,7 @@ class TestCallbacks(TestCase):
         for xystream, xstream, ystream in zip(
                 xystreamss[2] + xystreamss[3],
                 xstreamss[2] + xstreamss[3],
-                ystreamss[2] + ystreamss[3],
+                ystreamss[2] + ystreamss[3], strict=None,
         ):
             assert xystream.x_range is None
             assert xystream.y_range is None
@@ -317,7 +317,7 @@ class TestCallbacks(TestCase):
 
         # Check that all streams attached to 'third' were triggered
         for xystream, xstream, ystream in zip(
-                xystreamss[2], xstreamss[2], ystreamss[2]
+                xystreamss[2], xstreamss[2], ystreamss[2], strict=None
         ):
             assert xystream.x_range == (2, 5)
             assert xystream.y_range == (0, 6)
@@ -333,7 +333,7 @@ class TestCallbacks(TestCase):
 
         # Check that all streams attached to 'forth' were triggered
         for xystream, xstream, ystream in zip(
-                xystreamss[3], xstreamss[3], ystreamss[3]
+                xystreamss[3], xstreamss[3], ystreamss[3], strict=None
         ):
             assert xystream.x_range == (3, 6)
             assert xystream.y_range == (1, 7)
@@ -342,7 +342,7 @@ class TestCallbacks(TestCase):
 
         # Check that streams attached to a trace not in this plot are not triggered
         for xyevent, xevent, yevent in zip(
-                xyevents[4], xevents[4], yevents[4]
+                xyevents[4], xevents[4], yevents[4], strict=None
         ):
             assert len(xyevent) == 0
             assert len(xevent) == 0
@@ -473,7 +473,7 @@ class TestCallbacks(TestCase):
         for xystream, xstream, ystream in zip(
                 xystreamss[0] + xystreamss[1],
                 xstreamss[0] + xstreamss[1],
-                ystreamss[0] + ystreamss[1],
+                ystreamss[0] + ystreamss[1], strict=None,
         ):
             assert xystream.bounds == (1, -1, 4, 5)
             assert xstream.boundsx == (1, 4)
@@ -484,7 +484,7 @@ class TestCallbacks(TestCase):
         for xystream, xstream, ystream in zip(
                 xystreamss[2] + xystreamss[3],
                 xstreamss[2] + xstreamss[3],
-                ystreamss[2] + ystreamss[3],
+                ystreamss[2] + ystreamss[3], strict=None,
         ):
             assert xystream.bounds is None
             assert xstream.boundsx is None
@@ -499,7 +499,7 @@ class TestCallbacks(TestCase):
 
         # Check that all streams attached to 'second' were triggered
         for xystream, xstream, ystream in zip(
-                xystreamss[2], xstreamss[2], ystreamss[2],
+                xystreamss[2], xstreamss[2], ystreamss[2], strict=None,
         ):
             assert xystream.bounds == (2, 0, 5, 6)
             assert xstream.boundsx == (2, 5)
@@ -514,7 +514,7 @@ class TestCallbacks(TestCase):
 
         # Check that all streams attached to 'third' were triggered
         for xystream, xstream, ystream in zip(
-                xystreamss[3], xstreamss[3], ystreamss[3],
+                xystreamss[3], xstreamss[3], ystreamss[3], strict=None,
         ):
             assert xystream.bounds == (3, 1, 6, 7)
             assert xstream.boundsx == (3, 6)
@@ -532,7 +532,7 @@ class TestCallbacks(TestCase):
         for xystream, xstream, ystream in zip(
                 xystreamss[0] + xystreamss[1] + xystreamss[2] + xystreamss[3],
                 xstreamss[0] + xstreamss[1] + xstreamss[2] + xstreamss[3],
-                ystreamss[0] + ystreamss[1] + ystreamss[2] + ystreamss[3],
+                ystreamss[0] + ystreamss[1] + ystreamss[2] + ystreamss[3], strict=None,
         ):
             assert xystream.bounds is None
             assert xstream.boundsx is None
@@ -540,7 +540,7 @@ class TestCallbacks(TestCase):
 
         # Check that streams attached to plots not in this figure are not called
         for xyevent, xevent, yevent in zip(
-                xyevents[4], xevents[4], yevents[4]
+                xyevents[4], xevents[4], yevents[4], strict=None
         ):
             assert xyevent == []
             assert xevent == []
@@ -595,7 +595,7 @@ class TestCallbacks(TestCase):
         )
 
         # Check that all streams attached to the 'first' plots were triggered
-        for stream, events in zip(streamss[0], sel_events[0]):
+        for stream, events in zip(streamss[0], sel_events[0], strict=None):
             assert stream.index == [0, 2]
             assert len(events) == 1
 
@@ -638,9 +638,9 @@ class TestCallbacks(TestCase):
         )
 
         # Check that all streams attached to the 'forth' plot were triggered
-        for stream, _events in zip(streamss[3], sel_events[3]):
+        for stream, _events in zip(streamss[3], sel_events[3], strict=None):
             assert stream.index == [0, 2]
 
         # Check that streams attached to plots not in this figure are not called
-        for _stream, events in zip(streamss[4], sel_events[4]):
+        for _stream, events in zip(streamss[4], sel_events[4], strict=None):
             assert len(events) == 0

--- a/holoviews/tests/plotting/plotly/test_shapeplots.py
+++ b/holoviews/tests/plotting/plotly/test_shapeplots.py
@@ -132,7 +132,7 @@ class TestPathShape(TestShape):
         # Check svg path
         expected_path = 'M' + 'L'.join([
             f'{x} {y}' for x, y in
-            zip(element.dimension_values(0), element.dimension_values(1))]) + 'Z'
+            zip(element.dimension_values(0), element.dimension_values(1), strict=None)]) + 'Z'
 
         self.assertEqual(shape['path'], expected_path)
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -1086,8 +1086,8 @@ class Dynamic(param.ParameterizedFunction):
             if isinstance(hmap, Overlay):
                 dmap.callback.inputs[:] = list(hmap)
             return dmap
-        dim_values = zip(*hmap.data.keys())
+        dim_values = zip(*hmap.data.keys(), strict=None)
         params = util.get_param_values(hmap)
         kdims = [d.clone(values=list(util.unique_iterator(values))) for d, values in
-                 zip(hmap.kdims, dim_values)]
+                 zip(hmap.kdims, dim_values, strict=None)]
         return DynamicMap(dynamic_fn, streams=streams, **dict(params, kdims=kdims))

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -142,7 +142,7 @@ def bin(values, bins, labels=None):
         labels = np.asarray(labels)
     dtype = 'float' if labels.dtype.kind == 'f' else 'O'
     binned = np.full_like(values, (np.nan if dtype == 'f' else None), dtype=dtype)
-    for lower, upper, label in zip(bins[:-1], bins[1:], labels):
+    for lower, upper, label in zip(bins[:-1], bins[1:], labels, strict=None):
         condition = (values > lower) & (values <= upper)
         binned[np.where(condition)[0]] = label
     return binned

--- a/pixi.toml
+++ b/pixi.toml
@@ -16,10 +16,6 @@ default = [
     "dev",
 ]
 
-[environments.test-39]
-features = ["required", "py39", "optional", "test-core", "test-example", "test-unit-task"]
-no-default-feature = true
-
 [environments.test-310]
 features = ["required", "py310", "optional", "test-core", "test-example", "test-unit-task"]
 no-default-feature = true
@@ -82,10 +78,6 @@ sync-git-tags = 'python scripts/sync_git_tags.py holoviews'
 [feature.required.activation.env]
 PYTHONIOENCODING = "utf-8"
 
-[feature.py39.dependencies]
-python = "3.9.*"
-panel = "1.4.*"
-
 [feature.py310.dependencies]
 python = "3.10.*"
 bokeh_sampledata = "*"
@@ -126,7 +118,7 @@ plotly = ">=4.0"
 pooch = "*"
 pyarrow = "*"
 scikit-image = "*"
-scipy = ">=1.10" # Python 3.9 + Windows downloads 1.9
+scipy = "*"
 selenium = "*"
 shapely = "*"
 spatialpandas = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "A high-level plotting API for the PyData ecosystem built on HoloViews."
 readme = "README.md"
 license = { text = "BSD" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Jean-Luc Stevens", email = "developers@holoviz.org" },
     { name = "Philipp Rudiger", email = "developers@holoviz.org" },
@@ -17,7 +17,6 @@ maintainers = [{ name = "HoloViz developers", email = "developers@holoviz.org" }
 classifiers = [
     "License :: OSI Approved :: BSD License",
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,7 @@ ignore = [
     "D400", # Missing-trailing-period
     "D401", # Non-imperative-mood
     "D404", # Docstring-starts-with-this
+    "UP038", # isinstance and issubclass uses a |-separated union
 ]
 extend-unsafe-fixes = [
     "F401", # Unused imports


### PR DESCRIPTION
Dropping Python 3.9 for the next HoloViews minor release 1.21.0.

Most of the changes are related to [B905](https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/) (400 occurrences). I have set the default value to `None`, indicating that I have not decided whether it is True or False.  