### PR TITLE
fix: Don't select in decimate if start and end is the same

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -1010,8 +1010,12 @@ class decimate(Operation):
 
         # Slice element to current ranges
         xdim, ydim = element.dimensions(label=True)[0:2]
-        sliced = element.select(**{xdim: (xstart, xend),
-                                   ydim: (ystart, yend)})
+        select_dict = {}
+        if xstart != xend:
+            select_dict[xdim] = (xstart, xend)
+        if ystart != yend:
+            select_dict[ydim] = (ystart, yend)
+        sliced = element.select(**select_dict)
 
         if len(sliced) > self.p.max_samples:
             prng = np.random.RandomState(self.p.random_seed)

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -1015,7 +1015,7 @@ class decimate(Operation):
             select_dict[xdim] = (xstart, xend)
         if ystart != yend:
             select_dict[ydim] = (ystart, yend)
-        sliced = element.select(**select_dict)
+        sliced = element.select(**select_dict) if select_dict else element
 
         if len(sliced) > self.p.max_samples:
             prng = np.random.RandomState(self.p.random_seed)

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -719,6 +719,7 @@ class OperationTests(ComparisonTestCase):
         operation._preprocess_hooks = pre_backup
         operation._postprocess_hooks = post_backup
 
+    @pytest.mark.usefixtures("bokeh_backend")
     def test_decimate_ordering(self):
         x = np.linspace(0, 10, 100)
         y = np.sin(x)
@@ -729,6 +730,16 @@ class OperationTests(ComparisonTestCase):
         index = decimated.data[()].data.index
         assert np.all(index == np.sort(index))
 
+    @pytest.mark.usefixtures("bokeh_backend")
+    def test_decimate_same_y(self):
+        data = pd.DataFrame({'x': np.arange(10), 'y': np.ones(10)})
+        points = Points(data, kdims=['x', 'y']).opts(xlim=(0, 10))
+        decimated = decimate(points)
+
+        renderer("bokeh").get_plot(decimated)
+        output = decimated.data[()].data
+        pd.testing.assert_series_equal(data["x"], output["x"])
+        pd.testing.assert_series_equal(data["y"], output["y"])
 
 class TestDendrogramOperation:
 


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/6660

When the start and end are the same, no data is selected, which causes the empty plot.