### PR TITLE
compat: cuDF 25.06

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -179,9 +179,9 @@ NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS = "0"
 
 [feature.test-gpu.dependencies]
 cuda-version = "12.2.*"
-cudf = "25.04.*"
+cudf = "25.06.*"
 cupy = "*"
-cuspatial = "*"
+# cuspatial = "*"  # https://github.com/rapidsai/cuspatial/issues/1563#issuecomment-2845966364
 librmm = { version = "*", channel = "rapidsai" }
 rmm = { version = "*", channel = "rapidsai" }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/88fb1a3b-1f9c-4599-8d5a-f250f3851d88)

cuspatial has paused development. So have commented it out for now. 