### PR TITLE
fix: Don't assume all extents are string in `max_extents`

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1121,13 +1121,13 @@ def max_extents(extents, zrange=False):
             if lower and isinstance(lower[0], datetime_types):
                 extents[lidx] = np.min(lower)
             elif any(isinstance(l, str) for l in lower):
-                extents[lidx] = np.sort(lower)[0]
+                extents[lidx] = sorted(lower, key=str)[0]
             elif lower:
                 extents[lidx] = np.nanmin(lower)
             if upper and isinstance(upper[0], datetime_types):
                 extents[uidx] = np.max(upper)
             elif any(isinstance(u, str) for u in upper):
-                extents[uidx] = np.sort(upper)[-1]
+                extents[uidx] = sorted(upper, key=str)[-1]
             elif upper:
                 extents[uidx] = np.nanmax(upper)
     return tuple(extents)


### PR DESCRIPTION
Fixes the following hvplot problem.

``` python
import hvplot.pandas
import pandas as pd

df = pd.DataFrame({
    "col1": ["apple", "banana", "cherry", "date", "elderberry"],
    'date': pd.to_datetime(['2023-01-01', '2023-02-14', '2023-03-21', '2023-04-30', '2023-05-15'])
})
df.hvplot.scatter(x="index")
```

Or translated to HoloViews:

``` python
import holoviews as hv
import pandas as pd

hv.extension("bokeh") 

df = pd.DataFrame({
    "col1": ["apple", "banana", "cherry", "date", "elderberry"],
    'date': pd.to_datetime(['2023-01-01', '2023-02-14', '2023-03-21', '2023-04-30', '2023-05-15'])
})
hv.NdOverlay({col: hv.Scatter(df, kdims="index", vdims=col).opts(tools=["hover"]) for col in data})
```
