### PR TITLE
test: reset_store with module

### DIFF
--- a/holoviews/tests/conftest.py
+++ b/holoviews/tests/conftest.py
@@ -135,7 +135,7 @@ def serve_panel(page, port):  # noqa: F811
 
     return serve_and_return_page
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def reset_store():
     _custom_options = {k: {} for k in hv.Store._custom_options}
     _options = hv.Store._options.copy()


### PR DESCRIPTION
This should make it possible to use something use `pytest.mark.usefixture("bokeh_backend")` with `pytest.mark.parameterized` tests. 