### PR TITLE
enh(bokeh): Add `hide_toolbar` options

### DIFF
--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -696,7 +696,14 @@
    "source": [
     "#### Auto-hiding Toolbar\n",
     "\n",
-    "You can make the toolbar automatically hide until the user hovers over the plot by setting the ``autohide_toolbar`` option to ``True``. This is particularly useful for maximizing the available plot space while keeping the tools accessible:"
+    "You can make the toolbar automatically hide until the user hovers over the plot by setting the `autohide_toolbar` option to `True`. This is particularly useful for:\n",
+    "\n",
+    "1. Keeping the focus on your data visualization - the data should be foremost in the viewer's attention\n",
+    "2. Reducing visual clutter around the plot interface\n",
+    "3. Making tools available only when needed, rather than having them constantly visible\n",
+    "4. Creating cleaner exports of plots where tools aren't typically needed\n",
+    "\n",
+    "When saving or exporting the plot to an image format, the toolbar is typically not shown in the saved image.  However, when saving to HTML format using `hv.save(obj, 'file_path.html')`, the autohide functionality is preserved, allowing viewers access to the tools when needed while keeping the interface clean.\n"
    ]
   },
   {

--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -703,7 +703,7 @@
     "3. Making tools available only when needed, rather than having them constantly visible\n",
     "4. Creating cleaner exports of plots where tools aren't typically needed\n",
     "\n",
-    "When saving or exporting the plot to an image format, the toolbar is typically not shown in the saved image.  However, when saving to HTML format using `hv.save(obj, 'file_path.html')`, the autohide functionality is preserved, allowing viewers access to the tools when needed while keeping the interface clean.\n"
+    "When saving or exporting the plot to an image format, the toolbar is typically not shown in the saved image.  However, you can decide to show the toolbar by setting `toolbar=True` when using `hv.save()`, e.g `hv.save(obj, 'file_path.png', toolbar=True)`.\n"
    ]
   },
   {

--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -694,6 +694,60 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Auto-hiding Toolbar\n",
+    "\n",
+    "You can make the toolbar automatically hide until the user hovers over the plot by setting the ``autohide_toolbar`` option to ``True``. This is particularly useful for maximizing the available plot space while keeping the tools accessible:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.Curve([1, 2, 3]).opts(autohide_toolbar=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The feature works with all plot types, including layouts and overlays:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Layout example\n",
+    "(hv.Curve([1, 2, 3]) + hv.Curve([2, 3, 4])).opts(autohide_toolbar=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Overlay example\n",
+    "(hv.Curve([1, 2, 3]) * hv.Curve([2, 3, 4])).opts(autohide_toolbar=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "::: {note}\n",
+    "``autohide_toolbar`` has no effect if the toolbar is disabled (``toolbar=None``).\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Hover tools"
    ]
   },

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -340,9 +340,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         default=None, class_=(str, TickFormatter, FunctionType), doc="""
         Formatter for ticks along the x-axis.""")
 
-
-    hide_toolbar = param.Boolean(default=False)
-
     _categorical = False
     _allow_implicit_categories = True
 
@@ -999,7 +996,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             fig = bokeh.plotting.figure(title=title, **properties)
         fig.xaxis[0].update(**axis_props['x'])
         fig.yaxis[0].update(**axis_props['y'])
-        fig.toolbar.autohide = self.hide_toolbar
+        fig.toolbar.autohide = self.autohide_toolbar
 
         # Set up handlers to configure following behavior on streaming plots
         if self.streaming:
@@ -3079,7 +3076,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                           'min_height', 'max_height', 'min_width', 'min_height',
                           'margin', 'aspect', 'data_aspect', 'frame_width',
                           'frame_height', 'responsive', 'fontscale', 'subcoordinate_y',
-                          'subcoordinate_scale', 'autorange', 'default_tools', 'hide_toolbar']
+                          'subcoordinate_scale', 'autorange', 'default_tools', 'autohide_toolbar']
 
     def __init__(self, overlay, **kwargs):
         self._multi_y_propagation = self.lookup_options(overlay, 'plot').options.get('multi_y', False)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -340,6 +340,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         default=None, class_=(str, TickFormatter, FunctionType), doc="""
         Formatter for ticks along the x-axis.""")
 
+
+    hide_toolbar = param.Boolean(default=False)
+
     _categorical = False
     _allow_implicit_categories = True
 
@@ -989,15 +992,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         properties.update(**self._plot_properties(key, element))
 
-        figure = bokeh.plotting.figure
-
         with warnings.catch_warnings():
             # Bokeh raises warnings about duplicate tools but these
             # are not really an issue
             warnings.simplefilter('ignore', UserWarning)
