### PR TITLE
docs: docstring to use numpydoc

### DIFF
--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -1131,8 +1131,8 @@ def find_contiguous_subarray(sub_array, full_array):
     is a contiguous subarray of `full_array`. This expect that there is no
     duplicates in any of the arrays.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     sub_array: array_like
        The array that may or may not be a contiguous subset of `full_array`.
     full_array: array_like


### PR DESCRIPTION
Numpydoc uses [parameters](https://numpydoc.readthedocs.io/en/latest/format.html#parameters) and not arguments. Saw this in the logs. 