### PR TITLE
fix: BoxEdit stream data not initialized for Rectangles

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1686,6 +1686,10 @@ class BoxEditCallback(GlyphDrawCallback):
         renderer = self.plot.handles['glyph_renderer']
         if isinstance(self.plot, PathPlot):
             renderer = self._path_initialize()
+        else:
+            data = self._process_msg({'data': cds.data})['data']
+            for stream in self.streams:
+                stream.update(data=data)
         if stream.styles:
             self._create_style_callback(cds, renderer.glyph)
         if BOKEH_GE_3_3_0:

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -280,6 +280,16 @@ class TestEditToolCallbacks(CallbackTestCase):
         element = Rectangles([(-0.25, -1, 0.25, 1), (0, 0.75, 2, 1.25)])
         assert_element_equal(box_edit.element, element)
 
+    def test_box_edit_stream_data_initialized(self):
+        boxes = Rectangles([(-0.5, -0.5, 0.5, 0.5), (0, 0, 1, 1)])
+        box_edit = BoxEdit(source=boxes)
+        bokeh_server_renderer.get_plot(boxes)
+
+        assert list(box_edit.data['x0']) == [-0.5, 0]
+        assert list(box_edit.data['y0']) == [-0.5, 0]
+        assert list(box_edit.data['x1']) == [0.5, 1]
+        assert list(box_edit.data['y1']) == [0.5, 1]
+
     async def test_box_edit_callback_legacy(self):
         boxes = Polygons([Box(0, 0, 1)])
         box_edit = BoxEdit(source=boxes)


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/5471

The added logic is also used in `self._path_initialize`:

https://github.com/holoviz/holoviews/blob/6a2ab3e0e42b55875c1734f500fb82d948761479/holoviews/plotting/bokeh/callbacks.py#L1669-L1671