-            fig = figure(title=title, **properties)
+            fig = bokeh.plotting.figure(title=title, **properties)
         fig.xaxis[0].update(**axis_props['x'])
         fig.yaxis[0].update(**axis_props['y'])
+        fig.toolbar.autohide = self.hide_toolbar
 
         # Set up handlers to configure following behavior on streaming plots
         if self.streaming:
@@ -3077,7 +3079,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                           'min_height', 'max_height', 'min_width', 'min_height',
                           'margin', 'aspect', 'data_aspect', 'frame_width',
                           'frame_height', 'responsive', 'fontscale', 'subcoordinate_y',
-                          'subcoordinate_scale', 'autorange', 'default_tools']
+                          'subcoordinate_scale', 'autorange', 'default_tools', 'hide_toolbar']
 
     def __init__(self, overlay, **kwargs):
         self._multi_y_propagation = self.lookup_options(overlay, 'plot').options.get('multi_y', False)

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -504,8 +504,6 @@ class GridPlot(CompositePlot, GenericCompositePlot):
     sync_legends = param.Boolean(default=True, doc="""
         Whether to sync the legend when muted/unmuted based on the name""")
 
-    hide_toolbar = param.Boolean(default=False)
-
     def __init__(self, layout, ranges=None, layout_num=1, keys=None, **params):
         if not isinstance(layout, GridSpace):
             raise Exception("GridPlot only accepts GridSpace.")
@@ -629,7 +627,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             sync_legends(plot)
         plot = self._make_axes(plot)
         if hasattr(plot, "toolbar") and self.merge_tools:
-            plot.toolbar = merge_tools(plots, hide_toolbar=True)
+            plot.toolbar = merge_tools(plots, autohide_toolbar=True)
         title = self._get_title_div(self.keys[-1])
         if title:
             plot = Column(title, plot)
@@ -681,7 +679,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                 r1, r2 = r1[::-1], r2[::-1]
             plot = gridplot([r1, r2], merge_tools=False)
             if self.merge_tools:
-                plot.toolbar = merge_tools([r1, r2], autohide=self.hide_toolbar)
+                plot.toolbar = merge_tools([r1, r2], autohide=self.autohide_toolbar)
         elif y_axis:
             models = [y_axis, plot]
             if self.shared_yaxis: models = models[::-1]
@@ -744,8 +742,6 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
 
     tabs = param.Boolean(default=False, doc="""
         Whether to display overlaid plots in separate panes""")
-
-    hide_toolbar = param.Boolean(default=False)
 
     def __init__(self, layout, keys=None, **params):
         super().__init__(layout, keys=keys, **params)
@@ -990,7 +986,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                                         toolbar_location=self.toolbar,
                                         sizing_mode=sizing_mode)
                         if self.merge_tools:
-                            grid.toolbar = merge_tools(children, autohide=self.hide_toolbar)
+                            grid.toolbar = merge_tools(children, autohide=self.autohide_toolbar)
                     tab_plots.append((title, grid))
                     continue
 
@@ -1032,7 +1028,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             if self.sync_legends:
                 sync_legends(layout_plot)
             if self.merge_tools:
-                layout_plot.toolbar = merge_tools(plot_grid, autohide=self.hide_toolbar)
+                layout_plot.toolbar = merge_tools(plot_grid, autohide=self.autohide_toolbar)
 
         title = self._get_title_div(self.keys[-1])
         if title:

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -87,7 +87,15 @@ class BokehPlot(DimensionedPlot, CallbackPlot):
                                             "left", "right", None],
                                    doc="""
         The toolbar location, must be one of 'above', 'below',
-        'left', 'right', None.""")
+        'left', 'right', None.""",
+    )
+
+    autohide_toolbar = param.Boolean(
+        default=False,
+        doc="""
+        Whether to automatically hide the toolbar until the user hovers over the plot.
+        This parameter has no effect if the toolbar is disabled (toolbar=None).""",
+    )
 
     width = param.Integer(default=None, bounds=(0, None), doc="""
         The width of the component (in pixels). This can be either

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -496,6 +496,8 @@ class GridPlot(CompositePlot, GenericCompositePlot):
     sync_legends = param.Boolean(default=True, doc="""
         Whether to sync the legend when muted/unmuted based on the name""")
 
+    hide_toolbar = param.Boolean(default=False)
+
     def __init__(self, layout, ranges=None, layout_num=1, keys=None, **params):
         if not isinstance(layout, GridSpace):
             raise Exception("GridPlot only accepts GridSpace.")
