### PR TITLE
fix: Don't import with submodules with `_in_installed`

### DIFF
--- a/holoviews/core/util/dependencies.py
+++ b/holoviews/core/util/dependencies.py
@@ -18,6 +18,8 @@ class VersionError(Exception):
 
 @lru_cache
 def _is_installed(module_name):
+    # So we don't accidentally import it
+    module_name, *_ = module_name.split(".")
     return find_spec(module_name) is not None
 
 


### PR DESCRIPTION
Submodules are imported when used with find_spec. 

![image](https://github.com/user-attachments/assets/510f2343-fbcb-4dba-b2b4-e9017ff2cf56)


If it is not installed, it will just error:

![image](https://github.com/user-attachments/assets/ce6eb094-d681-4640-9879-4372177ae9ea)
