### PR TITLE
compat: revert pyparsing 3.2.2

### DIFF
--- a/holoviews/util/parser.py
+++ b/holoviews/util/parser.py
@@ -8,7 +8,6 @@ Pyparsing is required by matplotlib and will therefore be available if
 HoloViews is being used in conjunction with matplotlib.
 
 """
-from contextlib import suppress
 from itertools import groupby
 
 import numpy as np
@@ -30,8 +29,6 @@ allowed = r'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!#$%&\
 class ParserWarning(param.Parameterized):pass
 parsewarning = ParserWarning(name='Warning')
 
-with suppress(Exception):
-    pp.ParserElement.set_default_whitespace_chars(" ")
 
 class Parser:
     """Base class for magic line parsers, designed for forgiving parsing

--- a/pixi.toml
+++ b/pixi.toml
@@ -125,7 +125,7 @@ pillow = "*"
 plotly = ">=4.0"
 pooch = "*"
 pyarrow = "*"
-pyparsing = "*"
+pyparsing = "!=3.2.2" # Pinned 2025-03
 scikit-image = "*"
 scipy = ">=1.10" # Python 3.9 + Windows downloads 1.9
 selenium = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -125,6 +125,7 @@ pillow = "*"
 plotly = ">=4.0"
 pooch = "*"
 pyarrow = "*"
+pyparsing = "*"
 scikit-image = "*"
 scipy = ">=1.10" # Python 3.9 + Windows downloads 1.9
 selenium = "*"


### PR DESCRIPTION
Changes made in https://github.com/holoviz/holoviews/pull/6550 were not correct.

Fixes upstream in https://github.com/pyparsing/pyparsing/commit/4dace945ce8cd7211c5d935b6d7be21c86cad8da and a 3.2.3 release has already been made.  