### PR TITLE
test: Move from `unittest.skipIf` to `pytest.mark.skipif`

### DIFF
--- a/holoviews/tests/core/test_decollation.py
+++ b/holoviews/tests/core/test_decollation.py
@@ -1,6 +1,5 @@
-from unittest import skipIf
-
 import param
+import pytest
 
 from holoviews.core import DynamicMap, GridSpace, HoloMap, NdOverlay, Overlay
 from holoviews.element import Points
@@ -12,7 +11,7 @@ try:
 except ImportError:
     spread = datashade = None
 
-datashade_skip = skipIf(datashade is None, "datashade is not available")
+datashade_skip = pytest.mark.skipif(datashade is None, reason="datashade is not available")
 
 
 class XY(Stream):

--- a/holoviews/tests/element/test_selection.py
+++ b/holoviews/tests/element/test_selection.py
@@ -2,8 +2,6 @@
 Test cases for the Comparisons class over the Chart elements
 """
 
-from unittest import skipIf
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -52,11 +50,11 @@ try:
 except ImportError:
     dd = None
 
-spd_available = skipIf(spd is None, "spatialpandas is not available")
-shapelib_available = skipIf(shapely is None and spd is None,
-                            'Neither shapely nor spatialpandas are available')
-shapely_available = skipIf(shapely is None, 'shapely is not available')
-ds_available = skipIf(ds is None, 'datashader not available')
+spd_available = pytest.mark.skipif(spd is None, reason="spatialpandas is not available")
+shapelib_available = pytest.mark.skipif(shapely is None and spd is None,
+                            reason='Neither shapely nor spatialpandas are available')
+shapely_available = pytest.mark.skipif(shapely is None, reason='shapely is not available')
+ds_available = pytest.mark.skipif(ds is None, reason='datashader not available')
 dd_available = pytest.mark.skipif(dd is None, reason='dask.dataframe not available')
 
 

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1,6 +1,6 @@
 import datetime as dt
 from contextlib import suppress
-from unittest import SkipTest, skipIf
+from unittest import SkipTest
 
 import colorcet as cc
 import numpy as np
@@ -68,7 +68,7 @@ try:
 except ImportError:
     spatialpandas = None
 
-spatialpandas_skip = skipIf(spatialpandas is None, "SpatialPandas not available")
+spatialpandas_skip = pytest.mark.skipif(spatialpandas is None, reason="SpatialPandas not available")
 
 
 import logging

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import random
 from importlib.util import find_spec
-from unittest import SkipTest, skipIf
+from unittest import SkipTest
 
 import numpy as np
 import pandas as pd
@@ -64,8 +64,8 @@ from holoviews.operation.element import (
 )
 
 mpl = find_spec("matplotlib")
-da_skip = skipIf(da is None, "dask.array is not available")
-ibis_skip = skipIf(ibis is None, "ibis is not available")
+da_skip = pytest.mark.skipif(da is None, reason="dask.array is not available")
+ibis_skip = pytest.mark.skipif(ibis is None, reason="ibis is not available")
 
 
 class OperationTests(ComparisonTestCase):

--- a/holoviews/tests/operation/test_timeseriesoperations.py
+++ b/holoviews/tests/operation/test_timeseriesoperations.py
@@ -1,12 +1,11 @@
-from unittest import skipIf
-
 import pandas as pd
+import pytest
 
 try:
     import scipy
 except ImportError:
     scipy = None
-scipy_skip = skipIf(scipy is None, "SciPy is not available.")
+scipy_skip = pytest.mark.skipif(scipy is None, reason="SciPy is not available.")
 
 import numpy as np
 

--- a/holoviews/tests/test_selection.py
+++ b/holoviews/tests/test_selection.py
@@ -1,7 +1,8 @@
-from unittest import SkipTest, skip, skipIf
+from unittest import SkipTest, skip
 
 import pandas as pd
 import panel as pn
+import pytest
 
 import holoviews as hv
 from holoviews.core.options import Cycle, Store
@@ -16,7 +17,7 @@ try:
 except ImportError:
     datashade = None
 
-ds_skip = skipIf(datashade is None, "Datashader not available")
+ds_skip = pytest.mark.skipif(datashade is None, reason="Datashader not available")
 
 
 unselected_color = "#ff0000"

--- a/holoviews/tests/util/test_transform.py
+++ b/holoviews/tests/util/test_transform.py
@@ -3,11 +3,11 @@ Unit tests for dim transforms
 """
 import pickle
 import warnings
-from unittest import skipIf
 
 import numpy as np
 import pandas as pd
 import param
+import pytest
 
 import holoviews as hv
 
@@ -22,7 +22,7 @@ try:
 except ImportError:
     xr = None
 
-xr_skip = skipIf(xr is None, "xarray not available")
+xr_skip = pytest.mark.skipif(xr is None, reason="xarray not available")
 
 try:
     import spatialpandas as spd
@@ -34,8 +34,8 @@ try:
 except ImportError:
     shapely = None
 
-shapelib_available = skipIf(shapely is None and spd is None,
-                            'Neither shapely nor spatialpandas are available')
+shapelib_available = pytest.mark.skipif(shapely is None and spd is None,
+                            reason='Neither shapely nor spatialpandas are available')
 
 from holoviews.core.data import Dataset
 from holoviews.element.comparison import ComparisonTestCase


### PR DESCRIPTION
I'm not entirely sure why it happens, but it's likely due to a new release of pytest 9. Just moved it over to pytest.


<img width="1506" height="369" alt="image" src="https://github.com/user-attachments/assets/bfa52071-3e37-46aa-a474-849683c7fd2e" />
