### PR TITLE
enh: Add basic reactive expression support in a streams dictionary

### DIFF
--- a/examples/user_guide/12-Responding_to_Events.ipynb
+++ b/examples/user_guide/12-Responding_to_Events.ipynb
@@ -468,6 +468,7 @@
    "source": [
     "import asyncio\n",
     "\n",
+    "\n",
     "async def gen():\n",
     "    value = np.random.randn()\n",
     "    while True:\n",

--- a/examples/user_guide/12-Responding_to_Events.ipynb
+++ b/examples/user_guide/12-Responding_to_Events.ipynb
@@ -386,8 +386,128 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "account.balance=65.4\n",
-    "account.overdraft=350"
+    "account.balance = 65.4\n",
+    "account.overdraft = 350"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using parameter references\n",
+    "\n",
+    "In addition to simple parameters, the `ParamRefs` stream can be used to dynamically resolve arbitrary [parameter references](https://param.holoviz.org/user_guide/References). This includes:\n",
+    "\n",
+    "- Parameters from param.Parameterized classes\n",
+    "- Widgets from libraries like Panel\n",
+    "- Functions and async generators\n",
+    "- Reactive expressions (via param.rx)\n",
+    "\n",
+    "This approach lets you hook into rich, declarative data dependencies without writing explicit callbacks.\n",
+    "\n",
+    "#### What is a Parameter Reference?\n",
+    "\n",
+    "A parameter reference is a way of pointing to a value that may change over time. Rather than directly supplying a static value to a plot, you can supply a reference to a dynamic object — and HoloViews will automatically update the visualization when that object changes. One particularly useful type of reference are so called reactive expressions. They provide a way to declare some expression using dynamic inputs.\n",
+    "\n",
+    "For examples we can use a reactive expression to dynamically add up the balances of two accounts along with some fixed investments and debt:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "janes_account = BankAccount(name='Jane', balance=300)\n",
+    "bobs_account = BankAccount(name='Bob', balance=-200)\n",
+    "\n",
+    "investments = 2500\n",
+    "debt = 1800\n",
+    "total = janes_account.param.balance.rx() + bobs_account.param.balance.rx() + investments - debt\n",
+    "\n",
+    "refs = {'jane': janes_account.param.balance, 'bob': bobs_account.param.balance, 'total': total}\n",
+    "\n",
+    "def bars(jane, bob, total):\n",
+    "    return hv.Bars([('Jane', jane), ('Bob', bob), ('Combined', total)], 'Account', 'Balance ($)')\n",
+    "\n",
+    "hv.DynamicMap(bars, streams=[hv.streams.ParamRefs(refs=refs)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When we update Bob's account balance, the expression calculating the combined balance will also update:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bobs_account.balance = 300"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "References and expressions are an extremely powerful way to update a visualization given a dynamic value.\n",
+    "\n",
+    "#### Generators\n",
+    "\n",
+    "Another good example of this is a streaming example. Here we declare an `rx` expression driven by an asynchronous generator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "async def gen():\n",
+    "    value = np.random.randn()\n",
+    "    while True:\n",
+    "        value += np.random.randn()\n",
+    "        yield value\n",
+    "        await asyncio.sleep(0.2)\n",
+    "\n",
+    "gen_expr = param.rx(gen)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `gen_expr` dynamically reflects the value and when displayed in a live notebook will update every time the generator yields:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gen_expr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By using the `buffer` method we can accumulate the most recent 30 values and create a streaming plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.DynamicMap(hv.Curve, streams={'data': (gen_expr + 5).rx.buffer(30)}).opts(framewise=True, width=300)"
    ]
   },
   {
@@ -409,6 +529,7 @@
     "\n",
     "slider = pn.widgets.FloatSlider(start=0, end=500, name='Balance')\n",
     "checkbox = pn.widgets.Select(options=['student','regular', 'savings'], name='Account Type')\n",
+    "\n",
     "pn.Row(slider, checkbox)"
    ]
   },
@@ -425,7 +546,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "overdraft_limits = {'student':300, 'regular':100, 'savings':0} # Overdraft limits for different account types\n",
+    "overdraft_limits = {'student': 300, 'regular': 100, 'savings': 0} # Overdraft limits for different account types\n",
     "streams = dict(owner=account.param.name, total=slider.param.value, acc=checkbox.param.value)\n",
     "\n",
     "def account_info(owner, total, acc):\n",
@@ -984,5 +1105,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -65,7 +65,10 @@ def streams_list_from_dict(streams):
             params[k] = v
         else:
             refs[k] = v
