### PR TITLE
compat: pyparsing 3.2.2

### DIFF
--- a/holoviews/util/parser.py
+++ b/holoviews/util/parser.py
@@ -119,7 +119,7 @@ class Parser:
                 if cls.abort_on_eval_failure:
                     raise SyntaxError(f"Could not evaluate keyword: {keyword!r}") from None
                 msg = "Ignoring keyword pair that fails to evaluate: '%s'"
-                parsewarning.warning(msg % keyword)
+                parsewarning.param.warning(msg % keyword)
 
         return kwargs
 

--- a/holoviews/util/parser.py
+++ b/holoviews/util/parser.py
@@ -8,6 +8,7 @@ Pyparsing is required by matplotlib and will therefore be available if
 HoloViews is being used in conjunction with matplotlib.
 
 """
+from contextlib import suppress
 from itertools import groupby
 
 import numpy as np
@@ -28,6 +29,9 @@ allowed = r'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!#$%&\
 # logging at the class level.
 class ParserWarning(param.Parameterized):pass
 parsewarning = ParserWarning(name='Warning')
+
+with suppress(Exception):
+    pp.ParserElement.set_default_whitespace_chars(" ")
 
 class Parser:
     """Base class for magic line parsers, designed for forgiving parsing

--- a/pixi.toml
+++ b/pixi.toml
@@ -133,6 +133,7 @@ spatialpandas = "*"
 streamz = ">=0.5.0"
 xarray = ">=0.10.4"
 xyzservices = "*"
+pyparsing = "!=3.2.2" # Remove when no longer needed
 
 [feature.optional.target.unix.dependencies]
 tsdownsample = "*" # currently not available on Windows

--- a/pixi.toml
+++ b/pixi.toml
@@ -133,7 +133,6 @@ spatialpandas = "*"
 streamz = ">=0.5.0"
 xarray = ">=0.10.4"
 xyzservices = "*"
-pyparsing = "!=3.2.2" # Remove when no longer needed
 
 [feature.optional.target.unix.dependencies]
 tsdownsample = "*" # currently not available on Windows


### PR DESCRIPTION
A git bisect shows it is https://github.com/pyparsing/pyparsing/commit/b6719a63262af8b32c78564b25aad95f65ffdfb4

I'm also unsure if we should spend time fixing it as the plan is to deprecate/remove the IPython magic, c.f. https://github.com/holoviz/holoviews/issues/6445 