### PR TITLE
enh: Add details option for AbbreviatedException

### DIFF
--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -184,7 +184,7 @@ def _render_jupyter_exception(e):
       <summary><b>{exc_name}:</b> {exc_msg}</summary>
       <div class="hv-jupyter-full">{escaped_tb}</pre>
     </details>"""
-    return {"text/html": output_html}, {}
+    return {"text/html": output_html}
 
 
 def display_hook(fn):
@@ -225,7 +225,7 @@ def display_hook(fn):
             return {}, {}
         except AbbreviatedException as e:
             FULL_TRACEBACK = '\n'.join(traceback.format_exception(e.etype, e.value, e.traceback))
-            return _render_jupyter_exception(e)
+            return _render_jupyter_exception(e), {}
         except Exception:
             raise
     return wrapped

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -137,6 +137,55 @@ def option_state(element):
         dynamic_optstate(element, state=optstate)
         raise
 
+def _render_jupyter_exception(e):
+    import html
+
+    raw_tb = "\n".join(traceback.format_exception(e.etype, e.value, e.traceback)).strip()
+
+    escaped_tb = html.escape(raw_tb)
+    exc_name = e.etype.__name__
+    exc_msg = str(e.value).split("\n")[0]
+    if len(exc_msg) > 80:
+        exc_msg = exc_msg[:80].strip() + " ..."
+    exc_msg = html.escape(exc_msg)
+
+    output_html = f"""
+    <style>
+      .hv-jupyter-exc {{
+        font-family: monospace;
+        border-radius: 3px;
+        padding: 0.5em;
+        margin: 0.5em 0;
+      }}
+      .hv-jupyter-exc summary {{
+        cursor: pointer;
+        user-select: none;
+        list-style: none;
+        position: relative;
+        padding-left: 1.2em;
+      }}
+      .hv-jupyter-exc summary::after {{
+        content: "▶";
+        position: absolute;
+        left: 0;
+        top: 0;
+        transition: transform 0.2s ease;
+      }}
+      .hv-jupyter-exc[open] summary::after {{
+        transform: rotate(90deg);
+      }}
+      .hv-jupyter-full {{
+        padding: 0.5em 0 0 1em;
+        white-space: pre-wrap;
+        background-color: #fdd;
+      }}
+    </style>
+    <details class="hv-jupyter-exc">
+      <summary><b>{exc_name}:</b> {exc_msg}</summary>
+      <div class="hv-jupyter-full">{escaped_tb}</pre>
+    </details>"""
+    return {"text/html": output_html}, {}
+
 
 def display_hook(fn):
     """A decorator to wrap display hooks that return a MIME bundle or None.
@@ -175,14 +224,8 @@ def display_hook(fn):
                 sys.stderr.write(str(e))
             return {}, {}
         except AbbreviatedException as e:
-            FULL_TRACEBACK = '\n'.join(traceback.format_exception(e.etype,
-                                                                  e.value,
-                                                                  e.traceback))
-            info = dict(name=e.etype.__name__,
-                        message=str(e.value).replace('\n','<br>'))
-            msg =  '<i> [Call holoviews.ipython.show_traceback() for details]</i>'
-            return {'text/html': "<b>{name}</b>{msg}<br>{message}".format(msg=msg, **info)}, {}
-
+            FULL_TRACEBACK = '\n'.join(traceback.format_exception(e.etype, e.value, e.traceback))
+            return _render_jupyter_exception(e)
         except Exception:
             raise
     return wrapped

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -178,6 +178,7 @@ def _render_jupyter_exception(e):
         padding: 0.5em 0 0 1em;
         white-space: pre-wrap;
         background-color: #fdd;
+        color: #000;
       }}
     </style>
     <details class="hv-jupyter-exc">


### PR DESCRIPTION
``` python
import holoviews as hv

hv.extension("bokeh")

plot = hv.Points([]).opts(radius=2)
plot.opts(radius=None, size=2)
```

current:
![image](https://github.com/user-attachments/assets/221da91a-819e-4c70-b719-2e277069df69)

This pr 

JupyterLab

https://github.com/user-attachments/assets/2f95dd29-0a38-4984-82aa-82f146695d13

VS Code
![image](https://github.com/user-attachments/assets/edb74f78-51c6-49e1-9a58-4dbccfd413eb)

Classic Notebook (Version 6)

![image](https://github.com/user-attachments/assets/6b8609c6-4b52-4e85-9b6f-2ebd4b563325)

Colab

![image](https://github.com/user-attachments/assets/58d771f3-a206-427a-864a-f3bff23d2f06)


Note that the problem showing is fixed in: https://github.com/holoviz/holoviews/pull/6613


