### PR TITLE
fix: Use native bokeh "x" marker in plots and particularly in legends

### DIFF
--- a/holoviews/plotting/bokeh/styles.py
+++ b/holoviews/plotting/bokeh/styles.py
@@ -56,7 +56,6 @@ legend_dimensions = ['label_standoff', 'label_width', 'label_height', 'glyph_wid
 
 markers = {
     '+': {'marker': 'cross'},
-    'x': {'marker': 'cross', 'angle': np.pi/4},
     's': {'marker': 'square'},
     'd': {'marker': 'diamond'},
     '^': {'marker': 'triangle', 'angle': 0},

--- a/holoviews/tests/plotting/bokeh/test_pointplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pointplot.py
@@ -184,7 +184,6 @@ class TestPointPlot(TestBokehPlot):
                 with self.subTest(marker=marker):
                     self._test_native_marker_legend(marker)
 
-    @pytest.mark.xfail(reason='Holoviews converts "x" marker to angled "cross".')
     def test_x_native_marker_legend(self):
         """When one plots with a native bokeh marker, the legend uses that marker."""
         self._test_native_marker_legend("x")

--- a/holoviews/tests/plotting/bokeh/test_pointplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pointplot.py
@@ -3,6 +3,7 @@ import datetime as dt
 import numpy as np
 import pandas as pd
 import pytest
+from bokeh.core.enums import MarkerType
 from bokeh.models import (
     CategoricalColorMapper,
     Circle,
@@ -165,6 +166,28 @@ class TestPointPlot(TestBokehPlot):
         plot.initialize_plot()
         fig = plot.state
         self.assertEqual(len(fig.legend), 0)
+
+    def _test_native_marker_legend(self, marker):
+        # Plot with a categorical color mapper solely to obtain a legend.
+        points = Points([(0, 0, "A"), (0, 1, "B")], vdims="color").opts(
+            color="color", marker=marker
+        )
+        plot = bokeh_renderer.get_plot(points)
+        self.assertEqual(
+            plot.state.legend[0].items[0].renderers[0].glyph.marker, marker
+        )
+
+    def test_native_marker_legend(self):
+        """When one plots with a native bokeh marker, the legend uses that marker."""
+        for marker in MarkerType:
+            if marker != "x":  # Another test handles this case.
+                with self.subTest(marker=marker):
+                    self._test_native_marker_legend(marker)
+
+    @pytest.mark.xfail(reason='Holoviews converts "x" marker to angled "cross".')
+    def test_x_native_marker_legend(self):
+        """When one plots with a native bokeh marker, the legend uses that marker."""
+        self._test_native_marker_legend("x")
 
     def test_points_non_numeric_size_warning(self):
         data = (np.arange(10), np.arange(10), list(map(chr, range(94,104))))

--- a/holoviews/tests/plotting/bokeh/test_pointplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pointplot.py
@@ -167,26 +167,18 @@ class TestPointPlot(TestBokehPlot):
         fig = plot.state
         self.assertEqual(len(fig.legend), 0)
 
-    def _test_native_marker_legend(self, marker):
-        # Plot with a categorical color mapper solely to obtain a legend.
-        points = Points([(0, 0, "A"), (0, 1, "B")], vdims="color").opts(
-            color="color", marker=marker
-        )
-        plot = bokeh_renderer.get_plot(points)
-        self.assertEqual(
-            plot.state.legend[0].items[0].renderers[0].glyph.marker, marker
-        )
-
     def test_native_marker_legend(self):
         """When one plots with a native bokeh marker, the legend uses that marker."""
         for marker in MarkerType:
-            if marker != "x":  # Another test handles this case.
-                with self.subTest(marker=marker):
-                    self._test_native_marker_legend(marker)
-
-    def test_x_native_marker_legend(self):
-        """When one plots with a native bokeh marker, the legend uses that marker."""
-        self._test_native_marker_legend("x")
+            with self.subTest(marker=marker):
+                # Plot with a categorical color mapper solely to obtain a legend.
+                points = Points([(0, 0, "A"), (0, 1, "B")], vdims="color").opts(
+                    color="color", marker=marker
+                )
+                plot = bokeh_renderer.get_plot(points)
+                self.assertEqual(
+                    plot.state.legend[0].items[0].renderers[0].glyph.marker, marker
+                )
 
     def test_points_non_numeric_size_warning(self):
         data = (np.arange(10), np.arange(10), list(map(chr, range(94,104))))


### PR DESCRIPTION
Resolves #6345.

Previously, *Holoviews* converted the "x" into a rotated "+" as if it were a *matplotlib* marker that needed translation. However, because *Bokeh* draws legend markers with an angle of its choosing, the marker instead appeared as "+" within legends. Moreover, the translation appears to have been unnecessary, because *Bokeh* has had a native "x" marker for as far back as I could readily find.

With this change, *Holoviews* uses Bokeh's native "x" marker in plots and thereby obtains the expected "x" in legends also.