### PR TITLE
enh!: Deprecate old features

### DIFF
--- a/doc/user_guide/Configuring.md
+++ b/doc/user_guide/Configuring.md
@@ -34,28 +34,15 @@ import holoviews as hv
 hv.extension(case_sensitive_completion=True)
 ```
 
-## The holoviews.rc file
+## The HoloViews RC file
 
-HoloViews searches for the first rc file it finds in the following places (in order):
-
-1. `HOLOVIEWSRC` environment variable if it is a valid path
-1. `holoviews.rc` in the parent directory of the top-level `__init__.py` file (useful for developers working out of the HoloViews git repo)
-1. `~/.holoviews.rc`
-1. `~/.config/holoviews/holoviews.rc`
-
-The rc file is a Python script and can be loaded with:
+If the `HOLOVIEWSRC` environment variable is a valid path, HoloViews will load the configuration from that file.
+This allows users to set their preferred options globally without needing to modify their scripts each time.
+An example of an RC file to include the various options discussed above might look like this:
 
 ```python
 import holoviews as hv
 
-hv.extensions(load_rc=True)
-```
-
-An example rc file to include various options discussed above might look like this:
-
-```python
-import holoviews as hv
-
-hv.config(warn_options_call=True)
+hv.config(no_padding=True)
 hv.extension.case_sensitive_completion = True
 ```

--- a/doc/user_guide/Configuring.md
+++ b/doc/user_guide/Configuring.md
@@ -3,25 +3,19 @@
 ## `hv.config` settings
 
 The default HoloViews installation will use the latest defaults and options available, which is appropriate for new users.
-If you want to work with code written for older HoloViews versions, you can use the top-level `hv.config` object to control various backwards-compatibility options:
-
-- `future_deprecations`: Enables warnings about future deprecations.
-- `warn_options_call`: Warn when using the to-be-deprecated `__call__` syntax for specifying options, instead of the recommended `.opts` method.
-
-It is recommended you set `warn_options_call` to `True` in your holoviews.rc file (see section below).
 
 It is possible to set the configuration using `hv.config` directly:
 
 ```python
 import holoviews as hv
 
-hv.config(future_deprecations=True)
+hv.config(no_padding=True)
 ```
 
 However, because in some cases this configuration needs to be declared before the plotting extensions are imported, the recommended way of setting configuration options is:
 
 ```python
-hv.extension("bokeh", config=dict(future_deprecations=True))
+hv.extension("bokeh", config=dict(no_padding=True))
 ```
 
 In addition to backwards-compatibility options, `hv.config` holds some global options:
@@ -44,13 +38,20 @@ hv.extension(case_sensitive_completion=True)
 
 HoloViews searches for the first rc file it finds in the following places (in order):
 
+1. `HOLOVIEWSRC` environment variable if it is a valid path
 1. `holoviews.rc` in the parent directory of the top-level `__init__.py` file (useful for developers working out of the HoloViews git repo)
-2. `~/.holoviews.rc`
-3. `~/.config/holoviews/holoviews.rc`
+1. `~/.holoviews.rc`
+1. `~/.config/holoviews/holoviews.rc`
 
-The rc file location can be overridden via the `HOLOVIEWSRC` environment variable.
+The rc file is a Python script and can be loaded with:
 
-The rc file is a Python script, executed as HoloViews is imported. An example rc file to include various options discussed above might look like this:
+```python
+import holoviews as hv
+
+hv.extensions(load_rc=True)
+```
+
+An example rc file to include various options discussed above might look like this:
 
 ```python
 import holoviews as hv

--- a/examples/user_guide/Notebook_Magics.ipynb
+++ b/examples/user_guide/Notebook_Magics.ipynb
@@ -8,6 +8,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{error} Deprecation\n",
+    "Notebook Magic has been deprecated in version 1.21.0 and will be removed in version 1.23.0.\n",
+    ":::"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/examples/user_guide/Notebook_Magics.ipynb
+++ b/examples/user_guide/Notebook_Magics.ipynb
@@ -12,7 +12,7 @@
    "metadata": {},
    "source": [
     ":::{error} Deprecation\n",
-    "Notebook Magic has been deprecated in version 1.21.0 and will be removed in version 1.23.0.\n",
+    "Notebook magic commands `%%opts`, `%opts`, and `%output` have been deprecated in version 1.21.0 and will be removed in version 1.23.0.\n",
     ":::"
    ]
   },

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -140,22 +140,8 @@ if TYPE_CHECKING:
     from .util import extension
 
 # A single holoviews.rc file may be executed if found.
