### PR TITLE
fix: fix per-segment color mapping for hv.Path

### DIFF
--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -203,10 +203,7 @@ class MultiInterface(Interface):
         combined = []
         for d in dataset.data:
             ds.data = d
-            # Handle case where dim is a Dimension object but inner datasets only have string keys
-            # Convert Dimension objects to string names for compatibility with raw data dictionaries
-            dim_key = dim.name if hasattr(dim, "name") else dim
-            values = ds.interface.values(ds, dim_key, expanded=False)
+            values = ds.interface.values(ds, str(dim), expanded=False)
             unique = list(util.unique_iterator(values))
             if len(unique) > 1:
                 return False

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -203,7 +203,10 @@ class MultiInterface(Interface):
         combined = []
         for d in dataset.data:
             ds.data = d
-            values = ds.interface.values(ds, dim, expanded=False)
+            # Handle case where dim is a Dimension object but inner datasets only have string keys
+            # Convert Dimension objects to string names for compatibility with raw data dictionaries
+            dim_key = dim.name if hasattr(dim, "name") else dim
+            values = ds.interface.values(ds, dim_key, expanded=False)
             unique = list(util.unique_iterator(values))
             if len(unique) > 1:
                 return False

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2823,7 +2823,13 @@ class ColorbarPlot(ElementPlot):
                     util.is_int(dhigh)):
                     low, high = int(low), int(high)
             elif isinstance(eldim, dim):
-                low, high = np.nan, np.nan
+                # For dim objects, check if the referenced dimension has an explicit range
+                actual_dim = element.get_dimension(eldim.dimension)
+                if actual_dim and actual_dim.range != (None, None):
+                    low, high = actual_dim.range
+                # Fallback to data range if dimension lookup fails
+                else:
+                    low, high = element.range(eldim.dimension.name)
             else:
                 low, high = element.range(eldim.name)
             if self.symmetric:

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -104,7 +104,7 @@ class PathPlot(LegendPlot, ColorbarPlot):
             not (not isinstance(v, dim) and v == color and s == 'color')}
         mapping = dict(self._mapping)
 
-        if (not cdim) and not style_mapping and 'hover' not in self.handles:
+        if not (cdim or style_mapping or 'hover' in self.handles):
             if self.static_source:
                 data = {}
             else:

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -104,7 +104,7 @@ class PathPlot(LegendPlot, ColorbarPlot):
         scalar = element.interface.isunique(element, cdim, per_geom=True) if cdim else False
         style_mapping = {
             (s, v) for s, v in style.items() if (s not in self._nonvectorized_styles) and
-            ((isinstance(v, str) and v in element) or isinstance(v, dim) or isinstance(v, Dimension)) and
+            (isinstance(v, str) and v in element) or isinstance(v, (dim, Dimension)) and
             not (not isinstance(v, (dim, Dimension)) and v == color and s == 'color')}
         mapping = dict(self._mapping)
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -613,6 +613,18 @@ class ElementPlot(GenericElementPlot, MPLPlot):
 
 
     def _apply_transforms(self, element, ranges, style):
+        # Temporary workaround: raise NotImplementedError for hv.dim() and hv.Dimension()
+        # color options in Path plots
+        # See https://github.com/holoviz/holoviews/pull/6665 for more context
+        if isinstance(element, Path):
+            color_style = style.get('color')
+            if isinstance(color_style, (dim, Dimension)):
+                raise NotImplementedError(
+                    "Using hv.dim() or hv.Dimension() objects for color mapping in Path plots "
+                    "is currently not supported in the matplotlib backend. "
+                    "Please use a string column name instead (e.g., color='color_column')."
+                )
+
         new_style = dict(style)
         for k, v in style.items():
             if isinstance(v, (Dimension, str)):

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -45,7 +45,7 @@ class PathPlot(ColorbarPlot):
         # Support style-mapped color (e.g. .opts(color='c')) by resolving
         # a Dimension from the color style when no explicit color_index is set.
         color_style = style.get('color')
-        if cdim is None and isinstance(color_style, str):
+        if cdim is None and isinstance(color_style, (str, Dimension)):
             cdim = element.get_dimension(color_style)
 
         with abbreviated_exception():

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -45,7 +45,7 @@ class PathPlot(ColorbarPlot):
         # Support style-mapped color (e.g. .opts(color='c')) by resolving
         # a Dimension from the color style when no explicit color_index is set.
         color_style = style.get('color')
