### PR TITLE
enh: Improve information in hover tool for selector

### DIFF
--- a/examples/user_guide/Interactive_Hover_for_Big_Data.ipynb
+++ b/examples/user_guide/Interactive_Hover_for_Big_Data.ipynb
@@ -171,7 +171,7 @@
     "\n",
     "This design avoids sending all the raw data to the client and only transmits the necessary information on-demand. You can enable this by adding a `selector` to a `rasterize` or `datashade` operation. \n",
     "\n",
-    "By adding an `selector` we now get the information of all the dimensions in the DataFrame along with the original Hover Information, for this example the new information is `s`, `val`, and `cat`. "
+    "By adding an `selector` we now get the information of all the dimensions in the DataFrame along with the original Hover Information, for this example the new information is `s`, `val`, and `cat`. The new information is split with a horizontal rule."
    ]
   },
   {

--- a/examples/user_guide/Interactive_Hover_for_Big_Data.ipynb
+++ b/examples/user_guide/Interactive_Hover_for_Big_Data.ipynb
@@ -190,7 +190,7 @@
    "id": "90f093c4-3a3a-4c2f-9d5b-bbb6a1963d43",
    "metadata": {},
    "source": [
-    "You can specify which columns to show in the HoverTool with `hover_tooltips`. You can also rename the label by passing in a tuple with `(label, column)`."
+    "You can specify which columns to show in the HoverTool with `hover_tooltips`. You can also rename the label by passing in a tuple with `(label, column)`. The information about the selector itself can be disabled by setting `selector_in_hovertool=False`."
    ]
   },
   {
@@ -200,7 +200,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rasterized_with_selector.opts(hover_tooltips=[\"x\", \"y\", (\"s [mean(s)]\", \"x_y s\"), (\"s [min(s)]\", \"s\"), (\"cat [min(s)]\", \"cat\")])"
+    "hover_tooltips=[\"x\", \"y\", (\"s [mean(s)]\", \"x_y s\"), (\"s [min(s)]\", \"s\"), (\"cat [min(s)]\", \"cat\")]\n",
+    "rasterized_with_selector.opts(hover_tooltips=hover_tooltips, selector_in_hovertool=False)"
    ]
   },
   {

--- a/examples/user_guide/Interactive_Hover_for_Big_Data.ipynb
+++ b/examples/user_guide/Interactive_Hover_for_Big_Data.ipynb
@@ -210,7 +210,7 @@
    "metadata": {},
    "source": [
     ":::{note}\n",
-    "The syntax for `hover_tooltips` when using `selector` is only contain a subset of functionality compared to when used on a non-`selector` plot.\n",
+    "When `selector` is enabled, hover tooltips use a predefined grid layout with fixed styling, limiting the customization options that would otherwise be available through `hover_tooltips` in standard plots that don't utilize `selector`.\n",
     ":::"
    ]
   },

--- a/examples/user_guide/Interactive_Hover_for_Big_Data.ipynb
+++ b/examples/user_guide/Interactive_Hover_for_Big_Data.ipynb
@@ -190,7 +190,7 @@
    "id": "90f093c4-3a3a-4c2f-9d5b-bbb6a1963d43",
    "metadata": {},
    "source": [
-    "You can specify which columns to show in the HoverTool with `hover_tooltips`. "
+    "You can specify which columns to show in the HoverTool with `hover_tooltips`. You can also rename the label by passing in a tuple with `(label, column)`."
    ]
   },
   {
@@ -200,7 +200,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rasterized_with_selector.opts(hover_tooltips=[\"x\", \"y\", \"s\", \"cat\"])"
+    "rasterized_with_selector.opts(hover_tooltips=[\"x\", \"y\", (\"s [mean(s)]\", \"x_y s\"), (\"s [min(s)]\", \"s\"), (\"cat [min(s)]\", \"cat\")])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "214f31a0-16fe-4fc7-acc1-34e0bbe4f5ef",
+   "metadata": {},
+   "source": [
+    ":::{note}\n",
+    "The syntax for `hover_tooltips` when using `selector` is only contain a subset of functionality compared to when used on a non-`selector` plot.\n",
+    ":::"
    ]
   },
   {

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -75,7 +75,7 @@ DATASHADER_VERSION = ds_version.release
 DATASHADER_GE_0_14_0 = DATASHADER_VERSION >= (0, 14, 0)
 DATASHADER_GE_0_15_1 = DATASHADER_VERSION >= (0, 15, 1)
 DATASHADER_GE_0_16_0 = DATASHADER_VERSION >= (0, 16, 0)
-DATASHADER_GE_0_17_1 = DATASHADER_VERSION >= (0, 17, 1)
+DATASHADER_GE_0_18_1 = DATASHADER_VERSION >= (0, 18, 1)
 
 
 class AggregationOperation(ResampleOperation2D):
@@ -420,7 +420,7 @@ class aggregate(LineAggregationOperation):
             agg = self._apply_datashader(dfdata, cvs_fn, sum_agg, agg_kwargs, x, y, agg_state)
             agg.attrs["selector"] = (
                 str(sel_fn)
-                if DATASHADER_GE_0_17_1
+                if DATASHADER_GE_0_18_1
                 else f"{type(sel_fn).__name__}({getattr(sel_fn, 'column', '...')!r})"
             )
         else:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -418,7 +418,11 @@ class aggregate(LineAggregationOperation):
                 params["vdims"] = [params["vdims"]]
             sum_agg = ds.summary(**{str(params["vdims"][0]): agg_fn, "__index__": ds.where(sel_fn)})
             agg = self._apply_datashader(dfdata, cvs_fn, sum_agg, agg_kwargs, x, y, agg_state)
-            agg.attrs["selector"] = str(sel_fn) if DATASHADER_GE_0_17_1 else None
+            agg.attrs["selector"] = (
+                str(sel_fn)
+                if DATASHADER_GE_0_17_1
+                else f"{type(sel_fn).__name__}({getattr(sel_fn, 'column', '...')!r})"
+            )
         else:
             agg = self._apply_datashader(dfdata, cvs_fn, agg_fn, agg_kwargs, x, y, agg_state)
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -75,6 +75,7 @@ DATASHADER_VERSION = ds_version.release
 DATASHADER_GE_0_14_0 = DATASHADER_VERSION >= (0, 14, 0)
 DATASHADER_GE_0_15_1 = DATASHADER_VERSION >= (0, 15, 1)
 DATASHADER_GE_0_16_0 = DATASHADER_VERSION >= (0, 16, 0)
+DATASHADER_GE_0_17_1 = DATASHADER_VERSION >= (0, 17, 1)
 
 
 class AggregationOperation(ResampleOperation2D):
@@ -417,6 +418,7 @@ class aggregate(LineAggregationOperation):
                 params["vdims"] = [params["vdims"]]
             sum_agg = ds.summary(**{str(params["vdims"][0]): agg_fn, "__index__": ds.where(sel_fn)})
             agg = self._apply_datashader(dfdata, cvs_fn, sum_agg, agg_kwargs, x, y, agg_state)
+            agg.attrs["selector"] = str(sel_fn) if DATASHADER_GE_0_17_1 else None
         else:
             agg = self._apply_datashader(dfdata, cvs_fn, agg_fn, agg_kwargs, x, y, agg_state)
 
@@ -1448,6 +1450,7 @@ class shade(LinkableOperation):
             img_data = img_data.to_dataset(dim="band")
             img_data.update({k: sel_data[k] for k in sel_data.attrs["selector_columns"]})
             img_data.attrs["selector_columns"] = sel_data.attrs["selector_columns"]
+            img_data.attrs["selector"] = sel_data.attrs.get("selector")
         return img_data
 
 

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -52,8 +52,10 @@ class ServerHoverMixin:
         # Get dimensions
         coords, vars = list(data.coords), list(data.data_vars)
         vars.remove("__index__")
-        if ht := self.hover_tooltips:
+        ht = self.hover_tooltips or {}
+        if ht:
             ht = [ht] if isinstance(ht, str) else ht
+            ht = dict([t[::-1] if isinstance(t, tuple) else (t, t) for t in ht])
             coords = [c for c in coords if c in ht]
             vars = [v for v in vars if v in ht]
         elif isinstance(self, RGBPlot):
@@ -77,7 +79,7 @@ class ServerHoverMixin:
 
         hover_model = HoverModel()
         _create_row = lambda attr: (
-            Span(children=[f"{attr}:"], style={"color": "#26aae1", "text_align": "right"}),
+            Span(children=[f"{ht.get(attr, attr)}:"], style={"color": "#26aae1", "text_align": "right"}),
             Span(children=[ValueOf(obj=hover_model, attr=attr)], style={"text_align": "left"}),
         )
         children = [el for dim in dims for el in _create_row(dim)]

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -80,8 +80,23 @@ class ServerHoverMixin:
             Span(children=[f"{attr}:"], style={"color": "#26aae1", "text_align": "right"}),
             Span(children=[ValueOf(obj=hover_model, attr=attr)], style={"text_align": "left"}),
         )
+        children = [el for dim in dims for el in _create_row(dim)]
+
+        # Add a horizontal rule to separate selector columns
+        selector_columns = data.attrs["selector_columns"]
+        first_selector = next((i for i, dim in enumerate(dims) if dim in selector_columns), None)
+        if first_selector is not None:
+            divider_style={
+                "border": "none",
+                "height": "1px",
+                "background-color": "#ccc",
+                "margin": "4px 0",
+                "grid-column": "span 2",
+            }
+            children = [*children[:first_selector * 2], Div(style=divider_style), *children[first_selector * 2:]]
+
         style = Styles(display="grid", grid_template_columns="auto auto", column_gap="10px")
-        grid = Div(children=[el for dim in dims for el in _create_row(dim)], style=style)
+        grid = Div(children=children, style=style)
         hover.tooltips = grid
         hover.callback = CustomJS(
             args={"position": hover_model},

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -84,7 +84,7 @@ class ServerHoverMixin(param.Parameterized):
 
         hover_model = HoverModel()
         dtypes = {**data.coords.dtypes, **data.data_vars.dtypes}
-        is_datetime = [dtypes[c].kind == "M" for c in coords]
+        is_datetime = [dtypes[c].kind == "M" for c in data.coords]
         def _create_row(attr):
             kwargs = {}
             if BOKEH_GE_3_7_0:
@@ -103,27 +103,33 @@ class ServerHoverMixin(param.Parameterized):
         # Add a horizontal ruler and show the selector if available
         selector_columns = data.attrs["selector_columns"]
         first_selector = next((i for i, dim in enumerate(dims) if dim in selector_columns), None)
-        if first_selector is not None:
-            divider_style={
+        if first_selector:  # Don't show if first
+            divider = [Div(style={
                 "border": "none",
                 "height": "1px",
                 "background-color": "#ccc",
                 "margin": "4px 0",
                 "grid-column": "span 2",
-            }
-            if data.attrs.get("selector") and self.selector_in_hovertool:
-                selector_row = (
-                    Span(children=["Selector:"], style={"color": "#26aae1", "font-weight": "bold", "text_align": "right"}),
-                    Span(children=[data.attrs["selector"]], style={"font-weight": "bold", "text_align": "left"}),
-                 )
-            else:
-                selector_row = ()
-            children = [
-                *children[:first_selector * 2],
-                Div(style=divider_style),
-                *selector_row,
-                *children[first_selector * 2:],
-            ]
+            })]
+        else:
+            divider = ()
+
+
+        if first_selector is not None and data.attrs.get("selector") and self.selector_in_hovertool:
+            selector_row = (
+                Span(children=["Selector:"], style={"color": "#26aae1", "font-weight": "bold", "text_align": "right"}),
+                Span(children=[data.attrs["selector"]], style={"font-weight": "bold", "text_align": "left"}),
+             )
+        else:
+            selector_row = ()
+
+        first_selector = first_selector or 0
+        children = [
+            *children[:first_selector * 2],
+            *divider,
+            *selector_row,
+            *children[first_selector * 2:],
+        ]
 
         style = Styles(display="grid", grid_template_columns="auto auto", column_gap="10px")
         grid = Div(children=children, style=style)

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -20,8 +20,11 @@ from .styles import base_properties, fill_properties, line_properties, mpl_to_bo
 from .util import BOKEH_GE_3_3_0, BOKEH_GE_3_4_0, colormesh
 
 
-class ServerHoverMixin:
+class ServerHoverMixin(param.Parameterized):
     _model_cache = {}
+
+    selector_in_hovertool = param.Boolean(default=True, doc="""
+        Whether to show the selector in HoverTool.""")
 
     def _update_hover(self, element):
         tool = self.handles['hover']
@@ -95,7 +98,7 @@ class ServerHoverMixin:
                 "margin": "4px 0",
                 "grid-column": "span 2",
             }
-            if data.attrs.get("selector"):
+            if data.attrs.get("selector") and self.selector_in_hovertool:
                 selector_row = (
                     Span(children=["Selector:"], style={"color": "#26aae1", "font-weight": "bold", "text_align": "right"}),
                     Span(children=[data.attrs["selector"]], style={"font-weight": "bold", "text_align": "left"}),

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -84,7 +84,7 @@ class ServerHoverMixin:
         )
         children = [el for dim in dims for el in _create_row(dim)]
 
-        # Add a horizontal rule to separate selector columns
+        # Add a horizontal ruler and show the selector if available
         selector_columns = data.attrs["selector_columns"]
         first_selector = next((i for i, dim in enumerate(dims) if dim in selector_columns), None)
         if first_selector is not None:
@@ -95,7 +95,19 @@ class ServerHoverMixin:
                 "margin": "4px 0",
                 "grid-column": "span 2",
             }
-            children = [*children[:first_selector * 2], Div(style=divider_style), *children[first_selector * 2:]]
+            if data.attrs.get("selector"):
+                selector_row = (
+                    Span(children=["Selector:"], style={"color": "#26aae1", "font-weight": "bold", "text_align": "right"}),
+                    Span(children=[data.attrs["selector"]], style={"font-weight": "bold", "text_align": "left"}),
+                 )
+            else:
+                selector_row = ()
+            children = [
+                *children[:first_selector * 2],
+                Div(style=divider_style),
+                *selector_row,
+                *children[first_selector * 2:],
+            ]
 
         style = Styles(display="grid", grid_template_columns="auto auto", column_gap="10px")
         grid = Div(children=children, style=style)

--- a/holoviews/tests/ui/bokeh/test_hover.py
+++ b/holoviews/tests/ui/bokeh/test_hover.py
@@ -267,6 +267,59 @@ def test_hover_tooltips_rasterize_server_hover(serve_hv, rng):
 
 
 @pytest.mark.usefixtures("bokeh_backend")
+@pytest.mark.parametrize(
+    "hover_tooltips",
+    [None, ["x", "y"], ["x", "y", "s"], ["s"]],
+    ids=["default", "only_coords", "reduced_vars", "only_vars"],
+)
+@pytest.mark.parametrize("selector_in_hovertool", [True, False])
+def test_hover_tooltips_rasterize_server_hover_selector_ux(serve_hv, rng, hover_tooltips, selector_in_hovertool):
+    import datashader as ds
+
+    from holoviews.operation.datashader import rasterize
+
+    df = pd.DataFrame({
+        "x": rng.normal(45, 1, 100),
+        "y": rng.normal(85, 1, 100),
+        "s": 2,
+        "val": 10,
+        "cat": "cat1",
+    })
+    img = rasterize(hv.Points(df), selector=ds.first("val"))
+    img.opts(tools=["hover"], hover_tooltips=hover_tooltips, selector_in_hovertool=selector_in_hovertool)
+
+    page = serve_hv(img)
+    hv_plot = page.locator(".bk-events")
+    expect(hv_plot).to_have_count(1)
+    bbox = hv_plot.bounding_box()
+
+    # Hover over the plot, first time the hovertool only have null
+    # we then timeout and hover again to get hovertool with actual values
+    page.mouse.move(bbox["x"] + bbox["width"] / 2, bbox["y"] + bbox["height"] / 2)
+    page.mouse.up()
+
+    expect(page.locator(".bk-Tooltip")).to_have_count(1)
+    page.wait_for_timeout(100)
+
+    page.mouse.move(bbox["x"] + bbox["width"] / 4, bbox["y"] + bbox["height"] / 4)
+    page.mouse.up()
+
+
+    # Selector test
+    if hover_tooltips == ["x", "y"] or not selector_in_hovertool:
+        expect(page.locator(".bk-Tooltip")).not_to_contain_text("Selector:first('val')")
+    else:
+        expect(page.locator(".bk-Tooltip")).to_contain_text("Selector:first('val')")
+
+    # The dividing line
+    line_expect = expect(page.locator("div[style*='height: 1px'][style*='grid-column: span 2']"))
+    if hover_tooltips in (["x", "y"], ["s"]):
+        line_expect.to_have_count(0)
+    else:
+        line_expect.to_have_count(1)
+
+
+@pytest.mark.usefixtures("bokeh_backend")
 @pytest.mark.parametrize("convert_x", [True, False])
 @pytest.mark.parametrize("convert_y", [True, False])
 def test_hover_tooltips_rasterize_server_datetime_axis(serve_hv, rng, convert_x, convert_y):


### PR DESCRIPTION
fixes https://github.com/holoviz/holoviews/issues/6565

Currently, this does two things:

1) Add a horizontal ruler that separates the selector hover information from the rest.
2) Add a way to rename labels for a hover tool.


![image](https://github.com/user-attachments/assets/48fcea09-6535-4dce-83b4-40ca8ab34431)

I don't know how to provide more information without making it distracting after you have read it. 

At the same time, having the information on what is used for the selector if a long column name is long can be somewhat intrusive.
![image](https://github.com/user-attachments/assets/d0f71ea6-9dd3-4872-8545-4d9c2a0457a6)

I also don't want something showing that people find annoying because it is currently not easy to remove. 

Maybe having a label/item showing it could be a way to give the information without to much repeating:

![image](https://github.com/user-attachments/assets/5b596ac8-1dc3-4a92-83bf-2d28c1038925)

