### PR TITLE
enh: Add gridstyle to matplotlib

### DIFF
--- a/examples/user_guide/Plotting_with_Matplotlib.ipynb
+++ b/examples/user_guide/Plotting_with_Matplotlib.ipynb
@@ -144,14 +144,14 @@
    "source": [
     "## Grid lines\n",
     "\n",
-    "Grid lines can be controlled through the combination of ``show_grid`` and ``gridstyle`` parameters. The ``gridstyle`` allows specifying a number of options including:\n",
+    "Grid lines can be controlled through the combination of ``show_grid`` and ``gridstyle`` parameters. The ``gridstyle`` allows specifying a number of options including the following:\n",
     "\n",
-    "* ``grid_color``\n",
-    "* ``grid_alpha``\n",
-    "* ``grid_linestyle``\n",
-    "* ``grid_linewidth``\n",
+    "* ``color`` (or ``grid_color``)\n",
+    "* ``alpha`` (or ``grid_alpha``)\n",
+    "* ``linestyle`` (or ``grid_linestyle``)\n",
+    "* ``linewidth`` (or ``grid_linewidth``)\n",
     "\n",
-    "These options may also be applied to minor grid lines by prepending the ``'minor_'`` prefix and may be applied to a specific axis by replacing ``'grid_`` with ``'xgrid_'`` or ``'ygrid_'``. Here we combine some of these options to generate a complex grid pattern:"
+    "Here we combine some of these options to generate a complex grid pattern:"
    ]
   },
   {
@@ -161,6 +161,24 @@
    "outputs": [],
    "source": [
     "grid_style = {'grid_color': 'black', 'grid_linewidth': 1.5, 'xgrid_linestyle': 'dashed'}\n",
+    "\n",
+    "hv.Points(np.random.rand(10, 2)).opts(gridstyle=grid_style, show_grid=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can disable x or y grid lines individually by setting their alpha to 0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid_style = {'ygrid_alpha': 0}\n",
     "\n",
     "hv.Points(np.random.rand(10, 2)).opts(gridstyle=grid_style, show_grid=True)"
    ]

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -111,8 +111,8 @@ class MPLPlot(DimensionedPlot):
         Size relative to the supplied overall fig_inches in percent.""")
 
     gridstyle = param.Dict(default={}, doc="""
-        Allows customizing the grid style, e.g. grid_line_color defines
-        the line color for both grids while xgrid_line_color exclusively
+        Allows customizing the grid style, e.g. grid_color defines
+        the line color for both grids while xgrid_color exclusively
         customizes the x-axis grid lines.""")
 
     initial_hooks = param.HookList(default=[], doc="""

--- a/holoviews/tests/plotting/matplotlib/test_elementplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_elementplot.py
@@ -324,7 +324,24 @@ class TestElementPlot(LoggingComparisonTestCase, TestMPLPlot):
 
     ### Grid ###
     def test_grid_both(self):
-        curve = Curve(range(10)).opts(gridstyle={'grid_color': 'red', 'grid_linestyle': '--', 'grid_alpha': 0.5, 'grid_linewidth': 2, 'show_grid': True})
+        curve = Curve(range(10)).opts(gridstyle={'grid_color': 'red', 'grid_linestyle': '--', 'grid_alpha': 0.5, 'grid_linewidth': 2}, show_grid=True)
+        plot = mpl_renderer.get_plot(curve)
+        ax = plot.handles['axis']
+        gridlines = ax.get_xgridlines() + ax.get_ygridlines()
+        for line in gridlines:
+            self.assertEqual(line.get_color(), 'red')
+            self.assertEqual(line.get_linestyle(), '--')
+            self.assertEqual(line.get_alpha(), 0.5)
+            self.assertEqual(line.get_linewidth(), 2)
+
+    def test_grid_both_show_grid_False(self):
+        curve = Curve(range(10)).opts(gridstyle={'grid_color': 'red', 'grid_linestyle': '--', 'grid_alpha': 0.5, 'grid_linewidth': 2}, show_grid=False)
+        plot = mpl_renderer.get_plot(curve)
+        ax = plot.handles['axis']
+        assert not any(line.get_visible() for line in ax.get_xgridlines() + ax.get_ygridlines())
+
+    def test_grid_both_no_grid_prefix(self):
+        curve = Curve(range(10)).opts(gridstyle={'color': 'red', 'linestyle': '--', 'alpha': 0.5, 'linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         gridlines = ax.get_xgridlines() + ax.get_ygridlines()
@@ -335,7 +352,7 @@ class TestElementPlot(LoggingComparisonTestCase, TestMPLPlot):
             self.assertEqual(line.get_linewidth(), 2)
 
     def test_grid_x(self):
-        curve = Curve(range(10)).opts(gridstyle={'xgrid_color': 'blue', 'xgrid_linestyle': '--', 'xgrid_alpha': 0.5, 'xgrid_linewidth': 2, 'show_grid': True})
+        curve = Curve(range(10)).opts(gridstyle={'xgrid_color': 'blue', 'xgrid_linestyle': '--', 'xgrid_alpha': 0.5, 'xgrid_linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         xgridlines = ax.get_xgridlines()
@@ -351,8 +368,25 @@ class TestElementPlot(LoggingComparisonTestCase, TestMPLPlot):
             self.assertNotEqual(line.get_alpha(), 0.5)
             self.assertNotEqual(line.get_linewidth(), 2)
 
+    def test_grid_x_no_grid_prefix(self):
+        curve = Curve(range(10)).opts(gridstyle={'color': 'blue', 'linestyle': '--', 'alpha': 0.5, 'linewidth': 2}, show_grid=True)
+        plot = mpl_renderer.get_plot(curve)
+        ax = plot.handles['axis']
+        xgridlines = ax.get_xgridlines()
+        for line in xgridlines:
+            self.assertEqual(line.get_color(), 'blue')
+            self.assertEqual(line.get_linestyle(), '--')
+            self.assertEqual(line.get_alpha(), 0.5)
+            self.assertEqual(line.get_linewidth(), 2)
+        ygridlines = ax.get_ygridlines()
+        for line in ygridlines:
+            self.assertEqual(line.get_color(), 'blue')
+            self.assertEqual(line.get_linestyle(), '--')
+            self.assertEqual(line.get_alpha(), 0.5)
+            self.assertEqual(line.get_linewidth(), 2)
+
     def test_grid_y(self):
-        curve = Curve(range(10)).opts(gridstyle={'ygrid_color': 'green', 'ygrid_linestyle': '--', 'ygrid_alpha': 0.5, 'ygrid_linewidth': 2, 'show_grid': True})
+        curve = Curve(range(10)).opts(gridstyle={'ygrid_color': 'green', 'ygrid_linestyle': '--', 'ygrid_alpha': 0.5, 'ygrid_linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         ygridlines = ax.get_ygridlines()
@@ -368,8 +402,25 @@ class TestElementPlot(LoggingComparisonTestCase, TestMPLPlot):
             self.assertNotEqual(line.get_alpha(), 0.5)
             self.assertNotEqual(line.get_linewidth(), 2)
 
+    def test_grid_y_no_grid_prefix(self):
+        curve = Curve(range(10)).opts(gridstyle={'color': 'green', 'linestyle': '--', 'alpha': 0.5, 'linewidth': 2}, show_grid=True)
+        plot = mpl_renderer.get_plot(curve)
+        ax = plot.handles['axis']
+        ygridlines = ax.get_ygridlines()
+        for line in ygridlines:
+            self.assertEqual(line.get_color(), 'green')
+            self.assertEqual(line.get_linestyle(), '--')
+            self.assertEqual(line.get_alpha(), 0.5)
+            self.assertEqual(line.get_linewidth(), 2)
+        xgridlines = ax.get_xgridlines()
+        for line in xgridlines:
+            self.assertEqual(line.get_color(), 'green')
+            self.assertEqual(line.get_linestyle(), '--')
+            self.assertEqual(line.get_alpha(), 0.5)
+            self.assertEqual(line.get_linewidth(), 2)
+
     def test_grid_mix(self):
-        curve = Curve(range(10)).opts(gridstyle={'grid_color': 'red', 'ygrid_linestyle': '--', 'ygrid_alpha': 0.5, 'ygrid_linewidth': 2, 'show_grid': True})
+        curve = Curve(range(10)).opts(gridstyle={'grid_color': 'red', 'ygrid_linestyle': '--', 'ygrid_alpha': 0.5, 'ygrid_linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         xgridlines = ax.get_xgridlines()
@@ -384,6 +435,24 @@ class TestElementPlot(LoggingComparisonTestCase, TestMPLPlot):
             self.assertEqual(line.get_linestyle(), '--')
             self.assertEqual(line.get_alpha(), 0.5)
             self.assertEqual(line.get_linewidth(), 2)
+
+    def test_grid_mix_no_grid_prefix(self):
+        curve = Curve(range(10)).opts(gridstyle={'color': 'red', 'y_linestyle': '--', 'y_alpha': 0.5, 'y_linewidth': 2}, show_grid=True)
+        plot = mpl_renderer.get_plot(curve)
+        ax = plot.handles['axis']
+        xgridlines = ax.get_xgridlines()
+        for line in xgridlines:
+            self.assertEqual(line.get_color(), 'red')
+            self.assertNotEqual(line.get_linestyle(), '--')
+            self.assertNotEqual(line.get_alpha(), 0.5)
+            self.assertNotEqual(line.get_linewidth(), 2)
+        ygridlines = ax.get_ygridlines()
+        for line in ygridlines:
+            self.assertEqual(line.get_color(), 'red')
+            self.assertEqual(line.get_linestyle(), '--')
+            self.assertEqual(line.get_alpha(), 0.5)
+            self.assertEqual(line.get_linewidth(), 2)
+
 
 class TestColorbarPlot(TestMPLPlot):
 


### PR DESCRIPTION
In bokeh, it's possible to adjust the grid lines in a plot with `gridstyle`, but there was no equivalent for matplotlib.

```python
grid_style = {'grid_color': 'black', 'grid_linewidth': 1.5, 'xgrid_linestyle': 'dashed'}

hv.Points(np.random.rand(10, 2)).opts(gridstyle=grid_style, show_grid=True)
```

<img width="910" height="569" alt="image" src="https://github.com/user-attachments/assets/34da8c22-12d1-42ef-90b9-f3b991928bda" />
