### PR TITLE
fix(matplotlib): Heatmap y-axis wrong ordering

### DIFF
--- a/holoviews/plotting/mpl/heatmap.py
+++ b/holoviews/plotting/mpl/heatmap.py
@@ -94,6 +94,7 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
 
     def _compute_ticks(self, element, xvals, yvals, xfactors, yfactors):
         xdim, ydim = element.kdims
+        aggregate = element.gridded
         if self.invert_axes:
             xdim, ydim = ydim, xdim
 
@@ -103,7 +104,7 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
         if xticks is None:
             xpos = xvals[:-1] + np.diff(xvals)/2.
             if not xfactors:
-                xfactors = element.gridded.dimension_values(xdim, False)
+                xfactors = aggregate.dimension_values(xdim, False)
             xlabels = [xdim.pprint_value(k) for k in xfactors]
             xticks = list(zip(xpos, xlabels, strict=None))
 
@@ -111,10 +112,10 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
         if yticks is None:
             ypos = yvals[:-1] + np.diff(yvals)/2.
             if not yfactors:
-                yfactors = element.gridded.dimension_values(ydim, False)
+                yfactors = aggregate.dimension_values(ydim, False)
             ylabels = [ydim.pprint_value(k) for k in yfactors]
             # if y-axis is categorical, reverse labels to match `origin='upper'` policy
-            ytype = element.gridded.interface.dtype(element.gridded, ydim)
+            ytype = aggregate.interface.dtype(aggregate, ydim)
             if ytype.kind in 'SUO':
                 ylabels = ylabels[::-1]
             yticks = list(zip(ypos, ylabels, strict=None))
@@ -185,7 +186,7 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
         style['yfactors'] = yfactors
 
         if self.show_values:
-            style['annotations'] = self._annotate_values(element.gridded, xvals, yvals)
+            style['annotations'] = self._annotate_values(aggregate, xvals, yvals)
         vdim = element.vdims[0]
         self._norm_kwargs(element, ranges, style, vdim)
         if 'vmin' in style:

--- a/holoviews/plotting/mpl/heatmap.py
+++ b/holoviews/plotting/mpl/heatmap.py
@@ -113,6 +113,7 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
             if not yfactors:
                 yfactors = element.gridded.dimension_values(ydim, False)
             ylabels = [ydim.pprint_value(k) for k in yfactors]
+            # if y-axis is categorical, reverse labels to match `origin='upper'` policy
             ytype = element.gridded.interface.dtype(element.gridded, ydim)
             if ytype.kind in 'SUO':
                 ylabels = ylabels[::-1]

--- a/holoviews/plotting/mpl/heatmap.py
+++ b/holoviews/plotting/mpl/heatmap.py
@@ -1,4 +1,4 @@
-from itertools import product
+from itertools import product # noqa F401 # don't remove for now
 
 import numpy as np
 import param
@@ -81,14 +81,21 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
 
     def _annotate_values(self, element, xvals, yvals):
         val_dim = element.vdims[0]
-        vals = element.dimension_values(val_dim).flatten()
+        vals = element.dimension_values(val_dim, flat=False)
         xpos = xvals[:-1] + np.diff(xvals)/2.
         ypos = yvals[:-1] + np.diff(yvals)/2.
-        plot_coords = product(xpos, ypos)
+
+        # When invert_axes=True, `get_data` transposes and reverses both axes.
+        # Apply the same to the annotation values.
+        if self.invert_axes:
+            vals = vals.T[::-1, ::-1]
+
         annotations = {}
-        for plot_coord, v in zip(plot_coords, vals, strict=None):
-            text = '-' if is_nan(v) else val_dim.pprint_value(v)
-            annotations[plot_coord] = text
+        for j, y in enumerate(ypos):
+            for i, x in enumerate(xpos):
+                v = vals[j, i]
+                text = '-' if is_nan(v) else val_dim.pprint_value(v)
+                annotations[(x, y)] = text
         return annotations
 
 
@@ -114,11 +121,10 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
             if not yfactors:
                 yfactors = aggregate.dimension_values(ydim, False)
             ylabels = [ydim.pprint_value(k) for k in yfactors]
-            # if y-axis is categorical, reverse labels to match `origin='upper'` policy
             ytype = aggregate.interface.dtype(aggregate, ydim)
             if ytype.kind in 'SUO':
