### PR TITLE
test: fix flaky test in test-core

### DIFF
--- a/holoviews/tests/plotting/bokeh/test_rasterplot.py
+++ b/holoviews/tests/plotting/bokeh/test_rasterplot.py
@@ -479,8 +479,8 @@ class TestSyntheticLegendPlot(TestBokehPlot):
     __test__ = True
 
     def setUp(self):
-        super().setUp()
         ds = pytest.importorskip("datashader")
+        super().setUp()
 
         from holoviews.operation.datashader import datashade, rasterize
         points = Points([(0, 0, 'A'), (1, 1, 'B'), (2, 2, 'C')], vdims=['Label'])


### PR DESCRIPTION
Flaky test could be reproduced with: `pixi run -e test-core pytest "holoviews/tests/plotting/bokeh/test_rasterplot.py::TestSyntheticLegendPlot::test_image_stack_legend" "holoviews/tests/test_streams.py::test_dynamicmap_partial_bind_and_streams"`