-    return [*Params.from_params(params), ParamRefs(refs=refs)]
+    streams = Params.from_params(params)
+    if not refs:
+        return refs
+    return [*streams, ParamRefs(refs=refs)]
 
 
 class Stream(param.Parameterized):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -67,7 +67,7 @@ def streams_list_from_dict(streams):
             refs[k] = v
     streams = Params.from_params(params)
     if not refs:
-        return refs
+        return streams
     return [*streams, ParamRefs(refs=refs)]
 
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -58,14 +58,20 @@ def streams_list_from_dict(streams):
     """Converts a streams dictionary into a streams list
 
     """
-    params = {}
+    params, rxs = {}, []
     for k, v in streams.items():
+        if isinstance(v, param.reactive.rx):
+            rxs.append(v)
+            continue
         v = param.parameterized.transform_reference(v)
         if isinstance(v, param.Parameter) and v.owner is not None:
             params[k] = v
         else:
             raise TypeError(f'Cannot handle value {v!r} in streams dictionary')
-    return Params.from_params(params)
+    if rxs and params:
+        msg = "Currently, you can only passes either a dictionary of parameters or a dictionary of reactive expressions."
+        raise NotImplementedError(msg)
+    return rxs or Params.from_params(params)
 
 
 class Stream(param.Parameterized):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -63,12 +63,16 @@ def streams_list_from_dict(streams):
         v = param.parameterized.transform_reference(v)
         if isinstance(v, param.Parameter) and v.owner is not None:
             params[k] = v
-        else:
+            continue
+        deps = param.parameterized.resolve_ref(v, recursive=True)
+        if deps:
             refs[k] = v
+        else:
+            raise TypeError(f'Cannot handle {k!r} value {v!r} in streams dictionary')
     streams = Params.from_params(params)
     if not refs:
         return streams
-    return [*streams, ParamRefs(refs=refs)]
+    return [*streams, ParamRefs(refs=refs, recursive=True)]
 
 
 class Stream(param.Parameterized):

--- a/holoviews/tests/core/test_dynamic.py
+++ b/holoviews/tests/core/test_dynamic.py
@@ -78,11 +78,6 @@ class DynamicMapConstructor(ComparisonTestCase):
     def test_simple_constructor_streams_dict_class_parameter(self):
         DynamicMap(lambda x: x, streams=dict(x=ExampleParameterized.param.example))
 
-    def test_simple_constructor_streams_dict_invalid(self):
-        regexp = "Cannot handle value 3 in streams dictionary"
-        with self.assertRaisesRegex(TypeError, regexp):
-            DynamicMap(lambda x: x, streams=dict(x=3))
-
     def test_simple_constructor_streams_invalid_uninstantiated(self):
         regexp = ("The supplied streams list contains objects "
                   "that are not Stream instances:(.+?)")

--- a/holoviews/tests/core/test_dynamic.py
+++ b/holoviews/tests/core/test_dynamic.py
@@ -78,6 +78,11 @@ class DynamicMapConstructor(ComparisonTestCase):
     def test_simple_constructor_streams_dict_class_parameter(self):
         DynamicMap(lambda x: x, streams=dict(x=ExampleParameterized.param.example))
 
+    def test_simple_constructor_streams_dict_invalid(self):
+        regexp = "Cannot handle 'x' value 3 in streams dictionary"
+        with self.assertRaisesRegex(TypeError, regexp):
+            DynamicMap(lambda x: x, streams=dict(x=3))
+
     def test_simple_constructor_streams_invalid_uninstantiated(self):
         regexp = ("The supplied streams list contains objects "
                   "that are not Stream instances:(.+?)")


### PR DESCRIPTION
Resolves https://github.com/holoviz/holoviews/issues/6561

For simplicity, I allow the dict list to be either parameters or reactive expressions. There isn't any technical reason not to allow this, but the order should be correct if we allow both.

 ``` python
import param
import panel as pn
import numpy as np
import holoviews as hv

hv.extension("bokeh")

class P(param.Parameterized):
    n = param.Integer(10, bounds=(1, 1000))

    def __init__(self, **params):
        super().__init__(**params)
        self.n_rx = self.param.n.rx() * 10  # reactive expr.

p = P()
slider = pn.widgets.IntSlider.from_param(p.param.n)

def plot(n):
    return hv.Scatter(np.random.random((n, 2)))

dmap = hv.DynamicMap(plot, streams=dict(n=p.n_rx))
pn.Column(slider, dmap)
```

https://github.com/user-attachments/assets/0a5ccb73-6435-4086-aa51-05c1c69ac23e


# TODO: 
Add test + document this currently only work with one or the other

