### PR TITLE
fix: Support histogram groupby for LazyFrame

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -823,8 +823,13 @@ class histogram(Operation):
                 raise ValueError('Cannot use histogram groupby on non-Dataset Element')
             grouped = element.groupby(self.p.groupby, group_type=Dataset, container_type=NdOverlay)
             if self.p.groupby_range == 'shared' and not self.p.bin_range:
-                _, data = self._get_dim_and_data(element)
-                self.p.bin_range = (data.min(), data.max())
+                dim, data = self._get_dim_and_data(element)
+                if isinstance(data, nw.LazyFrame):
+                    col = nw.col(str(dim))
+                    summary = data.select(min=col.min(), max=col.max()).collect()
+                    self.p.bin_range = (summary["min"].item(), summary["max"].item())
+                else:
+                    self.p.bin_range = (data.min(), data.max())
             self.p.groupby = None
             return grouped.map(partial(self._process, groupby=True), Dataset)
 

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -3,7 +3,6 @@ import random
 from importlib.util import find_spec
 from unittest import SkipTest, skipIf
 
-import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
 import param
@@ -652,8 +651,8 @@ class OperationTests(ComparisonTestCase):
         self.assertEqual(op_hist, hist)
 
     def test_histogram_narwhals_pandas(self):
-        df = nw.from_native(pd.DataFrame({'x': range(10)}))
-        ds = Dataset(df, vdims='x')
+        df = pd.DataFrame({'x': range(10)})
+        ds = Dataset(df, vdims='x', datatype=["narwhals"])
         op_hist = histogram(ds, num_bins=3, normed=False)
 
         hist = Histogram(([0, 3, 6, 9], [3, 3, 4]),
@@ -662,7 +661,7 @@ class OperationTests(ComparisonTestCase):
 
     def test_histogram_narwhals_polars(self):
         pl = pytest.importorskip("polars")
-        df = nw.from_native(pl.DataFrame({'x': range(10)}))
+        df = pl.DataFrame({'x': range(10)})
         ds = Dataset(df, vdims='x')
         op_hist = histogram(ds, num_bins=3, normed=False)
 
@@ -672,13 +671,25 @@ class OperationTests(ComparisonTestCase):
 
     def test_histogram_narwhals_polars_lazy(self):
         pl = pytest.importorskip("polars")
-        df = nw.from_native(pl.LazyFrame({'x': range(10)}))
+        df = pl.LazyFrame({'x': range(10)})
         ds = Dataset(df, vdims='x')
         op_hist = histogram(ds, num_bins=3, normed=False)
 
         hist = Histogram(([0, 3, 6, 9], [3, 3, 4]),
                          vdims=('x_count', 'Count'))
         self.assertEqual(op_hist, hist)
+
+    def test_histogram_narwhals_polars_lazy_groupby(self):
+        pl = pytest.importorskip("polars")
+        df = pl.LazyFrame({"x": [1, 2], "y": [1, 2]})
+        ds = Dataset(df)
+        op_hist = histogram(ds, num_bins=2, groupby="x")
+
+        hist1 = Histogram(([1, 1.5, 2], [1, 0]), kdims="y", vdims=[('y_count', 'Count')])
+        hist2 = Histogram(([1, 1.5, 2], [0, 1]), kdims="y", vdims=[('y_count', 'Count')])
+        expected = NdOverlay({(1,): hist1, (2,): hist2}, kdims=['x'])
+
+        self.assertEqual(op_hist, expected)
 
     @pytest.mark.usefixtures("mpl_backend")
     def test_histogram_dask_array_mpl(self):


### PR DESCRIPTION
Previously, this would fail, now it doens't.

``` python
import polars as pl

import holoviews as hv
from holoviews.operation import histogram

hv.extension("bokeh")
lf = pl.LazyFrame({"x": [1, 2], "y": [1, 2]})

histogram(hv.Dataset(lf), num_bins=2, groupby="x")
```