### PR TITLE
perf: Don't import Panel and Pandas directly in IPython

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -25,6 +25,15 @@ def show_traceback():
     print(FULL_TRACEBACK)
 
 
+def __getattr__(attr):
+    if attr == "IPTestCase":
+        from ..element.comparison import IPTestCase
+        from ..util.warnings import deprecated
+        deprecated("1.22.0", old="holoviews.ipython.IPTestCase", new="holoviews.element.comparison.IPTestCase")
+        return IPTestCase
+    raise AttributeError(f"module {__name__} has no attribute {attr}")
+
+
 class notebook_extension(extension):
     """Notebook specific extension to hv.extension that offers options for
     controlling the notebook environment.

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -31,7 +31,7 @@ def __getattr__(attr):
         from ..util.warnings import deprecated
         deprecated("1.23.0", old="holoviews.ipython.IPTestCase", new="holoviews.element.comparison.IPTestCase")
         return IPTestCase
-    raise AttributeError(f"module {__name__} has no attribute {attr}")
+    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
 
 
 class notebook_extension(extension):

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -1,5 +1,4 @@
 import os
-from unittest import SkipTest
 
 import param
 from bokeh.settings import settings as bk_settings
@@ -12,8 +11,6 @@ import holoviews as hv
 from ..core.dimension import LabelledData
 from ..core.options import Store
 from ..core.tree import AttrTree
-from ..element.comparison import ComparisonTestCase
-from ..plotting.renderer import Renderer
 from ..util import extension
 from .display_hooks import display, png_display, pprint_display, svg_display
 from .magics import load_magics
@@ -26,56 +23,6 @@ def show_traceback():
     """
     from .display_hooks import FULL_TRACEBACK
     print(FULL_TRACEBACK)
-
-
-class IPTestCase(ComparisonTestCase):
-    """This class extends ComparisonTestCase to handle IPython specific
-    objects and support the execution of cells and magic.
-
-    """
-
-    def setUp(self):
-        super().setUp()
-        try:
-            import IPython
-            from IPython.display import HTML, SVG
-            self.ip = IPython.InteractiveShell()
-            if self.ip is None:
-                raise TypeError()
-        except Exception as e:
-            raise SkipTest("IPython could not be started") from e
-
-        self.ip.displayhook.flush = lambda: None  # To avoid gc.collect called in it
-        self.addTypeEqualityFunc(HTML, self.skip_comparison)
-        self.addTypeEqualityFunc(SVG,  self.skip_comparison)
-
-    def skip_comparison(self, obj1, obj2, msg): pass
-
-    def get_object(self, name):
-        obj = self.ip._object_find(name).obj
-        if obj is None:
-            raise self.failureException(f"Could not find object {name}")
-        return obj
-
-
-    def cell(self, line):
-        """Run an IPython cell
-
-        """
-        self.ip.run_cell(line, silent=True)
-
-    def cell_magic(self, *args, **kwargs):
-        """Run an IPython cell magic
-
-        """
-        self.ip.run_cell_magic(*args, **kwargs)
-
-
-    def line_magic(self, *args, **kwargs):
-        """Run an IPython line magic
-
-        """
-        self.ip.run_line_magic(*args, **kwargs)
 
 
 class notebook_extension(extension):
@@ -191,6 +138,8 @@ class notebook_extension(extension):
         same_cell_execution = published = getattr(self, '_repeat_execution_in_cell', False)
         for r in [r for r in resources if r != 'holoviews']:
             Store.renderers[r].load_nb(inline=p.inline)
+
+        from ..plotting.renderer import Renderer
         Renderer.load_nb(inline=p.inline, reloading=same_cell_execution, enable_mathjax=p.enable_mathjax)
 
         if not published and hasattr(panel_extension, "_display_globals"):
@@ -271,7 +220,11 @@ class notebook_extension(extension):
         publish_display_data(data={'text/html': html})
 
 
-notebook_extension.add_delete_action(Renderer._delete_plot)
+def _delete_plot(plot_id):
+    from ..plotting.renderer import Renderer
+    return Renderer._delete_plot(plot_id)
+
+notebook_extension.add_delete_action(_delete_plot)
 
 
 def load_ipython_extension(ip):

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -29,7 +29,7 @@ def __getattr__(attr):
     if attr == "IPTestCase":
         from ..element.comparison import IPTestCase
         from ..util.warnings import deprecated
-        deprecated("1.22.0", old="holoviews.ipython.IPTestCase", new="holoviews.element.comparison.IPTestCase")
+        deprecated("1.23.0", old="holoviews.ipython.IPTestCase", new="holoviews.element.comparison.IPTestCase")
         return IPTestCase
     raise AttributeError(f"module {__name__} has no attribute {attr}")
 

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -28,8 +28,6 @@ from ..core.io import FileArchive
 from ..core.options import AbbreviatedException, SkipRendering, Store, StoreOptions
 from ..core.traversal import unique_dimkeys
 from ..core.util import mimebundle_to_html
-from ..plotting import Plot
-from ..plotting.renderer import MIME_TYPES
 from ..util.settings import OutputSettings
 from .magics import OptsMagic, OutputMagic
 
@@ -158,6 +156,7 @@ def display_hook(fn):
             if mimebundle is None:
                 return {}, {}
             mime_data, mime_metadata = mimebundle
