### PR TITLE
enh: Add `invert_dendrogram` option to dendrogram operation

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -1311,9 +1311,10 @@ class dendrogram(Operation):
             ic = ddata["icoord"]
             if self.p.invert_dendrogram:
                 ic = np.asarray(ic)
-                # Convert the smallest to the largest, while still being
-                # positive, offset (5) so we don't divide by zero
+                # Convert the smallest value to the largest value, while still
+                # being positive, offset (5) so we don't divide by zero
                 ic = ic.max() - ic + 5
+            # Important the kdims are unique
             dendros[d] = Dendrogram(ic, ddata["dcoord"], kdims=[f"__dendrogram_x_{d}", f"__dendrogram_y_{d}"])
 
         if not self.p.adjoined:

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -1274,7 +1274,8 @@ class dendrogram(Operation):
         https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html#scipy.cluster.hierarchy.linkage
         """
     )
-    invert_dendrogram = param.Boolean(default=False)
+    invert_dendrogram = param.Boolean(default=False, doc="""
+        Whether to invert the dendrogram axis.""")
 
     def _compute_linkage(self, dataset, dim, vdim):
         try:

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -1235,7 +1235,7 @@ class dendrogram(Operation):
 
     adjoint_dims = param.List(item_type=str, doc="The adjoint dimension to cluster on")
 
-    main_dim = param.String(doc="The main dimension to cluster on")
+    main_dim = param.String(default=None, allow_None=False, doc="The main dimension to cluster on")
 
     main_element = param.ClassSelector(default=HeatMap, class_=Dataset, instantiate=False, is_instance=False, doc="""
         The Element type to use for the main plot if the input is a Dataset.""")
@@ -1298,6 +1298,8 @@ class dendrogram(Operation):
         return dendrogram(Z, labels=labels, no_plot=True)
 
     def _process(self, element, key=None):
+        if self.p.main_dim is None:
+            raise TypeError("'main_dim' cannot be None")
         element_kdims = element.kdims
         dataset = Dataset(element)
         sign = -1 if self.p.invert_dendrogram else 1

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -1274,7 +1274,7 @@ class dendrogram(Operation):
         https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html#scipy.cluster.hierarchy.linkage
         """
     )
