### PR TITLE
test: Fix flaky ui test

### DIFF
--- a/holoviews/tests/ui/bokeh/test_hover.py
+++ b/holoviews/tests/ui/bokeh/test_hover.py
@@ -420,7 +420,7 @@ def test_hover_tooltips_selector_update_plot(serve_panel):
 
     # Change the selector to 'option2'
     scb.value = "option2"
-    page.wait_for_timeout(1000)
+    page.wait_for_timeout(2000)
 
     # Move the mouse again to trigger updated tooltip
     page.mouse.move(bbox["x"] + bbox["width"] / 4, bbox["y"] + bbox["height"] / 4)


### PR DESCRIPTION
Seems like the mouse is hovering before the final render completes, making it appear and then disappear again before we check if it exists. I cannot recreate this locally; the screencast was created by walking through screenshots from a failing CI run. I have attached the screenshots below. 


https://github.com/user-attachments/assets/71cebba2-cf29-47f2-a3e5-177819af094c



[screenshots.zip](https://github.com/user-attachments/files/23711077/screenshots.zip)

