### PR TITLE
ci: Update packages

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -71,6 +71,7 @@ no-default-feature = true
 [feature.required.dependencies]
 nomkl = "*"
 pip = "*"
+python-gil = "*"
 # Required
 bokeh = ">=3.1"
 colorcet = "*"
@@ -141,7 +142,7 @@ plotly = ">=4.0"
 polars = "*"
 pooch = "*"
 pyarrow = "*"
-pyparsing = "*"
+pyparsing = "<3.3.0" # removed in HoloViews 1.23
 python-duckdb = "*"
 scikit-image = "*"
 scipy = "*"
@@ -173,7 +174,7 @@ plotly = ">=4.0"
 polars = "*"
 pooch = "*"
 pyarrow = "*"
-pyparsing = "*"
+pyparsing = "<3.3.0" # removed in HoloViews 1.23
 python-duckdb = "*"
 scikit-image = "*"
 scipy = "*"


### PR DESCRIPTION
This should make the CI pass again.

I don't know why Python 3.14t is pulled in on test-core.

pyparsing is likely not needed when removing IPython magic, so I just added an upper pin.