+            from ..plotting.renderer import MIME_TYPES
             if MIME_TYPES['js'] in mime_data:
                 mime_data['text/html'] = mimebundle_to_html(mime_data)
                 del mime_data[MIME_TYPES['js']]
@@ -253,6 +252,8 @@ def display(obj, raw_output=False, **kwargs):
         raise RuntimeError('To use display on a HoloViews object ensure '
                            'a backend is loaded using the holoviews '
                            'extension.')
+
+    from ..plotting import Plot
 
     raw = True
     if isinstance(obj, GridSpace):

--- a/holoviews/tests/ipython/test_displayhooks.py
+++ b/holoviews/tests/ipython/test_displayhooks.py
@@ -3,7 +3,8 @@ import pytest
 pytest.importorskip("IPython")
 
 from holoviews import Curve, Store
-from holoviews.ipython import IPTestCase, notebook_extension
+from holoviews.element.comparison import IPTestCase
+from holoviews.ipython import notebook_extension
 
 
 class TestDisplayHooks(IPTestCase):

--- a/holoviews/tests/ipython/test_magics.py
+++ b/holoviews/tests/ipython/test_magics.py
@@ -6,7 +6,8 @@ from holoviews.core.options import Store
 from holoviews.operation import Compositor
 
 try:
-    from holoviews.ipython import IPTestCase
+    import holoviews.ipython
+    from holoviews.element.comparison import IPTestCase
 except ImportError:
     pytest.skip("IPython required to test IPython magics", allow_module_level=True)
 

--- a/holoviews/tests/ipython/test_optscompleter.py
+++ b/holoviews/tests/ipython/test_optscompleter.py
@@ -5,7 +5,7 @@ Tests the OptsCompleter class for tab-completion in the opts magic.
 from unittest import SkipTest
 
 try:
-    from holoviews.ipython import IPTestCase
+    from holoviews.element.comparison import IPTestCase
     from holoviews.ipython.magics import OptsCompleter
 except ImportError:
     raise SkipTest("Required dependencies not satisfied for testing OptsCompleter")

--- a/holoviews/tests/util/test_init.py
+++ b/holoviews/tests/util/test_init.py
@@ -2,6 +2,8 @@ import sys
 from subprocess import check_output
 from textwrap import dedent
 
+import pytest
+
 
 def test_no_blocklist_imports():
     check = """\
@@ -13,8 +15,25 @@ def test_no_blocklist_imports():
 
     if mods:
         print(", ".join(mods), end="")
-        """
+    """
 
     output = check_output([sys.executable, '-c', dedent(check)])
+    assert output == b""
 
+
+def test_no_blocklist_imports_IPython():
+    pytest.importorskip("IPython")
+
+    check = """\
+    import sys
+    import holoviews as hv
+
+    blocklist = {"panel", "datashader", "ibis", "pandas"}
+    mods = blocklist & set(sys.modules)
+
+    if mods:
+        print(", ".join(mods), end="")
+    """
+
+    output = check_output([sys.executable, '-m', 'IPython', '-c', dedent(check)])
     assert output == b""


### PR DESCRIPTION
Continuing from https://github.com/holoviz/holoviews/pull/6476

I noticed that HoloViews was _very_ slow when importing in IPython. This is mainly because of the import of Panel and Pandas. This PR defers these imports. 

# Hyperfine

## Before (based on #6476)
 `hyperfine "ipython -c ''" "ipython -c 'import holoviews'" --warmup 5`

``` bash
❯ hyperfine "ipython -c ''" "ipython -c 'import holoviews'" --warmup 5
Benchmark 1: ipython -c ''
  Time (mean ± σ):     256.3 ms ±   2.9 ms    [User: 191.0 ms, System: 36.7 ms]
  Range (min … max):   252.2 ms … 260.9 ms    11 runs

Benchmark 2: ipython -c 'import holoviews'
  Time (mean ± σ):      1.398 s ±  0.017 s    [User: 2.820 s, System: 0.150 s]
  Range (min … max):    1.369 s …  1.416 s    10 runs

Summary
  ipython -c '' ran
    5.45 ± 0.09 times faster than ipython -c 'import holoviews'
```

## After (this PR)
``` bash
❯ hyperfine "ipython -c ''" "ipython -c 'import holoviews'" --warmup 5
Benchmark 1: ipython -c ''
  Time (mean ± σ):     256.7 ms ±   2.8 ms    [User: 194.2 ms, System: 34.5 ms]
  Range (min … max):   253.8 ms … 262.2 ms    11 runs

Benchmark 2: ipython -c 'import holoviews'
  Time (mean ± σ):     484.8 ms ±   5.7 ms    [User: 2020.4 ms, System: 57.8 ms]
  Range (min … max):   477.9 ms … 496.4 ms    10 runs

Summary
  ipython -c '' ran
    1.89 ± 0.03 times faster than ipython -c 'import holoviews'
```

# Tuna
`python -X importtime -m IPython -c 'import holoviews' 2> tuna.log && tuna tuna.log` (and not having setuptools_scm installed)

## Before (based on #6476)
![image](https://github.com/user-attachments/assets/0453a39d-0608-445c-a650-d26309fbe66c)

## After (this PR)
![image](https://github.com/user-attachments/assets/b590e704-f413-41fb-b36f-1fc3b41346ff)
