### PR TITLE
enh(bokeh): Add log support for Histogram

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -1,3 +1,4 @@
+import math
 from collections import defaultdict
 
 import numpy as np
@@ -478,6 +479,12 @@ class HistogramPlot(ColorbarPlot):
         s1 = max(s1, 0) if isfinite(s1) else 0
         ranges[ydim.label]['soft'] = (s0, s1)
         return super().get_extents(element, ranges, range_type)
+
+    def _update_range(self, axis_range, low, high, factors, invert, shared, log, streaming=False):
+        # We allow zero values with histogram
+        if log and low == 0:
+            low = 0.01 if high > 0.01 else 10**(math.log10(high)-2)
+        return super()._update_range(axis_range, low, high, factors, invert, shared, log, streaming)
 
 
 class SideHistogramPlot(HistogramPlot):

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -443,7 +443,8 @@ class HistogramPlot(ColorbarPlot):
                 range_ = plot.x_range
                 pos = "end" if self.invert_xaxis else "start"
             source = self.handles["source"]
-            source.data['bottom'] = [getattr(range_, pos)] * len(source.data['bottom'])
+            # Insert bottom to the lower value of the axis
+            source.data['bottom'] = [getattr(range_, pos)] * len(source.data['top'])
             callback = CustomJS(
                 args=dict(source=source, range=range_, pos=pos),
                 code="""
@@ -470,7 +471,7 @@ class HistogramPlot(ColorbarPlot):
             edges = element.interface.coords(element, x, edges=True)
             if hasattr(edges, 'compute'):
                 edges = edges.compute()
-            data = dict(top=values, left=edges[:-1], right=edges[1:], bottom=[np.nan] * len(values))
+            data = dict(top=values, left=edges[:-1], right=edges[1:])
             self._get_hover_data(data, element)
         return data, mapping, style
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -436,16 +436,18 @@ class HistogramPlot(ColorbarPlot):
         logx = self.logx and self.invert_axes
         logy = self.logy and not self.invert_axes
         if logx or logy:
-            label = "bottom"
-            pos = "start"
-            range_ = plot.y_range if logy else plot.x_range
-
+            if logy:
+                range_ = plot.y_range
+                pos = "end" if self.invert_yaxis else "start"
+            else:
+                range_ = plot.x_range
+                pos = "end" if self.invert_xaxis else "start"
             source = self.handles["source"]
-            source.data[label] = [getattr(range_, pos)] * len(source.data[label])
+            source.data['bottom'] = [getattr(range_, pos)] * len(source.data['bottom'])
             callback = CustomJS(
-                args=dict(source=source, range=range_, label=label, pos=pos),
+                args=dict(source=source, range=range_, pos=pos),
                 code="""
-                source.data[label].fill(range[pos]);
+                source.data['bottom'].fill(range[pos]);
                 source.change.emit();
             """,
             )

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -411,7 +411,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         lims = {}
         valid_lim = lambda c: util.isnumeric(c) and not np.isnan(c)
         if not isinstance(low, util.datetime_types) and log and (low is None or low <= 0):
-            low = 0.01 if high < 0.01 else 10**(np.log10(high)-2)
+            low = 0.01 if high > 0.01 else 10**(np.log10(high)-2)
             self.param.warning(
                 "Logarithmic axis range encountered value less "
                 "than or equal to zero, please supply explicit "

--- a/holoviews/tests/plotting/bokeh/test_histogramplot.py
+++ b/holoviews/tests/plotting/bokeh/test_histogramplot.py
@@ -132,7 +132,6 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(x_range.end, 3.8)
         self.assertEqual(y_range.start, 0.01)
         self.assertEqual(y_range.end, 3.3483695221017129)
-        self.log_handler.assertContains('WARNING', 'Logarithmic axis range encountered value less than')
 
     def test_histogram_padding_datetime_square(self):
         histogram = Histogram([(np.datetime64(f'2016-04-0{i}', 'ns'), i) for i in range(1, 4)]).opts(

--- a/holoviews/tests/plotting/bokeh/test_histogramplot.py
+++ b/holoviews/tests/plotting/bokeh/test_histogramplot.py
@@ -132,6 +132,9 @@ class TestSideHistogramPlot(LoggingComparisonTestCase, TestBokehPlot):
         self.assertEqual(x_range.end, 3.8)
         self.assertEqual(y_range.start, 0.01)
         self.assertEqual(y_range.end, 3.3483695221017129)
+        # We should not have logged 'Logarithmic axis range encountered value less than'
+        last_line = self.log_handler.tail('WARNING', n=1)
+        assert last_line == []
 
     def test_histogram_padding_datetime_square(self):
         histogram = Histogram([(np.datetime64(f'2016-04-0{i}', 'ns'), i) for i in range(1, 4)]).opts(

--- a/holoviews/tests/plotting/matplotlib/test_areaplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_areaplot.py
@@ -96,7 +96,7 @@ class TestAreaPlot(LoggingComparisonTestCase, TestMPLPlot):
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.8)
         self.assertEqual(x_range[1], 3.2)
-        self.assertEqual(y_range[0], 0.03348369522101712)
+        self.assertEqual(y_range[0], 0.01)
         self.assertEqual(y_range[1], 3.3483695221017129)
         self.log_handler.assertContains('WARNING', 'Logarithmic axis range encountered value less than')
 

--- a/holoviews/tests/plotting/matplotlib/test_histogramplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_histogramplot.py
@@ -76,7 +76,7 @@ class TestHistogramPlot(LoggingComparisonTestCase, TestMPLPlot):
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         self.assertEqual(x_range[0], 0.19999999999999996)
         self.assertEqual(x_range[1], 3.8)
-        self.assertEqual(y_range[0], 0.03348369522101712)
+        self.assertEqual(y_range[0], 0.01)
         self.assertEqual(y_range[1], 3.3483695221017129)
         self.log_handler.assertContains('WARNING', 'Logarithmic axis range encountered value less than')
 

--- a/holoviews/tests/ui/bokeh/test_histogram.py
+++ b/holoviews/tests/ui/bokeh/test_histogram.py
@@ -21,9 +21,20 @@ def watch_hook(dim, pos):
 
     return create_hook
 
+
 @pytest.mark.usefixtures("bokeh_backend")
-def test_histogram_logy(serve_hv):
-    hist = Histogram(([1, 3, 6, 9], [1, 10, 0, 100])).opts(logy=True, hooks=[watch_hook("y", "start")])
+@pytest.mark.parametrize(
+    ["opts_kwargs", "hook", "drag_direction"],
+    [
+        ({"logy": True}, watch_hook("y", "start"), "down"),
+        ({"logx": True, "invert_axes": True}, watch_hook("x", "start"), "right"),
+        ({"logy": True, "invert_yaxis": True}, watch_hook("y", "end"), "up"),
+        ({"logx": True, "invert_axes": True, "invert_xaxis": True}, watch_hook("x", "end"), "left"),
+    ],
+    ids=["logy", "logx", "logy-invert", "logx-invert"],
+)
+def test_histogram_log_scaling(serve_hv, opts_kwargs, hook, drag_direction):
+    hist = Histogram(([1, 3, 6, 9], [1, 10, 0, 100])).opts(hooks=[hook], **opts_kwargs)
 
     page = serve_hv(hist)
     hv_plot = page.locator(".bk-events")
@@ -34,93 +45,21 @@ def test_histogram_logy(serve_hv):
     center_y = bbox["y"] + bbox["height"] / 2
     page.mouse.move(center_x, center_y)
 
-    bottom_y = bbox["y"] - bbox["height"]
+    match drag_direction:
+        case "down":
+            target_x, target_y = center_x, bbox["y"] - bbox["height"]
+        case "up":
+            target_x, target_y = center_x, bbox["y"] + bbox["height"]
+        case "right":
+            target_x, target_y = bbox["x"] + bbox["width"], center_y
+        case "left":
+            target_x, target_y = bbox["x"] - bbox["width"], center_y
+        case _:
+            raise ValueError(f"Unknown drag direction: {drag_direction}")
+
     page.mouse.down()
-    page.mouse.move(center_x, bottom_y)
+    page.mouse.move(target_x, target_y)
     page.mouse.up()
-
-
-    def f():
-        cds_value = page.evaluate("() => window.bokeh_cds_data")[0]
-        range_value = page.evaluate("() => window.bokeh_range")
-        assert cds_value != 0.01  # default value
-        assert cds_value == range_value
-
-    wait_until(f, page=page)
-
-
-@pytest.mark.usefixtures("bokeh_backend")
-def test_histogram_logx(serve_hv):
-    hist = Histogram(([1, 3, 6, 9], [1, 10, 0, 100])).opts(logx=True, invert_axes=True, hooks=[watch_hook("x", "start")])
-
-    page = serve_hv(hist)
-    hv_plot = page.locator(".bk-events")
-    expect(hv_plot).to_have_count(1)
-    bbox = hv_plot.bounding_box()
-
-    center_x = bbox["x"] + bbox["width"] / 2
-    center_y = bbox["y"] + bbox["height"] / 2
-    page.mouse.move(center_x, center_y)
-
-    bottom_x = bbox["x"] + bbox["width"]
-    page.mouse.down()
-    page.mouse.move(bottom_x, center_y)
-    page.mouse.up()
-
-
-    def f():
-        cds_value = page.evaluate("() => window.bokeh_cds_data")[0]
-        range_value = page.evaluate("() => window.bokeh_range")
-        assert cds_value != 0.01  # default value
-        assert cds_value == range_value
-
-    wait_until(f, page=page)
-
-@pytest.mark.usefixtures("bokeh_backend")
-def test_histogram_logy_invert(serve_hv):
-    hist = Histogram(([1, 3, 6, 9], [1, 10, 0, 100])).opts(logy=True, invert_yaxis=True, hooks=[watch_hook("y", "end")])
-
-    page = serve_hv(hist)
-    hv_plot = page.locator(".bk-events")
-    expect(hv_plot).to_have_count(1)
-    bbox = hv_plot.bounding_box()
-
-    center_x = bbox["x"] + bbox["width"] / 2
-    center_y = bbox["y"] + bbox["height"] / 2
-    page.mouse.move(center_x, center_y)
-
-    bottom_y = bbox["y"] + bbox["height"]
-    page.mouse.down()
-    page.mouse.move(center_x, bottom_y)
-    page.mouse.up()
-
-    def f():
-        cds_value = page.evaluate("() => window.bokeh_cds_data")[0]
-        range_value = page.evaluate("() => window.bokeh_range")
-        assert cds_value != 0.01  # default value
-        assert cds_value == range_value
-
-    wait_until(f, page=page)
-
-
-@pytest.mark.usefixtures("bokeh_backend")
-def test_histogram_logx_invert(serve_hv):
-    hist = Histogram(([1, 3, 6, 9], [1, 10, 0, 100])).opts(logx=True, invert_axes=True, invert_xaxis=True, hooks=[watch_hook("x", "end")])
-
-    page = serve_hv(hist)
-    hv_plot = page.locator(".bk-events")
-    expect(hv_plot).to_have_count(1)
-    bbox = hv_plot.bounding_box()
-
-    center_x = bbox["x"] + bbox["width"] / 2
-    center_y = bbox["y"] + bbox["height"] / 2
-    page.mouse.move(center_x, center_y)
-
-    bottom_x = bbox["x"] - bbox["width"]
-    page.mouse.down()
-    page.mouse.move(bottom_x, center_y)
-    page.mouse.up()
-
 
     def f():
         cds_value = page.evaluate("() => window.bokeh_cds_data")[0]

--- a/holoviews/tests/ui/bokeh/test_histogram.py
+++ b/holoviews/tests/ui/bokeh/test_histogram.py
@@ -1,0 +1,131 @@
+import pytest
+from bokeh.models import CustomJS
+
+from holoviews.element import Histogram
+
+from .. import expect, wait_until
+
+
+def watch_hook(dim, pos):
+    # Setting up monitoring, as I cannot get the data to sync back to Python
+    def create_hook(plot, element):
+        range_ = getattr(plot.handles["plot"], f"{dim}_range")
+        cjs = CustomJS(
+            args=dict(source=plot.handles["source"], range_=range_),
+            code=f"""
+                window.bokeh_cds_data = source.data['bottom']
+                window.bokeh_range = range_.{pos}
+            """,
+        )
+        range_.js_on_change("start", cjs)
+
+    return create_hook
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_histogram_logy(serve_hv):
+    hist = Histogram(([1, 3, 6, 9], [1, 10, 0, 100])).opts(logy=True, hooks=[watch_hook("y", "start")])
+
+    page = serve_hv(hist)
+    hv_plot = page.locator(".bk-events")
+    expect(hv_plot).to_have_count(1)
+    bbox = hv_plot.bounding_box()
+
+    center_x = bbox["x"] + bbox["width"] / 2
+    center_y = bbox["y"] + bbox["height"] / 2
+    page.mouse.move(center_x, center_y)
+
+    bottom_y = bbox["y"] - bbox["height"]
+    page.mouse.down()
+    page.mouse.move(center_x, bottom_y)
+    page.mouse.up()
+
+
+    def f():
+        cds_value = page.evaluate("() => window.bokeh_cds_data")[0]
+        range_value = page.evaluate("() => window.bokeh_range")
+        assert cds_value != 0.01  # default value
+        assert cds_value == range_value
+
+    wait_until(f, page=page)
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_histogram_logx(serve_hv):
+    hist = Histogram(([1, 3, 6, 9], [1, 10, 0, 100])).opts(logx=True, invert_axes=True, hooks=[watch_hook("x", "start")])
+
+    page = serve_hv(hist)
+    hv_plot = page.locator(".bk-events")
+    expect(hv_plot).to_have_count(1)
+    bbox = hv_plot.bounding_box()
+
+    center_x = bbox["x"] + bbox["width"] / 2
+    center_y = bbox["y"] + bbox["height"] / 2
+    page.mouse.move(center_x, center_y)
+
+    bottom_x = bbox["x"] + bbox["width"]
+    page.mouse.down()
+    page.mouse.move(bottom_x, center_y)
+    page.mouse.up()
+
+
+    def f():
+        cds_value = page.evaluate("() => window.bokeh_cds_data")[0]
+        range_value = page.evaluate("() => window.bokeh_range")
+        assert cds_value != 0.01  # default value
+        assert cds_value == range_value
+
+    wait_until(f, page=page)
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_histogram_logy_invert(serve_hv):
+    hist = Histogram(([1, 3, 6, 9], [1, 10, 0, 100])).opts(logy=True, invert_yaxis=True, hooks=[watch_hook("y", "end")])
+
+    page = serve_hv(hist)
+    hv_plot = page.locator(".bk-events")
+    expect(hv_plot).to_have_count(1)
+    bbox = hv_plot.bounding_box()
+
+    center_x = bbox["x"] + bbox["width"] / 2
+    center_y = bbox["y"] + bbox["height"] / 2
+    page.mouse.move(center_x, center_y)
+
+    bottom_y = bbox["y"] + bbox["height"]
+    page.mouse.down()
+    page.mouse.move(center_x, bottom_y)
+    page.mouse.up()
+
+    def f():
+        cds_value = page.evaluate("() => window.bokeh_cds_data")[0]
+        range_value = page.evaluate("() => window.bokeh_range")
+        assert cds_value != 0.01  # default value
+        assert cds_value == range_value
+
+    wait_until(f, page=page)
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_histogram_logx_invert(serve_hv):
+    hist = Histogram(([1, 3, 6, 9], [1, 10, 0, 100])).opts(logx=True, invert_axes=True, invert_xaxis=True, hooks=[watch_hook("x", "end")])
+
+    page = serve_hv(hist)
+    hv_plot = page.locator(".bk-events")
+    expect(hv_plot).to_have_count(1)
+    bbox = hv_plot.bounding_box()
+
+    center_x = bbox["x"] + bbox["width"] / 2
+    center_y = bbox["y"] + bbox["height"] / 2
+    page.mouse.move(center_x, center_y)
+
+    bottom_x = bbox["x"] - bbox["width"]
+    page.mouse.down()
+    page.mouse.move(bottom_x, center_y)
+    page.mouse.up()
+
+
+    def f():
+        cds_value = page.evaluate("() => window.bokeh_cds_data")[0]
+        range_value = page.evaluate("() => window.bokeh_range")
+        assert cds_value != 0.01  # default value
+        assert cds_value == range_value
+
+    wait_until(f, page=page)


### PR DESCRIPTION
Resolve #2591 

Still POC, needs to be cleaned up, tested, etc. 

- [x] `invert_axes`, `invert_xaxis`, `invert_yaxis` implementation
- [x] Look into the limit from the mpl backend (not related, but noticed it)
- [x] Add / fix tests

This dynamically updates the bottom of the rectangle, never to run out.


![image](https://github.com/user-attachments/assets/0db94c17-7462-43b6-9eca-d5344d86ee1b)



``` python
import holoviews as hv
hv.extension("bokeh")

null = 0
a = hv.Histogram(([1, 3, 6, 9], [1, 10, null, 100])).opts(logy=True)
b = hv.Histogram(([1, 3, 6, 9], [1, 10, null, 100])).opts(logy=True, invert_yaxis=True)
c = hv.Histogram(([1, 3, 6, 9], [1, 10, null, 100])).opts(logx=True, invert_axes=True)
d = hv.Histogram(([1, 3, 6, 9], [1, 10, null, 100])).opts(logx=True, invert_axes=True, invert_xaxis=True)

(a + b + c + d).cols(2).opts(shared_axes=False)
```


https://github.com/user-attachments/assets/dd95f32c-3e42-40a5-932b-324a54f21b0c




``` python
import hvplot.pandas
import pandas as pd

pd.Series(range(1, 100)).hvplot.hist(logy=True)
```