### PR TITLE
ci: Reset cloudfront doing docs publish

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -79,9 +79,11 @@ jobs:
           (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           aws s3 sync --delete ./builtdocs s3://dev.holoviews.org/
+          aws cloudfront create-invalidation --distribution-id E3UIBUSHJOO6WO --paths "/*"
       - name: upload main
         if: |
           (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'main') ||
           (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           aws s3 sync --delete ./builtdocs s3://holoviews.org/
+          aws cloudfront create-invalidation --distribution-id E1UJPEXJIGBZWN --paths "/*"


### PR DESCRIPTION
When we move to docs versioning, this would be done by the docs-publish step.