-    invert_dendrogram = param.Boolean(default=False, doc="""
+    invert = param.Boolean(default=False, doc="""
         Whether to invert the dendrogram axis.""")
 
     def _compute_linkage(self, dataset, dim, vdim):
@@ -1302,7 +1302,7 @@ class dendrogram(Operation):
             raise TypeError("'main_dim' cannot be None")
         element_kdims = element.kdims
         dataset = Dataset(element)
-        sign = -1 if self.p.invert_dendrogram else 1
+        sign = -1 if self.p.invert else 1
         sort_dims, dendros = [], {}
         for d in self.p.adjoint_dims:
             ddata = self._compute_linkage(dataset, d, self.p.main_dim)
@@ -1312,7 +1312,7 @@ class dendrogram(Operation):
             sort_dims.append(sort_dim)
 
             ic = ddata["icoord"]
-            if self.p.invert_dendrogram:
+            if self.p.invert:
                 ic = np.asarray(ic)
                 # Convert the smallest value to the largest value, while still
                 # being positive, offset (5) so we don't divide by zero

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -1324,10 +1324,13 @@ class dendrogram(Operation):
                 return Layout(dendros.values())
 
         vdims = [dataset.get_dimension(self.p.main_dim), *[vd for vd in dataset.vdims if vd != self.p.main_dim]]
+        # Adding non_sort_dims to handle unstable sorting algorithms, which can differ between OSs
+        # https://github.com/holoviz/holoviews/pull/6625#issuecomment-2981268665
+        non_sort_dims = [d for d in element_kdims[:2] if str(d) not in self.p.adjoint_dims]
         if type(element) is not Dataset:
-            main = element.clone(dataset.sort(sort_dims).reindex(element_kdims), vdims=vdims)
+            main = element.clone(dataset.sort([*sort_dims, *non_sort_dims]).reindex(element_kdims), vdims=vdims)
         else:
-            main = self.p.main_element(dataset.sort(sort_dims).reindex(element_kdims[:2]), vdims=vdims)
+            main = self.p.main_element(dataset.sort([*sort_dims, *non_sort_dims]).reindex(element_kdims[:2]), vdims=vdims)
 
         for dim in map(str, main.kdims[::-1]):
             if dim not in self.p.adjoint_dims:

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -741,13 +741,26 @@ class TestDendrogramOperation:
             [(i, chr(65 + j), random.random()) for j in range(10) for i in range(5)],
             columns=["z", "x", "y"],
         )
+        data = [
+            [7, 8, 0, 0, 0, 0],
+            [8, 6, 0, 0, 0, 0],
+            [0, 0, 9, 8, 2, 7],
+            [0, 0, 0, 1, 8, 2],
+            [0, 7, 0, 7, 0, 0],
+        ]
+        self.df2 = pd.DataFrame([
+            {"cluster": f"clust {i}", "gene": f"gene {j}", "value": data[i][j]}
+            for j in range(6)
+            for i in range(5)
+        ])
+        self.bokeh_renderer = renderer("bokeh")
 
     def get_childrens(self, adjoint):
-        bk_childrens = renderer("bokeh").get_plot(adjoint).handles["plot"].children
+        bk_childrens = self.bokeh_renderer.get_plot(adjoint).handles["plot"].children
         (atop, *_), (amain, *_), (aright, *_) = bk_childrens
-        top = renderer("bokeh").get_plot(adjoint["top"]).handles["plot"]
-        main = renderer("bokeh").get_plot(adjoint["main"]).handles["plot"]
-        right = renderer("bokeh").get_plot(adjoint["right"]).handles["plot"]
+        top = self.bokeh_renderer.get_plot(adjoint["top"]).handles["plot"]
+        main = self.bokeh_renderer.get_plot(adjoint["main"]).handles["plot"]
+        right = self.bokeh_renderer.get_plot(adjoint["right"]).handles["plot"]
         return (atop, amain, aright), (top, main, right)
 
     def test_right_only(self):
@@ -821,3 +834,27 @@ class TestDendrogramOperation:
         assert len(dendro) == 2
         assert isinstance(dendro[0], Dendrogram)
         assert isinstance(dendro[1], Dendrogram)
+
+    @pytest.mark.parametrize(
+        "adjoint_dims",
+        (["cluster"], ["gene"], ["gene", "cluster"]),
+        ids=["right", "top", "both"],
+    )
+    def test_invert_dendrogram(self, adjoint_dims):
+        plot = Points(self.df2, kdims=["gene", "cluster"])
+        dendro1 = dendrogram(plot, adjoint_dims=adjoint_dims, main_dim="value")
+        dendro2 = dendrogram(plot, adjoint_dims=adjoint_dims, main_dim="value", invert_dendrogram=True)
+
+        main1 = self.bokeh_renderer.get_plot(dendro1["main"]).handles["plot"]
+        main2 = self.bokeh_renderer.get_plot(dendro2["main"]).handles["plot"]
+
+        match adjoint_dims:
+            case ["cluster"]:
+                assert main1.x_range.factors == main2.x_range.factors
+                assert main1.y_range.factors == main2.y_range.factors[::-1]
+            case ["gene"]:
+                assert main1.x_range.factors == main2.x_range.factors[::-1]
+                assert main1.y_range.factors == main2.y_range.factors
+            case _:
+                assert main1.y_range.factors == main2.y_range.factors[::-1]
+                assert main1.x_range.factors == main2.x_range.factors[::-1]

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -843,7 +843,7 @@ class TestDendrogramOperation:
     def test_invert_dendrogram(self, adjoint_dims):
         plot = Points(self.df2, kdims=["gene", "cluster"])
         dendro1 = dendrogram(plot, adjoint_dims=adjoint_dims, main_dim="value")
-        dendro2 = dendrogram(plot, adjoint_dims=adjoint_dims, main_dim="value", invert_dendrogram=True)
+        dendro2 = dendrogram(plot, adjoint_dims=adjoint_dims, main_dim="value", invert=True)
 
         main1 = self.bokeh_renderer.get_plot(dendro1["main"]).handles["plot"]
         main2 = self.bokeh_renderer.get_plot(dendro2["main"]).handles["plot"]

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -858,3 +858,18 @@ class TestDendrogramOperation:
             case _:
                 assert main1.y_range.factors == main2.y_range.factors[::-1]
                 assert main1.x_range.factors == main2.x_range.factors[::-1]
+
+    @pytest.mark.parametrize("adjoint_dims", (["cluster"], ["gene"],), ids=["right", "top"])
+    def test_assure_non_adjoined_axis_is_unchanged(self, adjoint_dims):
+        # See: https://github.com/holoviz/holoviews/pull/6625#issuecomment-2981268665
+        plot = Points(self.df2, kdims=["gene", "cluster"])
+        main1 = self.bokeh_renderer.get_plot(plot).handles["plot"]
+
+        dendro = dendrogram(plot, adjoint_dims=adjoint_dims, main_dim="value")
+        main2 = self.bokeh_renderer.get_plot(dendro["main"]).handles["plot"]
+
+        match adjoint_dims:
+            case ["cluster"]:
+                assert main1.x_range.factors == main2.x_range.factors
+            case ["gene"]:
+                assert main1.y_range.factors == main2.y_range.factors


### PR DESCRIPTION
Setting `invert_dendrogram=True` mimics how ScanPy does it, but I don't think it should be the default. @droumis, can you play around with this? 

![image](https://github.com/user-attachments/assets/83318b44-022d-48f1-a38d-1ee5483be279)


``` python
import holoviews as hv
import pandas as pd

hv.extension("bokeh")

data = [
    [7, 8, 0, 0, 0, 0],
    [8, 6, 0, 0, 0, 0],
    [0, 0, 9, 8, 2, 7],
    [0, 0, 0, 1, 8, 2],
    [0, 7, 0, 7, 0, 0],
]
df = pd.DataFrame([
    {"cluster": f"clust {i}", "gene": f"gene {j}", "value": data[i][j]}
    for j in range(6) 
    for i in range(5)
])

opts = dict(
    color=hv.dim("value").norm(), size=(hv.dim("value") != 0) * 30, cmap="Reds", tools=["hover"]
)
plot = hv.Points(df, kdims=["gene", "cluster"]).opts(**opts)

hv.operation.dendrogram(plot, adjoint_dims=["cluster"], main_dim="value")
hv.operation.dendrogram(plot, adjoint_dims=["cluster"], main_dim="value", invert_dendrogram=True)
```