-        if cdim is None and isinstance(color_style, (str, Dimension)):
+        if cdim is None and isinstance(color_style, str):
             cdim = element.get_dimension(color_style)
 
         with abbreviated_exception():

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -46,9 +46,7 @@ class PathPlot(ColorbarPlot):
         # a Dimension from the color style when no explicit color_index is set.
         color_style = style.get('color')
         if cdim is None and isinstance(color_style, str):
-            _cd = element.get_dimension(color_style)
-            if _cd is not None:
-                cdim = _cd
+            cdim = element.get_dimension(color_style)
 
         with abbreviated_exception():
             style = self._apply_transforms(element, ranges, style)

--- a/holoviews/tests/plotting/bokeh/test_pathplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pathplot.py
@@ -2,7 +2,12 @@ import datetime as dt
 
 import numpy as np
 import pandas as pd
-from bokeh.models import CategoricalColorMapper, LinearColorMapper
+from bokeh.models import (
+    CategoricalColorMapper,
+    LinearColorMapper,
+    MultiPolygons,
+    Patches,
+)
 
 from holoviews.core import HoloMap, NdOverlay
 from holoviews.core.options import Cycle
@@ -440,7 +445,6 @@ class TestPolygonPlot(TestBokehPlot):
         self.assertEqual(cds.data['line_width'], np.array([7, 3]))
 
     def test_polygons_holes_initialize(self):
