### PR TITLE
chore!: Remove 1.23 deprecations 

### DIFF
--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -67,7 +67,7 @@ concepts in HoloViews:
  reveal individual data points without sacrificing aggregation.
 
 `Working with Streaming Data`_
- Demonstrates how to leverage the streamz library with HoloViews to work with streaming datasets.
+ Demonstrates how to leverage streaming with HoloViews.
 
 `Creating interactive dashboards`_
  Use external widget libraries to build custom, interactive dashboards.

--- a/examples/user_guide/16-Streaming_Data.ipynb
+++ b/examples/user_guide/16-Streaming_Data.ipynb
@@ -10,9 +10,7 @@
     "\n",
     "This user guide shows a third way of building an interactive plot, using ``DynamicMap`` and streams.  Here, instead of pushing plot metadata (such as zoom ranges, user triggered events such as ``Tap`` and so on) to a ``DynamicMap`` callback, the underlying data in the visualized elements are updated directly using a HoloViews ``Stream``.\n",
     "\n",
-    "In particular, we will show how the HoloViews ``Pipe`` and ``Buffer`` streams can be used to work with streaming data sources without having to fetch or generate the data from inside the ``DynamicMap`` callable. Apart from simply setting element data from outside a ``DynamicMap``, we will also explore ways of working with streaming data coordinated by the separate [``streamz``](https://matthewrocklin.com/blog/work/2017/10/16/streaming-dataframes-1) library from Matt Rocklin, which can make building complex streaming pipelines much simpler.\n",
-    "\n",
-    "As this notebook makes use of the ``streamz`` library, you will need to install it with ``conda install streamz`` or ``pip install streamz``."
+    "In particular, we will show how the HoloViews ``Pipe`` and ``Buffer`` streams can be used to work with streaming data sources without having to fetch or generate the data from inside the ``DynamicMap`` callable."
    ]
   },
   {

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -7,7 +7,7 @@ the process of plotting.
 
 HoloViews
 
-- supports a wide range of data sources including Pandas, Dask, XArray Rapids cuDF, Intake, Geopandas, NetworkX and Ibis.
+- supports a wide range of data sources, including Pandas, Dask, polars, duckdb, Xarray, cuDF, NetworkX, and Ibis.
 
 - supports the plotting backends Bokeh (default), Matplotlib and Plotly.
 

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -7,7 +7,7 @@ the process of plotting.
 
 HoloViews
 
-- supports a wide range of data sources including Pandas, Dask, XArray Rapids cuDF, Streamz, Intake, Geopandas, NetworkX and Ibis.
+- supports a wide range of data sources including Pandas, Dask, XArray Rapids cuDF, Intake, Geopandas, NetworkX and Ibis.
 
 - supports the plotting backends Bokeh (default), Matplotlib and Plotly.
 

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -147,8 +147,6 @@ if TYPE_CHECKING:
     # Adding this here to have better docstring in LSP
     from .util import extension
 
-# A single holoviews.rc file may be executed if found.
-# In HoloViews 1.23.0, it will need to be set with env. var. HOLOVIEWSRC
 _load_rc_file()
 
 def help(obj, visualization=True, ansi=True, backend=None,

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -1,8 +1,6 @@
 import builtins
 import datetime as dt
-import functools
 import hashlib
-import importlib
 import inspect
 import itertools
 import json
@@ -2441,38 +2439,6 @@ def flatten(line):
             yield from flatten(element)
         else:
             yield element
-
-
-def lazy_isinstance(obj, class_or_tuple):
-    """Lazy isinstance check
-
-    Will only import the module of the object if the module of the
-    obj matches the first value of an item in class_or_tuple.
-
-    lazy_isinstance(obj, 'dask.dataframe:DataFrame')
-
-    Will :
-        1) check if the first module is dask
-        2) If it dask, import dask.dataframe
-        3) Do an isinstance check for dask.dataframe.DataFrame
-
-    """
-    from ...util.warnings import deprecated
-
-    deprecated("1.23.0", "lazy_isinstance") # Not used in HoloViews anymore
-
-    if isinstance(class_or_tuple, str):
-        class_or_tuple = (class_or_tuple,)
-
-    obj_mod_name = obj.__module__.split('.')[0]
-    for cls in class_or_tuple:
-        mod_name, _, attr_name = cls.partition(':')
-        if not obj_mod_name.startswith(mod_name.split(".")[0]):
-            continue
-        mod = importlib.import_module(mod_name)
-        if isinstance(obj, functools.reduce(getattr, attr_name.split('.'), mod)):
-            return True
-    return False
 
 
 def dtype_kind(obj) -> str:

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -25,15 +25,6 @@ def show_traceback():
     print(FULL_TRACEBACK)
 
 
-def __getattr__(attr):
-    if attr == "IPTestCase":
-        from ..element.comparison import IPTestCase
-        from ..util.warnings import deprecated
-        deprecated("1.23.0", old="holoviews.ipython.IPTestCase", new="holoviews.element.comparison.IPTestCase")
-        return IPTestCase
-    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
-
-
 class notebook_extension(extension):
     """Notebook specific extension to hv.extension that offers options for
     controlling the notebook environment.

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -18,7 +18,6 @@ import param
 
 from .core import util
 from .core.ndmapping import UniformNdMapping
-from .util.warnings import deprecated
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -576,30 +575,8 @@ class Buffer(Pipe):
                 raise ValueError("Columns in dictionary must all be the same length.")
             example = data
         else:
-            try:
-                from streamz.dataframe import StreamingDataFrame, StreamingSeries
-                loaded = True
-            except ImportError:
-                try:
-                    from streamz.dataframe import (
-                        DataFrame as StreamingDataFrame,
-                        Series as StreamingSeries,
-                    )
-                    loaded = True
-                except ImportError:
-                    loaded = False
-            if loaded:
-                # NOTE: there could still be some code in these classes which handles
-                # the streaming interface.
-                deprecated("1.23.0", "Buffer's streamz interface")
-            if not loaded or not isinstance(data, (StreamingDataFrame, StreamingSeries)):
-                raise ValueError("Buffer must be initialized with pandas DataFrame, "
-                                 "streamz.StreamingDataFrame or streamz.StreamingSeries.")
-            elif isinstance(data, StreamingSeries):
-                data = data.to_frame()
-            example = data.example
-            data.stream.sink(self.send)
-            self.sdf = data
+            msg = "Buffer must be initialized with pandas DataFrame, 2D numpy array, or dict"
+            raise ValueError(msg)
 
         params['data'] = example
         super().__init__(**params)

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -1107,29 +1107,16 @@ class Dynamic(param.ParameterizedFunction):
 
 
 def _load_rc_file():
-    files = [
-        os.environ.get("HOLOVIEWSRC", ''),
-        os.path.abspath(os.path.join(os.path.split(__file__)[0], '..', '..', 'holoviews.rc')),
-        "~/.holoviews.rc",
-        "~/.config/holoviews/holoviews.rc"
-    ]
+    file = os.getenv("HOLOVIEWSRC")
+    if not file:
+        return
+    filename = os.path.expanduser(file)
+    if not os.path.isfile(filename):
+        print(f"Warning: {filename!r} does not exist")
+        return
 
-    # A single holoviews.rc file may be executed if found.
-    for idx, file in enumerate(files):
-        filename = os.path.expanduser(file)
-        if os.path.isfile(filename):
-            with open(filename, encoding='utf8') as f:
-                try:
-                    exec(compile(f.read(), filename, 'exec'))
-                except Exception as e:
-                    print(f"Warning: Could not load {filename!r} [{str(e)!r}]")
-
-            if idx != 0:
-                from .warnings import deprecated
-                deprecated(
-                    "1.23.0",
-                    "Automatic detections of HoloViews config file",
-                    extra=f"You can disable this warning by setting the environment variable 'HOLOVIEWSRC' to {filename!r}.",
-                    repr_old=False,
-                )
-            return
+    with open(filename, encoding='utf8') as f:
+        try:
+            exec(compile(f.read(), filename, 'exec'))
+        except Exception as e:
+            print(f"Warning: Could not load {filename!r} [{str(e)!r}]")

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -26,7 +26,6 @@ from ..core.overlay import Overlay
 from ..operation.element import function
 from ..streams import Params, Stream, streams_list_from_dict
 from .settings import OutputSettings, list_backends, list_formats
-from .warnings import deprecated
 
 Store.output_settings = OutputSettings
 
@@ -704,14 +703,11 @@ class extension(_pyviz_extension):
             if p in self._backends:
                 imports.append((p, self._backends[p]))
         if not imports:
-            deprecated(
-                "1.23.0",
-                "Calling 'hv.extension()' without arguments",
-                'hv.extension("matplotlib")',
-                repr_old=False,
+            msg = (
+                "Calling 'hv.extension()' without arguments is not supported. "
+                "Use e.g. hv.extension('bokeh')."
             )
-            args = ['matplotlib']
-            imports = [('matplotlib', 'mpl')]
+            raise TypeError(msg)
 
         args = list(args)
         selected_backend = None


### PR DESCRIPTION
Remove the 1.23 deprecated functionality:
- Only support `HOLOVIEWSRC` environment variable for custom config
- Remove `lazy_isinstance`, not used anymore, and was only available in a few releases.
- Remove old location of IPTestCase (scheduled for removal in 1.25.0, as functionality is in IPythonCase)
- Remove streamz support.  

This was deprecated in 1.21.0 (released June 2025)

Resolves #5412 (streamz issue)
Resolves #4816 (streamz issue)
Resolves #5202 (streamz issue)