### PR TITLE
build: Move to dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ HoloViz = "https://holoviz.org/"
 
 [project.optional-dependencies]
 recommended = ["matplotlib >=3", "plotly >=4.0"]
+
+[dependency-groups]
 tests = ["pytest", "pytest-rerunfailures", "pytest-asyncio"]
 
 [project.scripts]


### PR DESCRIPTION
Applies [PEP-734](https://peps.python.org/pep-0735/), so we don't expose tests to the end user, but still make them available as an option when working with the repository.

Command to run is `pip install --group tests .`
