### PR TITLE
fix: Wrong ordered dendrogram and add more linkage options

### DIFF
--- a/examples/reference/elements/bokeh/Dendrogram.ipynb
+++ b/examples/reference/elements/bokeh/Dendrogram.ipynb
@@ -19,8 +19,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import random\n",
-    "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
@@ -77,12 +75,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.DataFrame(\n",
-    "    [(i, chr(65 + j), random.random()) for j in range(10) for i in range(5)],\n",
-    "    columns=[\"z\", \"x\", \"y\"],\n",
+    "data = [\n",
+    "    [7, 8, 0, 0, 0, 0],\n",
+    "    [8, 6, 0, 0, 0, 0],\n",
+    "    [0, 0, 9, 8, 2, 7],\n",
+    "    [0, 0, 0, 1, 8, 2],\n",
+    "    [0, 7, 0, 7, 0, 0],\n",
+    "]\n",
+    "df = pd.DataFrame([\n",
+    "    {\"cluster\": f\"clust {i}\", \"gene\": f\"gene {j}\", \"value\": data[i][j]}\n",
+    "    for j in range(6)\n",
+    "    for i in range(5)\n",
+    "])\n",
+    "\n",
+    "# Setting the colors to the normalized value and only have a size for non-zero values\n",
+    "opts = dict(\n",
+    "    color=hv.dim(\"value\").norm(), size=(hv.dim(\"value\") != 0) * 30, cmap=\"Reds\", tools=[\"hover\"]\n",
     ")\n",
-    "heatmap = hv.HeatMap(df)\n",
-    "heatmap"
+    "plot = hv.Points(df, kdims=[\"gene\", \"cluster\"]).opts(**opts)\n",
+    "plot"
    ]
   },
   {
@@ -93,7 +104,7 @@
    "source": [
     "from holoviews.operation import dendrogram\n",
     "\n",
-    "hv.operation.dendrogram(heatmap, adjoint_dims=[\"x\", \"z\"], main_dim=\"y\")"
+    "hv.operation.dendrogram(plot, adjoint_dims=[\"cluster\"], main_dim=\"value\")"
    ]
   }
  ],


### PR DESCRIPTION
Fixes a bug in the current implementation that reversed the order. The bokeh documentation has been updated to use the following example as it clearly (at least to me) shows how the dendrogram should behave.

Adding two more linkage options, `linkage_method` and `linkage_metric`. The default value for both is being set to mimic the scanpy implementation. 

I don't think a test is absolutely necessary, because, as far as I can see, we would only check for repeatability, not correctness, but I will, of course, add one if requested. 

``` python
import holoviews as hv
import pandas as pd

hv.extension("bokeh")

data = [
    [7, 8, 0, 0, 0, 0],
    [8, 6, 0, 0, 0, 0],
    [0, 0, 9, 8, 2, 7],
    [0, 0, 0, 1, 8, 2],
    [0, 7, 0, 7, 0, 0],
]
df = pd.DataFrame([
    {"cluster": f"clust {i}", "gene": f"gene {j}", "value": data[i][j]}
    for j in range(6) 
    for i in range(5)
])

opts = dict(
    color=hv.dim("value").norm(), size=(hv.dim("value") != 0) * 30, cmap="Reds", tools=["hover"]
)
plot = hv.Points(df, kdims=["gene", "cluster"]).opts(**opts)

hv.operation.dendrogram(plot, adjoint_dims=["cluster"], main_dim="value")

```
![image](https://github.com/user-attachments/assets/6be8660a-7aa2-45e1-9bfb-bc5d16c7f5fe)

Refs:
- https://gist.github.com/droumis/985e7ccefcaf25d2b73b7b7fac6d79c1
- https://github.com/scverse/scanpy/blob/89780ec9cbc7ca8cfacc39a0f060602639ef3b25/src/scanpy/tools/_dendrogram.py#L166-L174