### PR TITLE
docs: Remove tooltip in documentation

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -249,16 +249,19 @@ class notebook_extension(extension):
             import plotly
             plotly_version = plotly.__version__
 
-        html = template.render({'logo':        logo,
-                                'logo_src':    logo_src,
-                                'logo_link':   logo_link,
-                                'logo_title':  logo_title,
-                                'bokeh_logo':  bokeh_logo,
-                                'mpl_logo':    mpl_logo,
-                                'plotly_logo': plotly_logo,
-                                'bokeh_version':  bokeh_version,
-                                'mpl_version':    mpl_version,
-                                'plotly_version': plotly_version})
+        html = template.render({
+            'logo':        logo,
+            'logo_src':    logo_src,
+            'logo_link':   logo_link,
+            'logo_title':  logo_title,
+            'bokeh_logo':  bokeh_logo,
+            'mpl_logo':    mpl_logo,
+            'plotly_logo': plotly_logo,
+            'bokeh_version':  bokeh_version,
+            'mpl_version':    mpl_version,
+            'plotly_version': plotly_version,
+            'show_tooltip': not os.getenv("HV_DOCS_BUILD")
+        })
         publish_display_data(data={'text/html': html})
 
 

--- a/holoviews/ipython/load_notebook.html
+++ b/holoviews/ipython/load_notebook.html
@@ -158,9 +158,11 @@ z/8BE3VwbODCC/EAAAAASUVORK5CYII='
 </a>
 {% endif %}
 
+{% if show_tooltip %}
 <span style="float: left; margin-left: 5px; line-height: 15px; cursor: pointer; opacity: 0.7;"
-      onmouseover="this.style.opacity='1'" 
+      onmouseover="this.style.opacity='1'"
       onmouseout="this.style.opacity='0.7'"
       title="Extension loaded. This cell output contains code that enables plot interactivity, it should not be removed.">ⓘ</span>
 </div>
+{% endif %}
 {% endif %}

--- a/pixi.toml
+++ b/pixi.toml
@@ -200,6 +200,7 @@ python-kaleido = "*"
 selenium = "*"
 
 [feature.doc.activation.env]
+HV_DOCS_BUILD = "1"
 MOZ_HEADLESS = "1"
 MPLBACKEND = "Agg"
 PANEL_EMBED = "true"


### PR DESCRIPTION
A small follow up to https://github.com/holoviz/holoviews/pull/6586.

This disables the tooltip icon when building the documentation, as it, in my opinion, just confuses. 


![image](https://github.com/user-attachments/assets/7ed8ab4d-3fb0-4415-adce-db4af86c083e)
