### PR TITLE
enh(bokeh): Add `text_outline_color` style to Labels

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -181,8 +181,15 @@ class LabelsPlot(ColorbarPlot, AnnotationPlot):
 
     selection_display = BokehOverlaySelectionDisplay()
 
-    style_opts = (base_properties + text_properties
-                  + background_properties + border_properties + ['cmap', 'angle'])
+    style_opts = [
+        *base_properties,
+        *text_properties,
+        *background_properties,
+        *border_properties,
+        'cmap',
+        'angle',
+        'text_outline_color',
+    ]
 
     _nonvectorized_styles = [*base_properties, 'cmap']
 


### PR DESCRIPTION
Resolves https://github.com/holoviz/holoviews/issues/6737

<img width="1166" height="405" alt="image" src="https://github.com/user-attachments/assets/329843b8-4e30-4571-914f-3e81b0fec71e" />

No need to safeguard this with a version check as Bokeh added support for this in 3.0.