### PR TITLE
fix(bokeh): Labels with offset raising unreachable code

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -208,9 +208,9 @@ class LabelsPlot(ColorbarPlot, AnnotationPlot):
         mapping = dict(x=xdim, y=ydim, text=tdim)
         data = {d: element.dimension_values(d) for d in (xdim, ydim)}
         if self.xoffset is not None:
-            mapping['x'] = dodge(xdim, self.xoffset)
+            mapping['x'] = dodge(xdim, self.xoffset, range=self.handles.get('x_range'))
         if self.yoffset is not None:
-            mapping['y'] = dodge(ydim, self.yoffset)
+            mapping['y'] = dodge(ydim, self.yoffset, range=self.handles.get('y_range'))
         data[tdim] = [dims[2].pprint_value(v) for v in element.dimension_values(2)]
         self._categorize_data(data, (xdim, ydim), element.dimensions())
 

--- a/holoviews/tests/ui/bokeh/test_labels.py
+++ b/holoviews/tests/ui/bokeh/test_labels.py
@@ -1,0 +1,27 @@
+import pytest
+
+import holoviews as hv
+
+from .. import expect
+
+pytestmark = pytest.mark.ui
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+@pytest.mark.parametrize("offset", ["xoffset", "yoffset"])
+@pytest.mark.parametrize("with_scatter", [True, False])
+def test_labels_offset(serve_hv, offset, with_scatter):
+    labels = hv.Labels(
+        {("x", "y"): [["a", 1], ["b", 2]], "text": ["a", "b"]},
+        ["x", "y"],
+        "text",
+    ).opts(**{offset: 0.2})
+    if with_scatter:
+        scatter = hv.Scatter([("a", 1), ("b", 2)]).opts(padding=0.1)
+        plot = labels * scatter
+    else:
+        plot = labels
+
+    page = serve_hv(plot)
+    hv_plot = page.locator(".bk-events")
+    expect(hv_plot).to_have_count(1)


### PR DESCRIPTION
## Description
Fixes https://github.com/holoviz/holoviews/issues/3892

``` python
import holoviews as hv
hv.extension("bokeh")

hv.Labels({('x', 'y') : [['a',1], ['b',2]], 'text':['a', 'b']}, ['x','y'], 'text').opts(yoffset=0.2)*hv.Scatter([('a',1), ('b', 2)]).opts(padding=0.1)
```

<img width="451" height="327" alt="image" src="https://github.com/user-attachments/assets/e10595a5-8797-42be-9335-4c9e2da43bb9" />


## Checklist

- [x] Pull request title follows the conventional format
- [x] Tests added and is passing

<!--
Conventional format: <Type>(<Scope>): <Subject>
Valid Types: `build`, `chore`, `ci`, `compat`, `docs`, `enh`, `feat`, `fix`, `perf`, `refactor`, `test`, and `type`
Valid Scopes (optional): `dev`, `data`, `plotting`, `bokeh`, `matplotlib`, `plotly`, and `notebook`

For more information on how to contribute to this repository, see the [developer guide](https://www.holoviews.org/developer_guide/index.html)
-->
