### PR TITLE
ci(dev): remove osx-64 version for pixi.toml file

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,7 @@
 [project]
 name = "holoviews"
 channels = ["pyviz/label/dev", "bokeh/label/rc", "conda-forge"]
-platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
+platforms = ["linux-64", "osx-arm64", "win-64"]
 
 [environments]
 default = [


### PR DESCRIPTION
We don't use it in CI, and it will reduce solve time by ~25% because we no longer need to solve for the platform. 

I think the world is moving on from Intel Mac: 
- https://www.anaconda.com/blog/intel-mac-package-support-deprecation
- https://discuss.python.org/t/dropping-intel-mac-to-tier-2/102100
- https://www.pcmag.com/news/apple-confirms-end-of-support-for-intel-macs-after-macos-tahoe

We still test Mac, but only on ARM. 