### PR TITLE
fix: hv.help() to work outside IPython/Jupyter

### DIFF
--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -744,6 +744,9 @@ class extension(_pyviz_extension):
             raise ImportError('None of the backends could be imported')
         Store.set_current_backend(selected_backend)
 
+        from ..core.pprint import InfoPrinter
+        InfoPrinter.store = Store
+
         import panel as pn
 
         if params.get("enable_mathjax", False) and selected_backend == "bokeh":


### PR DESCRIPTION
## Description

Fixes #6775  - `hv.help()` now provides  visualization options (Style Options, Plot Options) when running in plain Python scripts, not just in Jupyter notebooks.

### Before 
<img width="807" height="446" alt="image" src="https://github.com/user-attachments/assets/981a4237-8a1d-4939-ad19-d9f451b0100e" />

### After 
<img width="1395" height="876" alt="image" src="https://github.com/user-attachments/assets/497a7ae1-ee58-4045-aa08-2978511ae134" />

## Checklist

- [x] Pull request title follows the conventional format
- [ ] Tests added and is passing
- [ ] Added documentation 
