### PR TITLE
enh: Add numpy masked array to  `masked_types`

### DIFF
--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -893,10 +893,8 @@ def isfinite(val):
     """
     is_dask = is_dask_array(val)
     if not np.isscalar(val) and not is_dask:
-        if isinstance(val, np.ma.core.MaskedArray):
-            return ~val.mask & isfinite(val.data)
-        elif isinstance(val, masked_types):
-            return ~val.isna() & isfinite(val._data)
+        if isinstance(val, masked_types):
+            return ~val._mask & isfinite(val._data)
         val = asarray(val, strict=False)
 
     isnan = pd.isna if pd else np.isnan

--- a/holoviews/core/util/types.py
+++ b/holoviews/core/util/types.py
@@ -98,6 +98,9 @@ def arraylike_types():
 
 @gen_types
 def masked_types():
+    if np:
+        yield np.ma.core.MaskedArray
+
     if pd:
         from pandas.core.arrays.masked import BaseMaskedArray
 

--- a/holoviews/tests/core/test_utils.py
+++ b/holoviews/tests/core/test_utils.py
@@ -39,6 +39,7 @@ from holoviews.core.util import (
     unique_array,
     wrap_tuple_streams,
 )
+from holoviews.core.util.types import masked_types
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import PointerXY
 
@@ -695,6 +696,15 @@ class TestNumericUtilities(ComparisonTestCase):
         dt64 = np.array([*dts, np.datetime64('NaT')])
         self.assertEqual(isfinite(dt64), np.array([True, True, True, False]))
 
+    def test_isfinite_masked_numpy(self):
+        masked = np.ma.core.MaskedArray([1, 2, 3], mask=[False, True, False])
+        assert isinstance(masked, masked_types)
+        assert list(isfinite(masked)) == [True, False, True]
+
+    def test_isfinite_masked_pandas(self):
+        masked = pd.array([1, None, 3], dtype="Int64")
+        assert isinstance(masked, masked_types)
+        assert list(isfinite(masked)) == [True, False, True]
 
 
 class TestComputeEdges(ComparisonTestCase):


### PR DESCRIPTION
Surprised that `masked_types` didn't have numpy in it. And could see it was only used in one place in our codebase. 

Also adding a test for it.