### PR TITLE
Don't show tooltip if CI is detected

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -260,7 +260,7 @@ class notebook_extension(extension):
             'bokeh_version':  bokeh_version,
             'mpl_version':    mpl_version,
             'plotly_version': plotly_version,
-            'show_tooltip': not os.getenv("HV_DOCS_BUILD")
+            'show_tooltip': not (os.getenv("CI") or os.getenv("HV_DOCS_BUILD"))
         })
         publish_display_data(data={'text/html': html})
 


### PR DESCRIPTION
Same as what is done in  https://github.com/holoviz/holoviews/pull/6630, but also looking at the CI environment variable, still to avoid it showing up when building docs.

https://www.scivision.dev/ci-detect-environment-variable/

We could also remove HV_DOCS_BUILD since it's not documented anywhere. 