-for rcfile in [os.environ.get("HOLOVIEWSRC", ''),
-               os.path.abspath(os.path.join(os.path.split(__file__)[0],
-                                            '..', 'holoviews.rc')),
-               "~/.holoviews.rc",
-               "~/.config/holoviews/holoviews.rc"]:
-    filename = os.path.expanduser(rcfile)
-    if os.path.isfile(filename):
-        with open(filename, encoding='utf8') as f:
-            code = compile(f.read(), filename, 'exec')
-            try:
-                exec(code)
-            except Exception as e:
-                print(f"Warning: Could not load {filename!r} [{str(e)!r}]")
-        del f, code
-        break
-    del filename
+# this is deprecated and will be removed in HoloViews 1.23.0
+extension._load_rc_file()
 
 def help(obj, visualization=True, ansi=True, backend=None,
          recursive=False, pattern=None):
@@ -183,7 +169,7 @@ def help(obj, visualization=True, ansi=True, backend=None,
         pydoc.help(obj)
 
 
-del builtins, os, rcfile, sys
+del builtins, os, sys
 
 def __getattr__(name):
     if name == "annotate":

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -108,7 +108,15 @@ from .element import *
 from .element import __all__ as elements_list
 from .operation import Operation  # noqa (API import)
 from .selection import link_selections  # noqa (API import)
-from .util import extension, opts, output, render, renderer, save  # noqa (API import)
+from .util import (  # noqa (API import)
+    _load_rc_file,
+    extension,
+    opts,
+    output,
+    render,
+    renderer,
+    save,
+)
 from .util._versions import show_versions  # noqa: F401
 from .util.transform import dim  # noqa (API import)
 from .util.warnings import (  # noqa: F401
@@ -140,8 +148,8 @@ if TYPE_CHECKING:
     from .util import extension
 
 # A single holoviews.rc file may be executed if found.
-# this is deprecated and will be removed in HoloViews 1.23.0
-extension._load_rc_file()
+# In HoloViews 1.23.0, it will need to be set with env. var. HOLOVIEWSRC
+_load_rc_file()
 
 def help(obj, visualization=True, ansi=True, backend=None,
          recursive=False, pattern=None):
@@ -169,7 +177,7 @@ def help(obj, visualization=True, ansi=True, backend=None,
         pydoc.help(obj)
 
 
-del builtins, os, sys
+del builtins, os, sys, _load_rc_file
 
 def __getattr__(name):
     if name == "annotate":

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -111,9 +111,6 @@ class Config(param.ParameterizedFunction):
 
     """
 
-    future_deprecations = param.Boolean(default=False, doc="""
-       Whether to warn about future deprecations""")
-
     image_rtol = param.Number(default=10e-4, doc="""
       The tolerance used to enforce regular sampling for regular,
       gridded data where regular sampling is expected. Expressed as the
@@ -122,12 +119,6 @@ class Config(param.ParameterizedFunction):
 
     no_padding = param.Boolean(default=False, doc="""
        Disable default padding (introduced in 1.13.0).""")
-
-    warn_options_call = param.Boolean(default=True, doc="""
-       Whether to warn when the deprecated __call__ options syntax is
-       used (the opts method should now be used instead). It is
-       recommended that users switch this on to update any uses of
-       __call__ as it will be deprecated in future.""")
 
     default_cmap = param.String(default='kbc_r', doc="""
        Global default colormap. Prior to HoloViews 1.14.0, the default
@@ -144,6 +135,10 @@ class Config(param.ParameterizedFunction):
        1.14.0, the default value was the 'RdYlBu_r' colormap.""")
 
     def __call__(self, **params):
+        # Old parameters, which does nothing
+        params.pop("future_deprecations", None)
+        params.pop("warn_options_call", None)
+
         self.param.update(**params)
         return self
 

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -23,6 +23,7 @@ from types import FunctionType, GeneratorType
 import numpy as np
 import param
 
+from ...util.warnings import warn
 from .dependencies import (  # noqa: F401
     NUMPY_GE_2_0_0,
     NUMPY_VERSION,
@@ -135,9 +136,11 @@ class Config(param.ParameterizedFunction):
        1.14.0, the default value was the 'RdYlBu_r' colormap.""")
 
     def __call__(self, **params):
-        # Old parameters, which does nothing
-        params.pop("future_deprecations", None)
-        params.pop("warn_options_call", None)
+        # Old parameters, removed in HoloViews 1.21.0
+        if params.pop("future_deprecations", None):
+            warn("The 'future_deprecations' parameter has no effect.")
+        if params.pop("warn_options_call", None):
+            warn("The 'warn_options_call' parameter has no effect.")
 
         self.param.update(**params)
         return self

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -237,7 +237,7 @@ notebook_extension.add_delete_action(_delete_plot)
 
 
 def load_ipython_extension(ip):
-    notebook_extension(ip=ip)
+    notebook_extension("matplotlib", ip=ip)
 
 def unload_ipython_extension(ip):
     notebook_extension._loaded = False

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -1,6 +1,5 @@
 import sys
 import time
-import warnings
 
 from IPython.core.magic import Magics, line_cell_magic, line_magic, magics_class
 from IPython.display import HTML, display
@@ -8,7 +7,7 @@ from IPython.display import HTML, display
 from ..core.options import Options, Store, StoreOptions, options_policy
 from ..core.pprint import InfoPrinter
 from ..operation import Compositor
-from ..util.warnings import HoloviewsDeprecationWarning, deprecated
+from ..util.warnings import deprecated
 
 #========#
 # Magics #
@@ -32,9 +31,7 @@ InfoPrinter.store = Store
 
 
 def _magic_deprecation():
-    with warnings.catch_warnings():
-        warnings.simplefilter("always", HoloviewsDeprecationWarning)
-        deprecated("1.23.0", old="IPython magic", repr_old=False)
+    deprecated("1.23.0", old="IPython magic", repr_old=False)
 
 
 @magics_class

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -31,6 +31,12 @@ from IPython.core import page
 InfoPrinter.store = Store
 
 
+def _magic_deprecation():
+    with warnings.catch_warnings():
+        warnings.simplefilter("always", HoloviewsDeprecationWarning)
+        deprecated("1.23.0", old="IPython magic", repr_old=False)
+
+
 @magics_class
 class OutputMagic(Magics):
 
@@ -79,6 +85,7 @@ class OutputMagic(Magics):
 
     @line_cell_magic
     def output(self, line, cell=None):
+        _magic_deprecation()
 
         if line == '':
             self.pprint()
@@ -116,6 +123,7 @@ class CompositorMagic(Magics):
 
     @line_magic
     def compositor(self, line):
+        _magic_deprecation()
         if line.strip():
             for definition in CompositorSpec.parse(line.strip(), ns=self.shell.user_ns):
                 group = {group:Options() for group in Options._option_groups}
@@ -322,9 +330,7 @@ class OptsMagic(Magics):
         util.parser.OptsSpec.
 
         """
-        with warnings.catch_warnings():
-            warnings.simplefilter("always", HoloviewsDeprecationWarning)
-            deprecated("1.23.0", old="IPython magic", repr_old=False)
+        _magic_deprecation()
         line, cell = self._partition_lines(line, cell)
         try:
             spec = OptsSpec.parse(line, ns=self.shell.user_ns)
@@ -401,6 +407,7 @@ class TimerMagic(Magics):
         calls to %timer start may also be used to reset the timer.
 
         """
+        _magic_deprecation()
         if line.strip() not in ['', 'start']:
             print("Invalid argument to %timer. For more information consult %timer?")
             return

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -1,5 +1,6 @@
 import sys
 import time
+import warnings
 
 from IPython.core.magic import Magics, line_cell_magic, line_magic, magics_class
 from IPython.display import HTML, display
@@ -7,6 +8,7 @@ from IPython.display import HTML, display
 from ..core.options import Options, Store, StoreOptions, options_policy
 from ..core.pprint import InfoPrinter
 from ..operation import Compositor
+from ..util.warnings import HoloviewsDeprecationWarning, deprecated
 
 #========#
 # Magics #
@@ -320,6 +322,9 @@ class OptsMagic(Magics):
         util.parser.OptsSpec.
 
         """
+        with warnings.catch_warnings():
+            warnings.simplefilter("always", HoloviewsDeprecationWarning)
+            deprecated("1.23.0", old="IPython magic", repr_old=False)
         line, cell = self._partition_lines(line, cell)
         try:
             spec = OptsSpec.parse(line, ns=self.shell.user_ns)

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -26,7 +26,6 @@ from holoviews.plotting.plotly.callbacks import (
 )
 from holoviews.plotting.plotly.util import clean_internal_figure_properties
 from holoviews.streams import Derived, History
-from holoviews.util.warnings import deprecated
 
 # Dash imports
 try:
@@ -38,8 +37,6 @@ except ImportError:
 import plotly.graph_objects as go
 from dash import callback_context
 from dash.dependencies import Input, Output, State
-
-deprecated("1.22.0", "dash")
 
 # Activate plotly as current HoloViews extension
 hv.extension("plotly")

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -26,6 +26,7 @@ from holoviews.plotting.plotly.callbacks import (
 )
 from holoviews.plotting.plotly.util import clean_internal_figure_properties
 from holoviews.streams import Derived, History
+from holoviews.util.warnings import deprecated
 
 # Dash imports
 try:
@@ -37,6 +38,8 @@ except ImportError:
 import plotly.graph_objects as go
 from dash import callback_context
 from dash.dependencies import Input, Output, State
+
+deprecated("1.22.0", "dash")
 
 # Activate plotly as current HoloViews extension
 hv.extension("plotly")

--- a/holoviews/tests/ipython/test_magics.py
+++ b/holoviews/tests/ipython/test_magics.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 from pyviz_comms import CommManager
 
@@ -24,6 +26,20 @@ class ExtensionTestCase(IPTestCase):
         self.ip.run_line_magic("unload_ext", "holoviews.ipython")
         del self.ip
         super().tearDown()
+
+    def cell_magic(self, *args, **kwargs):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            output = super().cell_magic(*args, **kwargs)
+        assert str(w[0].message).startswith("IPython magic is deprecated")
+        return output
+
+    def line_magic(self, *args, **kwargs):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            output = super().line_magic(*args, **kwargs)
+        assert str(w[0].message).startswith("IPython magic is deprecated")
+        return output
 
 
 class TestOptsMagic(ExtensionTestCase):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -807,7 +807,7 @@ class extension(_pyviz_extension):
                     from .warnings import deprecated
                     deprecated(
                         "1.23.0",
-                        "Automatic rc_file",
+                        f"Automatic rc_file ({filename!r})",
                         "hv.extension(rc_file=True)",
                         "You can disable this warning by setting the environment variable 'HOLOVIEWSRCWARNING'.",
                         repr_old=False,

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -700,9 +700,14 @@ class extension(_pyviz_extension):
 
     _loaded = False
 
+    rc_file = param.Boolean(False, doc="Whether to load rc file")
+
     def __call__(self, *args, **params):
         # Get requested backends
         config = params.pop('config', {})
+        if "load_rc" in params:
+            self._load_rc_file(params["load_rc"])
+
         util.config.param.update(**config)
         imports = [(arg, self._backends[arg]) for arg in args
                    if arg in self._backends]
@@ -775,6 +780,40 @@ class extension(_pyviz_extension):
 
         from bokeh.util.warnings import BokehUserWarning
         warnings.filterwarnings("ignore", category=BokehUserWarning, message="reference already known")
+
+    @classmethod
+    def _load_rc_file(cls, rc_file=None):
+        if rc_file is False:
+            return
+        files = [
+            os.environ.get("HOLOVIEWSRC", ''),
+            os.path.abspath(os.path.join(os.path.split(__file__)[0], '..', 'holoviews.rc')),
+            "~/.holoviews.rc",
+            "~/.config/holoviews/holoviews.rc"
+        ]
+
+        # A single holoviews.rc file may be executed if found.
+        for file in files:
+            filename = os.path.expanduser(file)
+            if os.path.isfile(filename):
+                with open(filename, encoding='utf8') as f:
+                    code = compile(f.read(), filename, 'exec')
+                    try:
+                        exec(code)
+                    except Exception as e:
+                        print(f"Warning: Could not load {filename!r} [{str(e)!r}]")
+
+                if rc_file is None and not os.environ.get("HOLOVIEWSRCWARNING"):
+                    from .warnings import deprecated
+                    deprecated(
+                        "1.23.0",
+                        "Automatic rc_file",
+                        "hv.extension(rc_file=True)",
+                        "You can disable this warning by setting the environment variable 'HOLOVIEWSRCWARNING'.",
+                        repr_old=False,
+                    )
+
+                return
 
 
 def save(obj, filename, fmt='auto', backend=None, resources='cdn', toolbar=None, title=None, **kwargs):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -2,6 +2,7 @@ import inspect
 import os
 import shutil
 import sys
+import warnings as std_warnings
 from collections import defaultdict
 from inspect import Parameter, Signature
 from pathlib import Path
@@ -23,10 +24,10 @@ from ..core import (
 from ..core.operation import Operation, OperationCallable
 from ..core.options import Keywords, Options, options_policy
 from ..core.overlay import Overlay
-from ..core.util import merge_options_to_dict
 from ..operation.element import function
 from ..streams import Params, Stream, streams_list_from_dict
 from .settings import OutputSettings, list_backends, list_formats
+from .warnings import HoloviewsDeprecationWarning, deprecated
 
 Store.output_settings = OutputSettings
 
@@ -296,7 +297,7 @@ class opts(param.ParameterizedFunction, metaclass=OptsMeta):
         if kwargs and len(kwargs) != 1 and next(iter(kwargs.keys())) != 'backend':
             raise Exception('opts.defaults only accepts "backend" keyword argument')
 
-        expanded = cls._expand_options(merge_options_to_dict(options))
+        expanded = cls._expand_options(util.merge_options_to_dict(options))
         expanded = expanded or {}
         cls._linemagic(expanded, backend=kwargs.get('backend'))
 
@@ -359,7 +360,7 @@ class opts(param.ParameterizedFunction, metaclass=OptsMeta):
 
         expanded = {}
         if isinstance(options, list):
-            options = merge_options_to_dict(options)
+            options = util.merge_options_to_dict(options)
 
         for objspec, option_values in options.items():
             objtype = objspec.split('.')[0]
@@ -710,6 +711,7 @@ class extension(_pyviz_extension):
             if p in self._backends:
                 imports.append((p, self._backends[p]))
         if not imports:
+            deprecated("1.23.0", "hv.extension()", 'hv.extension("matplotlib")')
             args = ['matplotlib']
             imports = [('matplotlib', 'mpl')]
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -710,7 +710,12 @@ class extension(_pyviz_extension):
             if p in self._backends:
                 imports.append((p, self._backends[p]))
         if not imports:
-            deprecated("1.23.0", "hv.extension()", 'hv.extension("matplotlib")')
+            deprecated(
+                "1.23.0",
+                "Calling 'hv.extension()' without arguments",
+                'hv.extension("matplotlib")',
+                repr_old=False,
+            )
             args = ['matplotlib']
             imports = [('matplotlib', 'mpl')]
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -2,7 +2,6 @@ import inspect
 import os
 import shutil
 import sys
-import warnings as std_warnings
 from collections import defaultdict
 from inspect import Parameter, Signature
 from pathlib import Path
@@ -27,7 +26,7 @@ from ..core.overlay import Overlay
 from ..operation.element import function
 from ..streams import Params, Stream, streams_list_from_dict
 from .settings import OutputSettings, list_backends, list_formats
-from .warnings import HoloviewsDeprecationWarning, deprecated
+from .warnings import deprecated
 
 Store.output_settings = OutputSettings
 

--- a/holoviews/util/_versions.py
+++ b/holoviews/util/_versions.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import sys
 from importlib.metadata import version
@@ -49,6 +50,7 @@ def show_versions():
     print(f"Python              :  {sys.version}")
     print(f"Operating system    :  {platform.platform()}")
     _panel_comms()
+    _hv_rc_file()
     print()
     _package_version("holoviews")
     print()
@@ -67,6 +69,12 @@ def _panel_comms():
     import panel as pn
 
     print(f"{'Panel comms':20}:  {pn.config.comms}")
+
+
+def _hv_rc_file():
+    rc_file = os.getenv('HOLOVIEWSRC')
+    if rc_file:
+        print(f"{'HoloViews config':20}:  {rc_file}")
 
 
 if __name__ == "__main__":

--- a/holoviews/util/warnings.py
+++ b/holoviews/util/warnings.py
@@ -64,10 +64,10 @@ def deprecated(remove_version, old, new=None, extra=None, repr_old=True, repr_ne
         )
 
     old = repr(old) if repr_old else str(old)
-    new = repr(new) if repr_new else str(new)
     message = f"{old} is deprecated and will be removed in version {remove_version}."
 
     if new:
+        new = repr(new) if repr_new else str(new)
         message = f"{message[:-1]}, use {new} instead."
 
     if extra:

--- a/holoviews/util/warnings.py
+++ b/holoviews/util/warnings.py
@@ -41,7 +41,7 @@ def find_stack_level():
     )
 
     with suppress(ImportError):
-        import IPython
+        import IPython.core
         ignore_paths = (*ignore_paths, os.path.dirname(IPython.core.__file__))
 
     frame = inspect.currentframe()

--- a/holoviews/util/warnings.py
+++ b/holoviews/util/warnings.py
@@ -49,7 +49,7 @@ def find_stack_level():
     return stacklevel
 
 
-def deprecated(remove_version, old, new=None, extra=None):
+def deprecated(remove_version, old, new=None, extra=None, repr_old=True, repr_new=True):
     import holoviews as hv
 
     current_version = Version(Version(hv.__version__).base_version)
@@ -63,10 +63,12 @@ def deprecated(remove_version, old, new=None, extra=None):
             f"{old!r} should have been removed in {remove_version}, current version {current_version}."
         )
 
-    message = f"{old!r} is deprecated and will be removed in version {remove_version}."
+    old = repr(old) if repr_old else str(old)
+    new = repr(new) if repr_new else str(new)
+    message = f"{old} is deprecated and will be removed in version {remove_version}."
 
     if new:
-        message = f"{message[:-1]}, use {new!r} instead."
+        message = f"{message[:-1]}, use {new} instead."
 
     if extra:
         message += " " + extra.strip()

--- a/holoviews/util/warnings.py
+++ b/holoviews/util/warnings.py
@@ -49,7 +49,7 @@ def find_stack_level():
     return stacklevel
 
 
-def deprecated(remove_version, old, new=None, extra=None, repr_old=True, repr_new=True):
+def deprecated(remove_version, old, new=None, extra=None, *, repr_old=True, repr_new=True):
     import holoviews as hv
 
     current_version = Version(Version(hv.__version__).base_version)

--- a/holoviews/util/warnings.py
+++ b/holoviews/util/warnings.py
@@ -63,12 +63,12 @@ def deprecated(remove_version, old, new=None, extra=None, *, repr_old=True, repr
             f"{old!r} should have been removed in {remove_version}, current version {current_version}."
         )
 
-    old = repr(old) if repr_old else str(old)
-    message = f"{old} is deprecated and will be removed in version {remove_version}."
+    old_str = repr(old) if repr_old else str(old)
+    message = f"{old_str} is deprecated and will be removed in version {remove_version}."
 
     if new:
-        new = repr(new) if repr_new else str(new)
-        message = f"{message[:-1]}, use {new} instead."
+        new_str = repr(new) if repr_new else str(new)
+        message = f"{message[:-1]}, use {new_str} instead."
 
     if extra:
         message += " " + extra.strip()


### PR DESCRIPTION
Part of the deprecation sprint in the fall, see https://github.com/holoviz/holoviews/issues/6445

1. Deprecate auto RC file loading (removed in 1.23.0)
This will now require a user to specify the HOLOVIEWSRC environment variable. Have refactored the code a bit. 

2. Remove unused `hv.configs`: `future_deprecations` and `warn_options_call`  (no timeline)
I'm also removing the unused parameters `future_deprecations` and `warn_options_call`, and adding a warning if a user has specified them for some reason. 

~~3. Deprecate dash  (removed in 1.22.0)
We don't test Dash at all, so I have moved this to the next minor version after this deprecation has been included.~~

4. Deprecate IPython magic (removed in 1.23.0)
This is done with a warning when it is called and a note in the notebook. 
	``` python
	import holoviews as hv
	
	hv.extension("bokeh")
	
	%%opts Curve (color="red" line_width=1.5)
	%%opts Curve  [height=200 width=900 xaxis=None tools=['hover']]
	
	hv.Curve([1, 2,3])
	```
5. Deprecate bare `hv.extension()`  (removed in 1.23.0)


--- 
![image](https://github.com/user-attachments/assets/4976a10e-ec43-4333-87bf-27188e131088)
