### PR TITLE
fix: categorical color mapping for Polygons in mpl backend

### DIFF
--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -153,18 +153,19 @@ class ContourPlot(PathPlot):
         with abbreviated_exception():
             style = self._apply_transforms(element, ranges, style)
 
+        # Determine color dimension before processing 'c' style option
+        # This is needed because 'c' gets converted to 'array' but we still
+        # need to know the dimension for categorical color handling
+        cdim = None
+        if 'array' not in style:
+            cidx = self.color_index+2 if isinstance(self.color_index, int) else self.color_index
+            cdim = element.get_dimension(cidx)
+
         if 'c' in style:
             style['array'] = style.pop('c')
             style['clim'] = style.pop('vmin'), style.pop('vmax')
         elif isinstance(style.get('color'), np.ndarray):
             style[color_prop] = style.pop('color')
-
-        # Process deprecated color_index
-        if 'array' not in style:
-            cidx = self.color_index+2 if isinstance(self.color_index, int) else self.color_index
-            cdim = element.get_dimension(cidx)
-        else:
-            cdim = None
 
         if cdim is None:
             return (paths,), style, {}


### PR DESCRIPTION
fixes #6761

With the help of @maximlt, I was able to figure out that the issue was with the use of the `color`/`c` parameter in the Polygon plots. The bug can be replicated using geoviews via:

```python
import geoviews as gv
import hvsampledata as hvsd

gv.extension('matplotlib')

us_states = hvsd.us_states(engine='geopandas')
gv.Polygons(us_states, vdims=['bea_region']).opts(c='bea_region', fig_size=233.33, title="Geoviews plot + color")
```

**Before fix**
<img width="1222" height="616" alt="image" src="https://github.com/user-attachments/assets/59397c02-61bb-48b5-b786-3a847cdaf26f" />

**After fix**
<img width="599" height="284" alt="Screenshot 2025-12-18 at 9 52 27 AM" src="https://github.com/user-attachments/assets/d5256f01-f7fc-4f6b-a1a3-58bf70c36404" />

The fix ensures that categorical color dimensions are properly identified before processing the `c` style parameter in [ContourPlot.get_data()](https://github.com/holoviz/holoviews/blob/main/holoviews/plotting/mpl/path.py#L156-L170). Previously, when using `c='dimension_name'` with categorical data, the dimension determination happened after `c` was already converted to array, causing the code to skip categorical-to-numeric conversion and resulting in incorrect color mapping. Moving the color dimension (`cdim`) determination before the `c` style processing ensures categorical values are consistently converted to numeric indices for proper mapping.