@@ -671,7 +673,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                 r1, r2 = r1[::-1], r2[::-1]
             plot = gridplot([r1, r2], merge_tools=False)
             if self.merge_tools:
-                plot.toolbar = merge_tools([r1, r2])
+                plot.toolbar = merge_tools([r1, r2], autohide=self.hide_toolbar)
         elif y_axis:
             models = [y_axis, plot]
             if self.shared_yaxis: models = models[::-1]
@@ -734,6 +736,8 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
 
     tabs = param.Boolean(default=False, doc="""
         Whether to display overlaid plots in separate panes""")
+
+    hide_toolbar = param.Boolean(default=False)
 
     def __init__(self, layout, keys=None, **params):
         super().__init__(layout, keys=keys, **params)
@@ -978,7 +982,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                                         toolbar_location=self.toolbar,
                                         sizing_mode=sizing_mode)
                         if self.merge_tools:
-                            grid.toolbar = merge_tools(children)
+                            grid.toolbar = merge_tools(children, autohide=self.hide_toolbar)
                     tab_plots.append((title, grid))
                     continue
 
@@ -1020,7 +1024,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             if self.sync_legends:
                 sync_legends(layout_plot)
             if self.merge_tools:
-                layout_plot.toolbar = merge_tools(plot_grid)
+                layout_plot.toolbar = merge_tools(plot_grid, autohide=self.hide_toolbar)
 
         title = self._get_title_div(self.keys[-1])
         if title:

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -627,7 +627,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             sync_legends(plot)
         plot = self._make_axes(plot)
         if hasattr(plot, "toolbar") and self.merge_tools:
-            plot.toolbar = merge_tools(plots, autohide_toolbar=True)
+            plot.toolbar = merge_tools(plots, autohide=self.autohide_toolbar)
         title = self._get_title_div(self.keys[-1])
         if title:
             plot = Column(title, plot)

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -627,7 +627,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             sync_legends(plot)
         plot = self._make_axes(plot)
         if hasattr(plot, "toolbar") and self.merge_tools:
