### PR TITLE
fix: Support pandas dtypes for interpolation

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -1068,10 +1068,14 @@ class interpolate_curve(Operation):
 
     @staticmethod
     def _get_dtype(obj):
-        if dtype_kind(obj) == "O":
+        dtype = obj.dtype
+        if hasattr(dtype, "numpy_dtype"):
+            # Handle non-numpy objects like Pandas Int64Dtype
+            return dtype.numpy_dtype
+        if dtype_kind(dtype) == "O":
             # Handle non-numpy objects like Pandas 3.0 StringArray
             return "O"
-        return obj.dtype
+        return dtype
 
     @classmethod
     def pts_to_prestep(cls, x, values):

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -765,6 +765,14 @@ class OperationTests:
         curve = Curve((dates_interp, [0, 0, 1, 1, 2, 2, 3]))
         assert_element_equal(interpolated, curve)
 
+    @pytest.mark.parametrize("dtype", [pd.Int64Dtype(), np.int64])
+    def test_interpolate_pandas_dtype_curve_post(self, dtype):
+        df = pd.DataFrame(dict(a=[1, 2, 3], b=[3, 4, 5]), dtype=dtype)
+        interpolated = interpolate_curve(Curve(df), interpolation='steps-post')
+        df = pd.DataFrame(dict(a=[1, 2, 2, 3, 3], b=[3, 3, 4, 4, 5]))
+        expected = Curve(df)
+        assert_element_equal(interpolated, expected)
+
     def test_stack_area_overlay(self):
         areas = Area([1, 2, 3]) * Area([1, 2, 3])
         stacked = Area.stack(areas)


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/6142