-        from bokeh.models import MultiPolygons
         xs = [1, 2, 3, np.nan, 6, 7, 3]
         ys = [2, 0, 7, np.nan, 7, 5, 2]
         holes = [
@@ -455,7 +459,6 @@ class TestPolygonPlot(TestBokehPlot):
         self.assertIsInstance(glyph, MultiPolygons)
 
     def test_polygons_no_holes_with_draw_tool(self):
-        from bokeh.models import Patches
         xs = [1, 2, 3, np.nan, 6, 7, 3]
         ys = [2, 0, 7, np.nan, 7, 5, 2]
         holes = [

--- a/holoviews/tests/plotting/bokeh/test_pathplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pathplot.py
@@ -229,15 +229,15 @@ class TestPathPlot(TestBokehPlot):
         glyph = plot.handles['glyph']
 
         # Expect 5 * (3-1) = 10 segments
-        self.assertEqual(len(source.data['xs']), 10)
-        self.assertEqual(len(source.data['ys']), 10)
+        assert len(source.data['xs']) == 10
+        assert len(source.data['ys']) == 10
         # Color column should be present and aligned to segments
-        self.assertIn('c', source.data)
-        self.assertEqual(len(source.data['c']), 10)
+        assert 'c' in source.data
+        assert len(source.data['c']) == 10
         # line_color should map to the 'c' field with a transform
         from holoviews.plotting.bokeh.util import property_to_dict
-        self.assertEqual(property_to_dict(glyph.line_color).get('field'), 'c')
-        self.assertIn('transform', property_to_dict(glyph.line_color))
+        assert property_to_dict(glyph.line_color).get('field') == 'c'
+        assert 'transform' in property_to_dict(glyph.line_color)
 
     def test_path_style_mapped_per_vertex_segments_lengths_match(self):
         # Five paths, per-vertex 'c' values; style-mapped color
@@ -253,10 +253,10 @@ class TestPathPlot(TestBokehPlot):
         source = plot.handles['source']
 
         # Expect 5 * (7-1) = 30 segments
-        self.assertEqual(len(source.data['xs']), 30)
-        self.assertEqual(len(source.data['ys']), 30)
-        self.assertIn('c', source.data)
-        self.assertEqual(len(source.data['c']), 30)
+        assert len(source.data['xs']) == 30
+        assert len(source.data['ys']) == 30
+        assert 'c' in source.data
+        assert len(source.data['c']) == 30
 
 
 class TestPolygonPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/test_pathplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pathplot.py
@@ -262,29 +262,28 @@ class TestPathPlot(TestBokehPlot):
         assert 'c' in source.data
         assert len(source.data['c']) == 30
 
-    def test_path_categorical_color_mapper_matches_mapping(self):
-        # Use categorical mapping so expected colors are exact
+    def test_path_color_mapping(self):
         n_pts = 3
-        cats = ['A','B','C','D','E']
-        cmap = {'A': "#1616C8", 'B': "#DC1212", 'C': "#1E8E2F", 'D': "#C0E178", 'E': "#EFE6E6"}
         data = [
-            {'x': np.arange(n_pts) + i,
+            {'x': np.arange(n_pts) + x,
              'y': np.arange(n_pts) + 1,
-             'c': cats[i]}
-            for i in range(5)
+             'c': x * 10}
+            for x in range(5)
         ]
-        path = Path(data, vdims=['c']).opts(color='c', cmap=cmap, colorbar=False)
+        path = Path(data, vdims=["c"]).opts(color="c", cmap="Turbo", colorbar=True)
+
         plot = bokeh_renderer.get_plot(path)
+        source = plot.handles['source']
+        output = source.data["c"]
+        expected = np.array([0, 0, 10, 10, 20, 20, 30, 30, 40, 40])
+        np.testing.assert_array_equal(output, expected)
 
         glyph = plot.handles['glyph']
         prop = property_to_dict(glyph.line_color)
         assert prop.get('field') == 'c'
         assert 'transform' in prop
         cmapper = prop['transform']
-        assert isinstance(cmapper, CategoricalColorMapper)
-        # The order of factors should match encountered categories
-        assert cmapper.factors == cats
-        assert list(cmapper.palette) == [cmap[k] for k in cats]
+        assert isinstance(cmapper, LinearColorMapper)
 
 class TestPolygonPlot(TestBokehPlot):
 

--- a/holoviews/tests/plotting/matplotlib/test_pathplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pathplot.py
@@ -58,6 +58,51 @@ class TestPathPlot(TestMPLPlot):
         plot.update((1,))
         self.assertEqual(artist.get_linewidths(), [3, 8, 2, 3])
 
+    def test_path_style_mapped_scalar_color_segments_array_and_cmap(self):
+        # Five paths, scalar 'c' per geometry; style-mapped color
+        n_pts = 3
+        data = [
+            {'x': np.arange(n_pts) + x,
+             'y': np.arange(n_pts) + 1,
+             'c': x * 10}
+            for x in range(5)
+        ]
+        path = Path(data, vdims=['c']).opts(color='c', cmap='viridis', colorbar=True)
+        plot = mpl_renderer.get_plot(path)
+        artist = plot.handles['artist']
+
+        # Must have a colormap and a data array
+        self.assertIsNotNone(artist.get_cmap())
+        arr = artist.get_array()
+        self.assertIsNotNone(arr)
+
+        # Expect 5 * (3-1) = 10 segment values
+        self.assertEqual(len(arr), 10)
+        # Value range should reflect our scalar-per-geometry inputs (0-40)
+        self.assertEqual(float(arr.min()), 0.0)
+        self.assertEqual(float(arr.max()), 40.0)
+
+    def test_path_style_mapped_per_vertex_color_segments_array(self):
+        # Five paths, per-vertex 'c' values; style-mapped color
+        n_pts = 7
+        data = [
+            {'x': np.arange(n_pts) + x,
+             'y': np.arange(n_pts) + 1,
+             'c': np.full(n_pts, x * 10)}  # per-vertex constant per geometry
+            for x in range(5)
+        ]
+        path = Path(data, vdims=['c']).opts(color='c', cmap='viridis', colorbar=True)
+        plot = mpl_renderer.get_plot(path)
+        artist = plot.handles['artist']
+
+        arr = artist.get_array()
+        self.assertIsNotNone(arr)
+        # Expect 5 * (7-1) = 30 segment values
+        self.assertEqual(len(arr), 30)
+        # Range again spans 0-40 for these inputs
+        self.assertEqual(float(arr.min()), 0.0)
+        self.assertEqual(float(arr.max()), 40.0)
+
 
 class TestPolygonPlot(TestMPLPlot):
 

--- a/holoviews/tests/plotting/matplotlib/test_pathplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pathplot.py
@@ -103,6 +103,29 @@ class TestPathPlot(TestMPLPlot):
         assert float(arr.min()) == 0.0
         assert float(arr.max()) == 40.0
 
+    def test_path_color_mapping(self):
+        n_pts = 3
+        data = [
+            {'x': np.arange(n_pts) + x,
+             'y': np.arange(n_pts) + 1,
+             'c': x * 10}
+            for x in range(5)
+        ]
+        path = Path(data, vdims=["c"]).opts(color="c", cmap="viridis", colorbar=True)
+
+        plot = mpl_renderer.get_plot(path)
+        artist = plot.handles['artist']
+
+        # Check that the color array has the expected values
+        arr = artist.get_array()
+        expected = np.array([0, 0, 10, 10, 20, 20, 30, 30, 40, 40])
+        np.testing.assert_array_equal(arr, expected)
+
+        # Check that colormap is properly set
+        assert artist.get_cmap() is not None
+        # Check color limits span the full range
+        assert artist.get_clim() == (0, 40)
+
 
 class TestPolygonPlot(TestMPLPlot):
 

--- a/holoviews/tests/plotting/matplotlib/test_pathplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pathplot.py
@@ -72,15 +72,15 @@ class TestPathPlot(TestMPLPlot):
         artist = plot.handles['artist']
 
         # Must have a colormap and a data array
-        self.assertIsNotNone(artist.get_cmap())
+        assert artist.get_cmap() is not None
         arr = artist.get_array()
-        self.assertIsNotNone(arr)
+        assert arr is not None
 
         # Expect 5 * (3-1) = 10 segment values
-        self.assertEqual(len(arr), 10)
+        assert len(arr) == 10
         # Value range should reflect our scalar-per-geometry inputs (0-40)
-        self.assertEqual(float(arr.min()), 0.0)
-        self.assertEqual(float(arr.max()), 40.0)
+        assert float(arr.min()) == 0.0
+        assert float(arr.max()) == 40.0
 
     def test_path_style_mapped_per_vertex_color_segments_array(self):
         # Five paths, per-vertex 'c' values; style-mapped color
@@ -96,12 +96,12 @@ class TestPathPlot(TestMPLPlot):
         artist = plot.handles['artist']
 
         arr = artist.get_array()
-        self.assertIsNotNone(arr)
+        assert arr is not None
         # Expect 5 * (7-1) = 30 segment values
-        self.assertEqual(len(arr), 30)
+        assert len(arr) == 30
         # Range again spans 0-40 for these inputs
-        self.assertEqual(float(arr.min()), 0.0)
-        self.assertEqual(float(arr.max()), 40.0)
+        assert float(arr.min()) == 0.0
+        assert float(arr.max()) == 40.0
 
 
 class TestPolygonPlot(TestMPLPlot):


### PR DESCRIPTION
fixes #6655 

This PR fixes the per-segment color mapping for `hv.Path` in both the Bokeh and Matplotlib backends when a value dimension is used for color:

1. `color_index` (Deprecated now, see https://github.com/holoviz/holoviews/blob/727eab6af028b15235d73b82726437489afdd88d/holoviews/plotting/bokeh/path.py#L35-L37) prevented per segment color mapping. The old logic passed the color dimension name directly as `color_index`, which only worked for per-geometry coloring. This broke cases where colors needed to vary along a path (per-segment), resulting in incorrect and/or missing color mapping and colorbars
2. Mismatch or override between scalar color and array color. In Matplotlib, a scalar `color` in `style` overrode the `array + cmap`, so all segments drew in one color.

```python
import holoviews as hv
import numpy as np

hv.extension('bokeh', 'matplotlib')

c_dim = hv.Dimension(('c', 'Color'), range=(0, 100))

def make_path(n_pts: int):
    p = hv.Path([{'x': np.arange(n_pts) + x, 'y': np.arange(n_pts) + 1, 'c': x * 10} for x in range(5)],
               vdims=c_dim).opts(color='c', cmap='Turbo', colorbar=True)
    return p

# Bokeh plot
make_path(3) + make_path(7)
```
<img width="1276" height="682" alt="image" src="https://github.com/user-attachments/assets/009b0200-e799-4eaa-b877-48d3c06f28fd" />

```python
# matplotlib plot
hv.output(backend='matplotlib')

make_path(3) + make_path(7)
```
<img width="1286" height="522" alt="image" src="https://github.com/user-attachments/assets/76ebdab6-88d8-40de-a58f-d1aa1ce5955f" />

