### PR TITLE
fix: Use `label` as source of truth

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -1061,7 +1061,7 @@ class Dataset(Element, metaclass=PipelineMeta):
         if group_type is None: group_type = type(self)
 
         dimensions = [self.get_dimension(d, strict=True) for d in dimensions]
-        dim_names = [d.name for d in dimensions]
+        dim_names = [d.label for d in dimensions]
 
         if dynamic:
             group_dims = [kd for kd in self.kdims if kd not in dimensions]
@@ -1079,7 +1079,7 @@ class Dataset(Element, metaclass=PipelineMeta):
                 if drop_dim and self.interface.gridded:
                     data = data.columns()
                 return group_type(data, **group_kwargs)
-            dynamic_dims = [d.clone(values=list(self.interface.values(self, d.name, False)))
+            dynamic_dims = [d.clone(values=list(self.interface.values(self, d.label, False)))
                             for d in dimensions]
             return DynamicMap(load_subset, kdims=dynamic_dims)
 
@@ -1224,9 +1224,9 @@ class Dataset(Element, metaclass=PipelineMeta):
         DataFrame of columns corresponding to each dimension
         """
         if dimensions is None:
-            dimensions = [d.name for d in self.dimensions()]
+            dimensions = [d.label for d in self.dimensions()]
         else:
-            dimensions = [self.get_dimension(d, strict=True).name for d in dimensions]
+            dimensions = [self.get_dimension(d, strict=True).label for d in dimensions]
         df = self.interface.dframe(self, dimensions)
         if multi_index:
             df = df.set_index([d for d in dimensions if d in self.kdims])


### PR DESCRIPTION
## Description

Looking at fixing the issue reported in https://github.com/holoviz/holoviews/issues/6799, based on https://github.com/holoviz/holoviews/issues/6260 as label as the source of truth. 

<!-- Please describe your changes here and if it fixes an issue-->

## Checklist

- [x] Pull request title follows the conventional format
- [ ] Tests added and is passing
- [ ] Added documentation <!-- Please delete if not applicable -->

<!--
Conventional format: <Type>(<Scope>): <Subject>
Valid Types: `build`, `chore`, `ci`, `compat`, `docs`, `enh`, `feat`, `fix`, `perf`, `refactor`, `test`, and `type`
Valid Scopes (optional): `dev`, `data`, `plotting`, `bokeh`, `matplotlib`, `plotly`, and `notebook`

For more information on how to contribute to this repository, see the [developer guide](https://www.holoviews.org/developer_guide/index.html)
-->