-            plot.toolbar = merge_tools(plots, autohide=self.autohide_toolbar)
+            plot.toolbar = merge_tools(plots, hide_toolbar=True)
         title = self._get_title_div(self.keys[-1])
         if title:
             plot = Column(title, plot)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -400,7 +400,7 @@ def compute_layout_properties(
     return aspect_info, dimension_info
 
 
-def merge_tools(plot_grid, *, disambiguation_properties=None, hide_toolbar=False):
+def merge_tools(plot_grid, *, disambiguation_properties=None, hide_toolbar=False, autohide=False):
     """Merges tools defined on a grid of plots into a single toolbar.
     All tools of the same type are merged unless they define one
     of the disambiguation properties. By default `name`, `icon`, `tags`
@@ -433,7 +433,10 @@ def merge_tools(plot_grid, *, disambiguation_properties=None, hide_toolbar=False
             if p not in disambiguation_properties:
                 ignore.add(p)
 
-    return Toolbar(tools=group_tools(tools, merge=merge, ignore=ignore)) if tools else Toolbar()
+    toolbar_kwargs = {"autohide": autohide}
+    if tools:
+        toolbar_kwargs["tools"] = group_tools(tools, merge=merge, ignore=ignore)
+    return Toolbar(**toolbar_kwargs)
 
 
 def sync_legends(bokeh_layout):

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -191,3 +191,59 @@ def test_span_not_cloned_crosshair():
     tool2 = next(t for t in fig2.tools if isinstance(t, CrosshairTool))
 
     assert tool1.overlay is tool2.overlay
+
+
+def test_autohide_toolbar_single_plot():
+    curve = Curve([1, 2, 3])
+
+    # Test with autohide_toolbar=False (default)
+    plot = bokeh_renderer.get_plot(curve)
+    assert plot.autohide_toolbar is False
+    assert plot.state.toolbar.autohide is False
+
+    # Test with autohide_toolbar=True
+    plot = bokeh_renderer.get_plot(curve.opts(autohide_toolbar=True))
+    assert plot.autohide_toolbar is True
+    assert plot.state.toolbar.autohide is True
+
+
+def test_autohide_toolbar_overlay():
+    overlay = Curve([1, 2, 3]) * Curve([2, 3, 4])
+
+    # Test with autohide_toolbar=False (default)
+    plot = bokeh_renderer.get_plot(overlay)
+    assert plot.autohide_toolbar is False
+    assert plot.state.toolbar.autohide is False
+
+    # Test with autohide_toolbar=True
+    plot = bokeh_renderer.get_plot(overlay.opts(autohide_toolbar=True))
+    assert plot.autohide_toolbar is True
+    assert plot.state.toolbar.autohide is True
+
+
+def test_autohide_toolbar_layout():
+    layout = Curve([1, 2, 3]) + Curve([2, 3, 4])
+
+    # Test with autohide_toolbar=False (default)
+    plot = bokeh_renderer.get_plot(layout)
+    assert plot.autohide_toolbar is False
+    grid = plot.handles['plot']
+    for child, *_ in grid.children:
+        assert child.toolbar.autohide is False
+
+    # Test with autohide_toolbar=True
+    plot = bokeh_renderer.get_plot(layout.opts(autohide_toolbar=True))
+    assert plot.autohide_toolbar is True
+    grid = plot.handles['plot']
+    assert grid.toolbar.autohide is True
+
+def test_autohide_toolbar_nested():
+    overlay = Curve([1, 2, 3]) * Curve([2, 3, 4])
+
+    # Test with different settings for components
+    mixed_layout = overlay.opts(autohide_toolbar=True) + Curve([3, 4, 5]).opts(autohide_toolbar=False)
+    plot = bokeh_renderer.get_plot(mixed_layout)
+    grid = plot.handles['plot']
+    child1, child2 = [child for child, *_ in grid.children]
+    assert child1.toolbar.autohide is True
+    assert child2.toolbar.autohide is False

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -820,7 +820,8 @@ def save(obj, filename, fmt='auto', backend=None, resources='cdn', toolbar=None,
     if backend == "bokeh":
         if toolbar is not None:
             if toolbar:
-                obj = obj.opts(toolbar="above", autohide_toolbar=False, backend="bokeh", clone=True)
+                toolbar_location = obj.opts.get().kwargs.get('toolbar', 'right')
+                obj = obj.opts(toolbar=toolbar_location, autohide_toolbar=False, backend="bokeh", clone=True)
             else:
                 obj = obj.opts(toolbar=None, backend="bokeh", clone=True)
         elif (

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -817,14 +817,17 @@ def save(obj, filename, fmt='auto', backend=None, resources='cdn', toolbar=None,
     """
     backend = backend or Store.current_backend
     renderer_obj = renderer(backend)
-    if (
-        not toolbar
-        and backend == "bokeh"
-        and (fmt == "png" or (isinstance(filename, str) and filename.endswith("png")))
-    ):
-        obj = obj.opts(toolbar=None, backend="bokeh", clone=True)
-    elif toolbar is not None and not toolbar:
-        obj = obj.opts(toolbar=None)
+    if backend == "bokeh":
+        if toolbar is not None:
+            if toolbar:
+                obj = obj.opts(toolbar="above", autohide_toolbar=False, backend="bokeh", clone=True)
+            else:
+                obj = obj.opts(toolbar=None, backend="bokeh", clone=True)
+        elif (
+            not toolbar
+            and (fmt == "png" or (isinstance(filename, str) and filename.endswith("png")))
+        ):
+            obj = obj.opts(toolbar=None, backend="bokeh", clone=True)
     if kwargs:
         renderer_obj = renderer_obj.instance(**kwargs)
     if isinstance(filename, Path):


### PR DESCRIPTION
resolves https://github.com/holoviz/holoviews/issues/6601

TODO:

- [x] Rename to `autohide_toolbar`
- [x] Don't enable it if the toolbar is disabled.
- [x] See if we can move the parameter up a parent class to avoid repeating (likely `BokehPlot`)
- [x] Add a test for each of the basic layouts (if we can't move it up into the parent class)
- [x] Add docstring to the parameter. 
- [x] Document this feature _somewhere_


Still draft! Primarily to illustrate the basic requirements for it to function. Kept the status quo for now, and the name is also up for debate. 


``` python
import holoviews as hv
import hvplot.pandas
import numpy as np
import pandas as pd

hv.extension("bokeh", logo=False)

df = pd.DataFrame({"x": np.random.normal(size=30), "y": np.random.normal(size=30)})
df.hvplot.scatter(height=200, width=400).opts(hide_toolbar=True)
```
![image](https://github.com/user-attachments/assets/7380f7cf-c317-46e7-af00-7a105cf1cf9a)
``` python
p = df.hvplot.scatter(height=200, width=400) + df.hvplot.scatter(height=200, width=500)
p.opts(hide_toolbar=True)
```


![image](https://github.com/user-attachments/assets/3287b73b-0440-4fa6-a75c-258884ee072e)



https://github.com/user-attachments/assets/dc7d1b4d-12c8-4dec-ae55-5a4193e58b2b

