### PR TITLE
enh: Allow to not have to specify column in selector

### DIFF
--- a/examples/user_guide/Interactive_Hover_for_Big_Data.ipynb
+++ b/examples/user_guide/Interactive_Hover_for_Big_Data.ipynb
@@ -151,7 +151,7 @@
     "- `ds.first(<column>)`: Select the first value in the column\n",
     "- `ds.last(<column>)`: Select the last value in the column\n",
     "\n",
-    "Under the hood, the selected value has a corresponding row-index, which allows the collection and presentation of the entire row in the hover tooltip.\n",
+    "Under the hood, the selected value has a corresponding row-index, which allows the collection and presentation of the entire row in the hover tooltip. If no column is set, the selector will use the index to determine the sample.\n",
     "\n",
     "![selector ](../assets/selector.png)"
    ]

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -380,6 +380,8 @@ class aggregate(LineAggregationOperation):
             category = agg_fn.cat_column
         else:
             category = agg_fn.column if isinstance(agg_fn, ds.count_cat) else None
+        if sel_fn and sel_fn.column is None:
+            sel_fn.column = rd.SpecialColumn.RowIndex
 
         if overlay_aggregate.applies(element, agg_fn, line_width=self.p.line_width, sel_fn=sel_fn):
             params = dict(
@@ -428,7 +430,7 @@ class aggregate(LineAggregationOperation):
                 str(sel_fn)
                 if DATASHADER_GE_0_18_1
                 else f"{type(sel_fn).__name__}({getattr(sel_fn, 'column', '...')!r})"
-            )
+            ).replace(repr(rd.SpecialColumn.RowIndex), "")
         else:
             agg = self._apply_datashader(dfdata, cvs_fn, agg_fn, agg_kwargs, x, y, agg_state)
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -380,8 +380,8 @@ class aggregate(LineAggregationOperation):
             category = agg_fn.cat_column
         else:
             category = agg_fn.column if isinstance(agg_fn, ds.count_cat) else None
-        if sel_fn and sel_fn.column is None:
-            sel_fn.column = rd.SpecialColumn.RowIndex
+        if DATASHADER_GE_0_15_1 and sel_fn and sel_fn.column is None:
+            sel_fn = type(sel_fn)(column=rd.SpecialColumn.RowIndex)
 
         if overlay_aggregate.applies(element, agg_fn, line_width=self.p.line_width, sel_fn=sel_fn):
             params = dict(

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1391,6 +1391,19 @@ def test_selector_rasterize(point_plot, sel_fn):
     img_count = rasterize(point_plot, **inputs)
     np.testing.assert_array_equal(img["Count"], img_count["Count"])
 
+
+@pytest.mark.parametrize("sel_fn", (ds.first, ds.last, ds.min, ds.max))
+def test_selector_rasterize_empty_selector(point_plot, sel_fn):
+    point_plot.data["index_col"] = point_plot.data.index
+    inputs = dict(dynamic=False,  x_range=(-1, 1), y_range=(-1, 1), width=10, height=10)
+    # Empty selector will use index
+    img = rasterize(point_plot, selector=sel_fn(), **inputs)
+    exp = rasterize(point_plot, selector=sel_fn("index_col"), **inputs)
+
+    for c in ["s", "val", "cat", "index_col"]:
+        np.testing.assert_array_equal(img.data[c], exp.data[c], err_msg=c)
+
+
 @pytest.mark.usefixtures("bokeh_backend")
 def test_selector_hover_in_overlay(point_plot):
     inputs = dict(dynamic=False,  x_range=(-1, 1), y_range=(-1, 1), width=10, height=10)


### PR DESCRIPTION
One of the main "complaints" about `selector` is that you have to specify the column for it. This uses the `rd.SpecialColumn.RowIndex` which was introduced in https://github.com/holoviz/datashader/pull/1234 and released in 1.15.1. I'm not entirely sure if I'm using RowIndex correctly, so I need someone to take a look at the code. 


``` python
import itertools

import datashader as ds
import numpy as np
import pandas as pd
import panel as pn

import holoviews as hv
from holoviews.operation.datashader import datashade, dynspread, rasterize

hv.extension("bokeh")

num = 10000
seed = np.random.default_rng(1)


dists = {
    cat: pd.DataFrame(
        {
            "x": seed.normal(x, s, num),
            "y": seed.normal(y, s, num),
            "cat": cat,
            "s": s,
            "val": val,
        }
    )
    for x, y, s, val, cat in [
        (2, 2, 0.03, 0, "d1"),
        (2, -2, 0.10, 1, "d2"),
        (-2, -2, 0.50, 2, "d3"),
        (-2, 2, 1.00, 3, "d4"),
        (0, 0, 3.00, 4, "d5"),
    ]
}

df = pd.concat(dists, ignore_index=True)
df["y"] += 100  # Offset to distinguish x from y
points = hv.Points(df)

plot = rasterize(points, aggregator=ds.first("s"), selector=ds.last()).opts(tools=["hover"])
plot
```

![image](https://github.com/user-attachments/assets/4cf43abb-1eef-4def-964b-ac01d4ef778b)
