### PR TITLE
fix: Fix extra hover tooltips for labels

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -214,6 +214,8 @@ class LabelsPlot(ColorbarPlot, AnnotationPlot):
         data[tdim] = [dims[2].pprint_value(v) for v in element.dimension_values(2)]
         self._categorize_data(data, (xdim, ydim), element.dimensions())
 
+        self._get_hover_data(data, element)
+
         cdim = element.get_dimension(self.color_index)
         if cdim is None:
             return data, mapping, style

--- a/holoviews/tests/plotting/bokeh/test_labels.py
+++ b/holoviews/tests/plotting/bokeh/test_labels.py
@@ -6,7 +6,7 @@ from holoviews.core.options import Cycle
 from holoviews.core.spaces import HoloMap
 from holoviews.element import Labels
 from holoviews.plotting.bokeh.util import property_to_dict
-from holoviews.testing import assert_data_equal
+from holoviews.testing import assert_data_equal, assert_dict_equal
 
 from ..utils import ParamLogStream
 from .test_plot import TestBokehPlot, bokeh_renderer
@@ -206,27 +206,19 @@ class TestLabelsPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(labels)
         source = plot.handles['source']
         glyph = plot.handles['glyph']
+        hover = plot.handles['hover']
 
         expected = {
             'x': np.array([0, 1]),
             'y': np.array([1, 0]),
             'text': ['A', 'B'],
             'value': np.array([10.5, 20.3]),
-            'count': np.array([100, 200])
+            'count': np.array([100, 200]),
         }
-        for k, vals in expected.items():
-            assert k in source.data, f"Expected key '{k}' not found in source.data"
-            np.testing.assert_array_equal(source.data[k], vals)
+        assert_dict_equal(source.data, expected)
 
         assert glyph.x == 'x'
         assert glyph.y == 'y'
         assert glyph.text == 'text'
 
-        assert 'hover' in plot.handles, "Hover tool should be present when hover_tooltips is specified"
-        hover = plot.handles['hover']
-        assert hover.tooltips is not None, "Hover tool should have tooltips configured"
-
-        tooltip_str = str(hover.tooltips)
-        assert '@{text}' in tooltip_str or '@text' in tooltip_str, "Tooltips should reference text field"
-        assert '@{value}' in tooltip_str or '@value' in tooltip_str, "Tooltips should reference value field"
-        assert '@{count}' in tooltip_str or '@count' in tooltip_str, "Tooltips should reference count field"
+        assert hover.tooltips == [('Text', '@{text}'), ('Value', '@{value}'), ('Count', '@{count}')]


### PR DESCRIPTION
Closes https://github.com/holoviz/holoviews/issues/6769

```python
import panel as pn
import hvsampledata
import holoviews as hv
from holoviews import opts

hv.extension('bokeh')

def get_earthquake_data():
    return hvsampledata.earthquakes("pandas")

def aggregate_by_magnitude(earthquake_data):
    aggregated = (
        earthquake_data
        .groupby('mag_class', observed=True)
        .agg({'mag': 'count', 'depth': 'mean'})
        .reset_index()
        .rename(columns={'mag': 'count', 'depth': 'avg_depth'})
        .sort_values('count', ascending=False)
    )
    
    aggregated['percentage'] = (
        aggregated['count'] / aggregated['count'].sum() * 100
    )
    
    return aggregated

def create_bar_chart(aggregated_data):
    bars = hv.Bars(
        aggregated_data,
        kdims=['mag_class'],
        vdims=['count', 'percentage', 'avg_depth']
    ).opts(
        title='Earthquake Distribution by Magnitude',
        xlabel='Magnitude',
        ylabel='Number of Events',
        width=800,
        height=500,
        color='#2E86AB',
        tools=['hover'],
        toolbar='above',
        show_grid=True,
        hover_tooltips=[
            ('Magnitude', '@mag_class'),
            ('Events', '@count{0,0}'),
            ('Percentage', '@percentage{0.1f}%'),
            ('Avg Depth', '@avg_depth{0.0f} km')
        ]
    )
    
    labels_data = aggregated_data.copy()
    labels_data['label_y'] = labels_data['count'] + 20
    
    text_labels = hv.Labels(
        labels_data,
        kdims=['mag_class', 'label_y'],
        vdims=['count', 'percentage', 'avg_depth']
    ).opts(
        text_font_size='11pt',
        text_font_style='bold',
        text_color='#333333',
        text_baseline='bottom',
        tools=['hover'],
        hover_tooltips=[
            ('Magnitude', '@mag_class'),
            ('Events', '@count{0,0}'),
            ('Percentage', '@percentage{0.1f}%'),
            ('Avg Depth', '@avg_depth{0.0f} km')
        ]
    )
    
    return bars * text_labels

def create_plot():
    earthquake_data = get_earthquake_data()
    aggregated = aggregate_by_magnitude(earthquake_data)
    chart = create_bar_chart(aggregated)
    return chart

pn.extension()

chart = create_plot()
pn.panel(chart, sizing_mode="stretch_both", margin=25).servable()
```

<img width="1717" height="893" alt="image" src="https://github.com/user-attachments/assets/959fc63d-bb4e-4caa-aa65-86feb14d8b6b" />
