### PR TITLE
test: Close down IPython shell

### DIFF
--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -791,8 +791,8 @@ class IPTestCase(ComparisonTestCase):
         try:
             import IPython
             from IPython.display import HTML, SVG
-        except Exception as e:
-            raise SkipTest("IPython could not be started") from e
+        except Exception:
+            raise SkipTest("IPython could not be imported") from None
 
         super().setUp()
         self.ip = IPython.InteractiveShell(history_length=0, history_load_length=0)

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -795,14 +795,17 @@ class IPTestCase(ComparisonTestCase):
             raise SkipTest("IPython could not be imported") from None
 
         super().setUp()
-        self.ip = IPython.InteractiveShell(history_length=0, history_load_length=0)
+        self.exits = []
+        with patch('atexit.register', lambda x: self.exits.append(x)):
+            self.ip = IPython.InteractiveShell(history_length=0, history_load_length=0)
         self.addTypeEqualityFunc(HTML, self.skip_comparison)
         self.addTypeEqualityFunc(SVG,  self.skip_comparison)
 
     def tearDown(self) -> None:
         # self.ip.displayhook.flush calls gc.collect
         with patch('gc.collect', lambda: None):
-            self.ip.reset()
+            for ex in self.exits:
+                ex()
         del self.ip
         super().tearDown()
 

--- a/holoviews/tests/ipython/test_displayhooks.py
+++ b/holoviews/tests/ipython/test_displayhooks.py
@@ -18,7 +18,6 @@ class TestDisplayHooks(IPTestCase):
 
     def tearDown(self):
         self.ip.run_line_magic("unload_ext", "holoviews.ipython")
-        del self.ip
         Store.display_hooks = self.backup
         notebook_extension._loaded = False
         super().tearDown()

--- a/holoviews/tests/ipython/test_magics.py
+++ b/holoviews/tests/ipython/test_magics.py
@@ -22,7 +22,6 @@ class ExtensionTestCase(IPTestCase):
 
     def tearDown(self):
         self.ip.run_line_magic("unload_ext", "holoviews.ipython")
-        del self.ip
         super().tearDown()
 
 


### PR DESCRIPTION
Saw some sqlite connection error yesterday when I ran ` pytest holoviews -k "ipython and magic" `, but cannot recreate those today.

This refactors the existing code to move `atexit.register` code to the tearDown and avoid all `gc.collect`.