### PR TITLE
docs: Add numpydoc extension to sphinx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /doc/_build
 /doc/Reference_Manual/*
 !/doc/Reference_Manual/index.rst
+builtdocs/
 .ipynb_checkpoints
 .coverage
 .pytest_cache

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,6 +63,7 @@ extensions += [
     'nbsite.gallery',
     'sphinx_copybutton',
     'nbsite.analytics',
+    'numpydoc',
 ]
 
 myst_enable_extensions = ["colon_fence", "deflist"]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,6 +66,13 @@ extensions += [
     'numpydoc',
 ]
 
+intersphinx_mapping = {
+    'panel':    ('https://panel.holoviz.org/', None),
+}
+
+numpydoc_xref_param_type = True
+numpydoc_xref_type       = True
+
 myst_enable_extensions = ["colon_fence", "deflist"]
 numpydoc_show_inherited_class_members = False
 numpydoc_class_members_toctree = False


### PR DESCRIPTION
This PR adds the `numpydoc` extension to the sphinx build process.