### PR TITLE
enh: Support passing selection dictionary to Dataset.select

### DIFF
--- a/examples/user_guide/10-Indexing_and_Selecting_Data.ipynb
+++ b/examples/user_guide/10-Indexing_and_Selecting_Data.ipynb
@@ -17,11 +17,11 @@
     "\n",
     "| Operation      | Example syntax   |  Description |\n",
     "|:---------------|:----------------:|:-------------|\n",
-    "| **indexing**   | e[5.5], e[3,5.5] | Selecting a single data value, returning one actual numerical value from the existing data\n",
-    "| **slice**      | e[3:5.5], e[3:5.5,0:1] | Selecting a contiguous portion from an Element, returning the same type of Element\n",
-    "| **sample**     | e.sample(y=5.5),<br>e.sample((3,3)) |  Selecting one or more regularly spaced data values, returning a new type of Element\n",
-    "| **select**     | e.select(y=5.5),<br>e.select(y=(3,5.5)) | More verbose notation covering all supported slice and index operations by dimension name.\n",
-    "| **iloc**       | e[2, :],<br>e[2:5, :]  | Indexes and slices by row and column tabular index supporting integer indexes, slices, lists and boolean indices.\n",
+    "| **indexing**   | `e[5.5]`, `e[3,5.5]` | Selecting a single data value, returning one actual numerical value from the existing data\n",
+    "| **slice**      | `e[3:5.5]`, `e[3:5.5,0:1]` | Selecting a contiguous portion from an Element, returning the same type of Element\n",
+    "| **sample**     | `e.sample(y=5.5)`,<br>`e.sample((3,3))` |  Selecting one or more regularly spaced data values, returning a new type of Element\n",
+    "| **select**     | `e.select(y=5.5)`,<br>`e.select(y=(3,5.5))`,<br>`e.select({\"y\": (3, 3.5)}` | More verbose notation covering all supported slice and index operations by dimension name.\n",
+    "| **iloc**       | `e[2, :]`,<br>`e[2:5, :]` | Indexes and slices by row and column tabular index supporting integer indexes, slices, lists and boolean indices.\n",
     "\n",
     "These operations are all concerned with selecting some subset of the data values, without combining across data values (e.g. averaging) or otherwise transforming the actual data. In the [Tabular Data](./08-Tabular_Datasets.ipynb) user guide we will look at additional operations on the data that reduce, summarize, or transform the data in other ways, in addition to the selections covered here.\n",
     "\n",
@@ -241,7 +241,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Tabular indexing and slicing"
+    "## Using `.select`\n",
+    "\n",
+    "The `[]` (i.e. `__getitem__`) syntax provides a convenient and concise mechanism for selecting and indexing, however to be very explicit even for nested objects the `.select` method provides an equivalent mechanism.\n",
+    "\n",
+    "The `.select` method allows providing selections as keyword arguments indexed by dimension name but also allows passing a dictionary of selectors directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img * box + img.select(x=(1, 9), y=(4, 5)) + img.select({\"x\": (1, 9), \"y\": (4, 5)})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The select operation also supports so called selection expressions built using the `hv.dim` transforms:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "curve = hv.Curve((xs, np.sin(xs)))\n",
+    "\n",
+    "curve * curve.select(hv.dim('x') > 12)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tabular indexing and slicing"
    ]
   },
   {
@@ -250,12 +288,9 @@
    "source": [
     "While most indexing in HoloViews works by selecting the values along a dimension it is also frequently useful to index and slice using integer row and column indices. For this purpose most HoloViews objects have a ``.iloc`` indexing interface (mirroring the [pandas](http://pandas.pydata.org/pandas-docs/stable/indexing.html#different-choices-for-indexing) API), which supports all the usual indexing semantics. Supported iloc arguments include:\n",
     "\n",
-    "* An integer e.g. 5\n",
-    "\n",
-    "* A list or array of integers [4, 3, 0]\n",
-    "\n",
-    "* A slice object with ints 1:7\n",
-    "\n",
+    "* An integer e.g. `5`\n",
+    "* A list or array of integers `[4, 3, 0]`\n",
+    "* A slice object with ints `1:7`\n",
     "* A boolean array"
    ]
   },

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -611,10 +611,16 @@ class Dataset(Element, metaclass=PipelineMeta):
             from holoviews import dim
             ds.select(selection_expr=dim('x') % 2 == 0)
 
+        * selections dictionary: A dictionary of selections per dimension
+
+            ds.select({x: 3})
+
         Parameters
         ----------
-        selection_expr : holoviews.dim predicate expression
-            specifying selection.
+        selection_expr : A dim expression or dictionary of selections.
+            holoviews.dim predicate expression specifying selection or
+            a dictionary of selections (as an alternative to selecting
+            via keyword arguments).
         selection_specs : List of specs to match on
             A list of types, functions, or type[.group][.label]
             strings specifying which objects to apply the
@@ -629,6 +635,13 @@ class Dataset(Element, metaclass=PipelineMeta):
         or a scalar if a single value was selected
         """
         from ...util.transform import dim
+        if isinstance(selection_expr, dict):
+            if selection:
+                raise ValueError("""\
+                Selections may be supplied as keyword arguments or as a positional
+                argument, never both.""")
+            selection = selection_expr
+            selection_expr = None
         if selection_expr is not None and not isinstance(selection_expr, dim):
             raise ValueError("""\
             The first positional argument to the Dataset.select method is expected to be a

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -592,7 +592,7 @@ class TriMesh(Graph):
         """
         return self._initialize_edgepaths()
 
-    def select(self, selection_specs=None, **selection):
+    def select(self, selection_expr=None, selection_specs=None, **selection):
         """Allows selecting data by the slices, sets and scalar values
         along a particular dimension. The indices should be supplied as
         keywords mapping between the selected dimension and
