### PR TITLE
fix(bokeh): Add option to convert back to `size` with Points

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -72,11 +72,13 @@ class PointPlot(LegendPlot, ColorbarPlot):
     _batched_style_opts = line_properties + fill_properties + ['size', 'marker', 'angle']
 
     def _init_glyph(self, plot, mapping, properties):
-        if "radius" in properties:
+        if properties.get("radius") is not None:
             self._plot_methods = dict(single='circle', batched='circle')
             properties.pop("size", None)
         else:
+            self._plot_methods = dict(single='scatter', batched='scatter')
             properties.pop("radius_dimension", None)
+            properties.pop("radius", None)
         return super()._init_glyph(plot, mapping, properties)
 
     def _get_size_data(self, element, ranges, style):


### PR DESCRIPTION
This would previously fail:

``` python
import holoviews as hv

hv.extension("bokeh")

plot = hv.Points([1, 2, 3]).opts(radius=0.1)
plot + plot.clone().opts(radius=None, size=2)
```

![image](https://github.com/user-attachments/assets/1c9bd55e-fe3e-40e7-8712-53d98bd113bc)