-                ylabels = ylabels[::-1]
-            yticks = list(zip(ypos, ylabels, strict=None))
+                positions = ypos[::-1]
+                yticks = list(zip(positions, ylabels, strict=None))
         return xticks, yticks
 
 

--- a/holoviews/plotting/mpl/heatmap.py
+++ b/holoviews/plotting/mpl/heatmap.py
@@ -113,6 +113,9 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
             if not yfactors:
                 yfactors = element.gridded.dimension_values(ydim, False)
             ylabels = [ydim.pprint_value(k) for k in yfactors]
+            ytype = element.gridded.interface.dtype(element.gridded, ydim)
+            if ytype.kind in 'SUO':
+                ylabels = ylabels[::-1]
             yticks = list(zip(ypos, ylabels, strict=None))
         return xticks, yticks
 

--- a/holoviews/tests/plotting/matplotlib/test_heatmapplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_heatmapplot.py
@@ -46,30 +46,85 @@ class TestHeatMapPlot(TestMPLPlot):
         masked = np.ma.array(expected, mask=np.logical_not(np.isfinite(expected)))
         np.testing.assert_equal(array, masked)
 
-    def test_heatmap_categorical_yaxis_label_order(self):
-        data = pd.DataFrame({
-            'depth_class': ['Shallow', 'Shallow', 'Intermediate', 'Intermediate', 'Deep', 'Deep'],
-            'mag_class': ['Light', 'Strong', 'Light', 'Strong', 'Light', 'Strong'],
-            'count': [100, 10, 50, 5, 20, 2]
-        })
-        data['depth_class'] = pd.Categorical(
-            data['depth_class'],
-            categories=['Shallow', 'Intermediate', 'Deep'],
-            ordered=True
+    def test_heatmap_categorical_factors_preserve_appearance_and_Z_edges(self):
+        """Categorical x/y should preserve first-seen order."""
+        data = pd.DataFrame(
+            {
+                "X": ["L", "N", "O", "L", "N", "L", "N", "M"],
+                "Y": ["C", "C", "C", "B", "B", "A", "A", "A"],
+                "count": [301, 37, 2, 212, 8, 34, 1, 1],
+            }
         )
-        data['mag_class'] = pd.Categorical(
-            data['mag_class'],
-            categories=['Light', 'Strong'],
-            ordered=True
+        # Categorical/object dtypes: appearance order should be preserved
+        hmap = HeatMap(data, ["X", "Y"]).aggregate(function=np.mean)
+        agg = hmap.aggregate(function=np.mean).gridded
+        xdim, ydim = agg.dimensions(label=True)[:2]
+
+        Z = agg.dimension_values(2, flat=False)
+        Z = np.ma.array(Z, mask=np.logical_not(np.isfinite(Z)))
+
+        # Expected factors: first-seen order in input rows
+        expected_x = ["L", "N", "O", "M"]
+        expected_y = ["A", "B", "C"]
+
+        assert list(agg.dimension_values(xdim, False)) == expected_x
+        assert list(agg.dimension_values(ydim, False)) == expected_y
+
+        # Expected Z edges match first and last y rows
+        assert Z[0].tolist() == [34.0, 1.0, None, 1.0]
+        assert Z[-1].tolist() == [301.0, 37.0, 2.0, None]
+
+    def test_heatmap_categorical_factors_preserve_appearance_with_inverted_input(self):
+        """Changing first-seen order in the input should change factors and Z edges accordingly."""
+        inv_data = pd.DataFrame(
+            {
+                "X": ["M", "N", "L", "N", "L", "O", "N", "L"],
+                "Y": ["A", "A", "A", "B", "B", "C", "C", "C"],
+                "count": [1, 1, 34, 8, 212, 2, 37, 301],
+            }
         )
 
-        hmap = HeatMap(data, ['mag_class', 'depth_class']).aggregate(function=np.mean)
-        plot = mpl_renderer.get_plot(hmap)
+        hmap = HeatMap(inv_data, ["X", "Y"]).aggregate(
+            function=np.mean
+        )
+        agg = hmap.aggregate(function=np.mean).gridded
+        xdim, ydim = agg.dimensions(label=True)[:2]
 
-        # Get y-tick labels from the plot
-        _, _, axis_kwargs = plot.get_data(hmap, {}, {})
-        yticks = axis_kwargs['yticks']
-        ylabels = [label for _, label in yticks]
+        Z = agg.dimension_values(2, flat=False)
+        Z = np.ma.array(Z, mask=np.logical_not(np.isfinite(Z)))
 
-        expected_order = ['Deep', 'Intermediate', 'Shallow']
-        assert ylabels == expected_order
+        # Expected factors: first-seen order in input rows
+        expected_x = ["M", "N", "L", "O"]
+        expected_y = ["C", "B", "A"]
+
+        assert list(agg.dimension_values(xdim, False)) == expected_x
+        assert list(agg.dimension_values(ydim, False)) == expected_y
+
+        # Expected Z edges match first and last y rows
+        assert Z[0].tolist() == [301.0, 37.0, 2.0, None]
+        assert Z[-1].tolist() == [34.0, 1.0, None, 1.0]
+
+    def test_heatmap_numeric_axes_sorted_and_Z_edges(self):
+        """Numeric axes should be sorted ascending; verify factors and Z edges."""
+        df = pd.DataFrame(
+            {
+                "x": [2, 1, 3, 1],
+                "y": [200, 100, 300, 100],
+                "val": [ 20, 10, 30, 11],
+            }
+        )
+        hmap = HeatMap(df, ["x", "y"]).aggregate(function=np.mean)
+        agg = hmap.aggregate(function=np.mean).gridded
+        xdim, ydim = agg.dimensions(label=True)[:2]
+
+        Z = agg.dimension_values(2, flat=False)
+        Z = np.ma.array(Z, mask=np.logical_not(np.isfinite(Z)))
+
+        # Numeric factors sorted ascending
+        assert list(agg.dimension_values(xdim, False)) == [1, 2, 3]
+        assert list(agg.dimension_values(ydim, False)) == [100, 200, 300]
+
+        # First row corresponds to min y=100; last row to max y=300
+        # Columns correspond to x=[1,2,3]
+        np.testing.assert_equal( Z[0], np.array([10.5, np.nan, np.nan]) )  # mean of (10,11)
+        np.testing.assert_equal(Z[-1], np.array([np.nan, np.nan, 30]))

--- a/holoviews/tests/plotting/matplotlib/test_heatmapplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_heatmapplot.py
@@ -71,5 +71,5 @@ class TestHeatMapPlot(TestMPLPlot):
         yticks = axis_kwargs['yticks']
         ylabels = [label for _, label in yticks]
 
-        expected_order = ['Shallow', 'Intermediate', 'Deep']
+        expected_order = ['Deep', 'Intermediate', 'Shallow']
         assert ylabels == expected_order


### PR DESCRIPTION
fixes #6644 

This PR:

- [x] Resolves the y-axis label mismatch by reversing the labelling, matching the `origin='upper'` policy used in other image-like plots in mpl, e.g, raster https://github.com/holoviz/holoviews/blob/9eb8203b61fdce1efdadedd264aa2f88dd6e7705/holoviews/plotting/mpl/raster.py#L119 This ensures that the index 0 label of a plot with categorical y-axes now appears at the top rather than at the bottom.
- [x] Add test.

```python
import pandas as pd
import holoviews as hv
import numpy as np

hv.extension('matplotlib')

data = pd.DataFrame({
    'depth_class': ['Shallow', 'Shallow', 'Shallow',
                    'Intermediate', 'Intermediate',
                    'Deep', 'Deep', 'Deep'],
    'mag_class': ['Light', 'Moderate', 'Strong',
                  'Light', 'Moderate',
                  'Light', 'Moderate', 'Major'],
    'count': [301, 37, 2, 212, 8, 34, 1, 1]
})

data['depth_class'] = pd.Categorical(data['depth_class'], categories=['Shallow', 'Intermediate', 'Deep'], ordered=True)
data['mag_class'] = pd.Categorical(data['mag_class'], categories=['Light', 'Moderate', 'Strong', 'Major'], ordered=True)

heatmap = hv.HeatMap(data, ['mag_class', 'depth_class'])
heatmap = heatmap.aggregate(function=np.mean)
heatmap
```
<img width="384" height="275" alt="Screenshot 2025-09-03 at 7 13 58 PM" src="https://github.com/user-attachments/assets/f57669ca-f245-4d4e-ba35-bedf35e228a9" />