@@ -603,9 +603,10 @@ class TriMesh(Graph):
 
         """
         self._initialize_edgepaths()
-        return super().select(selection_specs=None,
-                              selection_mode='nodes',
-                              **selection)
+        return super().select(
+            selection_expr=selection_expr, selection_specs=selection_specs,
+            selection_mode='nodes', **selection
+        )
 
 
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -405,7 +405,7 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
         agg = super().aggregate(dimensions, function, spreadfn, **kwargs)
         return Curve(agg) if isinstance(agg, Dataset) and len(self.vdims) == 1 else agg
 
-    def select(self, selection_specs=None, **selection):
+    def select(self, selection_expr=None, selection_specs=None, **selection):
         """Allows selecting data by the slices, sets and scalar values
         along a particular dimension. The indices should be supplied as
         keywords mapping between the selected dimension and
@@ -415,6 +415,13 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
         specs match the selected object.
 
         """
+        if isinstance(selection_expr, dict):
+            if selection:
+                raise ValueError("""\
+                Selections may be supplied as keyword arguments or as a positional
+                argument, never both.""")
+            selection = selection_expr
+            selection_expr = None
         if selection_specs and not any(self.matches(sp) for sp in selection_specs):
             return self
 

--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -693,6 +693,13 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
                           kdims=self.kdims, vdims=self.vdims)
         self.assertEqual(row, indexed)
 
+    def test_dataset_select_rows_gender_male_dict(self):
+        row = self.table.select({"Gender": 'M'})
+        indexed = Dataset({'Gender':['M', 'M'], 'Age':[10, 16],
+                           'Weight':[15,18], 'Height':[0.8,0.6]},
+                          kdims=self.kdims, vdims=self.vdims)
+        self.assertEqual(row, indexed)
+
     def test_dataset_select_rows_gender_male_expr(self):
         row = self.table.select(selection_expr=dim('Gender') == 'M')
         indexed = Dataset({'Gender': ['M', 'M'], 'Age': [10, 16],
@@ -703,6 +710,15 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
     def test_dataset_select_rows_gender_male_alias(self):
         row = self.alias_table.select(Gender='M')
         alias_row = self.alias_table.select(gender='M')
+        indexed = Dataset({'gender':['M', 'M'], 'age':[10, 16],
+                           'weight':[15,18], 'height':[0.8,0.6]},
+                          kdims=self.alias_kdims, vdims=self.alias_vdims)
+        self.assertEqual(row, indexed)
+        self.assertEqual(alias_row, indexed)
+
+    def test_dataset_select_rows_gender_male_alias_dict(self):
+        row = self.alias_table.select({"Gender": 'M'})
+        alias_row = self.alias_table.select({"gender": 'M'})
         indexed = Dataset({'gender':['M', 'M'], 'age':[10, 16],
                            'weight':[15,18], 'height':[0.8,0.6]},
                           kdims=self.alias_kdims, vdims=self.alias_vdims)
@@ -973,11 +989,23 @@ class GriddedInterfaceTests:
         )
         self.assertEqual(self.dataset_grid.select(y=slice(0, 0.25)), ds)
 
+    def test_select_slice_as_dict(self):
+        ds = self.element(
+            (self.grid_xs, self.grid_ys[:2], self.grid_zs[:2]), ['x', 'y'], ['z']
+        )
+        self.assertEqual(self.dataset_grid.select({"y": slice(0, 0.25)}), ds)
+
     def test_select_tuple(self):
         ds = self.element(
             (self.grid_xs, self.grid_ys[:2], self.grid_zs[:2]), ['x', 'y'], ['z']
         )
         self.assertEqual(self.dataset_grid.select(y=(0, 0.25)), ds)
+
+    def test_select_tuple_as_dict(self):
+        ds = self.element(
+            (self.grid_xs, self.grid_ys[:2], self.grid_zs[:2]), ['x', 'y'], ['z']
+        )
+        self.assertEqual(self.dataset_grid.select({"y": (0, 0.25)}), ds)
 
     def test_nodata_range(self):
         ds = self.dataset_grid.clone(vdims=[Dimension('z', nodata=0)])


### PR DESCRIPTION
This PR proposes an API change (or rather an additional signature) for `Dataset.select`.

Currently we support passing per-dimensions select specifications as keyword arguments. This is generally quite convenient because in most cases dimensions are valid identifiers so the keyword syntax, e.g. `.select(x=(0, 10))` provides the shortest and most convenient syntax. However when the dimension name is not a valid identifier, e.g. it's a string digit or contains other non-valid identifiers you have to write it out using dictionary unpacking:

```python
x = hv.Dimension('0')

curve = hv.Curve([], kdims=[x])

curve.select(**{'0': (1, 3)})
```

This is not even particularly contrived because when you construct an element from a pandas DataFrame with default column names this is what happens. While a little cumbersome this use case at least works.

However, we are currently in the process of creating a new data interface for `anndata` and because of the complex data model we have to create special dimension objects, which are not easily mapped onto simple string names. This is where the current select approach completely breaks down since keyword arguments must be string based we cannot perform a select operation on elements backed by an `anndata` dataset, e.g.:

```python
x = hv.Dimension('0')

curve = hv.Curve([], kdims=[x])

curve.select(**{x: 1})
```

Will error because x is not a string. Therefore I propose we overload the `selection_expr` argument for `.select` making it possible to instead write select operations as:

```python
x = hv.Dimension('0')

curve = hv.Curve([], kdims=[x])

curve.select({x: 1})
```

This is fully backward compatible since it would previously just error. Before I do any more work on this I'd love to hear feedback.