### PR TITLE
refactor: Make test use `hv.` import if it is top-level import

### DIFF
--- a/holoviews/tests/core/data/base.py
+++ b/holoviews/tests/core/data/base.py
@@ -7,17 +7,15 @@ import datetime
 import numpy as np
 import pytest
 
-from holoviews import Dataset, Dimension, HoloMap
+import holoviews as hv
 from holoviews.core.data import concat
 from holoviews.core.data.interface import DataError
-from holoviews.element import Curve, Scatter
 from holoviews.testing import assert_data_equal, assert_element_equal
-from holoviews.util.transform import dim
 
 
 class DatatypeContext:
 
-    def __init__(self, datatypes, dataset_type=Dataset):
+    def __init__(self, datatypes, dataset_type=hv.Dataset):
         self.datatypes = datatypes
         self.dataset_type = dataset_type
         self._old_datatypes = {}
@@ -47,7 +45,7 @@ class InterfaceTests:
 
     datatype = 'interface'
     data_type = None
-    element = Dataset
+    element = hv.Dataset
 
     def setup_method(self):
         self.restore_datatype = self.element.datatype
@@ -87,16 +85,16 @@ class HomogeneousColumnTests:
         self.xs_2 = self.xs**2
 
         self.y_ints = self.xs*2
-        self.dataset_hm = Dataset(self.frame({"x": self.xs, "y": self.y_ints}),
+        self.dataset_hm = hv.Dataset(self.frame({"x": self.xs, "y": self.y_ints}),
                                   kdims=['x'], vdims=['y'])
-        self.dataset_hm_alias = Dataset(self.frame({"x": self.xs, "y": self.y_ints}),
+        self.dataset_hm_alias = hv.Dataset(self.frame({"x": self.xs, "y": self.y_ints}),
                                         kdims=[('x', 'X')], vdims=[('y', 'Y')])
 
     # Test the array constructor (homogeneous data) to be supported by
     # all interfaces.
 
     def test_dataset_array_init_hm(self):
-        dataset = Dataset(np.column_stack([self.xs, self.xs_2]),
+        dataset = hv.Dataset(np.column_stack([self.xs, self.xs_2]),
                           kdims=['x'], vdims=['x2'])
         assert isinstance(dataset.data, self.data_type)
 
@@ -105,7 +103,7 @@ class HomogeneousColumnTests:
         assert self.dataset_hm.interface.dtype(self.dataset_hm, 'y') == np.dtype(int)
 
     def test_dataset_array_init_hm_tuple_dims(self):
-        dataset = Dataset(np.column_stack([self.xs, self.xs_2]),
+        dataset = hv.Dataset(np.column_stack([self.xs, self.xs_2]),
                           kdims=[('x', 'X')], vdims=[('x2', 'X2')])
         assert isinstance(dataset.data, self.data_type)
 
@@ -113,7 +111,7 @@ class HomogeneousColumnTests:
         "Tests support for homogeneous DataFrames"
         if self.frame is dict:
             pytest.skip("Only valid for non-dict frame")
-        dataset = Dataset(self.frame({'x':self.xs, 'x2':self.xs_2}),
+        dataset = hv.Dataset(self.frame({'x':self.xs, 'x2':self.xs_2}),
                           kdims=['x'], vdims=['x2'])
         assert isinstance(dataset.data, self.data_type)
 
@@ -121,22 +119,22 @@ class HomogeneousColumnTests:
         "Tests support for homogeneous DataFrames"
         if self.frame is dict:
             pytest.skip("Only valid for non-dict frame")
-        dataset = Dataset(self.frame({'x':self.xs, 'x2':self.xs_2}),
+        dataset = hv.Dataset(self.frame({'x':self.xs, 'x2':self.xs_2}),
                           kdims=[('x', 'X-label')], vdims=[('x2', 'X2-label')])
         assert isinstance(dataset.data, self.data_type)
 
     def test_dataset_empty_list_init(self):
-        dataset = Dataset([], kdims=['x'], vdims=['y'])
+        dataset = hv.Dataset([], kdims=['x'], vdims=['y'])
         for d in 'xy':
             assert_data_equal(dataset.dimension_values(d), np.array([]))
 
     def test_dataset_dict_dim_not_found_raises_on_array(self):
         with pytest.raises(ValueError):  # noqa: PT011
-            Dataset({'x': np.zeros(5)}, kdims=['Test'], vdims=[])
+            hv.Dataset({'x': np.zeros(5)}, kdims=['Test'], vdims=[])
 
     def test_dataset_dict_dim_not_found_raises_on_scalar(self):
         with pytest.raises(ValueError):  # noqa: PT011
-            Dataset({'x': 1}, kdims=['Test'], vdims=[])
+            hv.Dataset({'x': 1}, kdims=['Test'], vdims=[])
 
     # Properties and information
 
@@ -153,40 +151,40 @@ class HomogeneousColumnTests:
     # Operations
 
     def test_dataset_sort_hm(self):
-        ds = Dataset(([2, 2, 1], [2,1,2], [0.1, 0.2, 0.3]),
+        ds = hv.Dataset(([2, 2, 1], [2,1,2], [0.1, 0.2, 0.3]),
                      kdims=['x', 'y'], vdims=['z']).sort()
-        ds_sorted = Dataset(([1, 2, 2], [2, 1, 2], [0.3, 0.2, 0.1]),
+        ds_sorted = hv.Dataset(([1, 2, 2], [2, 1, 2], [0.3, 0.2, 0.1]),
                             kdims=['x', 'y'], vdims=['z'])
         assert_element_equal(ds.sort(), ds_sorted)
 
     def test_dataset_sort_reverse_hm(self):
-        ds = Dataset(([2, 1, 2, 1], [2, 2, 1, 1], [0.1, 0.2, 0.3, 0.4]),
+        ds = hv.Dataset(([2, 1, 2, 1], [2, 2, 1, 1], [0.1, 0.2, 0.3, 0.4]),
                      kdims=['x', 'y'], vdims=['z'])
-        ds_sorted = Dataset(([2, 2, 1, 1], [2, 1, 2, 1], [0.1, 0.3, 0.2, 0.4]),
+        ds_sorted = hv.Dataset(([2, 2, 1, 1], [2, 1, 2, 1], [0.1, 0.3, 0.2, 0.4]),
                             kdims=['x', 'y'], vdims=['z'])
         assert_element_equal(ds.sort(reverse=True), ds_sorted)
 
     def test_dataset_sort_vdim_hm(self):
         xs_2 = np.array(self.xs_2)
-        dataset = Dataset(np.column_stack([self.xs, -xs_2]),
+        dataset = hv.Dataset(np.column_stack([self.xs, -xs_2]),
                           kdims=['x'], vdims=['y'])
-        dataset_sorted = Dataset(np.column_stack([self.xs[::-1], -xs_2[::-1]]),
+        dataset_sorted = hv.Dataset(np.column_stack([self.xs[::-1], -xs_2[::-1]]),
                                  kdims=['x'], vdims=['y'])
         assert_element_equal(dataset.sort('y'), dataset_sorted)
 
     def test_dataset_sort_reverse_vdim_hm(self):
         xs_2 = np.array(self.xs_2)
-        dataset = Dataset(np.column_stack([self.xs, -xs_2]),
+        dataset = hv.Dataset(np.column_stack([self.xs, -xs_2]),
                           kdims=['x'], vdims=['y'])
-        dataset_sorted = Dataset(np.column_stack([self.xs, -xs_2]),
+        dataset_sorted = hv.Dataset(np.column_stack([self.xs, -xs_2]),
                                  kdims=['x'], vdims=['y'])
         assert_element_equal(dataset.sort('y', reverse=True), dataset_sorted)
 
     def test_dataset_sort_vdim_hm_alias(self):
         xs_2 = np.array(self.xs_2)
-        dataset = Dataset(np.column_stack([self.xs, -xs_2]),
+        dataset = hv.Dataset(np.column_stack([self.xs, -xs_2]),
                           kdims=[('x', 'X-label')], vdims=[('y', 'Y-label')])
-        dataset_sorted = Dataset(np.column_stack([self.xs[::-1], -xs_2[::-1]]),
+        dataset_sorted = hv.Dataset(np.column_stack([self.xs[::-1], -xs_2[::-1]]),
                                  kdims=[('x', 'X-label')], vdims=[('y', 'Y-label')])
         assert_element_equal(dataset.sort('y'), dataset_sorted)
         assert_element_equal(dataset.sort('Y-label'), dataset_sorted)
@@ -221,7 +219,7 @@ class HomogeneousColumnTests:
         )
 
     def test_dataset_redim_hm_vdim_alias(self):
-        redimmed = self.dataset_hm_alias.redim(y=Dimension(('val', 'Value')))
+        redimmed = self.dataset_hm_alias.redim(y=hv.Dimension(('val', 'Value')))
         assert_data_equal(redimmed.dimension_values('Value'),
                          self.dataset_hm_alias.dimension_values('y'))
 
@@ -250,43 +248,43 @@ class HomogeneousColumnTests:
         assert_data_equal(np.array(list(range(1,12))), table.dimension_values('z'))
 
     def test_dataset_slice_hm(self):
-        dataset_slice = Dataset(self.frame({'x':range(5, 9), 'y':[2 * i for i in range(5, 9)]}),
+        dataset_slice = hv.Dataset(self.frame({'x':range(5, 9), 'y':[2 * i for i in range(5, 9)]}),
                                 kdims=['x'], vdims=['y'])
         assert_element_equal(self.dataset_hm[5:9], dataset_slice)
 
     def test_dataset_slice_hm_alias(self):
-        dataset_slice = Dataset(self.frame({'x':range(5, 9), 'y':[2 * i for i in range(5, 9)]}),
+        dataset_slice = hv.Dataset(self.frame({'x':range(5, 9), 'y':[2 * i for i in range(5, 9)]}),
                                 kdims=[('x', 'X')], vdims=[('y', 'Y')])
         assert_element_equal(self.dataset_hm_alias[5:9], dataset_slice)
 
     def test_dataset_slice_fn_hm(self):
-        dataset_slice = Dataset(self.frame({'x':range(5, 9), 'y':[2 * i for i in range(5, 9)]}),
+        dataset_slice = hv.Dataset(self.frame({'x':range(5, 9), 'y':[2 * i for i in range(5, 9)]}),
                                 kdims=['x'], vdims=['y'])
         assert_element_equal(self.dataset_hm[lambda x: (x >= 5) & (x < 9)], dataset_slice)
 
     def test_dataset_1D_reduce_hm(self):
-        dataset = Dataset(self.frame({'x':self.xs, 'y':self.y_ints}), kdims=['x'], vdims=['y'])
+        dataset = hv.Dataset(self.frame({'x':self.xs, 'y':self.y_ints}), kdims=['x'], vdims=['y'])
         assert dataset.reduce('x', np.mean) == 10
 
     def test_dataset_1D_reduce_hm_alias(self):
-        dataset = Dataset(self.frame({'x':self.xs, 'y':self.y_ints}), kdims=[('x', 'X')],
+        dataset = hv.Dataset(self.frame({'x':self.xs, 'y':self.y_ints}), kdims=[('x', 'X')],
                           vdims=[('y', 'Y')])
         assert dataset.reduce('X', np.mean) == 10
 
     def test_dataset_2D_reduce_hm(self):
-        dataset = Dataset(self.frame({'x':self.xs, 'y':self.y_ints, 'z':[el ** 2 for el in self.y_ints]}),
+        dataset = hv.Dataset(self.frame({'x':self.xs, 'y':self.y_ints, 'z':[el ** 2 for el in self.y_ints]}),
                           kdims=['x', 'y'], vdims=['z'])
         assert_data_equal(np.array(dataset.reduce(['x', 'y'], np.mean)), np.array(140))
 
     def test_dataset_2D_aggregate_partial_hm(self):
         z_ints = [el**2 for el in self.y_ints]
-        dataset = Dataset(self.frame({'x':self.xs, 'y':self.y_ints, 'z':z_ints}),
+        dataset = hv.Dataset(self.frame({'x':self.xs, 'y':self.y_ints, 'z':z_ints}),
                           kdims=['x', 'y'], vdims=['z'])
         agg = dataset.aggregate(['x'], np.mean)
         if self.force_sort:
             agg = agg.sort("x")
 
-        expected = Dataset({'x':self.xs, 'z':z_ints}, kdims=['x'], vdims=['z'])
+        expected = hv.Dataset({'x':self.xs, 'z':z_ints}, kdims=['x'], vdims=['z'])
         assert_element_equal(agg, expected),
 
     # Indexing
@@ -301,49 +299,49 @@ class HomogeneousColumnTests:
 
     def test_dataset_iloc_slice_rows(self):
         sliced = self.dataset_hm.iloc[1:4]
-        table = Dataset({'x': self.xs[1:4], 'y': self.y_ints[1:4]},
+        table = hv.Dataset({'x': self.xs[1:4], 'y': self.y_ints[1:4]},
                         kdims=['x'], vdims=['y'], datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_slice_rows_slice_cols(self):
         sliced = self.dataset_hm.iloc[1:4, 1:]
-        table = Dataset({'y': self.y_ints[1:4]}, kdims=[], vdims=['y'],
+        table = hv.Dataset({'y': self.y_ints[1:4]}, kdims=[], vdims=['y'],
                         datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_slice_rows_list_cols(self):
         sliced = self.dataset_hm.iloc[1:4, [0, 1]]
-        table = Dataset({'x': self.xs[1:4], 'y': self.y_ints[1:4]},
+        table = hv.Dataset({'x': self.xs[1:4], 'y': self.y_ints[1:4]},
                         kdims=['x'], vdims=['y'], datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_slice_rows_index_cols(self):
         sliced = self.dataset_hm.iloc[1:4, 1]
-        table = Dataset({'y': self.y_ints[1:4]}, kdims=[], vdims=['y'],
+        table = hv.Dataset({'y': self.y_ints[1:4]}, kdims=[], vdims=['y'],
                         datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_list_rows(self):
         sliced = self.dataset_hm.iloc[[0, 2]]
-        table = Dataset({'x': self.xs[[0, 2]], 'y': self.y_ints[[0, 2]]},
+        table = hv.Dataset({'x': self.xs[[0, 2]], 'y': self.y_ints[[0, 2]]},
                         kdims=['x'], vdims=['y'], datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_list_rows_list_cols(self):
         sliced = self.dataset_hm.iloc[[0, 2], [0, 1]]
-        table = Dataset({'x': self.xs[[0, 2]], 'y': self.y_ints[[0, 2]]},
+        table = hv.Dataset({'x': self.xs[[0, 2]], 'y': self.y_ints[[0, 2]]},
                         kdims=['x'], vdims=['y'], datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_list_rows_list_cols_by_name(self):
         sliced = self.dataset_hm.iloc[[0, 2], ['x', 'y']]
-        table = Dataset({'x': self.xs[[0, 2]], 'y': self.y_ints[[0, 2]]},
+        table = hv.Dataset({'x': self.xs[[0, 2]], 'y': self.y_ints[[0, 2]]},
                         kdims=['x'], vdims=['y'], datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_list_rows_slice_cols(self):
         sliced = self.dataset_hm.iloc[[0, 2], slice(0, 2)]
-        table = Dataset({'x': self.xs[[0, 2]], 'y': self.y_ints[[0, 2]]},
+        table = hv.Dataset({'x': self.xs[[0, 2]], 'y': self.y_ints[[0, 2]]},
                         kdims=['x'], vdims=['y'], datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
@@ -353,31 +351,31 @@ class HomogeneousColumnTests:
 
     def test_dataset_iloc_index_rows_slice_cols(self):
         indexed = self.dataset_hm.iloc[1, :2]
-        table = Dataset({'x':self.xs[[1]],  'y':self.y_ints[[1]]},
+        table = hv.Dataset({'x':self.xs[[1]],  'y':self.y_ints[[1]]},
                         kdims=['x'], vdims=['y'], datatype=['dictionary'])
         assert_element_equal(indexed, table)
 
     def test_dataset_iloc_list_cols(self):
         sliced = self.dataset_hm.iloc[:, [0, 1]]
-        table = Dataset({'x':self.xs,  'y':self.y_ints},
+        table = hv.Dataset({'x':self.xs,  'y':self.y_ints},
                         kdims=['x'], vdims=['y'], datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_list_cols_by_name(self):
         sliced = self.dataset_hm.iloc[:, ['x', 'y']]
-        table = Dataset({'x':self.xs,  'y':self.y_ints},
+        table = hv.Dataset({'x':self.xs,  'y':self.y_ints},
                         kdims=['x'], vdims=['y'], datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_ellipsis_list_cols(self):
         sliced = self.dataset_hm.iloc[..., [0, 1]]
-        table = Dataset({'x':self.xs,  'y':self.y_ints},
+        table = hv.Dataset({'x':self.xs,  'y':self.y_ints},
                         kdims=['x'], vdims=['y'], datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_ellipsis_list_cols_by_name(self):
         sliced = self.dataset_hm.iloc[..., ['x', 'y']]
-        table = Dataset({'x':self.xs,  'y':self.y_ints},
+        table = hv.Dataset({'x':self.xs,  'y':self.y_ints},
                         kdims=['x'], vdims=['y'], datatype=['dictionary'])
         assert_element_equal(sliced, table)
 
@@ -397,13 +395,13 @@ class HomogeneousColumnTests:
         assert_data_equal(df, self.frame({'x': self.xs}, dtype=df.dtypes.iloc[0]))
 
     def test_dataset_transform_replace_hm(self):
-        transformed = self.dataset_hm.transform(y=dim('y')*2)
-        expected = Dataset((self.xs, self.y_ints*2), 'x', 'y')
+        transformed = self.dataset_hm.transform(y=hv.dim('y')*2)
+        expected = hv.Dataset((self.xs, self.y_ints*2), 'x', 'y')
         assert_element_equal(transformed, expected)
 
     def test_dataset_transform_add_hm(self):
-        transformed = self.dataset_hm.transform(y2=dim('y')*2)
-        expected = Dataset((self.xs, self.y_ints, self.y_ints*2), 'x', ['y', 'y2'])
+        transformed = self.dataset_hm.transform(y2=hv.dim('y')*2)
+        expected = hv.Dataset((self.xs, self.y_ints, self.y_ints*2), 'x', ['y', 'y2'])
         assert_element_equal(transformed, expected)
 
 
@@ -419,20 +417,20 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         self.vdims = ['Weight', 'Height']
         self.gender, self.age = np.array(['M','M','F']), np.array([10,16,12])
         self.weight, self.height = np.array([15,18,10]), np.array([0.8,0.6,0.8])
-        self.table = Dataset(self.frame({'Gender':self.gender, 'Age':self.age,
+        self.table = hv.Dataset(self.frame({'Gender':self.gender, 'Age':self.age,
                               'Weight':self.weight, 'Height':self.height}),
                              kdims=self.kdims, vdims=self.vdims)
 
         self.alias_kdims = [('gender', 'Gender'), ('age', 'Age')]
         self.alias_vdims = [('weight', 'Weight'), ('height', 'Height')]
-        self.alias_table = Dataset(self.frame({'gender':self.gender, 'age':self.age,
+        self.alias_table = hv.Dataset(self.frame({'gender':self.gender, 'age':self.age,
                                     'weight':self.weight, 'height':self.height}),
                                    kdims=self.alias_kdims, vdims=self.alias_vdims)
 
         super().init_column_data()
         self.ys = np.linspace(0, 1, 11)
         self.zs = np.sin(self.xs)
-        self.dataset_ht = Dataset(self.frame({'x':self.xs, 'y':self.ys}),
+        self.dataset_ht = hv.Dataset(self.frame({'x':self.xs, 'y':self.ys}),
                                   kdims=['x'], vdims=['y'])
 
     # Test the constructor to be supported by all interfaces supporting
@@ -443,7 +441,7 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         if self.frame is dict:
             pytest.skip("Only valid for non-dict frame")
 
-        dataset = Dataset(self.frame({'x':self.xs, 'y':self.ys}), kdims=['x'], vdims=['y'])
+        dataset = hv.Dataset(self.frame({'x':self.xs, 'y':self.ys}), kdims=['x'], vdims=['y'])
         assert isinstance(dataset.data, self.data_type)
 
     def test_dataset_dataframe_init_ht_alias(self):
@@ -451,7 +449,7 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         if self.frame is dict:
             pytest.skip("Only valid for non-dict frame")
 
-        dataset = Dataset(self.frame({'x':self.xs, 'y':self.ys}),
+        dataset = hv.Dataset(self.frame({'x':self.xs, 'y':self.ys}),
                           kdims=[('x', 'X')], vdims=[('y', 'Y')])
         assert isinstance(dataset.data, self.data_type)
 
@@ -476,27 +474,27 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         assert_data_equal(np.sort(data), np.array(['F', 'M']))
 
     def test_dataset_implicit_indexing_init(self):
-        dataset = Scatter(self.ys, kdims=['x'], vdims=['y'])
+        dataset = hv.Scatter(self.ys, kdims=['x'], vdims=['y'])
         assert isinstance(dataset.data, self.data_type)
 
     def test_dataset_tuple_init(self):
-        dataset = Dataset((self.xs, self.ys), kdims=['x'], vdims=['y'])
+        dataset = hv.Dataset((self.xs, self.ys), kdims=['x'], vdims=['y'])
         assert isinstance(dataset.data, self.data_type)
 
     def test_dataset_tuple_init_alias(self):
-        dataset = Dataset((self.xs, self.ys), kdims=[('x', 'X')], vdims=[('y', 'Y')])
+        dataset = hv.Dataset((self.xs, self.ys), kdims=[('x', 'X')], vdims=[('y', 'Y')])
         assert isinstance(dataset.data, self.data_type)
 
     def test_dataset_simple_zip_init(self):
-        dataset = Dataset(zip(self.xs, self.ys, strict=None), kdims=['x'], vdims=['y'])
+        dataset = hv.Dataset(zip(self.xs, self.ys, strict=None), kdims=['x'], vdims=['y'])
         assert isinstance(dataset.data, self.data_type)
 
     def test_dataset_simple_zip_init_alias(self):
-        dataset = Dataset(zip(self.xs, self.ys, strict=None), kdims=[('x', 'X')], vdims=[('y', 'Y')])
+        dataset = hv.Dataset(zip(self.xs, self.ys, strict=None), kdims=[('x', 'X')], vdims=[('y', 'Y')])
         assert isinstance(dataset.data, self.data_type)
 
     def test_dataset_zip_init(self):
-        dataset = Dataset(zip(self.gender, self.age,
+        dataset = hv.Dataset(zip(self.gender, self.age,
                               self.weight, self.height, strict=None),
                           kdims=self.kdims, vdims=self.vdims)
         assert isinstance(dataset.data, self.data_type)
@@ -507,17 +505,17 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         assert isinstance(dataset.data, self.data_type)
 
     def test_dataset_dict_init(self):
-        dataset = Dataset(dict(zip(self.xs, self.ys, strict=None)), kdims=['A'], vdims=['B'])
+        dataset = hv.Dataset(dict(zip(self.xs, self.ys, strict=None)), kdims=['A'], vdims=['B'])
         assert isinstance(dataset.data, self.data_type)
 
     def test_dataset_dict_init_alias(self):
-        dataset = Dataset(dict(zip(self.xs, self.ys, strict=None)),
+        dataset = hv.Dataset(dict(zip(self.xs, self.ys, strict=None)),
                           kdims=[('a', 'A')], vdims=[('b', 'B')])
         assert isinstance(dataset.data, self.data_type)
 
     def test_dataset_range_with_dimension_range(self):
         dt64 = np.array([np.datetime64(datetime.datetime(2017, 1, i)) for i in range(1, 4)])
-        ds = Dataset(dt64, [Dimension('Date', range=(dt64[0], dt64[-1]))])
+        ds = hv.Dataset(dt64, [hv.Dimension('Date', range=(dt64[0], dt64[-1]))])
         assert ds.range('Date') == (dt64[0], dt64[-1])
 
     # Operations
@@ -526,29 +524,29 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         if self.frame is dict:
             pytest.skip("Only valid for non-dict frame")
         test_df = self.frame({'x': range(10), 'y': range(0,20,2)})
-        dataset = Dataset(test_df, kdims=[('x', 'X-label')], vdims=['y'])
+        dataset = hv.Dataset(test_df, kdims=[('x', 'X-label')], vdims=['y'])
         redim_df = self.frame({'X': range(10), 'y': range(0,20,2)})
-        dataset_redim = Dataset(redim_df, kdims=['X'], vdims=['y'])
+        dataset_redim = hv.Dataset(redim_df, kdims=['X'], vdims=['y'])
         assert_element_equal(dataset.redim(**{'X-label':'X'}), dataset_redim)
         assert_element_equal(dataset.redim(x='X'), dataset_redim)
 
     def test_dataset_mixed_type_range(self):
-        ds = Dataset((['A', 'B', 'C', None],), 'A')
+        ds = hv.Dataset((['A', 'B', 'C', None],), 'A')
         assert ds.range(0) == ('A', 'C')
 
     def test_dataset_nodata_range(self):
-        table = self.table.clone(vdims=[Dimension('Weight', nodata=10), 'Height'])
+        table = self.table.clone(vdims=[hv.Dimension('Weight', nodata=10), 'Height'])
         assert table.range('Weight') == (15, 18)
 
     def test_dataset_sort_vdim_ht(self):
-        dataset = Dataset({'x':self.xs, 'y':-self.ys},
+        dataset = hv.Dataset({'x':self.xs, 'y':-self.ys},
                           kdims=['x'], vdims=['y'])
-        dataset_sorted = Dataset({'x': self.xs[::-1], 'y':-self.ys[::-1]},
+        dataset_sorted = hv.Dataset({'x': self.xs[::-1], 'y':-self.ys[::-1]},
                                  kdims=['x'], vdims=['y'])
         assert_element_equal(dataset.sort('y'), dataset_sorted)
 
     def test_dataset_sort_string_ht(self):
-        dataset_sorted = Dataset(self.frame({'Gender':['F', 'M', 'M'], 'Age':[12, 10, 16],
+        dataset_sorted = hv.Dataset(self.frame({'Gender':['F', 'M', 'M'], 'Age':[12, 10, 16],
                                   'Weight':[10,15,18], 'Height':[0.8,0.8,0.6]}),
                                  kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(self.table.sort(), dataset_sorted)
@@ -558,7 +556,7 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         assert_data_equal(np.array([0, 0.5, 1]), samples)
 
     def test_dataset_reduce_ht(self):
-        expected = Dataset(self.frame({'Age':self.age, 'Weight':self.weight, 'Height':self.height}),
+        expected = hv.Dataset(self.frame({'Age':self.age, 'Weight':self.weight, 'Height':self.height}),
                           kdims=self.kdims[1:], vdims=self.vdims)
         reduced = self.table.reduce(['Gender'], np.mean)
         if self.force_sort:
@@ -570,14 +568,14 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         np.testing.assert_almost_equal(self.dataset_ht.reduce('x', np.mean), np.float64(0.5))
 
     def test_dataset_2D_reduce_ht(self):
-        reduced = Dataset(self.frame({'Weight':[14.333333333333334], 'Height':[0.73333333333333339]}),
+        reduced = hv.Dataset(self.frame({'Weight':[14.333333333333334], 'Height':[0.73333333333333339]}),
                           kdims=[], vdims=self.vdims)
         assert_element_equal(self.table.reduce(function=np.mean), reduced)
 
     def test_dataset_2D_partial_reduce_ht(self):
-        dataset = Dataset(self.frame({'x':self.xs, 'y':self.ys, 'z':self.zs}),
+        dataset = hv.Dataset(self.frame({'x':self.xs, 'y':self.ys, 'z':self.zs}),
                           kdims=['x', 'y'], vdims=['z'])
-        expected = Dataset({'x':self.xs, 'z':self.zs},
+        expected = hv.Dataset({'x':self.xs, 'z':self.zs},
                           kdims=['x'], vdims=['z'])
         reduced = dataset.reduce(['y'], np.mean)
         if self.force_sort:
@@ -585,13 +583,13 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         assert_element_equal(reduced, expected)
 
     def test_dataset_2D_aggregate_spread_fn_with_duplicates(self):
-        dataset = Dataset(self.frame({'x': np.array([0, 0, 1, 1]), 'y': np.array([0, 1, 2, 3]),
+        dataset = hv.Dataset(self.frame({'x': np.array([0, 0, 1, 1]), 'y': np.array([0, 1, 2, 3]),
                            'z': np.array([1, 2, 3, 4])}),
                           kdims=['x', 'y'], vdims=['z'])
         agg = dataset.aggregate('x', function=np.mean, spreadfn=np.var)
         if self.force_sort:
             agg = agg.sort("x")
-        expected = Dataset({
+        expected = hv.Dataset({
             'x': np.array([0, 1]),
             'z': np.array([1.5, 3.5]),
             'z_var': np.array([0.25, 0.25]),
@@ -599,7 +597,7 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         assert_element_equal(agg, expected)
 
     def test_dataset_aggregate_ht(self):
-        expected = Dataset(self.frame({'Gender':['M', 'F'], 'Weight':[16.5, 10], 'Height':[0.7, 0.8]}),
+        expected = hv.Dataset(self.frame({'Gender':['M', 'F'], 'Weight':[16.5, 10], 'Height':[0.7, 0.8]}),
                              kdims=self.kdims[:1], vdims=self.vdims)
         aggregated = self.table.aggregate(['Gender'], np.mean)
         if self.force_sort:
@@ -608,21 +606,21 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         assert_element_equal(aggregated, expected)
 
     def test_dataset_aggregate_string_types(self):
-        ds = Dataset(self.frame({'Gender':['M', 'M'], 'Weight':[20, 10], 'Name':['Peter', 'Matt']}),
+        ds = hv.Dataset(self.frame({'Gender':['M', 'M'], 'Weight':[20, 10], 'Name':['Peter', 'Matt']}),
                              kdims='Gender', vdims=['Weight', 'Name'])
-        aggregated = Dataset({'Gender': ['M'], 'Weight': [15]},
+        aggregated = hv.Dataset({'Gender': ['M'], 'Weight': [15]},
                              kdims='Gender', vdims=['Weight'])
         assert_element_equal(ds.aggregate(['Gender'], np.mean), aggregated)
 
     def test_dataset_aggregate_string_types_size(self):
-        ds = Dataset(self.frame({'Gender':['M', 'M'], 'Weight':[20, 10], 'Name':['Peter', 'Matt']}),
+        ds = hv.Dataset(self.frame({'Gender':['M', 'M'], 'Weight':[20, 10], 'Name':['Peter', 'Matt']}),
                              kdims='Gender', vdims=['Weight', 'Name'])
-        aggregated = Dataset({'Gender': ['M'], 'Weight': [2], 'Name': [2]},
+        aggregated = hv.Dataset({'Gender': ['M'], 'Weight': [2], 'Name': [2]},
                              kdims='Gender', vdims=['Weight', 'Name'])
         assert_element_equal(ds.aggregate(['Gender'], np.size), aggregated)
 
     def test_dataset_aggregate_ht_alias(self):
-        expected = Dataset(self.frame({'gender':['M', 'F'], 'weight':[16.5, 10], 'height':[0.7, 0.8]}),
+        expected = hv.Dataset(self.frame({'gender':['M', 'F'], 'weight':[16.5, 10], 'height':[0.7, 0.8]}),
                              kdims=self.alias_kdims[:1], vdims=self.alias_vdims)
         aggregated = self.alias_table.aggregate('Gender', np.mean)
         if self.force_sort:
@@ -631,9 +629,9 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         assert_element_equal(aggregated, expected)
 
     def test_dataset_2D_aggregate_partial_ht(self):
-        dataset = Dataset(self.frame({'x':self.xs, 'y':self.ys, 'z':self.zs}),
+        dataset = hv.Dataset(self.frame({'x':self.xs, 'y':self.ys, 'z':self.zs}),
                           kdims=['x', 'y'], vdims=['z'])
-        expected = Dataset({'x':self.xs, 'z':self.zs},
+        expected = hv.Dataset({'x':self.xs, 'z':self.zs},
                           kdims=['x'], vdims=['z'])
         aggregated = dataset.aggregate(['x'], np.mean)
         if self.force_sort:
@@ -641,20 +639,20 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         assert_element_equal(aggregated, expected)
 
     def test_dataset_empty_aggregate(self):
-        dataset = Dataset([], kdims=self.kdims, vdims=self.vdims)
-        aggregated = Dataset([], kdims=self.kdims[:1], vdims=self.vdims)
+        dataset = hv.Dataset([], kdims=self.kdims, vdims=self.vdims)
+        aggregated = hv.Dataset([], kdims=self.kdims[:1], vdims=self.vdims)
         assert_element_equal(dataset.aggregate(['Gender'], np.mean), aggregated)
 
     def test_dataset_empty_aggregate_with_spreadfn(self):
-        dataset = Dataset([], kdims=self.kdims, vdims=self.vdims)
-        aggregated = Dataset([], kdims=self.kdims[:1], vdims=[d for vd in self.vdims for d in [vd, vd+'_std']])
+        dataset = hv.Dataset([], kdims=self.kdims, vdims=self.vdims)
+        aggregated = hv.Dataset([], kdims=self.kdims[:1], vdims=[d for vd in self.vdims for d in [vd, vd+'_std']])
         assert_element_equal(dataset.aggregate(['Gender'], np.mean, np.std), aggregated)
 
     def test_dataset_groupby(self):
         group1 = self.frame({'Age':[10,16], 'Weight':[15,18], 'Height':[0.8,0.6]})
         group2 = self.frame({'Age':[12], 'Weight':[10], 'Height':[0.8]})
-        grouped = HoloMap([('M', Dataset(group1, kdims=['Age'], vdims=self.vdims)),
-                           ('F', Dataset(group2, kdims=['Age'], vdims=self.vdims))],
+        grouped = hv.HoloMap([('M', hv.Dataset(group1, kdims=['Age'], vdims=self.vdims)),
+                           ('F', hv.Dataset(group2, kdims=['Age'], vdims=self.vdims))],
                           kdims=['Gender'], sort=self.force_sort)
         output = self.table.groupby(['Gender'])
         if self.force_sort:
@@ -664,9 +662,9 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
     def test_dataset_groupby_alias(self):
         group1 = self.frame({'age':[10,16], 'weight':[15,18], 'height':[0.8,0.6]})
         group2 = self.frame({'age':[12], 'weight':[10], 'height':[0.8]})
-        grouped = HoloMap([('M', Dataset(group1, kdims=[('age', 'Age')],
+        grouped = hv.HoloMap([('M', hv.Dataset(group1, kdims=[('age', 'Age')],
                                          vdims=self.alias_vdims)),
-                           ('F', Dataset(group2, kdims=[('age', 'Age')],
+                           ('F', hv.Dataset(group2, kdims=[('age', 'Age')],
                                          vdims=self.alias_vdims))],
                           kdims=[('gender', 'Gender')], sort=self.force_sort)
         output = self.alias_table.groupby('Gender')
@@ -678,9 +676,9 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         group1 = self.frame({'Gender':['M'], 'Weight':[15], 'Height':[0.8]})
         group2 = self.frame({'Gender':['M'], 'Weight':[18], 'Height':[0.6]})
         group3 = self.frame({'Gender':['F'], 'Weight':[10], 'Height':[0.8]})
-        grouped = HoloMap([(10, Dataset(group1, kdims=['Gender'], vdims=self.vdims)),
-                           (16, Dataset(group2, kdims=['Gender'], vdims=self.vdims)),
-                           (12, Dataset(group3, kdims=['Gender'], vdims=self.vdims))],
+        grouped = hv.HoloMap([(10, hv.Dataset(group1, kdims=['Gender'], vdims=self.vdims)),
+                           (16, hv.Dataset(group2, kdims=['Gender'], vdims=self.vdims)),
+                           (12, hv.Dataset(group3, kdims=['Gender'], vdims=self.vdims))],
                           kdims=['Age'], sort=self.force_sort)
         output = self.table.groupby(['Age'])
         if self.force_sort:
@@ -727,7 +725,7 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
     # Indexing
 
     def test_dataset_index_row_gender_female(self):
-        indexed = Dataset({'Gender':['F'], 'Age':[12],
+        indexed = hv.Dataset({'Gender':['F'], 'Age':[12],
                            'Weight':[10], 'Height':[0.8]},
                           kdims=self.kdims, vdims=self.vdims)
         row = self.table['F',:]
@@ -735,35 +733,35 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
 
     def test_dataset_index_rows_gender_male(self):
         row = self.table['M',:]
-        indexed = Dataset({'Gender':['M', 'M'], 'Age':[10, 16],
+        indexed = hv.Dataset({'Gender':['M', 'M'], 'Age':[10, 16],
                            'Weight':[15,18], 'Height':[0.8,0.6]},
                           kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(row, indexed)
 
     def test_dataset_select_rows_gender_male(self):
         row = self.table.select(Gender='M')
-        indexed = Dataset({'Gender':['M', 'M'], 'Age':[10, 16],
+        indexed = hv.Dataset({'Gender':['M', 'M'], 'Age':[10, 16],
                            'Weight':[15,18], 'Height':[0.8,0.6]},
                           kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(row, indexed)
 
     def test_dataset_select_rows_gender_male_dict(self):
         row = self.table.select({"Gender": 'M'})
-        indexed = Dataset({'Gender':['M', 'M'], 'Age':[10, 16],
+        indexed = hv.Dataset({'Gender':['M', 'M'], 'Age':[10, 16],
                            'Weight':[15,18], 'Height':[0.8,0.6]},
                           kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(row, indexed)
 
     def test_dataset_select_rows_gender_male_dimension_dict(self):
         row = self.table.select({self.table.kdims[0]: 'M'})
-        indexed = Dataset({'Gender':['M', 'M'], 'Age':[10, 16],
+        indexed = hv.Dataset({'Gender':['M', 'M'], 'Age':[10, 16],
                            'Weight':[15,18], 'Height':[0.8,0.6]},
                           kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(row, indexed)
 
     def test_dataset_select_rows_gender_male_expr(self):
-        row = self.table.select(selection_expr=dim('Gender') == 'M')
-        indexed = Dataset({'Gender': ['M', 'M'], 'Age': [10, 16],
+        row = self.table.select(selection_expr=hv.dim('Gender') == 'M')
+        indexed = hv.Dataset({'Gender': ['M', 'M'], 'Age': [10, 16],
                            'Weight': [15, 18], 'Height': [0.8,0.6]},
                           kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(row, indexed)
@@ -771,7 +769,7 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
     def test_dataset_select_rows_gender_male_alias(self):
         row = self.alias_table.select(Gender='M')
         alias_row = self.alias_table.select(gender='M')
-        indexed = Dataset({'gender':['M', 'M'], 'age':[10, 16],
+        indexed = hv.Dataset({'gender':['M', 'M'], 'age':[10, 16],
                            'weight':[15,18], 'height':[0.8,0.6]},
                           kdims=self.alias_kdims, vdims=self.alias_vdims)
         assert_element_equal(row, indexed)
@@ -780,20 +778,20 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
     def test_dataset_select_rows_gender_male_alias_dict(self):
         row = self.alias_table.select({"Gender": 'M'})
         alias_row = self.alias_table.select({"gender": 'M'})
-        indexed = Dataset({'gender':['M', 'M'], 'age':[10, 16],
+        indexed = hv.Dataset({'gender':['M', 'M'], 'age':[10, 16],
                            'weight':[15,18], 'height':[0.8,0.6]},
                           kdims=self.alias_kdims, vdims=self.alias_vdims)
         assert_element_equal(row, indexed)
         assert_element_equal(alias_row, indexed)
 
     def test_dataset_index_row_age(self):
-        indexed = Dataset({'Gender':['F'], 'Age':[12],
+        indexed = hv.Dataset({'Gender':['F'], 'Age':[12],
                            'Weight':[10], 'Height':[0.8]},
                           kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(self.table[:, 12], indexed)
 
     def test_dataset_index_item_table(self):
-        indexed = Dataset({'Gender':['F'], 'Age':[12],
+        indexed = hv.Dataset({'Gender':['F'], 'Age':[12],
                            'Weight':[10], 'Height':[0.8]},
                           kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(self.table['F', 12], indexed)
@@ -809,14 +807,14 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
 
     def test_dataset_boolean_index(self):
         row = self.table[np.array([True, True, False])]
-        indexed = Dataset({'Gender':['M', 'M'], 'Age':[10, 16],
+        indexed = hv.Dataset({'Gender':['M', 'M'], 'Age':[10, 16],
                            'Weight':[15,18], 'Height':[0.8,0.6]},
                           kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(row, indexed)
 
     def test_dataset_value_dim_index(self):
         row = self.table[:, :, 'Weight']
-        indexed = Dataset({'Gender':['M', 'M', 'F'], 'Age':[10, 16, 12],
+        indexed = hv.Dataset({'Gender':['M', 'M', 'F'], 'Age':[10, 16, 12],
                            'Weight':[15,18, 10]},
                           kdims=self.kdims, vdims=self.vdims[:1])
         assert_element_equal(row, indexed)
@@ -829,50 +827,50 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
 
     def test_dataset_iloc_slice_rows(self):
         sliced = self.table.iloc[1:2]
-        table = Dataset({'Gender':self.gender[1:2], 'Age':self.age[1:2],
+        table = hv.Dataset({'Gender':self.gender[1:2], 'Age':self.age[1:2],
                          'Weight':self.weight[1:2], 'Height':self.height[1:2]},
                         kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_slice_rows_slice_cols(self):
         sliced = self.table.iloc[1:2, 1:3]
-        table = Dataset({'Age':self.age[1:2], 'Weight':self.weight[1:2]},
+        table = hv.Dataset({'Age':self.age[1:2], 'Weight':self.weight[1:2]},
                         kdims=self.kdims[1:], vdims=self.vdims[:1])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_slice_rows_list_cols(self):
         sliced = self.table.iloc[1:2, [1, 3]]
-        table = Dataset({'Age':self.age[1:2], 'Height':self.height[1:2]},
+        table = hv.Dataset({'Age':self.age[1:2], 'Height':self.height[1:2]},
                         kdims=self.kdims[1:], vdims=self.vdims[1:])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_slice_rows_index_cols(self):
         sliced = self.table.iloc[1:2, 2]
-        table = Dataset({'Weight':self.weight[1:2]}, kdims=[], vdims=self.vdims[:1])
+        table = hv.Dataset({'Weight':self.weight[1:2]}, kdims=[], vdims=self.vdims[:1])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_list_rows(self):
         sliced = self.table.iloc[[0, 2]]
-        table = Dataset({'Gender':self.gender[[0, 2]], 'Age':self.age[[0, 2]],
+        table = hv.Dataset({'Gender':self.gender[[0, 2]], 'Age':self.age[[0, 2]],
                          'Weight':self.weight[[0, 2]], 'Height':self.height[[0, 2]]},
                         kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_list_rows_list_cols(self):
         sliced = self.table.iloc[[0, 2], [0, 2]]
-        table = Dataset({'Gender':self.gender[[0, 2]],  'Weight':self.weight[[0, 2]]},
+        table = hv.Dataset({'Gender':self.gender[[0, 2]],  'Weight':self.weight[[0, 2]]},
                         kdims=self.kdims[:1], vdims=self.vdims[:1])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_list_rows_list_cols_by_name(self):
         sliced = self.table.iloc[[0, 2], ['Gender', 'Weight']]
-        table = Dataset({'Gender':self.gender[[0, 2]],  'Weight':self.weight[[0, 2]]},
+        table = hv.Dataset({'Gender':self.gender[[0, 2]],  'Weight':self.weight[[0, 2]]},
                         kdims=self.kdims[:1], vdims=self.vdims[:1])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_list_rows_slice_cols(self):
         sliced = self.table.iloc[[0, 2], slice(1, 3)]
-        table = Dataset({'Age':self.age[[0, 2]],  'Weight':self.weight[[0, 2]]},
+        table = hv.Dataset({'Age':self.age[[0, 2]],  'Weight':self.weight[[0, 2]]},
                         kdims=self.kdims[1:], vdims=self.vdims[:1])
         assert_element_equal(sliced, table)
 
@@ -882,31 +880,31 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
 
     def test_dataset_iloc_index_rows_slice_cols(self):
         indexed = self.table.iloc[1, 1:3]
-        table = Dataset({'Age':self.age[[1]],  'Weight':self.weight[[1]]},
+        table = hv.Dataset({'Age':self.age[[1]],  'Weight':self.weight[[1]]},
                         kdims=self.kdims[1:], vdims=self.vdims[:1])
         assert_element_equal(indexed, table)
 
     def test_dataset_iloc_list_cols(self):
         sliced = self.table.iloc[:, [0, 2]]
-        table = Dataset({'Gender':self.gender,  'Weight':self.weight},
+        table = hv.Dataset({'Gender':self.gender,  'Weight':self.weight},
                         kdims=self.kdims[:1], vdims=self.vdims[:1])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_list_cols_by_name(self):
         sliced = self.table.iloc[:, ['Gender', 'Weight']]
-        table = Dataset({'Gender':self.gender,  'Weight':self.weight},
+        table = hv.Dataset({'Gender':self.gender,  'Weight':self.weight},
                         kdims=self.kdims[:1], vdims=self.vdims[:1])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_ellipsis_list_cols(self):
         sliced = self.table.iloc[..., [0, 2]]
-        table = Dataset({'Gender':self.gender,  'Weight':self.weight},
+        table = hv.Dataset({'Gender':self.gender,  'Weight':self.weight},
                         kdims=self.kdims[:1], vdims=self.vdims[:1])
         assert_element_equal(sliced, table)
 
     def test_dataset_iloc_ellipsis_list_cols_by_name(self):
         sliced = self.table.iloc[..., ['Gender', 'Weight']]
-        table = Dataset({'Gender':self.gender,  'Weight':self.weight},
+        table = hv.Dataset({'Gender':self.gender,  'Weight':self.weight},
                         kdims=self.kdims[:1], vdims=self.vdims[:1])
         assert_element_equal(sliced, table)
 
@@ -919,16 +917,16 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
 
     def test_dataset_transform_replace_ht(self):
         transformed = self.table.transform(
-            Age=dim('Age')**2, Weight=dim('Weight')*2, Height=dim('Height')/2.
+            Age=hv.dim('Age')**2, Weight=hv.dim('Weight')*2, Height=hv.dim('Height')/2.
         )
-        expected = Dataset({'Gender':self.gender, 'Age':self.age**2,
+        expected = hv.Dataset({'Gender':self.gender, 'Age':self.age**2,
                             'Weight':self.weight*2, 'Height':self.height/2.},
                            kdims=self.kdims, vdims=self.vdims)
         assert_element_equal(transformed, expected)
 
     def test_dataset_transform_add_ht(self):
-        transformed = self.table.transform(combined=dim('Age')*dim('Weight'))
-        expected = Dataset({'Gender':self.gender, 'Age':self.age,
+        transformed = self.table.transform(combined=hv.dim('Age')*hv.dim('Weight'))
+        expected = hv.Dataset({'Gender':self.gender, 'Age':self.age,
                               'Weight':self.weight, 'Height':self.height,
                               'combined': self.age*self.weight},
                              kdims=self.kdims, vdims=[*self.vdims, 'combined'])
@@ -951,55 +949,55 @@ class ScalarColumnTests:
     __test__ = False
 
     def test_dataset_scalar_constructor(self):
-        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        ds = hv.Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
         assert_data_equal(ds.dimension_values('A'), np.ones(10))
 
     def test_dataset_scalar_length(self):
-        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        ds = hv.Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
         assert len(ds) == 10
 
     def test_dataset_scalar_array(self):
-        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        ds = hv.Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
         assert_data_equal(ds.array(), np.column_stack([np.ones(10), np.arange(10)]))
 
     def test_dataset_scalar_select(self):
-        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        ds = hv.Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
         assert_data_equal(ds.select(A=1).dimension_values('B'), np.arange(10))
 
     def test_dataset_scalar_select_expr(self):
-        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        ds = hv.Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
         assert_data_equal(
-            ds.select(selection_expr=dim('A') == 1).dimension_values('B'),
+            ds.select(selection_expr=hv.dim('A') == 1).dimension_values('B'),
             np.arange(10)
         )
 
     def test_dataset_scalar_empty_select(self):
-        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        ds = hv.Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
         assert_data_equal(ds.select(A=0).dimension_values('B'), np.array([]))
 
     def test_dataset_scalar_empty_select_expr(self):
-        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        ds = hv.Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
         assert_data_equal(
-            ds.select(selection_expr=dim('A') == 0).dimension_values('B'),
+            ds.select(selection_expr=hv.dim('A') == 0).dimension_values('B'),
             np.array([])
         )
 
     def test_dataset_scalar_sample(self):
-        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        ds = hv.Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
         assert_data_equal(ds.sample([(1,)]).dimension_values('B'), np.arange(10))
 
     def test_dataset_scalar_sort(self):
-        ds = Dataset({'A': 1, 'B': np.arange(10)[::-1]}, kdims=['A', 'B'])
+        ds = hv.Dataset({'A': 1, 'B': np.arange(10)[::-1]}, kdims=['A', 'B'])
         assert_data_equal(ds.sort().dimension_values('B'), np.arange(10))
 
     def test_dataset_scalar_groupby(self):
-        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        ds = hv.Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
         groups = ds.groupby('A')
-        assert_element_equal(groups, HoloMap({1: Dataset({'B': np.arange(10)}, 'B')}, 'A'))
+        assert_element_equal(groups, hv.HoloMap({1: hv.Dataset({'B': np.arange(10)}, 'B')}, 'A'))
 
     def test_dataset_scalar_iloc(self):
-        ds = Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
-        assert_element_equal(ds.iloc[:5], Dataset({'A': 1, 'B': np.arange(5)}, kdims=['A', 'B']))
+        ds = hv.Dataset({'A': 1, 'B': np.arange(10)}, kdims=['A', 'B'])
+        assert_element_equal(ds.iloc[:5], hv.Dataset({'A': 1, 'B': np.arange(5)}, kdims=['A', 'B']))
 
 
 
@@ -1080,7 +1078,7 @@ class GriddedInterfaceTests:
         assert_element_equal(self.dataset_grid.select({self.dataset_grid.kdims[1]: (0, 0.25)}), ds)
 
     def test_nodata_range(self):
-        ds = self.dataset_grid.clone(vdims=[Dimension('z', nodata=0)])
+        ds = self.dataset_grid.clone(vdims=[hv.Dimension('z', nodata=0)])
         assert ds.range('z') == (1, 5)
 
     def test_dataset_ndloc_index(self):
@@ -1239,53 +1237,53 @@ class GriddedInterfaceTests:
 
     def test_dataset_groupby_with_transposed_dimensions(self):
         dat = np.zeros((3,5,7))
-        dataset = Dataset((range(7), range(5), range(3), dat), ['z','x','y'], 'value')
+        dataset = hv.Dataset((range(7), range(5), range(3), dat), ['z','x','y'], 'value')
         grouped = dataset.groupby('z', kdims=['y', 'x'])
         assert_data_equal(grouped.last.dimension_values(2, flat=False), dat[:, :, -1].T)
 
     def test_dataset_dynamic_groupby_with_transposed_dimensions(self):
         dat = np.zeros((3,5,7))
-        dataset = Dataset((range(7), range(5), range(3), dat), ['z','x','y'], 'value')
+        dataset = hv.Dataset((range(7), range(5), range(3), dat), ['z','x','y'], 'value')
         grouped = dataset.groupby('z', kdims=['y', 'x'], dynamic=True)
         assert_data_equal(grouped[2].dimension_values(2, flat=False), dat[:, :, -1].T)
 
     def test_dataset_slice_inverted_dimension(self):
         xs = np.arange(30)[::-1]
         ys = np.random.rand(30)
-        ds = Dataset((xs, ys), 'x', 'y')
+        ds = hv.Dataset((xs, ys), 'x', 'y')
         sliced = ds[5:15]
-        assert_element_equal(sliced, Dataset((xs[15:25], ys[15:25]), 'x', 'y'))
+        assert_element_equal(sliced, hv.Dataset((xs[15:25], ys[15:25]), 'x', 'y'))
 
     def test_sample_2d(self):
         xs = ys = np.linspace(0, 6, 50)
         XS, _YS = np.meshgrid(xs, ys)
         values = np.sin(XS)
-        sampled = Dataset((xs, ys, values), ['x', 'y'], 'z').sample(y=0)
-        assert_element_equal(sampled, Curve((xs, values[0]), vdims='z'))
+        sampled = hv.Dataset((xs, ys, values), ['x', 'y'], 'z').sample(y=0)
+        assert_element_equal(sampled, hv.Curve((xs, values[0]), vdims='z'))
 
     def test_aggregate_2d_with_spreadfn(self):
         array = np.random.rand(10, 5)
-        ds = Dataset((range(5), range(10), array), ['x', 'y'], 'z')
+        ds = hv.Dataset((range(5), range(10), array), ['x', 'y'], 'z')
         agg = ds.aggregate('x', np.mean, np.std)
-        example = Dataset((range(5), array.mean(axis=0), array.std(axis=0)), 'x', ['z', 'z_std'])
+        example = hv.Dataset((range(5), array.mean(axis=0), array.std(axis=0)), 'x', ['z', 'z_std'])
         assert_element_equal(agg, example)
 
     def test_concat_grid_3d(self):
         array = np.random.rand(4, 5, 3, 2)
-        orig = Dataset((range(2), range(3), range(5), range(4), array), ['A', 'B', 'x', 'y'], 'z')
-        hmap = HoloMap({(i, j): self.element((range(5), range(4), array[:, :, j, i]), ['x', 'y'], 'z')
+        orig = hv.Dataset((range(2), range(3), range(5), range(4), array), ['A', 'B', 'x', 'y'], 'z')
+        hmap = hv.HoloMap({(i, j): self.element((range(5), range(4), array[:, :, j, i]), ['x', 'y'], 'z')
                         for i in range(2) for j in range(3)}, ['A', 'B'])
         ds = concat(hmap)
         assert_element_equal(ds, orig)
 
     def test_concat_grid_3d_shape_mismatch(self):
-        ds1 = Dataset(([0, 1], [1, 2, 3], np.random.rand(3, 2)), ['x', 'y'], 'z')
-        ds2 = Dataset(([0, 1, 2], [1, 2], np.random.rand(2, 3)), ['x', 'y'], 'z')
-        hmap = HoloMap({1: ds1, 2: ds2})
+        ds1 = hv.Dataset(([0, 1], [1, 2, 3], np.random.rand(3, 2)), ['x', 'y'], 'z')
+        ds2 = hv.Dataset(([0, 1, 2], [1, 2], np.random.rand(2, 3)), ['x', 'y'], 'z')
+        hmap = hv.HoloMap({1: ds1, 2: ds2})
         with pytest.raises(DataError):
             concat(hmap)
 
     def test_grid_3d_groupby_concat_roundtrip(self):
         array = np.random.rand(4, 5, 3, 2)
-        orig = Dataset((range(2), range(3), range(5), range(4), array), ['A', 'B', 'x', 'y'], 'z')
+        orig = hv.Dataset((range(2), range(3), range(5), range(4), array), ['A', 'B', 'x', 'y'], 'z')
         assert_element_equal(concat(orig.groupby(['A', 'B'])), orig)

--- a/holoviews/tests/core/data/test_arrayinterface.py
+++ b/holoviews/tests/core/data/test_arrayinterface.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from holoviews.core.data import Dataset
+import holoviews as hv
 from holoviews.testing import assert_element_equal
 
 from .base import HomogeneousColumnTests, InterfaceTests
@@ -18,31 +18,31 @@ class ArrayDatasetTest(HomogeneousColumnTests, InterfaceTests):
     __test__ = True
 
     def test_dataset_empty_list_init_dtypes(self):
-        dataset = Dataset([], kdims=['x'], vdims=['y'])
+        dataset = hv.Dataset([], kdims=['x'], vdims=['y'])
         for d in 'xy':
             assert dataset.dimension_values(d).dtype == np.float64
 
     def test_dataset_empty_list_dtypes(self):
-        dataset = Dataset([], kdims=['x'], vdims=['y'])
+        dataset = hv.Dataset([], kdims=['x'], vdims=['y'])
         for d in 'xy':
             assert dataset.interface.dtype(dataset, d) == np.float64
 
     def test_dataset_simple_dict_sorted(self):
-        dataset = Dataset({2: 2, 1: 1, 3: 3}, kdims=['x'], vdims=['y'])
-        assert_element_equal(dataset, Dataset([(i, i) for i in range(1, 4)],
+        dataset = hv.Dataset({2: 2, 1: 1, 3: 3}, kdims=['x'], vdims=['y'])
+        assert_element_equal(dataset, hv.Dataset([(i, i) for i in range(1, 4)],
                                           kdims=['x'], vdims=['y']))
 
     def test_dataset_sort_hm(self):
-        ds = Dataset(([2, 2, 1], [2,1,2], [1, 2, 3]),
+        ds = hv.Dataset(([2, 2, 1], [2,1,2], [1, 2, 3]),
                      kdims=['x', 'y'], vdims=['z']).sort()
-        ds_sorted = Dataset(([1, 2, 2], [2, 1, 2], [3, 2, 1]),
+        ds_sorted = hv.Dataset(([1, 2, 2], [2, 1, 2], [3, 2, 1]),
                             kdims=['x', 'y'], vdims=['z'])
         assert_element_equal(ds.sort(), ds_sorted)
 
     def test_dataset_sort_reverse_hm(self):
-        ds = Dataset(([2, 1, 2, 1], [2, 2, 1, 1], [0, 1, 2, 3]),
+        ds = hv.Dataset(([2, 1, 2, 1], [2, 2, 1, 1], [0, 1, 2, 3]),
                      kdims=['x', 'y'], vdims=['z'])
-        ds_sorted = Dataset(([2, 2, 1, 1], [2, 1, 2, 1], [0, 2, 1, 3]),
+        ds_sorted = hv.Dataset(([2, 2, 1, 1], [2, 1, 2, 1], [0, 2, 1, 3]),
                             kdims=['x', 'y'], vdims=['z'])
         assert_element_equal(ds.sort(reverse=True), ds_sorted)
 

--- a/holoviews/tests/core/data/test_binneddatasets.py
+++ b/holoviews/tests/core/data/test_binneddatasets.py
@@ -5,13 +5,9 @@ Tests for binned interfaces including GridInterface and XArrayInterface
 import numpy as np
 import pytest
 
-from holoviews.core.data import Dataset
+import holoviews as hv
 from holoviews.core.data.interface import DataError
-from holoviews.core.dimension import Dimension
-from holoviews.core.spaces import HoloMap
-from holoviews.element import Histogram, QuadMesh
 from holoviews.testing import assert_data_equal, assert_element_equal
-from holoviews.util.transform import dim
 
 
 class Binned1DTest:
@@ -19,7 +15,7 @@ class Binned1DTest:
     def setup_method(self):
         self.values = np.arange(10)
         self.edges =  np.arange(11)
-        self.dataset1d = Histogram((self.edges, self.values))
+        self.dataset1d = hv.Histogram((self.edges, self.values))
 
     def test_slice_all(self):
         sliced = self.dataset1d[:]
@@ -95,8 +91,8 @@ class Binned1DTest:
             self.dataset1d[10]
 
     def test_groupby_kdim(self):
-        grouped = self.dataset1d.groupby('x', group_type=Dataset)
-        holomap = HoloMap({self.edges[i:i+2].mean(): Dataset([(i,)], vdims=['Frequency'])
+        grouped = self.dataset1d.groupby('x', group_type=hv.Dataset)
+        holomap = hv.HoloMap({self.edges[i:i+2].mean(): hv.Dataset([(i,)], vdims=['Frequency'])
                            for i in range(10)}, kdims=['x'])
         assert_element_equal(grouped, holomap)
 
@@ -108,7 +104,7 @@ class Binned2DTest:
         self.xs = np.logspace(1, 3, n)
         self.ys = np.linspace(1, 10, n)
         self.zs = np.arange((n-1)**2).reshape(n-1, n-1)
-        self.dataset2d = QuadMesh((self.xs, self.ys, self.zs))
+        self.dataset2d = hv.QuadMesh((self.xs, self.ys, self.zs))
 
     def test_qmesh_index_lower_left(self):
         assert self.dataset2d[10, 1] == 0
@@ -123,46 +119,46 @@ class Binned2DTest:
         assert self.dataset2d[216, 7] == 8
 
     def test_qmesh_index_xcoords(self):
-        sliced = QuadMesh((self.xs[2:4], self.ys, self.zs[:, 2:3]))
+        sliced = hv.QuadMesh((self.xs[2:4], self.ys, self.zs[:, 2:3]))
         assert_element_equal(self.dataset2d[300, :], sliced)
 
     def test_qmesh_index_ycoords(self):
-        sliced = QuadMesh((self.xs, self.ys[-2:], self.zs[-1:, :]))
+        sliced = hv.QuadMesh((self.xs, self.ys[-2:], self.zs[-1:, :]))
         assert_element_equal(self.dataset2d[:, 7], sliced)
 
     def test_qmesh_slice_xcoords(self):
-        sliced = QuadMesh((self.xs[1:], self.ys, self.zs[:, 1:]))
+        sliced = hv.QuadMesh((self.xs[1:], self.ys, self.zs[:, 1:]))
         assert_element_equal(self.dataset2d[100:1000, :], sliced)
 
     def test_qmesh_slice_ycoords(self):
-        sliced = QuadMesh((self.xs, self.ys[:-1], self.zs[:-1, :]))
+        sliced = hv.QuadMesh((self.xs, self.ys[:-1], self.zs[:-1, :]))
         assert_element_equal(self.dataset2d[:, 2:7], sliced)
 
     def test_qmesh_slice_xcoords_ycoords(self):
-        sliced = QuadMesh((self.xs[1:], self.ys[:-1], self.zs[:-1, 1:]))
+        sliced = hv.QuadMesh((self.xs[1:], self.ys[:-1], self.zs[:-1, 1:]))
         assert_element_equal(self.dataset2d[100:1000, 2:7], sliced)
 
     def test_groupby_xdim(self):
-        grouped = self.dataset2d.groupby('x', group_type=Dataset)
-        holomap = HoloMap({(self.xs[i]+np.diff(self.xs[i:i+2])/2.)[0]:
-                           Dataset((self.ys, self.zs[:, i]), 'y', 'z')
+        grouped = self.dataset2d.groupby('x', group_type=hv.Dataset)
+        holomap = hv.HoloMap({(self.xs[i]+np.diff(self.xs[i:i+2])/2.)[0]:
+                           hv.Dataset((self.ys, self.zs[:, i]), 'y', 'z')
                            for i in range(3)}, kdims=['x'])
         assert_element_equal(grouped, holomap)
 
     def test_groupby_ydim(self):
-        grouped = self.dataset2d.groupby('y', group_type=Dataset)
-        holomap = HoloMap({self.ys[i:i+2].mean(): Dataset((self.xs, self.zs[i]), 'x', 'z')
+        grouped = self.dataset2d.groupby('y', group_type=hv.Dataset)
+        holomap = hv.HoloMap({self.ys[i:i+2].mean(): hv.Dataset((self.xs, self.zs[i]), 'x', 'z')
                            for i in range(3)}, kdims=['y'])
         assert_element_equal(grouped, holomap)
 
     def test_qmesh_transform_replace_kdim(self):
-        transformed = self.dataset2d.transform(x=dim('x')*2)
-        expected = QuadMesh((self.xs*2, self.ys, self.zs))
+        transformed = self.dataset2d.transform(x=hv.dim('x')*2)
+        expected = hv.QuadMesh((self.xs*2, self.ys, self.zs))
         assert_element_equal(expected, transformed)
 
     def test_qmesh_transform_replace_vdim(self):
-        transformed = self.dataset2d.transform(z=dim('z')*2)
-        expected = QuadMesh((self.xs, self.ys, self.zs*2))
+        transformed = self.dataset2d.transform(z=hv.dim('z')*2)
+        expected = hv.QuadMesh((self.xs, self.ys, self.zs*2))
         assert_element_equal(expected, transformed)
 
 
@@ -178,7 +174,7 @@ class Irregular2DBinsTest:
         self.zs = np.arange(24).reshape(4, 6)
 
     def test_construct_from_dict(self):
-        dataset = Dataset((self.xs, self.ys, self.zs), ['x', 'y'], 'z')
+        dataset = hv.Dataset((self.xs, self.ys, self.zs), ['x', 'y'], 'z')
         assert_data_equal(dataset.dimension_values('x'), self.xs.T.flatten())
         assert_data_equal(dataset.dimension_values('y'), self.ys.T.flatten())
         assert_data_equal(dataset.dimension_values('z'), self.zs.T.flatten())
@@ -189,11 +185,11 @@ class Irregular2DBinsTest:
                               ('lon', (('y', 'x'), self.xs))])
         da = xr.DataArray(self.zs, dims=['y', 'x'],
                           coords=coords, name='z')
-        dataset = Dataset(da)
+        dataset = hv.Dataset(da)
 
         # Ensure that dimensions are inferred correctly
-        assert dataset.kdims == [Dimension('lat'), Dimension('lon')]
-        assert dataset.vdims == [Dimension('z')]
+        assert dataset.kdims == [hv.Dimension('lat'), hv.Dimension('lon')]
+        assert dataset.vdims == [hv.Dimension('z')]
 
         # Ensure that canonicalization works on multi-dimensional coordinates
         assert_data_equal(dataset.dimension_values('lon', flat=False), self.xs)
@@ -207,7 +203,7 @@ class Irregular2DBinsTest:
                           coords = {'lat': (('y', 'x'), self.ys),
                                     'lon': (('y', 'x'), self.xs),
                                     'z': [0, 1]}, name='A')
-        dataset = Dataset(da, ['lon', 'lat', 'z'], 'A')
+        dataset = hv.Dataset(da, ['lon', 'lat', 'z'], 'A')
         assert_data_equal(dataset.dimension_values('lon'), self.xs.T.flatten())
         assert_data_equal(dataset.dimension_values('lat'), self.ys.T.flatten())
         assert_data_equal(dataset.dimension_values('z', expanded=False), np.array([0, 1]))
@@ -221,7 +217,7 @@ class Irregular2DBinsTest:
                                     'lon': (('y', 'x'), self.xs),
                                     'z': [0, 1]}, name='A')
         with pytest.raises(DataError):
-            Dataset(da, ['z', 'lon', 'lat'])
+            hv.Dataset(da, ['z', 'lon', 'lat'])
 
     def test_3d_xarray_with_constant_dim_canonicalized_to_2d(self):
         xr = pytest.importorskip("xarray")
@@ -232,7 +228,7 @@ class Irregular2DBinsTest:
                                     'lon': (('y', 'x'), self.xs),
                                     'z': [0]}, name='A')
         # Declare Dataset without declaring constant dimension
-        dataset = Dataset(da, ['lon', 'lat'], 'A')
+        dataset = hv.Dataset(da, ['lon', 'lat'], 'A')
         # Ensure that canonicalization drops the constant dimension
         assert_data_equal(dataset.dimension_values('A', flat=False), zs[0])
 
@@ -243,17 +239,17 @@ class Irregular2DBinsTest:
                           coords = {'lat': (('y', 'x'), self.ys),
                                     'lon': (('y', 'x'), self.xs),
                                     'z': [0, 1]}, name='A')
-        grouped = Dataset(da, ['lon', 'lat', 'z'], 'A').groupby('z')
-        hmap = HoloMap({0: Dataset((self.xs, self.ys, zs[0]), ['lon', 'lat'], 'A'),
-                        1: Dataset((self.xs, self.ys, zs[1]), ['lon', 'lat'], 'A')}, kdims='z')
+        grouped = hv.Dataset(da, ['lon', 'lat', 'z'], 'A').groupby('z')
+        hmap = hv.HoloMap({0: hv.Dataset((self.xs, self.ys, zs[0]), ['lon', 'lat'], 'A'),
+                        1: hv.Dataset((self.xs, self.ys, zs[1]), ['lon', 'lat'], 'A')}, kdims='z')
         assert_element_equal(grouped, hmap)
 
     def test_irregular_transform_replace_kdim(self):
-        transformed = Dataset((self.xs, self.ys, self.zs), ['x', 'y'], 'z').transform(x=dim('x')*2)
-        expected = Dataset((self.xs*2, self.ys, self.zs), ['x', 'y'], 'z')
+        transformed = hv.Dataset((self.xs, self.ys, self.zs), ['x', 'y'], 'z').transform(x=hv.dim('x')*2)
+        expected = hv.Dataset((self.xs*2, self.ys, self.zs), ['x', 'y'], 'z')
         assert_element_equal(expected, transformed)
 
     def test_irregular_transform_replace_vdim(self):
-        transformed = Dataset((self.xs, self.ys, self.zs), ['x', 'y'], 'z').transform(z=dim('z')*2)
-        expected = Dataset((self.xs, self.ys, self.zs*2), ['x', 'y'], 'z')
+        transformed = hv.Dataset((self.xs, self.ys, self.zs), ['x', 'y'], 'z').transform(z=hv.dim('z')*2)
+        expected = hv.Dataset((self.xs, self.ys, self.zs*2), ['x', 'y'], 'z')
         assert_element_equal(expected, transformed)

--- a/holoviews/tests/core/data/test_cudfinterface.py
+++ b/holoviews/tests/core/data/test_cudfinterface.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 import pytest
 
-from holoviews.core.data import Dataset
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .base import HeterogeneousColumnTests, InterfaceTests
@@ -47,7 +47,7 @@ class cuDFInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
         super().test_dataset_2D_aggregate_spread_fn_with_duplicates()
 
     def test_dataset_mixed_type_range(self):
-        ds = Dataset((['A', 'B', 'C', None],), 'A')
+        ds = hv.Dataset((['A', 'B', 'C', None],), 'A')
         vmin, vmax = ds.range(0)
         assert np.isnan(vmin)
         assert np.isnan(vmax)

--- a/holoviews/tests/core/data/test_daskinterface.py
+++ b/holoviews/tests/core/data/test_daskinterface.py
@@ -2,14 +2,13 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core.data import Dataset
+import holoviews as hv
 from holoviews.core.util.dependencies import (
     PANDAS_GE_3_0_0,
     PANDAS_VERSION,
     _no_import_version,
 )
 from holoviews.testing import assert_data_equal, assert_element_equal
-from holoviews.util.transform import dim
 
 from ...utils import optional_dependencies
 from .test_pandasinterface import BasePandasInterfaceTests
@@ -110,24 +109,24 @@ class DaskDatasetTest(BasePandasInterfaceTests):
         pytest.skip("Temporarily skipped")
         df = pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)})
         ddf = dd.from_pandas(df, 1)
-        ds = Dataset(ddf.groupby(['x', 'y']).mean(), ['x', 'y'])
-        assert_element_equal(ds, Dataset(df, ['x', 'y']))
+        ds = hv.Dataset(ddf.groupby(['x', 'y']).mean(), ['x', 'y'])
+        assert_element_equal(ds, hv.Dataset(df, ['x', 'y']))
 
     def test_dataset_from_multi_index_tuple_dims(self):
         pytest.skip("Temporarily skipped")
         df = pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)})
         ddf = dd.from_pandas(df, 1)
-        ds = Dataset(ddf.groupby(['x', 'y']).mean(), [('x', 'X'), ('y', 'Y')])
-        assert_element_equal(ds, Dataset(df, [('x', 'X'), ('y', 'Y')]))
+        ds = hv.Dataset(ddf.groupby(['x', 'y']).mean(), [('x', 'X'), ('y', 'Y')])
+        assert_element_equal(ds, hv.Dataset(df, [('x', 'X'), ('y', 'Y')]))
 
     def test_dataset_range_categorical_dimension(self):
         ddf = self.frame({'a': ['1', '2', '3']})
-        ds = Dataset(ddf)
+        ds = hv.Dataset(ddf)
         assert ds.range(0) == ('1', '3')
 
     def test_dataset_range_categorical_dimension_empty(self):
         ddf = self.frame({'a': ['1', '2', '3']})
-        ds = Dataset(ddf).iloc[:0]
+        ds = hv.Dataset(ddf).iloc[:0]
         ds_range = ds.range(0)
         assert np.isnan(ds_range[0])
         assert np.isnan(ds_range[1])
@@ -138,8 +137,8 @@ class DaskDatasetTest(BasePandasInterfaceTests):
             'b': [10, 10, 11, 11, 10],
         })
         ddf = self.frame(df)
-        ds = Dataset(ddf)
-        new_ds = ds.select(selection_expr=dim('b') == 10)
+        ds = hv.Dataset(ddf)
+        new_ds = ds.select(selection_expr=hv.dim('b') == 10)
 
         # Make sure that selecting by expression didn't cause evaluation
         assert isinstance(new_ds.data, dd.DataFrame)

--- a/holoviews/tests/core/data/test_dictinterface.py
+++ b/holoviews/tests/core/data/test_dictinterface.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.core.data import Dataset
+import holoviews as hv
 from holoviews.testing import assert_data_equal, assert_element_equal
 
 from .base import HeterogeneousColumnTests, InterfaceTests, ScalarColumnTests
@@ -17,8 +17,8 @@ class DictDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
     __test__ = True
 
     def test_dataset_simple_dict_sorted(self):
-        dataset = Dataset({2: 2, 1: 1, 3: 3}, kdims=['x'], vdims=['y'])
-        assert_element_equal(dataset, Dataset([(i, i) for i in range(1, 4)],
+        dataset = hv.Dataset({2: 2, 1: 1, 3: 3}, kdims=['x'], vdims=['y'])
+        assert_element_equal(dataset, hv.Dataset([(i, i) for i in range(1, 4)],
                                           kdims=['x'], vdims=['y']))
 
     def test_dataset_dataset_ht_dtypes(self):
@@ -30,26 +30,26 @@ class DictDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
         assert ds.interface.dtype(ds, 'Height') == np.dtype('float64')
 
     def test_dataset_empty_list_init_dtypes(self):
-        dataset = Dataset([], kdims=['x'], vdims=['y'])
+        dataset = hv.Dataset([], kdims=['x'], vdims=['y'])
         for d in 'xy':
             assert dataset.dimension_values(d).dtype == np.float64
 
     def test_dataset_empty_combined_dimension(self):
-        ds = Dataset({('x', 'y'): []}, kdims=['x', 'y'])
-        ds2 = Dataset({'x': [], 'y': []}, kdims=['x', 'y'])
+        ds = hv.Dataset({('x', 'y'): []}, kdims=['x', 'y'])
+        ds2 = hv.Dataset({'x': [], 'y': []}, kdims=['x', 'y'])
         assert_element_equal(ds, ds2)
 
     def test_dataset_allow_none_value(self):
-        ds = Dataset({'x': None, 'y': [1]}, kdims=['x', 'y'])
+        ds = hv.Dataset({'x': None, 'y': [1]}, kdims=['x', 'y'])
         assert_data_equal(ds.dimension_values(0), np.array([None]))
 
     def test_dataset_allow_none_values(self):
-        ds = Dataset({'x': None, 'y': [0, 1]}, kdims=['x', 'y'])
+        ds = hv.Dataset({'x': None, 'y': [0, 1]}, kdims=['x', 'y'])
         assert_data_equal(ds.dimension_values(0), np.array([None, None]))
 
     def test_dataset_ignore_non_dimensions(self):
-        ds = Dataset({'x': [0, 1], 'y': [1, 2], 'ignore_scalar': 1,
+        ds = hv.Dataset({'x': [0, 1], 'y': [1, 2], 'ignore_scalar': 1,
                       'ignore_array': np.array([2, 3]), 'ignore_None': None},
                      kdims=['x', 'y'])
-        ds2 = Dataset({'x': [0, 1], 'y': [1, 2]}, kdims=['x', 'y'])
+        ds2 = hv.Dataset({'x': [0, 1], 'y': [1, 2]}, kdims=['x', 'y'])
         assert_element_equal(ds, ds2)

--- a/holoviews/tests/core/data/test_gridinterface.py
+++ b/holoviews/tests/core/data/test_gridinterface.py
@@ -5,12 +5,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core.data import Dataset
+import holoviews as hv
 from holoviews.core.data.interface import DataError
 from holoviews.core.util import date_range
-from holoviews.element import HSV, RGB, Curve, Image
 from holoviews.testing import assert_data_equal, assert_element_equal
-from holoviews.util.transform import dim
 
 from ...utils import optional_dependencies
 from .base import (
@@ -33,27 +31,27 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 
     def test_dataset_dataframe_init_hm(self):
         with pytest.raises(DataError):
-            Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
+            hv.Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
                     kdims=['x'], vdims=['x2'])
 
     def test_dataset_dataframe_init_hm_alias(self):
         with pytest.raises(DataError):
-            Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
+            hv.Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
                     kdims=['x'], vdims=['x2'])
 
     def test_dataset_empty_constructor(self):
-        ds = Dataset([], ['x', 'y'], ['z'])
+        ds = hv.Dataset([], ['x', 'y'], ['z'])
         assert ds.interface.shape(ds, gridded=True) == (0, 0)
 
     def test_dataset_multi_vdim_empty_constructor(self):
-        ds = Dataset([], ['x', 'y'], ['z1', 'z2', 'z3'])
+        ds = hv.Dataset([], ['x', 'y'], ['z1', 'z2', 'z3'])
         assert all(ds.dimension_values(vd, flat=False).shape == (0, 0) for vd in ds.vdims)
 
     def test_irregular_grid_data_values(self):
         nx, ny = 20, 5
         xs, ys = np.meshgrid(np.arange(nx)+0.5, np.arange(ny)+0.5)
         zs = np.arange(100).reshape(5, 20)
-        ds = Dataset((xs, ys, zs), ['x', 'y'], 'z')
+        ds = hv.Dataset((xs, ys, zs), ['x', 'y'], 'z')
         assert_data_equal(ds.dimension_values(2, flat=False), zs)
         assert_data_equal(ds.interface.coords(ds, 'x'), xs)
         assert_data_equal(ds.interface.coords(ds, 'y'), ys)
@@ -62,7 +60,7 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
         nx, ny = 20, 5
         xs, ys = np.meshgrid(np.arange(nx)+0.5, np.arange(ny)*-1+0.5)
         zs = np.arange(100).reshape(5, 20)
-        ds = Dataset((xs, ys, zs), ['x', 'y'], 'z')
+        ds = hv.Dataset((xs, ys, zs), ['x', 'y'], 'z')
         assert_data_equal(ds.dimension_values(2, flat=False), zs)
         assert_data_equal(ds.interface.coords(ds, 'x'), xs)
         assert_data_equal(ds.interface.coords(ds, 'y'), ys)
@@ -110,35 +108,35 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 
     def test_dataset_2D_columnar_shape(self):
         array = np.random.rand(11, 11)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=['x', 'y'], vdims=['z'])
         assert dataset.shape == (11*11, 3)
 
     def test_dataset_2D_gridded_shape(self):
         array = np.random.rand(12, 11)
-        dataset = Dataset({'x':self.xs, 'y': range(12), 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y': range(12), 'z': array},
                           kdims=['x', 'y'], vdims=['z'])
         assert dataset.interface.shape(dataset, gridded=True) == (12, 11)
 
     def test_dataset_2D_aggregate_partial_hm(self):
         array = np.random.rand(11, 11)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=['x', 'y'], vdims=['z'])
         assert_element_equal(dataset.aggregate(['x'], np.mean),
-                         Dataset({'x':self.xs, 'z': np.mean(array, axis=0)},
+                         hv.Dataset({'x':self.xs, 'z': np.mean(array, axis=0)},
                                  kdims=['x'], vdims=['z']))
 
     def test_dataset_2D_aggregate_partial_hm_alias(self):
         array = np.random.rand(11, 11)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=[('x', 'X'), ('y', 'Y')], vdims=[('z', 'Z')])
         assert_element_equal(dataset.aggregate(['X'], np.mean),
-                         Dataset({'x':self.xs, 'z': np.mean(array, axis=0)},
+                         hv.Dataset({'x':self.xs, 'z': np.mean(array, axis=0)},
                                  kdims=[('x', 'X')], vdims=[('z', 'Z')]))
 
     def test_dataset_2D_reduce_hm(self):
         array = np.random.rand(11, 11)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=['x', 'y'], vdims=['z'])
         output = np.array(dataset.reduce(['x', 'y'], np.mean)),
         expected = np.mean(array)
@@ -146,7 +144,7 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 
     def test_dataset_2D_reduce_hm_alias(self):
         array = np.random.rand(11, 11)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=[('x', 'X'), ('y', 'Y')], vdims=[('z', 'Z')])
         output = np.array(dataset.reduce(['x', 'y'], np.mean)),
         expected = np.mean(array)
@@ -156,26 +154,26 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 
     def test_dataset_groupby_dynamic(self):
         array = np.random.rand(11, 11)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=['x', 'y'], vdims=['z'])
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], dataset):
             grouped = dataset.groupby('x', dynamic=True)
-        first = Dataset({'y': self.y_ints, 'z': array[:, 0]},
+        first = hv.Dataset({'y': self.y_ints, 'z': array[:, 0]},
                         kdims=['y'], vdims=['z'])
         assert_element_equal(grouped[0], first)
 
     def test_dataset_groupby_dynamic_alias(self):
         array = np.random.rand(11, 11)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=[('x', 'X'), ('y', 'Y')], vdims=[('z', 'Z')])
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], dataset):
             grouped = dataset.groupby('X', dynamic=True)
-        first = Dataset({'y': self.y_ints, 'z': array[:, 0]},
+        first = hv.Dataset({'y': self.y_ints, 'z': array[:, 0]},
                         kdims=[('y', 'Y')], vdims=[('z', 'Z')])
         assert_element_equal(grouped[0], first)
 
     def test_dataset_groupby_multiple_dims(self):
-        dataset = Dataset((range(8), range(8), range(8), range(8),
+        dataset = hv.Dataset((range(8), range(8), range(8), range(8),
                            np.random.rand(8, 8, 8, 8)),
                           kdims=['a', 'b', 'c', 'd'], vdims=['Value'])
         grouped = dataset.groupby(['c', 'd'])
@@ -186,34 +184,34 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 
     def test_dataset_groupby_drop_dims(self):
         array = np.random.rand(3, 20, 10)
-        ds = Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array},
+        ds = hv.Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array},
                      kdims=['x', 'y', 'z'], vdims=['Val'])
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, Dataset)):
-            partial = ds.to(Dataset, kdims=['x'], vdims=['Val'], groupby='y')
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, hv.Dataset)):
+            partial = ds.to(hv.Dataset, kdims=['x'], vdims=['Val'], groupby='y')
         assert_data_equal(partial.last['Val'], array[:, -1, :].T.flatten())
 
     def test_dataset_groupby_drop_dims_dynamic(self):
         array = np.random.rand(3, 20, 10)
-        ds = Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array},
+        ds = hv.Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array},
                      kdims=['x', 'y', 'z'], vdims=['Val'])
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, Dataset)):
-            partial = ds.to(Dataset, kdims=['x'], vdims=['Val'], groupby='y', dynamic=True)
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, hv.Dataset)):
+            partial = ds.to(hv.Dataset, kdims=['x'], vdims=['Val'], groupby='y', dynamic=True)
             assert_data_equal(partial[19]['Val'], array[:, -1, :].T.flatten())
 
     def test_dataset_groupby_drop_dims_with_vdim(self):
         array = np.random.rand(3, 20, 10)
-        ds = Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array, 'Val2': array*2},
+        ds = hv.Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array, 'Val2': array*2},
                      kdims=['x', 'y', 'z'], vdims=['Val', 'Val2'])
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, Dataset)):
-            partial = ds.to(Dataset, kdims=['Val'], vdims=['Val2'], groupby='y')
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, hv.Dataset)):
+            partial = ds.to(hv.Dataset, kdims=['Val'], vdims=['Val2'], groupby='y')
         assert_data_equal(partial.last['Val'], array[:, -1, :].T.flatten())
 
     def test_dataset_groupby_drop_dims_dynamic_with_vdim(self):
         array = np.random.rand(3, 20, 10)
-        ds = Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array, 'Val2': array*2},
+        ds = hv.Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array, 'Val2': array*2},
                      kdims=['x', 'y', 'z'], vdims=['Val', 'Val2'])
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, Dataset)):
-            partial = ds.to(Dataset, kdims=['Val'], vdims=['Val2'], groupby='y', dynamic=True)
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, hv.Dataset)):
+            partial = ds.to(hv.Dataset, kdims=['Val'], vdims=['Val2'], groupby='y', dynamic=True)
             assert_data_equal(partial[19]['Val'], array[:, -1, :].T.flatten())
 
     def test_dataset_ndloc_lists(self):
@@ -260,23 +258,23 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 
     def test_reindex_drop_scalars_xs(self):
         reindexed = self.dataset_grid.ndloc[:, 0].reindex()
-        ds = Dataset((self.grid_ys, self.grid_zs[:, 0]), 'y', 'z')
+        ds = hv.Dataset((self.grid_ys, self.grid_zs[:, 0]), 'y', 'z')
         assert_element_equal(reindexed, ds)
 
     def test_reindex_drop_scalars_ys(self):
         reindexed = self.dataset_grid.ndloc[0].reindex()
-        ds = Dataset((self.grid_xs, self.grid_zs[0]), 'x', 'z')
+        ds = hv.Dataset((self.grid_xs, self.grid_zs[0]), 'x', 'z')
         assert_element_equal(reindexed, ds)
 
     def test_reindex_2d_grid_to_1d(self):
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], self.dataset_grid):
             ds = self.dataset_grid.reindex(kdims=['x'])
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], Dataset):
-            assert_element_equal(ds, Dataset(self.dataset_grid.columns(), 'x', 'z'))
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], hv.Dataset):
+            assert_element_equal(ds, hv.Dataset(self.dataset_grid.columns(), 'x', 'z'))
 
     def test_mask_2d_array(self):
         array = np.random.rand(4, 3)
-        ds = Dataset(([0, 1, 2], [1, 2, 3, 4], array), ['x', 'y'], 'z')
+        ds = hv.Dataset(([0, 1, 2], [1, 2, 3, 4], array), ['x', 'y'], 'z')
         mask = np.array([[1, 1, 0], [1, 0, 1], [0, 1, 1], [1, 0, 1]], dtype='bool')
         masked = ds.clone(ds.interface.mask(ds, mask))
         masked_array = masked.dimension_values(2, flat=False)
@@ -286,7 +284,7 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 
     def test_mask_2d_array_x_reversed(self):
         array = np.random.rand(4, 3)
-        ds = Dataset(([0, 1, 2][::-1], [1, 2, 3, 4], array[:, ::-1]), ['x', 'y'], 'z')
+        ds = hv.Dataset(([0, 1, 2][::-1], [1, 2, 3, 4], array[:, ::-1]), ['x', 'y'], 'z')
         mask = np.array([[1, 1, 0], [1, 0, 1], [0, 1, 1], [1, 0, 1]], dtype='bool')
         masked = ds.clone(ds.interface.mask(ds, mask))
         masked_array = masked.dimension_values(2, flat=False)
@@ -296,7 +294,7 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 
     def test_mask_2d_array_y_reversed(self):
         array = np.random.rand(4, 3)
-        ds = Dataset(([0, 1, 2], [1, 2, 3, 4][::-1], array[::-1]), ['x', 'y'], 'z')
+        ds = hv.Dataset(([0, 1, 2], [1, 2, 3, 4][::-1], array[::-1]), ['x', 'y'], 'z')
         mask = np.array([[1, 1, 0], [1, 0, 1], [0, 1, 1], [1, 0, 1]], dtype='bool')
         masked = ds.clone(ds.interface.mask(ds, mask))
         masked_array = masked.dimension_values(2, flat=False)
@@ -306,7 +304,7 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 
     def test_mask_2d_array_xy_reversed(self):
         array = np.random.rand(4, 3)
-        ds = Dataset(([0, 1, 2][::-1], [1, 2, 3, 4][::-1], array[::-1, ::-1]), ['x', 'y'], 'z')
+        ds = hv.Dataset(([0, 1, 2][::-1], [1, 2, 3, 4][::-1], array[::-1, ::-1]), ['x', 'y'], 'z')
         mask = np.array([[1, 1, 0], [1, 0, 1], [0, 1, 1], [1, 0, 1]], dtype='bool')
         masked = ds.clone(ds.interface.mask(ds, mask))
         masked_array = masked.dimension_values(2, flat=False)
@@ -315,28 +313,28 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
         assert_data_equal(masked_array, expected)
 
     def test_dataset_transform_replace_kdim_on_grid(self):
-        transformed = self.dataset_grid.transform(x=dim('x')*2)
+        transformed = self.dataset_grid.transform(x=hv.dim('x')*2)
         expected = self.element(
             ([0, 2], self.grid_ys, self.grid_zs), ['x', 'y'], ['z']
         )
         assert_element_equal(transformed, expected)
 
     def test_dataset_transform_replace_vdim_on_grid(self):
-        transformed = self.dataset_grid.transform(z=dim('z')*2)
+        transformed = self.dataset_grid.transform(z=hv.dim('z')*2)
         expected = self.element(
             (self.grid_xs, self.grid_ys, self.grid_zs*2), ['x', 'y'], ['z']
         )
         assert_element_equal(transformed, expected)
 
     def test_dataset_transform_replace_kdim_on_inverted_grid(self):
-        transformed = self.dataset_grid_inv.transform(x=dim('x')*2)
+        transformed = self.dataset_grid_inv.transform(x=hv.dim('x')*2)
         expected = self.element(
             ([2, 0], self.grid_ys[::-1], self.grid_zs), ['x', 'y'], ['z']
         )
         assert_element_equal(transformed, expected)
 
     def test_dataset_transform_replace_vdim_on_inverted_grid(self):
-        transformed = self.dataset_grid_inv.transform(z=dim('z')*2)
+        transformed = self.dataset_grid_inv.transform(z=hv.dim('z')*2)
         expected = self.element(
             (self.grid_xs[::-1], self.grid_ys[::-1], self.grid_zs*2), ['x', 'y'], ['z']
         )
@@ -347,7 +345,7 @@ class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Inte
 class GridInterfaceTests(BaseGridInterfaceTests):
     datatype = 'grid'
     data_type = (dict,)
-    element = Dataset
+    element = hv.Dataset
 
     __test__ = True
 
@@ -382,7 +380,7 @@ class DaskGridInterfaceTests(GridInterfaceTests):
 
     def test_select_lazy(self):
         arr = da.from_array(np.arange(1, 12), 3)
-        ds = Dataset({'x': range(11), 'y': arr}, 'x', 'y')
+        ds = hv.Dataset({'x': range(11), 'y': arr}, 'x', 'y')
         assert isinstance(ds.select(x=(0, 5)).data['y'], da.Array)
 
     # TODO: Some of the test below are copy/pasted
@@ -408,42 +406,42 @@ class DaskGridInterfaceTests(GridInterfaceTests):
 
     def test_dataset_2D_columnar_shape(self):
         array = da.from_array(np.random.rand(11, 11), 3)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=['x', 'y'], vdims=['z'])
         assert dataset.shape == (11*11, 3)
 
     def test_dataset_2D_gridded_shape(self):
         array = da.from_array(np.random.rand(12, 11), 3)
-        dataset = Dataset({'x':self.xs, 'y': range(12), 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y': range(12), 'z': array},
                           kdims=['x', 'y'], vdims=['z'])
         assert dataset.interface.shape(dataset, gridded=True) == (12, 11)
 
     def test_dataset_2D_aggregate_partial_hm(self):
         array = da.from_array(np.random.rand(11, 11), 3)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=['x', 'y'], vdims=['z'])
         assert_element_equal(dataset.aggregate(['x'], np.mean),
-                         Dataset({'x':self.xs, 'z': np.mean(array, axis=0).compute()},
+                         hv.Dataset({'x':self.xs, 'z': np.mean(array, axis=0).compute()},
                                  kdims=['x'], vdims=['z']))
 
     def test_dataset_2D_aggregate_partial_hm_alias(self):
         array = da.from_array(np.random.rand(11, 11), 3)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=[('x', 'X'), ('y', 'Y')], vdims=[('z', 'Z')])
         assert_element_equal(dataset.aggregate(['X'], np.mean),
-                         Dataset({'x':self.xs, 'z': np.mean(array, axis=0).compute()},
+                         hv.Dataset({'x':self.xs, 'z': np.mean(array, axis=0).compute()},
                                  kdims=[('x', 'X')], vdims=[('z', 'Z')]))
 
     def test_dataset_2D_reduce_hm(self):
         array = da.from_array(np.random.rand(11, 11), 3)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=['x', 'y'], vdims=['z'])
         output = dataset.reduce(['x', 'y'], np.mean),
         assert np.isclose(output, np.mean(array).compute())
 
     def test_dataset_2D_reduce_hm_alias(self):
         array = np.random.rand(11, 11)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=[('x', 'X'), ('y', 'Y')], vdims=[('z', 'Z')])
         output = np.array(dataset.reduce(['x', 'y'], np.mean))
         expected = np.mean(array)
@@ -453,26 +451,26 @@ class DaskGridInterfaceTests(GridInterfaceTests):
 
     def test_dataset_groupby_dynamic(self):
         array = da.from_array(np.random.rand(11, 11), 3)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=['x', 'y'], vdims=['z'])
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], dataset):
             grouped = dataset.groupby('x', dynamic=True)
-        first = Dataset({'y': self.y_ints.compute(), 'z': array[:, 0]},
+        first = hv.Dataset({'y': self.y_ints.compute(), 'z': array[:, 0]},
                         kdims=['y'], vdims=['z'])
         assert_element_equal(grouped[0], first)
 
     def test_dataset_groupby_dynamic_alias(self):
         array = da.from_array(np.random.rand(11, 11), 3)
-        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+        dataset = hv.Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=[('x', 'X'), ('y', 'Y')], vdims=[('z', 'Z')])
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], dataset):
             grouped = dataset.groupby('X', dynamic=True)
-        first = Dataset({'y': self.y_ints.compute(), 'z': array[:, 0].compute()},
+        first = hv.Dataset({'y': self.y_ints.compute(), 'z': array[:, 0].compute()},
                         kdims=[('y', 'Y')], vdims=[('z', 'Z')])
         assert_element_equal(grouped[0], first)
 
     def test_dataset_groupby_multiple_dims(self):
-        dataset = Dataset((range(8), range(8), range(8), range(8),
+        dataset = hv.Dataset((range(8), range(8), range(8), range(8),
                            da.from_array(np.random.rand(8, 8, 8, 8), 4)),
                           kdims=['a', 'b', 'c', 'd'], vdims=['Value'])
         grouped = dataset.groupby(['c', 'd'])
@@ -483,34 +481,34 @@ class DaskGridInterfaceTests(GridInterfaceTests):
 
     def test_dataset_groupby_drop_dims(self):
         array = da.from_array(np.random.rand(3, 20, 10), 3)
-        ds = Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array},
+        ds = hv.Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array},
                      kdims=['x', 'y', 'z'], vdims=['Val'])
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, Dataset)):
-            partial = ds.to(Dataset, kdims=['x'], vdims=['Val'], groupby='y')
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, hv.Dataset)):
+            partial = ds.to(hv.Dataset, kdims=['x'], vdims=['Val'], groupby='y')
         assert_data_equal(partial.last['Val'], array[:, -1, :].T.flatten().compute())
 
     def test_dataset_groupby_drop_dims_dynamic(self):
         array = da.from_array(np.random.rand(3, 20, 10), 3)
-        ds = Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array},
+        ds = hv.Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array},
                      kdims=['x', 'y', 'z'], vdims=['Val'])
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, Dataset)):
-            partial = ds.to(Dataset, kdims=['x'], vdims=['Val'], groupby='y', dynamic=True)
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, hv.Dataset)):
+            partial = ds.to(hv.Dataset, kdims=['x'], vdims=['Val'], groupby='y', dynamic=True)
             assert_data_equal(partial[19]['Val'], array[:, -1, :].T.flatten().compute())
 
     def test_dataset_groupby_drop_dims_with_vdim(self):
         array = da.from_array(np.random.rand(3, 20, 10), 3)
-        ds = Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array, 'Val2': array*2},
+        ds = hv.Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array, 'Val2': array*2},
                      kdims=['x', 'y', 'z'], vdims=['Val', 'Val2'])
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, Dataset)):
-            partial = ds.to(Dataset, kdims=['Val'], vdims=['Val2'], groupby='y')
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, hv.Dataset)):
+            partial = ds.to(hv.Dataset, kdims=['Val'], vdims=['Val2'], groupby='y')
         assert_data_equal(partial.last['Val'], array[:, -1, :].T.flatten().compute())
 
     def test_dataset_groupby_drop_dims_dynamic_with_vdim(self):
         array = da.from_array(np.random.rand(3, 20, 10), 3)
-        ds = Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array, 'Val2': array*2},
+        ds = hv.Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array, 'Val2': array*2},
                      kdims=['x', 'y', 'z'], vdims=['Val', 'Val2'])
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, Dataset)):
-            partial = ds.to(Dataset, kdims=['Val'], vdims=['Val2'], groupby='y', dynamic=True)
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], (ds, hv.Dataset)):
+            partial = ds.to(hv.Dataset, kdims=['Val'], vdims=['Val2'], groupby='y', dynamic=True)
             assert_data_equal(partial[19]['Val'], array[:, -1, :].T.flatten().compute())
 
     def test_dataset_get_dframe(self):
@@ -530,40 +528,40 @@ class ImageElement_GridInterfaceTests(BaseImageElementInterfaceTests):
     __test__ = True
 
     def init_data(self):
-        self.image = Image((self.xs, self.ys, self.array))
-        self.image_inv = Image((self.xs[::-1], self.ys[::-1], self.array[::-1, ::-1]))
+        self.image = hv.Image((self.xs, self.ys, self.array))
+        self.image_inv = hv.Image((self.xs[::-1], self.ys[::-1], self.array[::-1, ::-1]))
 
     def test_init_data_datetime_xaxis(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10)
-        Image((xs, self.ys, self.array))
+        hv.Image((xs, self.ys, self.array))
 
     def test_init_data_datetime_yaxis(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10)
-        Image((self.xs, ys, self.array))
+        hv.Image((self.xs, ys, self.array))
 
     def test_init_bounds_datetime_xaxis(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10)
-        image = Image((xs, self.ys, self.array))
+        image = hv.Image((xs, self.ys, self.array))
         assert image.bounds.lbrt() == (start, 0, end, 10)
 
     def test_init_bounds_datetime_yaxis(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10)
-        image = Image((self.xs, ys, self.array))
+        image = hv.Image((self.xs, ys, self.array))
         assert image.bounds.lbrt() == (-10, start, 10, end)
 
     def test_init_densities_datetime_xaxis(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10)
-        image = Image((xs, self.ys, self.array))
+        image = hv.Image((xs, self.ys, self.array))
         assert image.xdensity == 1e-5
         assert image.ydensity == 1
 
@@ -571,7 +569,7 @@ class ImageElement_GridInterfaceTests(BaseImageElementInterfaceTests):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10)
-        image = Image((self.xs, ys, self.array))
+        image = hv.Image((self.xs, ys, self.array))
         assert image.xdensity == 0.5
         assert image.ydensity == 1e-5
 
@@ -579,51 +577,51 @@ class ImageElement_GridInterfaceTests(BaseImageElementInterfaceTests):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10)
-        image = Image((xs, self.ys, self.array))
+        image = hv.Image((xs, self.ys, self.array))
         curve = image.sample(x=xs[3])
-        assert_element_equal(curve, Curve((self.ys, self.array[:, 3]), 'y', 'z'))
+        assert_element_equal(curve, hv.Curve((self.ys, self.array[:, 3]), 'y', 'z'))
 
     def test_sample_datetime_yaxis(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10)
-        image = Image((self.xs, ys, self.array))
+        image = hv.Image((self.xs, ys, self.array))
         curve = image.sample(y=ys[3])
-        assert_element_equal(curve, Curve((self.xs, self.array[3]), 'x', 'z'))
+        assert_element_equal(curve, hv.Curve((self.xs, self.array[3]), 'x', 'z'))
 
     def test_range_datetime_xdim(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10)
-        image = Image((xs, self.ys, self.array))
+        image = hv.Image((xs, self.ys, self.array))
         assert image.range(0) == (start, end)
 
     def test_range_datetime_ydim(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10)
-        image = Image((self.xs, ys, self.array))
+        image = hv.Image((self.xs, ys, self.array))
         assert image.range(1) == (start, end)
 
     def test_dimension_values_datetime_xcoords(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10)
-        image = Image((xs, self.ys, self.array))
+        image = hv.Image((xs, self.ys, self.array))
         assert_data_equal(image.dimension_values(0, expanded=False), xs)
 
     def test_dimension_values_datetime_ycoords(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10)
-        image = Image((self.xs, ys, self.array))
+        image = hv.Image((self.xs, ys, self.array))
         assert_data_equal(image.dimension_values(1, expanded=False), ys)
 
     def test_slice_datetime_xaxis(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10)
-        image = Image((xs, self.ys, self.array))
+        image = hv.Image((xs, self.ys, self.array))
         sliced = image[start+np.timedelta64(530, 'ms'): start+np.timedelta64(770, 'ms')]
         assert_data_equal(sliced.dimension_values(2, flat=False),
                          self.array[:, 5:8])
@@ -632,7 +630,7 @@ class ImageElement_GridInterfaceTests(BaseImageElementInterfaceTests):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10)
-        image = Image((self.xs, ys, self.array))
+        image = hv.Image((self.xs, ys, self.array))
         sliced = image[:, start+np.timedelta64(120, 'ms'): start+np.timedelta64(520, 'ms')]
         assert_data_equal(sliced.dimension_values(2, flat=False),
                          self.array[1:5, :])
@@ -687,7 +685,7 @@ class RGBElement_GridInterfaceTests(BaseRGBElementInterfaceTests):
     __test__ = True
 
     def init_data(self):
-        self.rgb = RGB((self.xs, self.ys, self.rgb_array[:, :, 0],
+        self.rgb = hv.RGB((self.xs, self.ys, self.rgb_array[:, :, 0],
                         self.rgb_array[:, :, 1], self.rgb_array[:, :, 2]))
 
 
@@ -699,7 +697,7 @@ class RGBElement_PackedGridInterfaceTests(BaseRGBElementInterfaceTests):
     __test__ = True
 
     def init_data(self):
-        self.rgb = RGB((self.xs, self.ys, self.rgb_array))
+        self.rgb = hv.RGB((self.xs, self.ys, self.rgb_array))
 
 
 class HSVElement_GridInterfaceTests(BaseHSVElementInterfaceTests):
@@ -710,5 +708,5 @@ class HSVElement_GridInterfaceTests(BaseHSVElementInterfaceTests):
     __test__ = True
 
     def init_data(self):
-        self.hsv = HSV((self.xs, self.ys, self.hsv_array[:, :, 0],
+        self.hsv = hv.HSV((self.xs, self.ys, self.hsv_array[:, :, 0],
                         self.hsv_array[:, :, 1], self.hsv_array[:, :, 2]))

--- a/holoviews/tests/core/data/test_ibisinterface.py
+++ b/holoviews/tests/core/data/test_ibisinterface.py
@@ -5,9 +5,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core.data import Dataset
+import holoviews as hv
 from holoviews.core.data.ibis import IBIS_VERSION, IbisInterface
-from holoviews.core.spaces import HoloMap
 from holoviews.testing import assert_element_equal
 
 from ...utils import optional_dependencies
@@ -69,7 +68,7 @@ class IbisDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
             columns=["Gender", "Age", "Weight", "Height"],
         )
         hetero_db = create_temp_db(hetero_df, "hetero")
-        self.table = Dataset(
+        self.table = hv.Dataset(
             hetero_db.table("hetero"), kdims=self.kdims, vdims=self.vdims
         )
 
@@ -86,7 +85,7 @@ class IbisDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
             columns=["gender", "age", "weight", "height"],
         )
         alias_db = create_temp_db(alias_df, "alias")
-        self.alias_table = Dataset(
+        self.alias_table = hv.Dataset(
             alias_db.table("alias"), kdims=self.alias_kdims, vdims=self.alias_vdims
         )
 
@@ -98,12 +97,12 @@ class IbisDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
 
         ht_df = pd.DataFrame({"x": self.xs, "y": self.ys}, columns=["x", "y"])
         ht_db = create_temp_db(ht_df, "ht")
-        self.dataset_ht = Dataset(ht_db.table("ht"), kdims=["x"], vdims=["y"])
+        self.dataset_ht = hv.Dataset(ht_db.table("ht"), kdims=["x"], vdims=["y"])
 
         hm_df = pd.DataFrame({"x": self.xs, "y": self.y_ints}, columns=["x", "y"])
         hm_db = create_temp_db(hm_df, "hm")
-        self.dataset_hm = Dataset(hm_db.table("hm"), kdims=["x"], vdims=["y"])
-        self.dataset_hm_alias = Dataset(
+        self.dataset_hm = hv.Dataset(hm_db.table("hm"), kdims=["x"], vdims=["y"])
+        self.dataset_hm_alias = hv.Dataset(
             hm_db.table("hm"), kdims=[("x", "X")], vdims=[("y", "Y")]
         )
 
@@ -175,7 +174,7 @@ class IbisDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
         assert self.dataset_hm.interface.dtype(self.dataset_hm, "y") == int_dtype
 
     def test_dataset_reduce_ht(self):
-        reduced = Dataset(
+        reduced = hv.Dataset(
             {"Age": self.age, "Weight": self.weight, "Height": self.height},
             kdims=self.kdims[1:],
             vdims=self.vdims,
@@ -183,7 +182,7 @@ class IbisDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
         assert_element_equal(self.table.reduce(["Gender"], np.mean).sort(), reduced.sort())
 
     def test_dataset_aggregate_ht(self):
-        aggregated = Dataset(
+        aggregated = hv.Dataset(
             {"Gender": ["M", "F"], "Weight": [16.5, 10], "Height": [0.7, 0.8]},
             kdims=self.kdims[:1],
             vdims=self.vdims,
@@ -193,7 +192,7 @@ class IbisDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
         )
 
     def test_dataset_aggregate_ht_alias(self):
-        aggregated = Dataset(
+        aggregated = hv.Dataset(
             {"gender": ["M", "F"], "weight": [16.5, 10], "height": [0.7, 0.8]},
             kdims=self.alias_kdims[:1],
             vdims=self.alias_vdims,
@@ -205,10 +204,10 @@ class IbisDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
     def test_dataset_groupby(self):
         group1 = {"Age": [10, 16], "Weight": [15, 18], "Height": [0.8, 0.6]}
         group2 = {"Age": [12], "Weight": [10], "Height": [0.8]}
-        grouped = HoloMap(
+        grouped = hv.HoloMap(
             [
-                ("M", Dataset(group1, kdims=["Age"], vdims=self.vdims)),
-                ("F", Dataset(group2, kdims=["Age"], vdims=self.vdims)),
+                ("M", hv.Dataset(group1, kdims=["Age"], vdims=self.vdims)),
+                ("F", hv.Dataset(group2, kdims=["Age"], vdims=self.vdims)),
             ],
             kdims=["Gender"],
         )
@@ -219,10 +218,10 @@ class IbisDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
     def test_dataset_groupby_alias(self):
         group1 = {"age": [10, 16], "weight": [15, 18], "height": [0.8, 0.6]}
         group2 = {"age": [12], "weight": [10], "height": [0.8]}
-        grouped = HoloMap(
+        grouped = hv.HoloMap(
             [
-                ("M", Dataset(group1, kdims=[("age", "Age")], vdims=self.alias_vdims)),
-                ("F", Dataset(group2, kdims=[("age", "Age")], vdims=self.alias_vdims)),
+                ("M", hv.Dataset(group1, kdims=[("age", "Age")], vdims=self.alias_vdims)),
+                ("F", hv.Dataset(group2, kdims=[("age", "Age")], vdims=self.alias_vdims)),
             ],
             kdims=[("gender", "Gender")],
         )
@@ -232,11 +231,11 @@ class IbisDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
         group1 = {"Gender": ["M"], "Weight": [15], "Height": [0.8]}
         group2 = {"Gender": ["M"], "Weight": [18], "Height": [0.6]}
         group3 = {"Gender": ["F"], "Weight": [10], "Height": [0.8]}
-        grouped = HoloMap(
+        grouped = hv.HoloMap(
             [
-                (10, Dataset(group1, kdims=["Gender"], vdims=self.vdims)),
-                (16, Dataset(group2, kdims=["Gender"], vdims=self.vdims)),
-                (12, Dataset(group3, kdims=["Gender"], vdims=self.vdims)),
+                (10, hv.Dataset(group1, kdims=["Gender"], vdims=self.vdims)),
+                (16, hv.Dataset(group2, kdims=["Gender"], vdims=self.vdims)),
+                (12, hv.Dataset(group3, kdims=["Gender"], vdims=self.vdims)),
             ],
             kdims=["Age"],
             sort=True,

--- a/holoviews/tests/core/data/test_imageinterface.py
+++ b/holoviews/tests/core/data/test_imageinterface.py
@@ -3,7 +3,7 @@ import datetime as dt
 import numpy as np
 import pytest
 
-from holoviews import HSV, RGB, Curve, Dataset, Dimension, Image, Table
+import holoviews as hv
 from holoviews.core.data.interface import DataError
 from holoviews.core.util import date_range
 from holoviews.testing import assert_data_equal, assert_element_equal
@@ -18,7 +18,7 @@ class ImageInterfaceTests(GriddedInterfaceTests, InterfaceTests):
 
     datatype = 'image'
     data_type = np.ndarray
-    element = Image
+    element = hv.Image
 
     __test__ = True
 
@@ -28,7 +28,7 @@ class ImageInterfaceTests(GriddedInterfaceTests, InterfaceTests):
         z = np.array([[ 0.06925999,  0.05800389,  0.05620127],
                       [ 0.06240918,  0.05800931,  0.04969735],
                       [ 0.05376789,  0.04669417,  0.03880118]])
-        dataset = Image((x, y, z), kdims=['x', 'y'], vdims=['z'])
+        dataset = hv.Image((x, y, z), kdims=['x', 'y'], vdims=['z'])
         canonical = np.array([[ 0.05376789,  0.04669417,  0.03880118],
                               [ 0.06240918,  0.05800931,  0.04969735],
                               [ 0.06925999,  0.05800389,  0.05620127]])
@@ -60,7 +60,7 @@ class BaseImageElementInterfaceTests(InterfaceTests):
     Tests for ImageInterface
     """
 
-    element = Image
+    element = hv.Image
 
     __test__ = False
 
@@ -70,36 +70,36 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         self.array = np.arange(10) * np.arange(10)[:, np.newaxis]
 
     def init_data(self):
-        self.image = Image(np.flipud(self.array), bounds=(-10, 0, 10, 10))
+        self.image = hv.Image(np.flipud(self.array), bounds=(-10, 0, 10, 10))
 
     def test_init_data_tuple(self):
         xs = np.arange(5)
         ys = np.arange(10)
         array = xs * ys[:, np.newaxis]
-        Image((xs, ys, array))
+        hv.Image((xs, ys, array))
 
     def test_init_data_tuple_error(self):
         xs = np.arange(5)
         ys = np.arange(10)
         array = xs * ys[:, np.newaxis]
         with pytest.raises(DataError):
-            Image((ys, xs, array))
+            hv.Image((ys, xs, array))
 
     def test_bounds_mismatch(self):
         with pytest.raises(ValueError):  # noqa: PT011
-            Image((range(10), range(10), np.random.rand(10, 10)), bounds=0.5)
+            hv.Image((range(10), range(10), np.random.rand(10, 10)), bounds=0.5)
 
     def test_init_data_datetime_xaxis(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10).astype("datetime64[ns]")
-        Image((xs, self.ys, self.array))
+        hv.Image((xs, self.ys, self.array))
 
     def test_init_data_datetime_yaxis(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10).astype("datetime64[ns]")
-        Image((self.xs, ys, self.array))
+        hv.Image((self.xs, ys, self.array))
 
     def test_init_bounds(self):
         assert self.image.bounds.lbrt() == (-10, 0, 10, 10)
@@ -109,7 +109,7 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10).astype("datetime64[ns]")
         bounds = (start, 0, end, 10)
-        image = Image((xs, self.ys, self.array), bounds=bounds)
+        image = hv.Image((xs, self.ys, self.array), bounds=bounds)
         assert image.bounds.lbrt() == bounds
 
     def test_init_bounds_datetime_yaxis(self):
@@ -117,7 +117,7 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10).astype("datetime64[ns]")
         bounds = (-10, start, 10, end)
-        image = Image((self.xs, ys, self.array))
+        image = hv.Image((self.xs, ys, self.array))
         assert image.bounds.lbrt() == bounds
 
     def test_init_densities(self):
@@ -128,7 +128,7 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10).astype("datetime64[ns]")
-        image = Image((xs, self.ys, self.array))
+        image = hv.Image((xs, self.ys, self.array))
         assert image.xdensity == 1e-5
         assert image.ydensity == 1
 
@@ -136,7 +136,7 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10).astype("datetime64[ns]")
-        image = Image((self.xs, ys, self.array))
+        image = hv.Image((self.xs, ys, self.array))
         assert image.xdensity == 0.5
         assert image.ydensity == 1e-5
 
@@ -168,7 +168,7 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         end = start+np.timedelta64(1, 's')
         bounds = (start, 0, end, 10)
         xs = date_range(start, end, 10).astype("datetime64[ns]")
-        image = Image((xs, self.ys, self.array), bounds=bounds)
+        image = hv.Image((xs, self.ys, self.array), bounds=bounds)
         sliced = image[start+np.timedelta64(530, 'ms'): start+np.timedelta64(770, 'ms')]
         assert_data_equal(sliced.dimension_values(2, flat=False),
                          self.array[:, 5:8])
@@ -185,7 +185,7 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10).astype("datetime64[ns]")
-        image = Image((self.xs, ys, self.array))
+        image = hv.Image((self.xs, ys, self.array))
         sliced = image[:, start+np.timedelta64(120, 'ms'): start+np.timedelta64(520, 'ms')]
         assert_data_equal(sliced.dimension_values(2, flat=False),
                          self.array[1:5, :])
@@ -221,7 +221,7 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10).astype("datetime64[ns]")
-        image = Image((xs, self.ys, self.array))
+        image = hv.Image((xs, self.ys, self.array))
         assert image.range(0) == (start, end)
 
     def test_range_ydim(self):
@@ -231,7 +231,7 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         ys = date_range(start, end, 10).astype("datetime64[ns]")
-        image = Image((self.xs, ys, self.array))
+        image = hv.Image((self.xs, ys, self.array))
         assert image.range(1) == (start, end)
 
     def test_range_vdim(self):
@@ -245,7 +245,7 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
         xs = date_range(start, end, 10).astype("datetime64[ns]")
-        image = Image((xs, self.ys, self.array))
+        image = hv.Image((xs, self.ys, self.array))
         assert_data_equal(image.dimension_values(0, expanded=False),
                          date_range(start, end, 10))
 
@@ -258,25 +258,25 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         zs = [0, 7, 14, 21, 28, 35, 42, 49, 56, 63]
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], self.image):
             assert_element_equal(self.image.sample(x=5),
-                             Curve((ys, zs), kdims=['y'], vdims=['z']))
+                             hv.Curve((ys, zs), kdims=['y'], vdims=['z']))
 
     def test_sample_ycoord(self):
         xs = np.linspace(-9, 9, 10)
         zs = [0, 4, 8, 12, 16, 20, 24, 28, 32, 36]
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], self.image):
             assert_element_equal(self.image.sample(y=5),
-                             Curve((xs, zs), kdims=['x'], vdims=['z']))
+                             hv.Curve((xs, zs), kdims=['x'], vdims=['z']))
 
     def test_sample_coords(self):
         arr = np.arange(10)*np.arange(5)[np.newaxis].T
         xs = np.linspace(0.12, 0.81, 10)
         ys = np.linspace(0.12, 0.391, 5)
-        img = Image((xs, ys, arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype])
+        img = hv.Image((xs, ys, arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype])
         sampled = img.sample([(0.15, 0.15), (0.15, 0.4), (0.8, 0.4), (0.8, 0.15)])
-        assert isinstance(sampled, Table)
+        assert isinstance(sampled, hv.Table)
         yidx = [0, 4, 4, 0]
         xidx = [0, 0, 9, 9]
-        table = Table((xs[xidx], ys[yidx], arr[yidx, xidx]), kdims=['x', 'y'], vdims=['z'])
+        table = hv.Table((xs[xidx], ys[yidx], arr[yidx, xidx]), kdims=['x', 'y'], vdims=['z'])
         assert_element_equal(sampled, table)
 
     def test_reduce_to_scalar(self):
@@ -285,30 +285,30 @@ class BaseImageElementInterfaceTests(InterfaceTests):
     def test_reduce_x_dimension(self):
         ys = np.linspace(0.5, 9.5, 10)
         zs = [0., 4.5, 9., 13.5, 18., 22.5, 27., 31.5, 36., 40.5]
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], Image):
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], hv.Image):
             assert_element_equal(self.image.reduce(x=np.mean),
-                             Curve((ys, zs), kdims=['y'], vdims=['z']))
+                             hv.Curve((ys, zs), kdims=['y'], vdims=['z']))
 
     def test_reduce_y_dimension(self):
         xs = np.linspace(-9, 9, 10)
         zs = [0., 4.5, 9., 13.5, 18., 22.5, 27., 31.5, 36., 40.5]
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], Image):
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], hv.Image):
             assert_element_equal(self.image.reduce(y=np.mean),
-                             Curve((xs, zs), kdims=['x'], vdims=['z']))
+                             hv.Curve((xs, zs), kdims=['x'], vdims=['z']))
 
     def test_dataset_reindex_constant(self):
         with DatatypeContext([self.datatype, 'dictionary', 'dataframe', 'grid'], self.image):
-            selected = Dataset(self.image.select(x=0))
+            selected = hv.Dataset(self.image.select(x=0))
             reindexed = selected.reindex(['y'])
-        data = Dataset(selected.columns(['y', 'z']),
+        data = hv.Dataset(selected.columns(['y', 'z']),
                        kdims=['y'], vdims=['z'])
         assert_element_equal(reindexed, data)
 
     def test_dataset_reindex_non_constant(self):
         with DatatypeContext([self.datatype, 'dictionary', 'dataframe', 'grid'], self.image):
-            ds = Dataset(self.image)
+            ds = hv.Dataset(self.image)
             reindexed = ds.reindex(['y'])
-        data = Dataset(ds.columns(['y', 'z']),
+        data = hv.Dataset(ds.columns(['y', 'z']),
                        kdims=['y'], vdims=['z'])
         assert_element_equal(reindexed, data)
 
@@ -318,7 +318,7 @@ class BaseImageElementInterfaceTests(InterfaceTests):
         xs = self.image.dimension_values('x', expanded=False)
         mean = self.array.mean(axis=0)
         std = self.array.std(axis=0)
-        assert_element_equal(agg, Curve((xs, mean, std), kdims=['x'],
+        assert_element_equal(agg, hv.Curve((xs, mean, std), kdims=['x'],
                                     vdims=['z', 'z_std']))
 
 
@@ -332,7 +332,7 @@ class ImageElement_ImageInterfaceTests(BaseImageElementInterfaceTests):
 
 class BaseRGBElementInterfaceTests(InterfaceTests):
 
-    element = RGB
+    element = hv.RGB
 
     __test__ = False
 
@@ -342,7 +342,7 @@ class BaseRGBElementInterfaceTests(InterfaceTests):
         self.rgb_array = np.random.rand(10, 10, 3)
 
     def init_data(self):
-        self.rgb = RGB(self.rgb_array[::-1], bounds=(-10, 0, 10, 10))
+        self.rgb = hv.RGB(self.rgb_array[::-1], bounds=(-10, 0, 10, 10))
 
     def test_init_bounds(self):
         assert self.rgb.bounds.lbrt() == (-10, 0, 10, 10)
@@ -410,21 +410,21 @@ class BaseRGBElementInterfaceTests(InterfaceTests):
     def test_select_value_dimension_rgb(self):
 
         assert_element_equal(self.rgb[..., 'R'],
-                         Image(np.flipud(self.rgb_array[:, :, 0]), bounds=self.rgb.bounds,
-                               vdims=[Dimension('R', range=(0, 1))], datatype=['image']))
+                         hv.Image(np.flipud(self.rgb_array[:, :, 0]), bounds=self.rgb.bounds,
+                               vdims=[hv.Dimension('R', range=(0, 1))], datatype=['image']))
 
     def test_select_single_coordinate(self):
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], self.rgb):
             assert_element_equal(self.rgb[5.2, 3.1],
                              self.rgb.clone([tuple(self.rgb_array[3, 7])],
-                                            kdims=[], new_type=Dataset))
+                                            kdims=[], new_type=hv.Dataset))
 
 
     def test_reduce_to_single_values(self):
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], self.rgb):
             assert_element_equal(self.rgb.reduce(['x', 'y'], function=np.mean),
                              self.rgb.clone([tuple(np.mean(self.rgb_array, axis=(0, 1)))],
-                                            kdims=[], new_type=Dataset))
+                                            kdims=[], new_type=hv.Dataset))
 
     def test_sample_xcoord(self):
         ys = np.linspace(0.5, 9.5, 10)
@@ -432,7 +432,7 @@ class BaseRGBElementInterfaceTests(InterfaceTests):
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], self.rgb):
             assert_element_equal(self.rgb.sample(x=5),
                              self.rgb.clone(data, kdims=['y'],
-                                            new_type=Curve))
+                                            new_type=hv.Curve))
 
     def test_sample_ycoord(self):
         xs = np.linspace(-9, 9, 10)
@@ -440,21 +440,21 @@ class BaseRGBElementInterfaceTests(InterfaceTests):
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], self.rgb):
             assert_element_equal(self.rgb.sample(y=5),
                              self.rgb.clone(data, kdims=['x'],
-                                            new_type=Curve))
+                                            new_type=hv.Curve))
 
     def test_dataset_reindex_constant(self):
         with DatatypeContext([self.datatype, 'dictionary', 'dataframe', 'grid'], self.rgb):
-            ds = Dataset(self.rgb.select(x=0))
+            ds = hv.Dataset(self.rgb.select(x=0))
             reindexed = ds.reindex(['y'], ['R'])
-        data = Dataset(ds.columns(['y', 'R']),
+        data = hv.Dataset(ds.columns(['y', 'R']),
                        kdims=['y'], vdims=[ds.vdims[0]])
         assert_element_equal(reindexed, data)
 
     def test_dataset_reindex_non_constant(self):
         with DatatypeContext([self.datatype, 'dictionary' , 'dataframe', 'grid'], self.rgb):
-            ds = Dataset(self.rgb)
+            ds = hv.Dataset(self.rgb)
             reindexed = ds.reindex(['y'], ['R'])
-        data = Dataset(ds.columns(['y', 'R']),
+        data = hv.Dataset(ds.columns(['y', 'R']),
                        kdims=['y'], vdims=[ds.vdims[0]])
         assert_element_equal(reindexed, data)
 
@@ -471,7 +471,7 @@ class RGBElement_ImageInterfaceTests(BaseRGBElementInterfaceTests):
 
 class BaseHSVElementInterfaceTests(InterfaceTests):
 
-    element = HSV
+    element = hv.HSV
 
     __test__ = False
 
@@ -482,7 +482,7 @@ class BaseHSVElementInterfaceTests(InterfaceTests):
         self.hsv_array[0, 0] = 1
 
     def init_data(self):
-        self.hsv = HSV(self.hsv_array[::-1], bounds=(-10, 0, 10, 10))
+        self.hsv = hv.HSV(self.hsv_array[::-1], bounds=(-10, 0, 10, 10))
 
     def test_hsv_rgb_interface(self):
         R = self.hsv.rgb[..., 'R'].dimension_values(2, expanded=False, flat=False)

--- a/holoviews/tests/core/data/test_multiinterface.py
+++ b/holoviews/tests/core/data/test_multiinterface.py
@@ -9,8 +9,8 @@ import pandas as pd
 import pytest
 from param import get_logger
 
-from holoviews.core.data import Dataset, MultiInterface
-from holoviews.element import Path, Points, Polygons
+import holoviews as hv
+from holoviews.core.data import MultiInterface
 from holoviews.testing import assert_data_equal, assert_element_equal
 
 
@@ -27,14 +27,14 @@ class GeomTests:
 
     def test_array_dataset(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         for i, array in enumerate(mds.split(datatype='array')):
             assert_data_equal(array, arrays[i])
 
     def test_dict_dataset(self):
         dicts = [{'x': np.arange(i, i+2), 'y': np.arange(i, i+2)} for i in range(2)]
-        mds = Path(dicts, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path(dicts, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         for i, cols in enumerate(mds.split(datatype='columns')):
             output = dict(cols)
@@ -49,51 +49,51 @@ class GeomTests:
     def test_df_dataset(self):
         dfs = [pd.DataFrame(np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]), columns=['x', 'y'])
                   for i in range(2)]
-        mds = Path(dfs, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path(dfs, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         for i, ds in enumerate(mds.split(datatype='dataframe')):
             assert_data_equal(ds, dfs[i])
 
     def test_array_dataset_add_dimension_scalar(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype]).add_dimension('A', 0, 'Scalar', True)
+        mds = hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype]).add_dimension('A', 0, 'Scalar', True)
         assert mds.interface is self.interface
-        assert_element_equal(mds, Path([{('x', 'y'): arrays[i], 'A': 'Scalar'} for i in range(2)],
+        assert_element_equal(mds, hv.Path([{('x', 'y'): arrays[i], 'A': 'Scalar'} for i in range(2)],
                                    ['x', 'y'], 'A'))
 
     def test_dict_dataset_add_dimension_scalar(self):
         arrays = [{'x': np.arange(i, i+2), 'y': np.arange(i, i+2)} for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype]).add_dimension('A', 0, 'Scalar', True)
+        mds = hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype]).add_dimension('A', 0, 'Scalar', True)
         assert mds.interface is self.interface
-        assert_element_equal(mds, Path([dict(arrays[i], A='Scalar') for i in range(2)], ['x', 'y'],
+        assert_element_equal(mds, hv.Path([dict(arrays[i], A='Scalar') for i in range(2)], ['x', 'y'],
                                    'A', datatype=['multitabular']))
 
     def test_dict_dataset_add_dimension_values(self):
         arrays = [{'x': np.arange(i, i+2), 'y': np.arange(i, i+2)} for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype]).add_dimension('A', 0, [0,1], True)
+        mds = hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype]).add_dimension('A', 0, [0,1], True)
         assert mds.interface is self.interface
-        assert_element_equal(mds, Path([dict(arrays[i], A=i) for i in range(2)], ['x', 'y'],
+        assert_element_equal(mds, hv.Path([dict(arrays[i], A=i) for i in range(2)], ['x', 'y'],
                                    'A', datatype=['multitabular']))
 
     def test_array_length(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert len(mds) == 2
 
     def test_array_length_points(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
-        mds = Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert len(mds) == 4
 
     def test_empty_length(self):
-        mds = Path([], kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path([], kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert len(mds) == 0
 
     def test_empty_range(self):
-        mds = Path([], kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path([], kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         x0, _x1 = mds.range(0)
         assert not np.isfinite(x0)
@@ -104,41 +104,41 @@ class GeomTests:
 
     def test_array_range(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert mds.range(0) == (0, 2)
 
     def test_array_shape(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert mds.shape == (2, 2)
 
     def test_array_shape_points(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
-        mds = Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert mds.shape == (4, 2)
 
     def test_empty_shape(self):
-        mds = Path([], kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path([], kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert mds.shape == (0, 2)
 
     def test_array_values(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert_data_equal(mds.dimension_values(0), np.array([0., 1, np.nan, 1, 2]))
 
     def test_empty_array_values(self):
-        mds = Path([], kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path([], kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert_data_equal(mds.dimension_values(0), np.array([]))
 
     def test_array_values_coordinates_nonexpanded(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         values = mds.dimension_values(0, expanded=False)
         assert_data_equal(values[0], np.array([0., 1]))
@@ -146,54 +146,54 @@ class GeomTests:
 
     def test_array_values_coordinates_nonexpanded_constant_kdim(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2), np.ones(2)*i]) for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype])
+        mds = hv.Path(arrays, kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert_data_equal(mds.dimension_values(2, expanded=False), np.array([0, 1]))
 
     def test_scalar_value_isscalar_per_geom(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': 0},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': 0},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': 1}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
         assert path.interface.isscalar(path, 'value', per_geom=True)
 
     def test_unique_values_isscalar_per_geom(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.full(5, 0)},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.full(5, 0)},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': np.full(5, 1)}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
         assert path.interface.isscalar(path, 'value', per_geom=True)
 
     def test_scalar_and_unique_values_isscalar_per_geom(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': 0},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': 0},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': np.full(5, 1)}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
         assert path.interface.isscalar(path, 'value', per_geom=True)
 
     def test_varying_values_not_isscalar_per_geom(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.arange(5)},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.arange(5)},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': np.full(5, 1)}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
         assert not path.interface.isscalar(path, 'value', per_geom=True)
 
     def test_varying_values_and_scalar_not_isscalar_per_geom(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.arange(5)},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.arange(5)},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': 1}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
         assert not path.interface.isscalar(path, 'value', per_geom=True)
 
     def test_scalar_value_dimension_values_expanded(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': 0},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': 0},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': 1}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
         assert_data_equal(path.dimension_values('value'), np.array([0, 0, 0, 0, 0, np.nan, 1, 1, 1, 1, 1]))
 
     def test_scalar_value_dimension_values_not_expanded(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': 0},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': 0},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': 1}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
@@ -201,14 +201,14 @@ class GeomTests:
                          np.array([0, 1]))
 
     def test_unique_value_dimension_values_expanded(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.full(5, 0)},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.full(5, 0)},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': np.full(5, 1)}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
         assert_data_equal(path.dimension_values('value'), np.array([0, 0, 0, 0, 0, np.nan, 1, 1, 1, 1, 1]))
 
     def test_unique_value_dimension_values_not_expanded(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.full(5, 0)},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.full(5, 0)},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': np.full(5, 1)}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
@@ -216,14 +216,14 @@ class GeomTests:
                          np.array([0, 1]))
 
     def test_varying_value_dimension_values_expanded(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.arange(5)},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.arange(5)},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': np.full(5, 1)}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
         assert_data_equal(path.dimension_values('value'), np.array([0, 1, 2, 3, 4, np.nan, 1, 1, 1, 1, 1]))
 
     def test_varying_value_dimension_values_not_expanded(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.arange(5)},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': np.arange(5)},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': np.full(5, 1)}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
@@ -234,80 +234,80 @@ class GeomTests:
 
     def test_array_redim(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype]).redim(x='x2')
+        mds = hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype]).redim(x='x2')
         assert mds.interface is self.interface
-        assert_element_equal(mds, Path([arrays[i] for i in range(2)], ['x2', 'y']))
+        assert_element_equal(mds, hv.Path([arrays[i] for i in range(2)], ['x2', 'y']))
 
     def test_mixed_dims_raises(self):
         arrays = [{'x': range(10), 'y' if j else 'z': range(10)}
                   for i in range(2) for j in range(2)]
         with pytest.raises(ValueError):  # noqa: PT011
-            Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+            hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
 
     def test_split_into_arrays(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         for arr1, arr2 in zip(mds.split(datatype='array'), arrays, strict=True):
             assert_data_equal(arr1, arr2)
 
     def test_split_empty(self):
-        mds = Path([], kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path([], kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert len(mds.split()) == 0
 
     def test_values_empty(self):
-        mds = Path([], kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Path([], kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert_data_equal(mds.dimension_values(0), np.array([]))
 
     def test_dict_groupby_non_scalar(self):
         arrays = [{'x': np.arange(i, i+2), 'y': i} for i in range(2)]
-        mds = Dataset(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Dataset(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         with pytest.raises(ValueError):  # noqa: PT011
             mds.groupby('x')
 
     def test_array_groupby_non_scalar(self):
         arrays = [np.array([(1+i, i), (2+i, i), (3+i, i)]) for i in range(2)]
-        mds = Dataset(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Dataset(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         with pytest.raises(ValueError):  # noqa: PT011
             mds.groupby('x')
 
     def test_array_points_iloc_index_row(self):
         arrays = [np.array([(1+i, i), (2+i, i), (3+i, i)]) for i in range(2)]
-        mds = Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
-        assert_element_equal(mds.iloc[1], Points([(2, 0)], ['x', 'y']))
+        assert_element_equal(mds.iloc[1], hv.Points([(2, 0)], ['x', 'y']))
 
     def test_array_points_iloc_slice_rows(self):
         arrays = [np.array([(1+i, i), (2+i, i), (3+i, i)]) for i in range(2)]
-        mds = Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
-        assert_element_equal(mds.iloc[2:4], Points([(3, 0), (2, 1)], ['x', 'y']))
+        assert_element_equal(mds.iloc[2:4], hv.Points([(3, 0), (2, 1)], ['x', 'y']))
 
     def test_array_points_iloc_slice_rows_no_start(self):
         arrays = [np.array([(1+i, i), (2+i, i), (3+i, i)]) for i in range(2)]
-        mds = Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
-        assert_element_equal(mds.iloc[:4], Points([(1, 0), (2, 0), (3, 0), (2, 1)], ['x', 'y']))
+        assert_element_equal(mds.iloc[:4], hv.Points([(1, 0), (2, 0), (3, 0), (2, 1)], ['x', 'y']))
 
     def test_array_points_iloc_slice_rows_no_stop(self):
         arrays = [np.array([(1+i, i), (2+i, i), (3+i, i)]) for i in range(2)]
-        mds = Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
-        assert_element_equal(mds.iloc[2:], Points([(3, 0), (2, 1), (3, 1), (4, 1)], ['x', 'y']))
+        assert_element_equal(mds.iloc[2:], hv.Points([(3, 0), (2, 1), (3, 1), (4, 1)], ['x', 'y']))
 
     def test_array_points_iloc_index_rows(self):
         arrays = [np.array([(1+i, i), (2+i, i), (3+i, i)]) for i in range(2)]
-        mds = Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
-        assert_element_equal(mds.iloc[[1, 3, 4]], Points([(2, 0), (2, 1), (3, 1)], ['x', 'y']))
+        assert_element_equal(mds.iloc[[1, 3, 4]], hv.Points([(2, 0), (2, 1), (3, 1)], ['x', 'y']))
 
     def test_array_points_iloc_index_rows_index_cols(self):
         arrays = [np.array([(1+i, i), (2+i, i), (3+i, i)]) for i in range(2)]
-        mds = Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Points(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         assert mds.iloc[3, 0] == 2
         assert mds.iloc[3, 1] == 1
@@ -319,10 +319,10 @@ class GeomTests:
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 2}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
-        expected = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1}],
+        expected = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1}],
                             ['x', 'y'], 'z', datatype=[self.datatype])
         assert poly.interface is self.interface
         assert_element_equal(poly.iloc[0], expected)
@@ -334,11 +334,11 @@ class GeomTests:
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 2},
                          {'x': xs, 'y': ys, 'z': 3}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
-        expected = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
+        expected = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
                              {'x': xs, 'y': ys, 'holes': holes, 'z': 3}],
                             ['x', 'y'], 'z', datatype=[self.datatype])
         assert poly.interface is self.interface
@@ -351,11 +351,11 @@ class GeomTests:
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 2},
                          {'x': xs, 'y': ys, 'z': 3}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
-        expected = Polygons([{'x': xs[::-1], 'y': ys[::-1], 'z': 2},
+        expected = hv.Polygons([{'x': xs[::-1], 'y': ys[::-1], 'z': 2},
                              {'x': xs, 'y': ys, 'holes': holes, 'z': 3}],
                             ['x', 'y'], 'z', datatype=[self.datatype])
         assert poly.interface is self.interface
@@ -364,7 +364,7 @@ class GeomTests:
     def test_polygon_expanded_values(self):
         xs = [1, 2, 3]
         ys = [2, 0, 7]
-        poly = Polygons([{'x': xs, 'y': ys, 'z': 1}],
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'z': 1}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
         assert_data_equal(poly.dimension_values(0), np.array([1, 2, 3, 1]))
         assert_data_equal(poly.dimension_values(1), np.array([2, 0, 7, 2]))
@@ -373,7 +373,7 @@ class GeomTests:
     def test_polygons_expanded_values(self):
         xs = [1, 2, 3]
         ys = [2, 0, 7]
-        poly = Polygons([{'x': xs, 'y': ys, 'z': 1},
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'z': 1},
                          {'x': xs, 'y': ys, 'z': 2}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
         assert_data_equal(poly.dimension_values(0), np.array([1, 2, 3, 1, np.nan, 1, 2, 3, 1]))
@@ -383,7 +383,7 @@ class GeomTests:
     def test_multi_polygon_expanded_values(self):
         xs = [1, 2, 3, np.nan, 1, 2, 3]
         ys = [2, 0, 7, np.nan, 2, 0, 7]
-        poly = Polygons([{'x': xs, 'y': ys, 'z': 1}],
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'z': 1}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
         assert_data_equal(poly.dimension_values(0), np.array([1, 2, 3, 1, np.nan, 1, 2, 3, 1]))
         assert_data_equal(poly.dimension_values(1), np.array([2, 0, 7, 2, np.nan, 2, 0, 7, 2]))
@@ -395,7 +395,7 @@ class GeomTests:
         holes = [
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5), (2.1, 4.5)]]
         ]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 2}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
         holes = [
@@ -412,7 +412,7 @@ class GeomTests:
             [[(1.5, 2), (2, 3), (1.6, 1.6), (1.5, 2)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 2}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
         holes = [
@@ -423,7 +423,7 @@ class GeomTests:
         np.testing.assert_equal(poly.holes(), holes)
 
     def test_polygon_dtype(self):
-        poly = Polygons([{'x': [1, 2, 3], 'y': [2, 0, 7]}], datatype=[self.datatype])
+        poly = hv.Polygons([{'x': [1, 2, 3], 'y': [2, 0, 7]}], datatype=[self.datatype])
         assert poly.interface is self.interface
         assert poly.interface.dtype(poly, 'x') == np.dtype('int')
 
@@ -434,10 +434,10 @@ class GeomTests:
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 2}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
-        expected = Polygons([{'x': xs[::-1], 'y': ys[::-1], 'z': 2}],
+        expected = hv.Polygons([{'x': xs[::-1], 'y': ys[::-1], 'z': 2}],
                             ['x', 'y'], 'z', datatype=[self.datatype])
         assert poly.interface is self.interface
         assert_element_equal(poly.select(z=2), expected)
@@ -449,11 +449,11 @@ class GeomTests:
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 2},
                          {'x': xs[:3], 'y': ys[:3], 'z': 3}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
-        expected = Polygons([{'x': xs[::-1], 'y': ys[::-1], 'z': 2},
+        expected = hv.Polygons([{'x': xs[::-1], 'y': ys[::-1], 'z': 2},
                              {'x': xs[:3], 'y': ys[:3], 'z': 3}],
                             ['x', 'y'], 'z', datatype=[self.datatype])
         assert poly.interface is self.interface
@@ -466,22 +466,22 @@ class GeomTests:
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 2},
                          {'x': xs[:3], 'y': ys[:3], 'z': 3}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
-        expected = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
+        expected = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
                              {'x': xs[:3], 'y': ys[:3], 'z': 3}],
                             ['x', 'y'], 'z', datatype=[self.datatype])
         assert poly.interface is self.interface
         assert_element_equal(poly.select(z=[1, 3]), expected)
 
     def test_sort_by_value(self):
-        path = Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': 1},
+        path = hv.Path([{'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': 1},
                      {'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': 0}],
                     vdims='value', datatype=[self.datatype])
         assert path.interface is self.interface
-        sorted = Path([{'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': 0},
+        sorted = hv.Path([{'x': [5, 4, 3, 2, 1], 'y': [2, 2, 1, 1, 0], 'value': 0},
                      {'x': [1, 2, 3, 4, 5], 'y': [0, 0, 1, 1, 2], 'value': 1}], vdims='value')
         assert_element_equal(path.sort('value'), sorted)
 
@@ -522,6 +522,6 @@ def test_narwhals_multidict():
     import narwhals.stable.v2 as nw
 
     df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
-    pd_el = Path(df, kdims=["A", "B"], vdims=[])
-    nw_el = Path(nw.from_native(df), kdims=["A", "B"], vdims=[])
+    pd_el = hv.Path(df, kdims=["A", "B"], vdims=[])
+    nw_el = hv.Path(nw.from_native(df), kdims=["A", "B"], vdims=[])
     pd.testing.assert_frame_equal(pd_el.data[0], nw_el.data[0].to_pandas())

--- a/holoviews/tests/core/data/test_narwhalsinterface.py
+++ b/holoviews/tests/core/data/test_narwhalsinterface.py
@@ -5,7 +5,7 @@ import narwhals.stable.v2 as nw
 import numpy as np
 import pytest
 
-from holoviews import Dataset, Dimension
+import holoviews as hv
 from holoviews.core.data import NarwhalsInterface
 from holoviews.testing import assert_data_equal
 
@@ -117,8 +117,8 @@ class BaseNarwhalsInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
 
     def test_dataset_range_with_dimension_range(self):
         dt64 = [datetime(2017, 1, i) for i in range(1, 4)]
-        ds = Dataset(
-            self.frame({"Date": dt64}), [Dimension("Date", range=(dt64[0], dt64[-1]))]
+        ds = hv.Dataset(
+            self.frame({"Date": dt64}), [hv.Dimension("Date", range=(dt64[0], dt64[-1]))]
         )
         assert ds.range("Date") == (dt64[0], dt64[-1])
 
@@ -152,7 +152,7 @@ class BaseNarwhalsInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
             "day": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
             "count": [1, 2, 3, 4, 5, 6, 7],
         }))
-        ds = Dataset(df, kdims=["day"], vdims=["count"])
+        ds = hv.Dataset(df, kdims=["day"], vdims=["count"])
         assert ds["Mon"] == 1
 
     def test_non_scalar_getitem(self):
@@ -160,7 +160,7 @@ class BaseNarwhalsInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
             "day": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
             "count": [1, 2, 3, 4, 5, 6, 7],
         }))
-        ds = Dataset(df, kdims=["day"], vdims=["count"])
+        ds = hv.Dataset(df, kdims=["day"], vdims=["count"])
         result = ds[["Mon"]].data
         assert isinstance(result, self.data_type)
         if isinstance(result, nw.LazyFrame):

--- a/holoviews/tests/core/data/test_pandasinterface.py
+++ b/holoviews/tests/core/data/test_pandasinterface.py
@@ -2,13 +2,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core.data import Dataset
+import holoviews as hv
 from holoviews.core.data.interface import DataError
 from holoviews.core.data.pandas import PandasInterface
-from holoviews.core.dimension import Dimension
-from holoviews.core.spaces import HoloMap
 from holoviews.core.util.dependencies import PANDAS_GE_3_0_0
-from holoviews.element import Distribution, Points, Scatter
 from holoviews.testing import assert_element_equal
 
 from .base import HeterogeneousColumnTests, InterfaceTests
@@ -24,154 +21,154 @@ class BasePandasInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
     frame = pd.DataFrame
 
     def test_duplicate_dimension_constructor(self):
-        ds = Dataset(([1, 2, 3], [1, 2, 3]), ['A', 'B'], ['A'])
+        ds = hv.Dataset(([1, 2, 3], [1, 2, 3]), ['A', 'B'], ['A'])
         assert list(ds.data.columns) == ['A', 'B']
 
     def test_dataset_empty_list_init_dtypes(self):
-        dataset = Dataset([], kdims=['x'], vdims=['y'])
+        dataset = hv.Dataset([], kdims=['x'], vdims=['y'])
         for d in 'xy':
             assert dataset.dimension_values(d).dtype == np.float64
 
     def test_dataset_series_construct(self):
-        ds = Scatter(pd.Series([1, 2, 3], name='A'))
-        assert_element_equal(ds, Scatter(([0, 1, 2], [1, 2, 3]), 'index', 'A'))
+        ds = hv.Scatter(pd.Series([1, 2, 3], name='A'))
+        assert_element_equal(ds, hv.Scatter(([0, 1, 2], [1, 2, 3]), 'index', 'A'))
 
     def test_dataset_df_construct_autoindex(self):
-        ds = Scatter(pd.DataFrame([1, 2, 3], columns=['A'], index=[1, 2, 3]), 'test', 'A')
-        assert_element_equal(ds, Scatter(([0, 1, 2], [1, 2, 3]), 'test', 'A'))
+        ds = hv.Scatter(pd.DataFrame([1, 2, 3], columns=['A'], index=[1, 2, 3]), 'test', 'A')
+        assert_element_equal(ds, hv.Scatter(([0, 1, 2], [1, 2, 3]), 'test', 'A'))
 
     def test_dataset_df_construct_not_autoindex(self):
-        ds = Scatter(pd.DataFrame([1, 2, 3], columns=['A'], index=[1, 2, 3]), 'index', 'A')
-        assert_element_equal(ds, Scatter(([1, 2, 3], [1, 2, 3]), 'index', 'A'))
+        ds = hv.Scatter(pd.DataFrame([1, 2, 3], columns=['A'], index=[1, 2, 3]), 'index', 'A')
+        assert_element_equal(ds, hv.Scatter(([1, 2, 3], [1, 2, 3]), 'index', 'A'))
 
     def test_dataset_single_column_construct(self):
-        ds = Scatter(pd.DataFrame([1, 2, 3], columns=['A']))
-        assert_element_equal(ds, Scatter(([0, 1, 2], [1, 2, 3]), 'index', 'A'))
+        ds = hv.Scatter(pd.DataFrame([1, 2, 3], columns=['A']))
+        assert_element_equal(ds, hv.Scatter(([0, 1, 2], [1, 2, 3]), 'index', 'A'))
 
     def test_dataset_df_duplicate_columns_raises(self):
         df = pd.DataFrame(np.random.randint(-100,100, size=(100, 2)), columns=list("AB"))
         with pytest.raises(DataError):
-            Dataset(df[['A', 'A']])
+            hv.Dataset(df[['A', 'A']])
 
     def test_dataset_extract_vdims(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])
-        ds = Dataset(df, kdims=['x'])
-        assert ds.vdims == [Dimension('y'), Dimension('z')]
+        ds = hv.Dataset(df, kdims=['x'])
+        assert ds.vdims == [hv.Dimension('y'), hv.Dimension('z')]
 
     def test_dataset_process_index(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])
-        ds = Dataset(df, 'index')
-        assert ds.kdims == [Dimension('index')]
-        assert ds.vdims == [Dimension('x'), Dimension('y'), Dimension('z')]
+        ds = hv.Dataset(df, 'index')
+        assert ds.kdims == [hv.Dimension('index')]
+        assert ds.vdims == [hv.Dimension('x'), hv.Dimension('y'), hv.Dimension('z')]
 
     def test_dataset_extract_kdims_and_vdims_no_bounds(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])
-        ds = Dataset(df)
-        assert ds.kdims == [Dimension('x'), Dimension('y'), Dimension('z')]
+        ds = hv.Dataset(df)
+        assert ds.kdims == [hv.Dimension('x'), hv.Dimension('y'), hv.Dimension('z')]
         assert ds.vdims == []
 
     def test_dataset_extract_kdims(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])
-        ds = Distribution(df)
-        assert ds.kdims == [Dimension('x')]
+        ds = hv.Distribution(df)
+        assert ds.kdims == [hv.Dimension('x')]
 
     def test_dataset_extract_kdims_and_vdims(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])
-        ds = Points(df)
-        assert ds.kdims == [Dimension('x'), Dimension('y')]
-        assert ds.vdims == [Dimension('z')]
+        ds = hv.Points(df)
+        assert ds.kdims == [hv.Dimension('x'), hv.Dimension('y')]
+        assert ds.vdims == [hv.Dimension('z')]
 
     def test_dataset_element_allowing_two_kdims_with_one_default_kdim(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])
-        ds = Scatter(df)
-        assert ds.kdims == [Dimension('x')]
-        assert ds.vdims == [Dimension('y'), Dimension('z')]
+        ds = hv.Scatter(df)
+        assert ds.kdims == [hv.Dimension('x')]
+        assert ds.vdims == [hv.Dimension('y'), hv.Dimension('z')]
 
     def test_dataset_extract_kdims_with_vdims_defined(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])
-        ds = Points(df, vdims=['x'])
-        assert ds.kdims == [Dimension('y'), Dimension('z')]
-        assert ds.vdims == [Dimension('x')]
+        ds = hv.Points(df, vdims=['x'])
+        assert ds.kdims == [hv.Dimension('y'), hv.Dimension('z')]
+        assert ds.vdims == [hv.Dimension('x')]
 
     def test_dataset_extract_all_kdims_with_vdims_defined(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])
-        ds = Dataset(df, vdims=['x'])
-        assert ds.kdims == [Dimension('y'), Dimension('z')]
-        assert ds.vdims == [Dimension('x')]
+        ds = hv.Dataset(df, vdims=['x'])
+        assert ds.kdims == [hv.Dimension('y'), hv.Dimension('z')]
+        assert ds.vdims == [hv.Dimension('x')]
 
     def test_dataset_extract_kdims_declare_no_vdims(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])
-        ds = Points(df, vdims=[])
-        assert ds.kdims == [Dimension('x'), Dimension('y')]
+        ds = hv.Points(df, vdims=[])
+        assert ds.kdims == [hv.Dimension('x'), hv.Dimension('y')]
         assert ds.vdims == []
 
     def test_dataset_extract_no_kdims_extract_only_vdims(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])
-        ds = Dataset(df, kdims=[])
+        ds = hv.Dataset(df, kdims=[])
         assert ds.kdims == []
-        assert ds.vdims == [Dimension('x'), Dimension('y'), Dimension('z')]
+        assert ds.vdims == [hv.Dimension('x'), hv.Dimension('y'), hv.Dimension('z')]
 
     def test_dataset_extract_vdims_with_kdims_defined(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])
-        ds = Points(df, kdims=['x', 'z'])
-        assert ds.kdims == [Dimension('x'), Dimension('z')]
-        assert ds.vdims == [Dimension('y')]
+        ds = hv.Points(df, kdims=['x', 'z'])
+        assert ds.kdims == [hv.Dimension('x'), hv.Dimension('z')]
+        assert ds.vdims == [hv.Dimension('y')]
 
     def test_multi_dimension_groupby(self):
         x, y, z = list('AB'*10), np.arange(20)%3, np.arange(20)
-        ds = Dataset((x, y, z), kdims=['x', 'y'], vdims=['z'],  datatype=[self.datatype])
+        ds = hv.Dataset((x, y, z), kdims=['x', 'y'], vdims=['z'],  datatype=[self.datatype])
         keys = [('A', 0), ('B', 1), ('A', 2), ('B', 0), ('A', 1), ('B', 2)]
         grouped = ds.groupby(['x', 'y'])
         assert grouped.keys() == keys
-        group = Dataset({'z': [5, 11, 17]}, vdims=['z'])
+        group = hv.Dataset({'z': [5, 11, 17]}, vdims=['z'])
         assert_element_equal(grouped.last, group)
 
     def test_dataset_simple_dict_sorted(self):
-        dataset = Dataset({2: 2, 1: 1, 3: 3}, kdims=['x'], vdims=['y'])
-        assert_element_equal(dataset, Dataset([(i, i) for i in range(1, 4)],
+        dataset = hv.Dataset({2: 2, 1: 1, 3: 3}, kdims=['x'], vdims=['y'])
+        assert_element_equal(dataset, hv.Dataset([(i, i) for i in range(1, 4)],
                                           kdims=['x'], vdims=['y']))
 
     def test_dataset_conversion_with_index(self):
         df = pd.DataFrame({'y': [1, 2, 3]}, index=[0, 1, 2])
-        scatter = Dataset(df).to(Scatter, 'index', 'y')
-        assert_element_equal(scatter, Scatter(([0, 1, 2], [1, 2, 3]), 'index', 'y'))
+        scatter = hv.Dataset(df).to(hv.Scatter, 'index', 'y')
+        assert_element_equal(scatter, hv.Scatter(([0, 1, 2], [1, 2, 3]), 'index', 'y'))
 
     def test_dataset_conversion_groupby_with_index(self):
         df = pd.DataFrame({'y': [1, 2, 3], 'x': [0, 0, 1]}, index=[0, 1, 2])
-        scatters = Dataset(df).to(Scatter, 'index', 'y')
-        hmap = HoloMap({0: Scatter(([0, 1], [1, 2]), 'index', 'y'),
-                        1: Scatter([(2, 3)], 'index', 'y')}, 'x')
+        scatters = hv.Dataset(df).to(hv.Scatter, 'index', 'y')
+        hmap = hv.HoloMap({0: hv.Scatter(([0, 1], [1, 2]), 'index', 'y'),
+                        1: hv.Scatter([(2, 3)], 'index', 'y')}, 'x')
         assert_element_equal(scatters, hmap)
 
     def test_dataset_from_multi_index(self):
         df = pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)})
-        ds = Dataset(df.groupby(['x', 'y']).mean(), ['x', 'y'])
-        assert_element_equal(ds, Dataset(df, ['x', 'y']))
+        ds = hv.Dataset(df.groupby(['x', 'y']).mean(), ['x', 'y'])
+        assert_element_equal(ds, hv.Dataset(df, ['x', 'y']))
 
     def test_dataset_from_multi_index_tuple_dims(self):
         df = pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)})
-        ds = Dataset(df.groupby(['x', 'y']).mean(), [('x', 'X'), ('y', 'Y')])
-        assert_element_equal(ds, Dataset(df, [('x', 'X'), ('y', 'Y')]))
+        ds = hv.Dataset(df.groupby(['x', 'y']).mean(), [('x', 'X'), ('y', 'Y')])
+        assert_element_equal(ds, hv.Dataset(df, [('x', 'X'), ('y', 'Y')]))
 
     def test_dataset_with_interface_column(self):
         df = pd.DataFrame([1], columns=['interface'])
-        ds = Dataset(df)
+        ds = hv.Dataset(df)
         assert list(ds.data.columns) == ['interface']
 
     def test_dataset_range_with_object_index(self):
         df = pd.DataFrame(range(4), columns=["values"], index=list("BADC"))
-        ds = Dataset(df, kdims='index')
+        ds = hv.Dataset(df, kdims='index')
         assert ds.range('index') == ('A', 'D')
 
     def test_dataset_dataset_ht_dtypes(self):
@@ -194,19 +191,19 @@ class PandasInterfaceTests(BasePandasInterfaceTests):
         dates = pd.date_range("2018-01-01", periods=3, freq="h")
         dates_tz = dates.tz_localize("UTC")
         df = pd.DataFrame({"dates": dates_tz})
-        data = Dataset(df).dimension_values("dates")
+        data = hv.Dataset(df).dimension_values("dates")
         np.testing.assert_equal(dates, data)
 
     def test_data_groupby_categorial(self):
         # Test for https://github.com/holoviz/holoviews/issues/6305
         df = pd.DataFrame({"y": [1, 2], "by": ["A", "B"]})
         df["by"] = pd.Categorical(df["by"])
-        ds = Dataset(df, kdims="index", vdims="y").to(Scatter, groupby="by")
+        ds = hv.Dataset(df, kdims="index", vdims="y").to(hv.Scatter, groupby="by")
         assert ds.keys() == ["A", "B"]
 
     @pytest.mark.xfail(reason="Breaks hvplot")
     def test_reindex(self):
-        ds = Dataset(pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)}))
+        ds = hv.Dataset(pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)}))
         df = ds.interface.reindex(ds, ['x'])
         assert df.index.names == ['x']
         df = ds.interface.reindex(ds, ['y'])
@@ -232,116 +229,116 @@ class PandasInterfaceMultiIndexTests(HeterogeneousColumnTests, InterfaceTests):
         from pandas.core.indexes.multi import _lexsort_depth  # noqa
 
     def test_no_kdims(self):
-        ds = Dataset(self.df)
-        assert ds.kdims == [Dimension("values")]
+        ds = hv.Dataset(self.df)
+        assert ds.kdims == [hv.Dimension("values")]
         assert isinstance(ds.data.index, pd.MultiIndex)
 
     def test_index_kdims(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
-        assert ds.kdims == [Dimension("number"), Dimension("color")]
-        assert ds.vdims == [Dimension("values")]
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
+        assert ds.kdims == [hv.Dimension("number"), hv.Dimension("color")]
+        assert ds.vdims == [hv.Dimension("values")]
         assert isinstance(ds.data.index, pd.MultiIndex)
 
     def test_index_aggregate(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         expected = pd.DataFrame({'number': [1, 2], 'values': [0.5, 2.5], 'values_var': [0.25, 0.25]})
         agg = ds.aggregate("number", function=np.mean, spreadfn=np.var)
         pd.testing.assert_frame_equal(agg.data, expected)
 
     def test_index_select_monotonic(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.select(number=1)
         expected = pd.DataFrame({'color': ['red', 'blue'], 'values': [0, 1], 'number': [1, 1]}).set_index(['number', 'color'])
         assert isinstance(selected.data.index, pd.MultiIndex)
         pd.testing.assert_frame_equal(selected.data, expected)
 
     def test_index_select(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.select(number=1)
         expected = pd.DataFrame({'color': ['red', 'blue'], 'values': [0, 1], 'number': [1, 1]}).set_index(['number', 'color'])
         assert isinstance(selected.data.index, pd.MultiIndex)
         pd.testing.assert_frame_equal(selected.data, expected)
 
     def test_index_select_all_indexes(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.select(number=1, color='red')
         assert selected == 0
 
     def test_index_select_all_indexes_lists(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.select(number=[1], color=['red'])
         expected = pd.DataFrame({'color': ['red'], 'values': [0], 'number': [1]}).set_index(['number', 'color'])
         assert isinstance(selected.data.index, pd.MultiIndex)
         pd.testing.assert_frame_equal(selected.data, expected)
 
     def test_index_select_all_indexes_slice_and_scalar(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.select(number=(0, 1), color='red')
         expected = pd.DataFrame({'color': ['red'], 'values': [0], 'number': [1]}).set_index(['number', 'color'])
         assert isinstance(selected.data.index, pd.MultiIndex)
         pd.testing.assert_frame_equal(selected.data, expected)
 
     def test_iloc_scalar_scalar_only_index(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[0, 0]
         expected = 1
         assert selected == expected
 
     def test_iloc_slice_scalar_only_index(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[:, 0]
         expected = self.df.reset_index()[["number"]]
         pd.testing.assert_frame_equal(selected.data, expected)
 
     def test_iloc_slice_slice_only_index(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[:, :2]
         expected = self.df.reset_index()[["number", "color"]]
         pd.testing.assert_frame_equal(selected.data, expected)
 
     def test_iloc_scalar_slice_only_index(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[0, :2]
         expected = pd.DataFrame({"number": 1, "color": "red"}, index=[0])
         pd.testing.assert_frame_equal(selected.data, expected)
 
     def test_iloc_scalar_scalar(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[0, 2]
         expected = 0
         assert selected == expected
 
     def test_iloc_slice_scalar(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[:, 2]
         expected = self.df.iloc[:, [0]]
         pd.testing.assert_frame_equal(selected.data, expected)
 
     def test_iloc_slice_slice(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[:, :3]
         expected = self.df.iloc[:, [0]]
         pd.testing.assert_frame_equal(selected.data, expected)
 
     def test_iloc_scalar_slice(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.iloc[0, :3]
         expected = self.df.iloc[[0], [0]]
         pd.testing.assert_frame_equal(selected.data, expected)
 
     def test_out_of_bounds(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         with pytest.raises(ValueError, match="column is out of bounds"):
             ds.iloc[0, 3]
 
     def test_sort(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         sorted_ds = ds.sort("color")
         np.testing.assert_array_equal(sorted_ds.dimension_values("values"), [1, 3, 0, 2])
         np.testing.assert_array_equal(sorted_ds.dimension_values("number"), [1, 2, 1, 2])
 
     def test_select_monotonic(self):
-        ds = Dataset(self.df.sort_index(), kdims=["number", "color"])
+        ds = hv.Dataset(self.df.sort_index(), kdims=["number", "color"])
         selected = ds.select(color="red")
         pd.testing.assert_frame_equal(selected.data, self.df.iloc[[0, 2], :])
 
@@ -352,14 +349,14 @@ class PandasInterfaceMultiIndexTests(HeterogeneousColumnTests, InterfaceTests):
         frame = pd.DataFrame({"number": [1, 1, 2, 2], "color": [2, 1, 2, 1]})
         index = pd.MultiIndex.from_frame(frame, names=frame.columns)
         df = pd.DataFrame(range(4), index=index, columns=["values"])
-        ds = Dataset(df, kdims=list(frame.columns))
+        ds = hv.Dataset(df, kdims=list(frame.columns))
 
         data = ds.select(color=slice(2, 3)).data
         expected = pd.DataFrame({"number": [1, 2], "color": [2, 2], "values": [0, 2]}).set_index(['number', 'color'])
         pd.testing.assert_frame_equal(data, expected)
 
     def test_select_not_in_index(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         selected = ds.select(number=[2, 3])
         expected = self.df.loc[[2]]
         pd.testing.assert_frame_equal(selected.data, expected)
@@ -369,29 +366,29 @@ class PandasInterfaceMultiIndexTests(HeterogeneousColumnTests, InterfaceTests):
         frame = pd.DataFrame({"number": [1, 1, 2, 2], "color": ["red", "blue", "red", "blue"]})
         index = pd.MultiIndex.from_frame(frame, names=("number", "color"))
         df = pd.DataFrame({"cat": list("abab"), "values": range(4)}, index=index)
-        ds = Dataset(df, kdims=["number"], vdims=["cat", "values"])
+        ds = hv.Dataset(df, kdims=["number"], vdims=["cat", "values"])
         selected = ds.select(number=[1], cat=["a"])
         expected = df[(df.index.get_level_values(0) == 1) & (df["cat"] == "a")]
         pd.testing.assert_frame_equal(selected.data, expected)
 
     def test_sample(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         sample = ds.interface.sample(ds, [1])
         assert sample.to_dict() == {'values': {(1, 'blue'): 1}}
 
         self.df.iloc[0, 0] = 1
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         sample = ds.interface.sample(ds, [1])
         assert sample.to_dict() == {'values': {(1, 'red'): 1, (1, 'blue'): 1}}
 
     def test_values(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         assert (ds.interface.values(ds, 'color') == ['red', 'blue', 'red', 'blue']).all()
         assert (ds.interface.values(ds, 'number') == [1, 1, 2, 2]).all()
         assert (ds.interface.values(ds, 'values') == [0, 1, 2, 3]).all()
 
     def test_reindex(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         df = ds.interface.reindex(ds, ['number', 'color'])
         assert df.index.names == ['number', 'color']
 
@@ -402,21 +399,21 @@ class PandasInterfaceMultiIndexTests(HeterogeneousColumnTests, InterfaceTests):
         assert df.index.names == ['values']
 
     def test_groupby_one_index(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         grouped = ds.groupby("number")
         assert list(grouped.keys()) == [1, 2]
         for k, v in grouped.items():
             pd.testing.assert_frame_equal(v.data, ds.select(number=k).data)
 
     def test_groupby_two_indexes(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         grouped = ds.groupby(["number", "color"])
         assert list(grouped.keys()) == list(self.df.index)
         for k, v in grouped.items():
             pd.testing.assert_frame_equal(v.data, ds.select(number=[k[0]], color=[k[1]]).data)
 
     def test_groupby_one_index_one_column(self):
-        ds = Dataset(self.df, kdims=["number", "color"])
+        ds = hv.Dataset(self.df, kdims=["number", "color"])
         grouped = ds.groupby('values')
         assert list(grouped.keys()) == [0, 1, 2, 3]
         for k, v in grouped.items():
@@ -433,7 +430,7 @@ class PandasInterfaceMultiIndexTests(HeterogeneousColumnTests, InterfaceTests):
     def test_regression_no_auto_index(self):
         # https://github.com/holoviz/holoviews/issues/6298
 
-        plot = Scatter(self.df, kdims="number")
+        plot = hv.Scatter(self.df, kdims="number")
         np.testing.assert_equal(plot.dimension_values('number'), self.df.index.get_level_values('number'))
 
 

--- a/holoviews/tests/core/data/test_spatialpandas.py
+++ b/holoviews/tests/core/data/test_spatialpandas.py
@@ -5,15 +5,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews import Dimension
-from holoviews.core.data import (
-    DaskSpatialPandasInterface,
-    Dataset,
-    SpatialPandasInterface,
-)
+import holoviews as hv
+from holoviews.core.data import DaskSpatialPandasInterface, SpatialPandasInterface
 from holoviews.core.data.interface import DataError
 from holoviews.core.data.spatialpandas import get_value_array
-from holoviews.element import Path, Points, Polygons
 from holoviews.testing import assert_data_equal, assert_element_equal
 
 from ...utils import optional_dependencies
@@ -35,13 +30,13 @@ class RoundTripTests:
     __test__ = False
 
     def test_point_roundtrip(self):
-        points = Points([{'x': 0, 'y': 1, 'z': 0},
+        points = hv.Points([{'x': 0, 'y': 1, 'z': 0},
                          {'x': 1, 'y': 0, 'z': 1}], ['x', 'y'],
                         'z', datatype=[self.datatype])
         assert isinstance(points.data.geometry.dtype, sgeom.PointDtype)
         roundtrip = points.clone(datatype=['multitabular'])
         assert roundtrip.interface.datatype == 'multitabular'
-        expected = Points([{'x': 0, 'y': 1, 'z': 0},
+        expected = hv.Points([{'x': 0, 'y': 1, 'z': 0},
                            {'x': 1, 'y': 0, 'z': 1}], ['x', 'y'],
                           'z', datatype=['multitabular'])
         assert_element_equal(roundtrip, expected)
@@ -49,13 +44,13 @@ class RoundTripTests:
     def test_multi_point_roundtrip(self):
         xs = [1, 2, 3, 2]
         ys = [2, 0, 7, 4]
-        points = Points([{'x': xs, 'y': ys, 'z': 0},
+        points = hv.Points([{'x': xs, 'y': ys, 'z': 0},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 1}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
         assert isinstance(points.data.geometry.dtype, sgeom.MultiPointDtype)
         roundtrip = points.clone(datatype=['multitabular'])
         assert roundtrip.interface.datatype == 'multitabular'
-        expected = Points([{'x': xs, 'y': ys, 'z': 0},
+        expected = hv.Points([{'x': xs, 'y': ys, 'z': 0},
                            {'x': xs[::-1], 'y': ys[::-1], 'z': 1}],
                           ['x', 'y'], 'z', datatype=['multitabular'])
         assert_element_equal(roundtrip, expected)
@@ -63,13 +58,13 @@ class RoundTripTests:
     def test_line_roundtrip(self):
         xs = [1, 2, 3]
         ys = [2, 0, 7]
-        path = Path([{'x': xs, 'y': ys, 'z': 1},
+        path = hv.Path([{'x': xs, 'y': ys, 'z': 1},
                      {'x': xs[::-1], 'y': ys[::-1], 'z': 2}],
                     ['x', 'y'], 'z', datatype=[self.datatype])
         assert isinstance(path.data.geometry.dtype, sgeom.LineDtype)
         roundtrip = path.clone(datatype=['multitabular'])
         assert roundtrip.interface.datatype == 'multitabular'
-        expected = Path([{'x': xs, 'y': ys, 'z': 1},
+        expected = hv.Path([{'x': xs, 'y': ys, 'z': 1},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 2}],
                         ['x', 'y'], 'z', datatype=['multitabular'])
         assert_element_equal(roundtrip, expected)
@@ -77,13 +72,13 @@ class RoundTripTests:
     def test_multi_line_roundtrip(self):
         xs = [1, 2, 3, np.nan, 6, 7, 3]
         ys = [2, 0, 7, np.nan, 7, 5, 2]
-        path = Path([{'x': xs, 'y': ys, 'z': 0},
+        path = hv.Path([{'x': xs, 'y': ys, 'z': 0},
                      {'x': xs[::-1], 'y': ys[::-1], 'z': 1}],
                     ['x', 'y'], 'z', datatype=[self.datatype])
         assert isinstance(path.data.geometry.dtype, sgeom.MultiLineDtype)
         roundtrip = path.clone(datatype=['multitabular'])
         assert roundtrip.interface.datatype == 'multitabular'
-        expected = Path([{'x': xs, 'y': ys, 'z': 0},
+        expected = hv.Path([{'x': xs, 'y': ys, 'z': 0},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 1}],
                         ['x', 'y'], 'z', datatype=['multitabular'])
         assert_element_equal(roundtrip, expected)
@@ -91,13 +86,13 @@ class RoundTripTests:
     def test_polygon_roundtrip(self):
         xs = [1, 2, 3]
         ys = [2, 0, 7]
-        poly = Polygons([{'x': xs, 'y': ys, 'z': 0},
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'z': 0},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 1}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
         assert isinstance(poly.data.geometry.dtype, sgeom.PolygonDtype)
         roundtrip = poly.clone(datatype=['multitabular'])
         assert roundtrip.interface.datatype == 'multitabular'
-        expected = Polygons([{'x': [*xs, 1], 'y': [*ys, 2], 'z': 0},
+        expected = hv.Polygons([{'x': [*xs, 1], 'y': [*ys, 2], 'z': 0},
                              {'x': [3, *xs], 'y': [7, *ys], 'z': 1}],
                             ['x', 'y'], 'z', datatype=['multitabular'])
         assert_element_equal(roundtrip, expected)
@@ -109,13 +104,13 @@ class RoundTripTests:
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'z': 1},
                          {'x': xs[::-1], 'y': ys[::-1], 'z': 2}],
                         ['x', 'y'], 'z', datatype=[self.datatype])
         assert isinstance(poly.data.geometry.dtype, sgeom.MultiPolygonDtype)
         roundtrip = poly.clone(datatype=['multitabular'])
         assert roundtrip.interface.datatype == 'multitabular'
-        expected = Polygons([{'x': [1, 2, 3, 1, np.nan, 6, 3, 7, 6],
+        expected = hv.Polygons([{'x': [1, 2, 3, 1, np.nan, 6, 3, 7, 6],
                               'y': [2, 0, 7, 2, np.nan, 7, 2, 5, 7], 'holes': holes, 'z': 1},
                              {'x': [3, 7, 6, 3, np.nan, 3, 1, 2, 3],
                               'y': [2, 5, 7, 2, np.nan, 7, 2, 0, 7], 'z': 2}],
@@ -138,13 +133,13 @@ class SpatialPandasTest(GeomTests, RoundTripTests):
 
     def test_array_points_iloc_index_rows_index_cols(self):
         arrays = [np.array([(1+i, i), (2+i, i), (3+i, i)]) for i in range(2)]
-        mds = Dataset(arrays, kdims=['x', 'y'], datatype=[self.datatype])
+        mds = hv.Dataset(arrays, kdims=['x', 'y'], datatype=[self.datatype])
         assert mds.interface is self.interface
         with pytest.raises(DataError):
             mds.iloc[3, 0]
 
     def test_point_constructor(self):
-        points = Points([{'x': 0, 'y': 1}, {'x': 1, 'y': 0}], ['x', 'y'],
+        points = hv.Points([{'x': 0, 'y': 1}, {'x': 1, 'y': 0}], ['x', 'y'],
                         datatype=[self.datatype])
         assert isinstance(points.data.geometry.dtype, sgeom.PointDtype)
         assert_data_equal(points.data.iloc[0, 0].flat_values, np.array([0, 1]))
@@ -153,7 +148,7 @@ class SpatialPandasTest(GeomTests, RoundTripTests):
     def test_multi_point_constructor(self):
         xs = [1, 2, 3, 2]
         ys = [2, 0, 7, 4]
-        points = Points([{'x': xs, 'y': ys}, {'x': xs[::-1], 'y': ys[::-1]}], ['x', 'y'],
+        points = hv.Points([{'x': xs, 'y': ys}, {'x': xs[::-1], 'y': ys[::-1]}], ['x', 'y'],
                         datatype=[self.datatype])
         assert isinstance(points.data.geometry.dtype, sgeom.MultiPointDtype)
         assert_data_equal(points.data.iloc[0, 0].buffer_values,
@@ -164,7 +159,7 @@ class SpatialPandasTest(GeomTests, RoundTripTests):
     def test_line_constructor(self):
         xs = [1, 2, 3]
         ys = [2, 0, 7]
-        path = Path([{'x': xs, 'y': ys}, {'x': xs[::-1], 'y': ys[::-1]}],
+        path = hv.Path([{'x': xs, 'y': ys}, {'x': xs[::-1], 'y': ys[::-1]}],
                     ['x', 'y'], datatype=[self.datatype])
         assert isinstance(path.data.geometry.dtype, sgeom.LineDtype)
         assert_data_equal(path.data.iloc[0, 0].buffer_values,
@@ -175,7 +170,7 @@ class SpatialPandasTest(GeomTests, RoundTripTests):
     def test_multi_line_constructor(self):
         xs = [1, 2, 3, np.nan, 6, 7, 3]
         ys = [2, 0, 7, np.nan, 7, 5, 2]
-        path = Path([{'x': xs, 'y': ys}, {'x': xs[::-1], 'y': ys[::-1]}],
+        path = hv.Path([{'x': xs, 'y': ys}, {'x': xs[::-1], 'y': ys[::-1]}],
                     ['x', 'y'], datatype=[self.datatype])
         assert isinstance(path.data.geometry.dtype, sgeom.MultiLineDtype)
         assert_data_equal(path.data.iloc[0, 0].buffer_values,
@@ -189,7 +184,7 @@ class SpatialPandasTest(GeomTests, RoundTripTests):
         holes = [
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]]
         ]
-        path = Polygons([{'x': xs, 'y': ys, 'holes': holes}, {'x': xs[::-1], 'y': ys[::-1]}],
+        path = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes}, {'x': xs[::-1], 'y': ys[::-1]}],
                         ['x', 'y'], datatype=[self.datatype])
         assert isinstance(path.data.geometry.dtype, sgeom.PolygonDtype)
         assert_data_equal(path.data.iloc[0, 0].buffer_values,
@@ -205,7 +200,7 @@ class SpatialPandasTest(GeomTests, RoundTripTests):
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        path = Polygons([{'x': xs, 'y': ys, 'holes': holes},
+        path = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes},
                          {'x': xs[::-1], 'y': ys[::-1]}],
                         ['x', 'y'], datatype=[self.datatype])
         assert isinstance(path.data.geometry.dtype, sgeom.MultiPolygonDtype)
@@ -230,7 +225,7 @@ class SpatialPandasTest(GeomTests, RoundTripTests):
               [1.5, 0.25, 3.75, 0.25, 3.75, 1.75, 1.5, 1.75, 1.5, 0.25]],]
         ]) # Rectangular hole (CW order)
 
-        path = Polygons(polygons)
+        path = hv.Polygons(polygons)
         assert isinstance(path.data.geometry.dtype, sgeom.MultiPolygonDtype)
 
 
@@ -290,6 +285,6 @@ def test_regression_get_value_array():
     df = pd.DataFrame(
         {"Longitude": [0, 1, 2], "Latitude": [0, 1, 2], "Sensor": ["S1", "S2", "S1"]}
     )
-    result = get_value_array(df, Dimension("Sensor"), False, None, None, None)
+    result = get_value_array(df, hv.Dimension("Sensor"), False, None, None, None)
 
     np.testing.assert_array_equal(df.Sensor, result)

--- a/holoviews/tests/core/data/test_xarrayinterface.py
+++ b/holoviews/tests/core/data/test_xarrayinterface.py
@@ -4,10 +4,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core.data import Dataset, XArrayInterface, concat
-from holoviews.core.dimension import Dimension
-from holoviews.core.spaces import HoloMap
-from holoviews.element import HSV, RGB, Image, ImageStack, QuadMesh
+import holoviews as hv
+from holoviews.core.data import XArrayInterface, concat
 from holoviews.testing import assert_data_equal, assert_element_equal
 
 from ...utils import optional_dependencies
@@ -70,16 +68,16 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         da = xr.DataArray(np.arange(8).reshape((2, 2, 2)),
                           coords, ['time', 'lat', 'lon']).assign_coords(
                               lat1=xr.DataArray([2,3], dims=['lat']))
-        assert Dataset(da, ['time', 'lat', 'lon'], vdims='value').kdims == ['time', 'lat', 'lon']
-        assert Dataset(da, ['time', 'lat1', 'lon'], vdims='value').kdims == ['time', 'lat1', 'lon']
+        assert hv.Dataset(da, ['time', 'lat', 'lon'], vdims='value').kdims == ['time', 'lat', 'lon']
+        assert hv.Dataset(da, ['time', 'lat1', 'lon'], vdims='value').kdims == ['time', 'lat1', 'lon']
 
     def test_xarray_dataset_irregular_shape(self):
-        ds = Dataset(self.get_multi_dim_irregular_dataset())
+        ds = hv.Dataset(self.get_multi_dim_irregular_dataset())
         shape = ds.interface.shape(ds, gridded=True)
         assert shape == (np.nan, np.nan, 3, 4)
 
     def test_xarray_irregular_dataset_values(self):
-        ds = Dataset(self.get_multi_dim_irregular_dataset())
+        ds = hv.Dataset(self.get_multi_dim_irregular_dataset())
         values = ds.dimension_values('z', expanded=False)
         assert_data_equal(values, np.array([0, 1, 2, 3]))
 
@@ -89,7 +87,7 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         zs = np.array([[[0, 1], [2, 3], [4, 5]]])
         xrarr = xr.DataArray(zs, coords={'x': xs, 'y': ys, 't': [1]}, dims=['t', 'y', 'x'])
         xrds = xr.Dataset({'v': xrarr})
-        ds = Dataset(xrds, kdims=['x', 'y'], vdims=['v'], datatype=['xarray'])
+        ds = hv.Dataset(xrds, kdims=['x', 'y'], vdims=['v'], datatype=['xarray'])
         canonical = ds.dimension_values(2, flat=False)
         assert canonical.ndim == 2
         expected = np.array([[0, 1], [2, 3], [4, 5]])
@@ -104,11 +102,11 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         da.attrs['units'] = "array_unit"
         da.x_dim.attrs['units'] = "x_unit"
         da.y_dim.attrs['long_name'] = "y axis long name"
-        dataset = Dataset(da)
-        assert_element_equal(dataset.get_dimension("x_dim"), Dimension("x_dim", unit="x_unit"))
-        assert_element_equal(dataset.get_dimension("y_dim"), Dimension("y_dim", label="y axis long name"))
+        dataset = hv.Dataset(da)
+        assert_element_equal(dataset.get_dimension("x_dim"), hv.Dimension("x_dim", unit="x_unit"))
+        assert_element_equal(dataset.get_dimension("y_dim"), hv.Dimension("y_dim", label="y axis long name"))
         assert_element_equal(dataset.get_dimension("data_name"),
-                         Dimension("data_name", label="data long name", unit="array_unit"))
+                         hv.Dimension("data_name", label="data long name", unit="array_unit"))
 
     def test_xarray_dataset_dataarray_vs_dataset(self):
         xs = [0.1, 0.2, 0.3]
@@ -120,8 +118,8 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         da.x_dim.attrs['units'] = "x_unit"
         da.y_dim.attrs['long_name'] = "y axis long name"
         ds = da.to_dataset()
-        dataset_from_da = Dataset(da)
-        dataset_from_ds = Dataset(ds)
+        dataset_from_da = hv.Dataset(da)
+        dataset_from_ds = hv.Dataset(ds)
         assert_element_equal(dataset_from_da, dataset_from_ds)
         # same with reversed names:
         da_rev = xr.DataArray(zs, coords=[('x_dim', xs), ('y_dim', ys)], name="data_name", dims=['x_dim', 'y_dim'])
@@ -130,8 +128,8 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         da_rev.x_dim.attrs['units'] = "x_unit"
         da_rev.y_dim.attrs['long_name'] = "y axis long name"
         ds_rev = da_rev.to_dataset()
-        dataset_from_da_rev = Dataset(da_rev)
-        dataset_from_ds_rev = Dataset(ds_rev)
+        dataset_from_da_rev = hv.Dataset(da_rev)
+        dataset_from_ds_rev = hv.Dataset(ds_rev)
         assert_element_equal(dataset_from_da_rev, dataset_from_ds_rev)
 
     def test_xarray_override_dims(self):
@@ -143,17 +141,17 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         da.attrs['units'] = "array_unit"
         da.x_dim.attrs['units'] = "x_unit"
         da.y_dim.attrs['long_name'] = "y axis long name"
-        ds = Dataset(da, kdims=["x_dim", "y_dim"], vdims=["z_dim"])
-        x_dim = Dimension("x_dim")
-        y_dim = Dimension("y_dim")
-        z_dim = Dimension("z_dim")
+        ds = hv.Dataset(da, kdims=["x_dim", "y_dim"], vdims=["z_dim"])
+        x_dim = hv.Dimension("x_dim")
+        y_dim = hv.Dimension("y_dim")
+        z_dim = hv.Dimension("z_dim")
         assert_element_equal(ds.kdims[0], x_dim)
         assert_element_equal(ds.kdims[1], y_dim)
         assert_element_equal(ds.vdims[0], z_dim)
-        ds_from_ds = Dataset(da.to_dataset(), kdims=["x_dim", "y_dim"], vdims=["data_name"])
+        ds_from_ds = hv.Dataset(da.to_dataset(), kdims=["x_dim", "y_dim"], vdims=["data_name"])
         assert_element_equal(ds_from_ds.kdims[0], x_dim)
         assert_element_equal(ds_from_ds.kdims[1], y_dim)
-        data_dim = Dimension("data_name")
+        data_dim = hv.Dimension("data_name")
         assert_element_equal(ds_from_ds.vdims[0], data_dim)
 
     def test_xarray_coord_ordering(self):
@@ -161,59 +159,59 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         coords = dict([('b', range(3)), ('c', range(4)), ('a', range(5))])
         darray = xr.DataArray(data, coords=coords, dims=['b', 'c', 'a'])
         dataset = xr.Dataset({'value': darray}, coords=coords)
-        ds = Dataset(dataset)
+        ds = hv.Dataset(dataset)
         assert ds.kdims == ['b', 'c', 'a']
 
     def test_irregular_and_regular_coordinate_inference(self):
         data = self.get_irregular_dataarray()
-        ds = Dataset(data, vdims='Value')
-        assert ds.kdims == [Dimension('band'), Dimension('x'), Dimension('y')]
+        ds = hv.Dataset(data, vdims='Value')
+        assert ds.kdims == [hv.Dimension('band'), hv.Dimension('x'), hv.Dimension('y')]
         assert_data_equal(ds.dimension_values(3, flat=False), data.values[:, ::-1].transpose([1, 2, 0]))
 
     def test_irregular_and_regular_coordinate_inference_inverted(self):
         data = self.get_irregular_dataarray(False)
-        ds = Dataset(data, vdims='Value')
-        assert ds.kdims == [Dimension('band'), Dimension('x'), Dimension('y')]
+        ds = hv.Dataset(data, vdims='Value')
+        assert ds.kdims == [hv.Dimension('band'), hv.Dimension('x'), hv.Dimension('y')]
         assert_data_equal(ds.dimension_values(3, flat=False), data.values.transpose([1, 2, 0]))
     def test_irregular_and_regular_coordinate_explicit_regular_coords(self):
         data = self.get_irregular_dataarray()
-        ds = Dataset(data, ['x', 'y'], vdims='Value')
-        assert ds.kdims == [Dimension('x'), Dimension('y')]
+        ds = hv.Dataset(data, ['x', 'y'], vdims='Value')
+        assert ds.kdims == [hv.Dimension('x'), hv.Dimension('y')]
         assert_data_equal(ds.dimension_values(2, flat=False), data.values[0, ::-1])
 
     def test_irregular_and_regular_coordinate_explicit_regular_coords_inverted(self):
         data = self.get_irregular_dataarray(False)
-        ds = Dataset(data, ['x', 'y'], vdims='Value')
-        assert ds.kdims == [Dimension('x'), Dimension('y')]
+        ds = hv.Dataset(data, ['x', 'y'], vdims='Value')
+        assert ds.kdims == [hv.Dimension('x'), hv.Dimension('y')]
         assert_data_equal(ds.dimension_values(2, flat=False), data.values[0])
 
     def test_irregular_and_regular_coordinate_explicit_irregular_coords(self):
         data = self.get_irregular_dataarray()
-        ds = Dataset(data, ['xc', 'yc'], vdims='Value')
-        assert ds.kdims == [Dimension('xc'), Dimension('yc')]
+        ds = hv.Dataset(data, ['xc', 'yc'], vdims='Value')
+        assert ds.kdims == [hv.Dimension('xc'), hv.Dimension('yc')]
         assert_data_equal(ds.dimension_values(2, flat=False), data.values[0])
 
     def test_irregular_and_regular_coordinate_explicit_irregular_coords_inverted(self):
         data = self.get_irregular_dataarray(False)
-        ds = Dataset(data, ['xc', 'yc'], vdims='Value')
-        assert ds.kdims == [Dimension('xc'), Dimension('yc')]
+        ds = hv.Dataset(data, ['xc', 'yc'], vdims='Value')
+        assert ds.kdims == [hv.Dimension('xc'), hv.Dimension('yc')]
         assert_data_equal(ds.dimension_values(2, flat=False), data.values[0])
 
     def test_concat_grid_3d_shape_mismatch(self):
         arr1 = np.random.rand(3, 2)
         arr2 = np.random.rand(2, 3)
-        ds1 = Dataset(([0, 1], [1, 2, 3], arr1), ['x', 'y'], 'z')
-        ds2 = Dataset(([0, 1, 2], [1, 2], arr2), ['x', 'y'], 'z')
-        hmap = HoloMap({1: ds1, 2: ds2})
+        ds1 = hv.Dataset(([0, 1], [1, 2, 3], arr1), ['x', 'y'], 'z')
+        ds2 = hv.Dataset(([0, 1, 2], [1, 2], arr2), ['x', 'y'], 'z')
+        hmap = hv.HoloMap({1: ds1, 2: ds2})
         arr = np.full((3, 3, 2), np.nan)
         arr[:, :2, 0] = arr1
         arr[:2, :, 1] = arr2
-        ds = Dataset(([1, 2], [0, 1, 2], [1, 2, 3], arr), ['Default', 'x', 'y'], 'z')
+        ds = hv.Dataset(([1, 2], [0, 1, 2], [1, 2, 3], arr), ['Default', 'x', 'y'], 'z')
         assert_element_equal(concat(hmap), ds)
 
     def test_zero_sized_coordinates_range(self):
         da = xr.DataArray(np.empty((2, 0)), dims=('y', 'x'), coords={'x': [], 'y': [0 ,1]}, name='A')
-        ds = Dataset(da)
+        ds = hv.Dataset(da)
         x0, x1 = ds.range('x')
         assert np.isnan(x0)
         assert np.isnan(x1)
@@ -225,7 +223,7 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         xs = [dt.datetime(2018, 1, i) for i in range(1, 11)]
         ys = np.arange(10)
         array = np.random.rand(10, 10)
-        ds = QuadMesh((xs, ys, array))
+        ds = hv.QuadMesh((xs, ys, array))
         assert ds.interface.datatype == 'xarray'
         expected = (np.datetime64(dt.datetime(2017, 12, 31, 12, 0)),
                     np.datetime64(dt.datetime(2018, 1, 10, 12, 0)))
@@ -241,7 +239,7 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         )
         ys = np.arange(10)
         array = np.random.rand(10, 10)
-        ds = QuadMesh((xs, ys, array))
+        ds = hv.QuadMesh((xs, ys, array))
         assert ds.interface.datatype == 'xarray'
         expected = (np.datetime64(dt.datetime(2017, 12, 31, 12, 0)),
                     np.datetime64(dt.datetime(2018, 1, 10, 12, 0)))
@@ -251,7 +249,7 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         d = np.random.randn(3, 8)
         da = xr.DataArray(d, name='stuff', dims=['chain', 'value'],
             coords=dict(chain=range(d.shape[0]), value=range(d.shape[1])))
-        ds = Dataset(da)
+        ds = hv.Dataset(da)
         t = ds.select(chain=0)
         if hasattr(t.data, "sizes"):
             # Started to warn in xarray 2023.12.0:
@@ -267,7 +265,7 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
     def test_mask_2d_array_transposed(self):
         array = np.random.rand(4, 3)
         da = xr.DataArray(array.T, coords={'x': [0, 1, 2], 'y': [0, 1, 2, 3]}, dims=['x', 'y'])
-        ds = Dataset(da, ['x', 'y'], 'z')
+        ds = hv.Dataset(da, ['x', 'y'], 'z')
         mask = np.array([[1, 1, 0], [1, 0, 1], [0, 1, 1], [1, 0, 1]], dtype='bool')
         masked = ds.clone(ds.interface.mask(ds, mask))
         masked_array = masked.dimension_values(2, flat=False)
@@ -281,7 +279,7 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         """
         kdims = ["dim_0", "dim_1"]
         vdims = ["dim_2"]
-        ds = XArrayInterface.init(Image, np.array([]), kdims, vdims)
+        ds = XArrayInterface.init(hv.Image, np.array([]), kdims, vdims)
         assert isinstance(ds[0], xr.Dataset)
         assert ds[0][vdims[0]].size == 0
         assert ds[1]["kdims"] == kdims
@@ -298,10 +296,10 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
             {"a": (["x", "y"], a), "b": (["x", "y"], b), "c": (["x", "y"], c)},
             coords={"x": x, "y": y},
         )
-        img_stack = ImageStack(ds, kdims=["x", "y"])
+        img_stack = hv.ImageStack(ds, kdims=["x", "y"])
         assert img_stack.interface is XArrayInterface
-        assert img_stack.kdims == [Dimension("x"), Dimension("y")]
-        assert img_stack.vdims == [Dimension("a"), Dimension("b"), Dimension("c")]
+        assert img_stack.kdims == [hv.Dimension("x"), hv.Dimension("y")]
+        assert img_stack.vdims == [hv.Dimension("a"), hv.Dimension("b"), hv.Dimension("c")]
 
     def test_image_stack_xarray_dataarray(self):
         x = np.arange(0, 3)
@@ -314,10 +312,10 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
             {"a": (["x", "y"], a), "b": (["x", "y"], b), "c": (["x", "y"], c)},
             coords={"x": x, "y": y},
         ).to_array("level")
-        img_stack = ImageStack(ds, vdims=["level"])
+        img_stack = hv.ImageStack(ds, vdims=["level"])
         assert img_stack.interface is XArrayInterface
-        assert img_stack.kdims == [Dimension("x"), Dimension("y")]
-        assert img_stack.vdims == [Dimension("a"), Dimension("b"), Dimension("c")]
+        assert img_stack.kdims == [hv.Dimension("x"), hv.Dimension("y")]
+        assert img_stack.vdims == [hv.Dimension("a"), hv.Dimension("b"), hv.Dimension("c")]
 
     # Disabled tests for NotImplemented methods
     def test_dataset_array_init_hm(self):
@@ -362,9 +360,9 @@ class DaskXArrayInterfaceTest(XArrayInterfaceTests):
 
         self.y_ints = self.xs*2
         dask_y = da.from_array(np.array(self.y_ints), 2)
-        self.dataset_hm = Dataset((self.xs, dask_y),
+        self.dataset_hm = hv.Dataset((self.xs, dask_y),
                                   kdims=['x'], vdims=['y'])
-        self.dataset_hm_alias = Dataset((self.xs, dask_y),
+        self.dataset_hm_alias = hv.Dataset((self.xs, dask_y),
                                         kdims=[('x', 'X')], vdims=[('y', 'Y')])
 
     def init_grid_data(self):
@@ -388,7 +386,7 @@ class DaskXArrayInterfaceTest(XArrayInterfaceTests):
         zs = da.from_array(np.array([[[0, 1], [2, 3], [4, 5]]]), 2)
         xrarr = xr.DataArray(zs, coords={'x': xs, 'y': ys, 't': [1]}, dims=['t', 'y', 'x'])
         xrds = xr.Dataset({'v': xrarr})
-        ds = Dataset(xrds, kdims=['x', 'y'], vdims=['v'], datatype=['xarray'])
+        ds = hv.Dataset(xrds, kdims=['x', 'y'], vdims=['v'], datatype=['xarray'])
         canonical = ds.dimension_values(2, flat=False)
         assert canonical.ndim == 2
         expected = np.array([[0, 1], [2, 3], [4, 5]])
@@ -409,9 +407,9 @@ class GPUXArrayInterfaceTest(XArrayInterfaceTests):
 
         self.y_ints = self.xs*2
         cupy_y = cp.array(self.y_ints)
-        self.dataset_hm = Dataset((self.xs, cupy_y),
+        self.dataset_hm = hv.Dataset((self.xs, cupy_y),
                                   kdims=['x'], vdims=['y'])
-        self.dataset_hm_alias = Dataset((self.xs, cupy_y),
+        self.dataset_hm_alias = hv.Dataset((self.xs, cupy_y),
                                         kdims=[('x', 'X')], vdims=[('y', 'Y')])
 
     def init_grid_data(self):
@@ -444,23 +442,23 @@ class ImageElement_XArrayInterfaceTests(BaseImageElementInterfaceTests):
         return xr.Dataset
 
     def init_data(self):
-        self.image = Image((self.xs, self.ys, self.array))
-        self.image_inv = Image((self.xs[::-1], self.ys[::-1], self.array[::-1, ::-1]))
+        self.image = hv.Image((self.xs, self.ys, self.array))
+        self.image_inv = hv.Image((self.xs[::-1], self.ys[::-1], self.array[::-1, ::-1]))
 
     def test_dataarray_dimension_order(self):
         x = np.linspace(-3, 7, 53)
         y = np.linspace(-5, 8, 89)
         z = np.exp(-1*(x**2 + y[:, np.newaxis]**2))
         array = xr.DataArray(z, coords=[y, x], dims=['x', 'y'])
-        img = Image(array)
-        assert img.kdims == [Dimension('x'), Dimension('y')]
+        img = hv.Image(array)
+        assert img.kdims == [hv.Dimension('x'), hv.Dimension('y')]
 
     def test_dataarray_shape(self):
         x = np.linspace(-3, 7, 53)
         y = np.linspace(-5, 8, 89)
         z = np.exp(-1*(x**2 + y[:, np.newaxis]**2))
         array = xr.DataArray(z, coords=[y, x], dims=['x', 'y'])
-        img = Image(array, ['x', 'y'])
+        img = hv.Image(array, ['x', 'y'])
         assert img.interface.shape(img, gridded=True) == (53, 89)
 
     def test_dataarray_shape_transposed(self):
@@ -468,7 +466,7 @@ class ImageElement_XArrayInterfaceTests(BaseImageElementInterfaceTests):
         y = np.linspace(-5, 8, 89)
         z = np.exp(-1*(x**2 + y[:, np.newaxis]**2))
         array = xr.DataArray(z, coords=[y, x], dims=['x', 'y'])
-        img = Image(array, ['y', 'x'])
+        img = hv.Image(array, ['y', 'x'])
         assert img.interface.shape(img, gridded=True) == (89, 53)
 
     def test_select_on_transposed_dataarray(self):
@@ -476,8 +474,8 @@ class ImageElement_XArrayInterfaceTests(BaseImageElementInterfaceTests):
         y = np.linspace(-5, 8, 89)
         z = np.exp(-1*(x**2 + y[:, np.newaxis]**2))
         array = xr.DataArray(z, coords=[y, x], dims=['x', 'y'])
-        img = Image(array)[1:3]
-        assert_data_equal(img['z'], Image(array.sel(x=slice(1, 3)))['z'])
+        img = hv.Image(array)[1:3]
+        assert_data_equal(img['z'], hv.Image(array.sel(x=slice(1, 3)))['z'])
 
     def test_dataarray_with_no_coords(self):
         expected_xs = list(range(2))
@@ -485,11 +483,11 @@ class ImageElement_XArrayInterfaceTests(BaseImageElementInterfaceTests):
         zs = np.arange(6).reshape(2, 3)
         xrarr = xr.DataArray(zs, dims=('x','y'))
 
-        img = Image(xrarr)
+        img = hv.Image(xrarr)
         assert all(img.data.x == expected_xs)
         assert all(img.data.y == expected_ys)
 
-        img = Image(xrarr, kdims=['x', 'y'])
+        img = hv.Image(xrarr, kdims=['x', 'y'])
         assert all(img.data.x == expected_xs)
         assert all(img.data.y == expected_ys)
 
@@ -499,10 +497,10 @@ class ImageElement_XArrayInterfaceTests(BaseImageElementInterfaceTests):
         xrarr = xr.DataArray(zs, dims=('x','y'), coords={'x': xs})
 
         with pytest.raises(ValueError):  # noqa: PT011
-            Image(xrarr)
+            hv.Image(xrarr)
 
         with pytest.raises(ValueError):  # noqa: PT011
-            Image(xrarr, kdims=['x', 'y'])
+            hv.Image(xrarr, kdims=['x', 'y'])
 
 
 @xr_skip
@@ -517,7 +515,7 @@ class RGBElement_XArrayInterfaceTests(BaseRGBElementInterfaceTests):
         return xr.Dataset
 
     def init_data(self):
-        self.rgb = RGB((self.xs, self.ys, self.rgb_array[:, :, 0],
+        self.rgb = hv.RGB((self.xs, self.ys, self.rgb_array[:, :, 0],
                         self.rgb_array[:, :, 1], self.rgb_array[:, :, 2]))
 
 
@@ -532,7 +530,7 @@ class RGBElement_PackedXArrayInterfaceTests(BaseRGBElementInterfaceTests):
         return xr.Dataset
 
     def init_data(self):
-        self.rgb = RGB((self.xs, self.ys, self.rgb_array))
+        self.rgb = hv.RGB((self.xs, self.ys, self.rgb_array))
 
 
 @xr_skip
@@ -547,5 +545,5 @@ class HSVElement_XArrayInterfaceTest(BaseHSVElementInterfaceTests):
         return xr.Dataset
 
     def init_data(self):
-        self.hsv = HSV((self.xs, self.ys, self.hsv_array[:, :, 0],
+        self.hsv = hv.HSV((self.xs, self.ys, self.hsv_array[:, :, 0],
                         self.hsv_array[:, :, 1], self.hsv_array[:, :, 2]))

--- a/holoviews/tests/core/test_apply.py
+++ b/holoviews/tests/core/test_apply.py
@@ -4,9 +4,7 @@ import param
 import pytest
 from panel.widgets import IntSlider, RadioButtonGroup, TextInput
 
-from holoviews import Dataset, util
-from holoviews.core.spaces import DynamicMap, HoloMap
-from holoviews.element import Curve, Image
+import holoviews as hv
 from holoviews.streams import ParamMethod, Params
 from holoviews.testing import assert_element_equal
 
@@ -31,7 +29,7 @@ class ParamClass(param.Parameterized):
 class TestApplyElement:
 
     def setup_method(self):
-        self.element = Curve([1, 2, 3])
+        self.element = hv.Curve([1, 2, 3])
 
     def test_element_apply_simple(self):
         applied = self.element.apply(lambda x: x.relabel('Test'))
@@ -176,10 +174,10 @@ class TestApplyElement:
         assert_element_equal(applied[()], self.element.relabel('Another label!'))
 
     def test_holomap_apply_with_method(self):
-        hmap = HoloMap({i: Image(np.array([[i, 2], [3, 4]])) for i in range(3)})
+        hmap = hv.HoloMap({i: hv.Image(np.array([[i, 2], [3, 4]])) for i in range(3)})
         reduced = hmap.apply.reduce(x=np.min)
 
-        expected = HoloMap({i: Curve([(-0.25, 3), (0.25, i)], 'y', 'z') for i in range(3)})
+        expected = hv.HoloMap({i: hv.Curve([(-0.25, 3), (0.25, i)], 'y', 'z') for i in range(3)})
         assert_element_equal(reduced, expected)
 
 
@@ -187,8 +185,8 @@ class TestApplyElement:
 class TestApplyDynamicMap:
 
     def setup_method(self):
-        self.element = Curve([1, 2, 3])
-        self.dmap_unsampled = DynamicMap(lambda i: Curve([0, 1, i]), kdims='Y')
+        self.element = hv.Curve([1, 2, 3])
+        self.dmap_unsampled = hv.DynamicMap(lambda i: hv.Curve([0, 1, i]), kdims='Y')
         self.dmap = self.dmap_unsampled.redim.values(Y=[0, 1, 2])
 
     def test_dmap_apply_not_dynamic_unsampled(self):
@@ -197,21 +195,21 @@ class TestApplyDynamicMap:
 
     def test_dmap_apply_not_dynamic(self):
         applied = self.dmap.apply(lambda x: x.relabel('Test'), dynamic=False)
-        assert_element_equal(applied, HoloMap(self.dmap[[0, 1, 2]]).relabel('Test'))
+        assert_element_equal(applied, hv.HoloMap(self.dmap[[0, 1, 2]]).relabel('Test'))
 
     def test_dmap_apply_not_dynamic_with_kwarg(self):
         applied = self.dmap.apply(lambda x, label: x.relabel(label), dynamic=False, label='Test')
-        assert_element_equal(applied, HoloMap(self.dmap[[0, 1, 2]]).relabel('Test'))
+        assert_element_equal(applied, hv.HoloMap(self.dmap[[0, 1, 2]]).relabel('Test'))
 
     def test_dmap_apply_not_dynamic_with_instance_param(self):
         pinst = ParamClass()
         applied = self.dmap.apply(lambda x, label: x.relabel(label), label=pinst.param.label, dynamic=False)
-        assert_element_equal(applied, HoloMap(self.dmap[[0, 1, 2]]).relabel('Test'))
+        assert_element_equal(applied, hv.HoloMap(self.dmap[[0, 1, 2]]).relabel('Test'))
 
     def test_dmap_apply_not_dynamic_with_param_method(self):
         pinst = ParamClass()
         applied = self.dmap.apply(lambda x, label: x.relabel(label), label=pinst.dynamic_label, dynamic=False)
-        assert_element_equal(applied, HoloMap(self.dmap[[0, 1, 2]]).relabel('Test!'))
+        assert_element_equal(applied, hv.HoloMap(self.dmap[[0, 1, 2]]).relabel('Test!'))
 
     def test_dmap_apply_dynamic(self):
         applied = self.dmap.apply(lambda x: x.relabel('Test'))
@@ -286,8 +284,8 @@ class TestApplyDynamicMap:
 def test_nested_widgets():
     df = makeDataFrame()
     column = RadioButtonGroup(value="A", options=list("ABC"))
-    ds = Dataset(df)
-    transform = util.transform.df_dim("*").groupby(["D", column]).mean()
+    ds = hv.Dataset(df)
+    transform = hv.util.transform.df_dim("*").groupby(["D", column]).mean()
 
     params = list(transform.params.values())
     assert len(params) == 1
@@ -301,8 +299,8 @@ def test_nested_widgets():
 def test_slice_iloc():
     df = makeDataFrame()
     column = IntSlider(start=10, end=40)
-    ds = Dataset(df)
-    transform = util.transform.df_dim("*").iloc[:column].mean(axis=0)
+    ds = hv.Dataset(df)
+    transform = hv.util.transform.df_dim("*").iloc[:column].mean(axis=0)
 
     params = list(transform.params.values())
     assert len(params) == 1
@@ -317,8 +315,8 @@ def test_slice_loc():
     df = makeDataFrame()
     df.index = np.arange(5, len(df) + 5)
     column = IntSlider(start=10, end=40)
-    ds = Dataset(df)
-    transform = util.transform.df_dim("*").loc[:column].mean(axis=0)
+    ds = hv.Dataset(df)
+    transform = hv.util.transform.df_dim("*").loc[:column].mean(axis=0)
 
     params = list(transform.params.values())
     assert len(params) == 1
@@ -336,8 +334,8 @@ def test_slice_loc():
 def test_int_iloc():
     df = makeDataFrame()
     column = IntSlider(start=10, end=40)
-    ds = Dataset(df)
-    transform = util.transform.df_dim("*").iloc[column]
+    ds = hv.Dataset(df)
+    transform = hv.util.transform.df_dim("*").iloc[column]
 
     params = list(transform.params.values())
     assert len(params) == 1
@@ -352,8 +350,8 @@ def test_int_loc():
     df = makeDataFrame()
     df.index = np.arange(5, len(df) + 5)
     column = IntSlider(start=10, end=40)
-    ds = Dataset(df)
-    transform = util.transform.df_dim("*").loc[column]
+    ds = hv.Dataset(df)
+    transform = hv.util.transform.df_dim("*").loc[column]
 
     params = list(transform.params.values())
     assert len(params) == 1

--- a/holoviews/tests/core/test_archives.py
+++ b/holoviews/tests/core/test_archives.py
@@ -9,15 +9,15 @@ import zipfile
 
 import numpy as np
 
-from holoviews import Image
+import holoviews as hv
 from holoviews.core.io import FileArchive, Serializer
 
 
 class TestFileArchive:
 
     def setup_method(self):
-        self.image1 = Image(np.array([[1,2],[4,5]]), group='Group1', label='Im1')
-        self.image2 = Image(np.array([[5,4],[3,2]]), group='Group2', label='Im2')
+        self.image1 = hv.Image(np.array([[1,2],[4,5]]), group='Group1', label='Im1')
+        self.image2 = hv.Image(np.array([[5,4],[3,2]]), group='Group2', label='Im2')
 
     def test_filearchive_init(self):
         FileArchive()

--- a/holoviews/tests/core/test_boundingregion.py
+++ b/holoviews/tests/core/test_boundingregion.py
@@ -2,7 +2,8 @@
 Test cases for boundingregion
 """
 
-from holoviews.core import AARectangle, BoundingBox
+import holoviews as hv
+from holoviews.core import AARectangle
 
 
 class TestAARectangle:
@@ -37,7 +38,7 @@ class TestBoundingBox:
         self.top     =  0.4
         self.lbrt = (self.left,self.bottom,self.right,self.top)
 
-        self.region = BoundingBox(points = ((self.left,self.bottom),(self.right,self.top)))
+        self.region = hv.BoundingBox(points = ((self.left,self.bottom),(self.right,self.top)))
         self.xc,self.yc = self.region.aarect().centroid()
 
     def test_way_inside(self):

--- a/holoviews/tests/core/test_callable.py
+++ b/holoviews/tests/core/test_callable.py
@@ -7,10 +7,9 @@ from functools import partial
 import param
 import pytest
 
-from holoviews import streams
+import holoviews as hv
 from holoviews.core.operation import OperationCallable
-from holoviews.core.spaces import Callable, DynamicMap, Generator
-from holoviews.element import Scatter
+from holoviews.core.spaces import Generator
 from holoviews.operation import contours
 from holoviews.testing import assert_element_equal
 
@@ -46,13 +45,13 @@ class TestCallableName:
 
     def test_simple_function_name(self):
         def foo(x,y): pass
-        assert Callable(foo).name == 'foo'
+        assert hv.Callable(foo).name == 'foo'
 
     def test_simple_lambda_name(self):
-        assert Callable(lambda x: x).name == '<lambda>'
+        assert hv.Callable(lambda x: x).name == '<lambda>'
 
     def test_partial_name(self):
-        cb = Callable(partial(lambda x,y: x, y=4))
+        cb = hv.Callable(partial(lambda x,y: x, y=4))
         assert cb.name.startswith('functools.partial(')
 
     def test_generator_expression_name(self):
@@ -65,112 +64,112 @@ class TestCallableName:
         assert cb.name == 'innergen'
 
     def test_callable_class_name(self):
-        assert Callable(CallableClass()).name == 'CallableClass'
+        assert hv.Callable(CallableClass()).name == 'CallableClass'
 
     def test_callable_class_call_method(self):
-        assert Callable(CallableClass().__call__).name == 'CallableClass'
+        assert hv.Callable(CallableClass().__call__).name == 'CallableClass'
 
     def test_callable_instance_method(self):
-        assert Callable(CallableClass().someinstancemethod).name == 'CallableClass.someinstancemethod'
+        assert hv.Callable(CallableClass().someinstancemethod).name == 'CallableClass.someinstancemethod'
 
     def test_classmethod_name(self):
-        assert Callable(CallableClass().someclsmethod).name == 'CallableClass.someclsmethod'
+        assert hv.Callable(CallableClass().someclsmethod).name == 'CallableClass.someclsmethod'
 
     def test_staticmethod_name(self):
-        assert Callable(CallableClass().somestaticmethod).name == 'somestaticmethod'
+        assert hv.Callable(CallableClass().somestaticmethod).name == 'somestaticmethod'
 
     def test_parameterized_fn_name(self):
-        assert Callable(ParamFunc).name == 'ParamFunc'
+        assert hv.Callable(ParamFunc).name == 'ParamFunc'
 
     def test_parameterized_fn_instance_name(self):
-        assert Callable(ParamFunc.instance()).name == 'ParamFunc'
+        assert hv.Callable(ParamFunc.instance()).name == 'ParamFunc'
 
     def test_operation_name(self):
-        assert Callable(contours).name == 'contours'
+        assert hv.Callable(contours).name == 'contours'
 
     def test_operation_instance_name(self):
-        assert Callable(contours.instance()).name == 'contours'
+        assert hv.Callable(contours.instance()).name == 'contours'
 
     def test_operation_callable_name(self):
         opcallable = OperationCallable(lambda x: x, operation=contours.instance())
-        assert Callable(opcallable).name == 'contours'
+        assert hv.Callable(opcallable).name == 'contours'
 
 
 class TestSimpleCallableInvocation(LoggingComparison):
 
     def test_callable_fn(self):
         def callback(x): return x
-        assert Callable(callback)(3) == 3
+        assert hv.Callable(callback)(3) == 3
 
     def test_callable_lambda(self):
-        assert Callable(lambda x,y: x+y)(3,5) == 8
+        assert hv.Callable(lambda x,y: x+y)(3,5) == 8
 
     def test_callable_lambda_extras(self):
         substr = "Ignoring extra positional argument"
-        assert Callable(lambda x,y: x+y)(3,5,10) == 8
+        assert hv.Callable(lambda x,y: x+y)(3,5,10) == 8
         self.log_handler.assert_contains('WARNING', substr)
 
     def test_callable_lambda_extras_kwargs(self):
         substr = "['x'] overridden by keywords"
-        assert Callable(lambda x,y: x+y)(3,5,x=10) == 15
+        assert hv.Callable(lambda x,y: x+y)(3,5,x=10) == 15
         self.log_handler.assert_endswith('WARNING', substr)
 
     def test_callable_partial(self):
-        assert Callable(partial(lambda x,y: x+y,x=4))(5) == 9
+        assert hv.Callable(partial(lambda x,y: x+y,x=4))(5) == 9
 
     def test_callable_class(self):
-        assert Callable(CallableClass())(1,2,3,4) == 10
+        assert hv.Callable(CallableClass())(1,2,3,4) == 10
 
     def test_callable_instance_method(self):
-        assert Callable(CallableClass().someinstancemethod)(1, 2) == 3
+        assert hv.Callable(CallableClass().someinstancemethod)(1, 2) == 3
 
     def test_callable_partial_instance_method(self):
-        assert Callable(partial(CallableClass().someinstancemethod, x=1))(2) == 3
+        assert hv.Callable(partial(CallableClass().someinstancemethod, x=1))(2) == 3
 
     def test_callable_paramfunc(self):
-        assert Callable(ParamFunc)(3,b=5) == 15
+        assert hv.Callable(ParamFunc)(3,b=5) == 15
 
     def test_callable_paramfunc_instance(self):
-        assert Callable(ParamFunc.instance())(3,b=5) == 15
+        assert hv.Callable(ParamFunc.instance())(3,b=5) == 15
 
 
 class TestCallableArgspec:
 
     def test_callable_fn_argspec(self):
         def callback(x): return x
-        assert Callable(callback).argspec.args == ['x']
-        assert Callable(callback).argspec.keywords is None
+        assert hv.Callable(callback).argspec.args == ['x']
+        assert hv.Callable(callback).argspec.keywords is None
 
     def test_callable_lambda_argspec(self):
-        assert Callable(lambda x,y: x+y).argspec.args == ['x','y']
-        assert Callable(lambda x,y: x+y).argspec.keywords is None
+        assert hv.Callable(lambda x,y: x+y).argspec.args == ['x','y']
+        assert hv.Callable(lambda x,y: x+y).argspec.keywords is None
 
     def test_callable_partial_argspec(self):
-        assert Callable(partial(lambda x,y: x+y, x=4)).argspec.args == ['y']
-        assert Callable(partial(lambda x,y: x+y,x=4)).argspec.keywords is None
+        assert hv.Callable(partial(lambda x,y: x+y, x=4)).argspec.args == ['y']
+        assert hv.Callable(partial(lambda x,y: x+y,x=4)).argspec.keywords is None
 
     def test_callable_class_argspec(self):
-        assert Callable(CallableClass()).argspec.args == []
-        assert Callable(CallableClass()).argspec.keywords is None
-        assert Callable(CallableClass()).argspec.varargs == 'testargs'
+        assert hv.Callable(CallableClass()).argspec.args == []
+        assert hv.Callable(CallableClass()).argspec.keywords is None
+        assert hv.Callable(CallableClass()).argspec.varargs == 'testargs'
 
     def test_callable_instance_method(self):
-        assert Callable(CallableClass().someinstancemethod).argspec.args == ['x', 'y']
-        assert Callable(CallableClass().someinstancemethod).argspec.keywords is None
+        assert hv.Callable(CallableClass().someinstancemethod).argspec.args == ['x', 'y']
+        assert hv.Callable(CallableClass().someinstancemethod).argspec.keywords is None
 
     def test_callable_partial_instance_method(self):
-        assert Callable(partial(CallableClass().someinstancemethod, x=1)).argspec.args == ['y']
-        assert Callable(partial(CallableClass().someinstancemethod, x=1)).argspec.keywords is None
+        assert hv.Callable(partial(CallableClass().someinstancemethod, x=1)).argspec.args == ['y']
+        assert hv.Callable(partial(CallableClass().someinstancemethod, x=1)).argspec.keywords is None
 
     def test_callable_paramfunc_argspec(self):
-        assert Callable(ParamFunc).argspec.args == ['a']
-        assert Callable(ParamFunc).argspec.keywords == 'params'
-        assert Callable(ParamFunc).argspec.varargs is None
+        assert hv.Callable(ParamFunc).argspec.args == ['a']
+        assert hv.Callable(ParamFunc).argspec.keywords == 'params'
+        assert hv.Callable(ParamFunc).argspec.varargs is None
 
     def test_callable_paramfunc_instance_argspec(self):
-        assert Callable(ParamFunc.instance()).argspec.args == ['a']
-        assert Callable(ParamFunc.instance()).argspec.keywords == 'params'
-        assert Callable(ParamFunc.instance()).argspec.varargs is None
+        assert hv.Callable(ParamFunc.instance()).argspec.args == ['a']
+        assert hv.Callable(ParamFunc.instance()).argspec.keywords == 'params'
+        assert hv.Callable(ParamFunc.instance()).argspec.varargs is None
 
 
 class TestKwargCallableInvocation:
@@ -181,22 +180,22 @@ class TestKwargCallableInvocation:
 
     def test_callable_fn(self):
         def callback(x): return x
-        assert Callable(callback)(x=3) == 3
+        assert hv.Callable(callback)(x=3) == 3
 
     def test_callable_lambda(self):
-        assert Callable(lambda x,y: x+y)(x=3,y=5) == 8
+        assert hv.Callable(lambda x,y: x+y)(x=3,y=5) == 8
 
     def test_callable_partial(self):
-        assert Callable(partial(lambda x,y: x+y,x=4))(y=5) == 9
+        assert hv.Callable(partial(lambda x,y: x+y,x=4))(y=5) == 9
 
     def test_callable_instance_method(self):
-        assert Callable(CallableClass().someinstancemethod)(x=1, y=2) == 3
+        assert hv.Callable(CallableClass().someinstancemethod)(x=1, y=2) == 3
 
     def test_callable_partial_instance_method(self):
-        assert Callable(partial(CallableClass().someinstancemethod, x=1))(y=2) == 3
+        assert hv.Callable(partial(CallableClass().someinstancemethod, x=1))(y=2) == 3
 
     def test_callable_paramfunc(self):
-        assert Callable(ParamFunc)(a=3,b=5) == 15
+        assert hv.Callable(ParamFunc)(a=3,b=5) == 15
 
 
 class TestMixedCallableInvocation:
@@ -207,31 +206,31 @@ class TestMixedCallableInvocation:
     def test_callable_mixed_1(self):
         def mixed_example(a,b, c=10, d=20):
             return a+b+c+d
-        assert Callable(mixed_example)(a=3,b=5) == 38
+        assert hv.Callable(mixed_example)(a=3,b=5) == 38
 
     def test_callable_mixed_2(self):
         def mixed_example(a,b, c=10, d=20):
             return a+b+c+d
-        assert Callable(mixed_example)(3,5,5) == 33
+        assert hv.Callable(mixed_example)(3,5,5) == 33
 
 
 class TestLastArgsKwargs:
 
     def test_args_none_before_invocation(self):
-        c = Callable(lambda x,y: x+y)
+        c = hv.Callable(lambda x,y: x+y)
         assert c.args is None
 
     def test_kwargs_none_before_invocation(self):
-        c = Callable(lambda x,y: x+y)
+        c = hv.Callable(lambda x,y: x+y)
         assert c.kwargs is None
 
     def test_args_invocation(self):
-        c = Callable(lambda x,y: x+y)
+        c = hv.Callable(lambda x,y: x+y)
         c(1,2)
         assert c.args == (1,2)
 
     def test_kwargs_invocation(self):
-        c = Callable(lambda x,y: x+y)
+        c = hv.Callable(lambda x,y: x+y)
         c(x=1,y=4)
         assert c.kwargs == dict(x=1,y=4)
 
@@ -244,92 +243,92 @@ class TestDynamicMapInvocation:
 
     def test_dynamic_kdims_only(self):
         def fn(A,B):
-            return Scatter([(B,2)], label=A)
+            return hv.Scatter([(B,2)], label=A)
 
-        dmap = DynamicMap(fn, kdims=['A','B'])
-        assert_element_equal(dmap['Test', 1], Scatter([(1, 2)], label='Test'))
+        dmap = hv.DynamicMap(fn, kdims=['A','B'])
+        assert_element_equal(dmap['Test', 1], hv.Scatter([(1, 2)], label='Test'))
 
     def test_dynamic_kdims_only_by_position(self):
         def fn(A,B):
-            return Scatter([(B,2)], label=A)
+            return hv.Scatter([(B,2)], label=A)
 
-        dmap = DynamicMap(fn, kdims=['A-dim','B-dim'])
-        assert_element_equal(dmap['Test', 1], Scatter([(1, 2)], label='Test'))
+        dmap = hv.DynamicMap(fn, kdims=['A-dim','B-dim'])
+        assert_element_equal(dmap['Test', 1], hv.Scatter([(1, 2)], label='Test'))
 
     def test_dynamic_kdims_swapped_by_name(self):
         def fn(A,B):
-            return Scatter([(B,2)], label=A)
+            return hv.Scatter([(B,2)], label=A)
 
-        dmap = DynamicMap(fn, kdims=['B','A'])
-        assert_element_equal(dmap[1,'Test'], Scatter([(1, 2)], label='Test'))
+        dmap = hv.DynamicMap(fn, kdims=['B','A'])
+        assert_element_equal(dmap[1,'Test'], hv.Scatter([(1, 2)], label='Test'))
 
 
     def test_dynamic_kdims_only_invalid(self):
         def fn(A,B):
-            return Scatter([(B,2)], label=A)
+            return hv.Scatter([(B,2)], label=A)
 
         regexp="Callable 'fn' accepts more positional arguments than there are kdims and stream parameters"
         with pytest.raises(KeyError, match=regexp):
-            DynamicMap(fn, kdims=['A'])
+            hv.DynamicMap(fn, kdims=['A'])
 
 
     def test_dynamic_kdims_args_only(self):
         def fn(*args):
             (A,B) = args
-            return Scatter([(B,2)], label=A)
+            return hv.Scatter([(B,2)], label=A)
 
-        dmap = DynamicMap(fn, kdims=['A','B'])
-        assert_element_equal(dmap['Test', 1], Scatter([(1, 2)], label='Test'))
+        dmap = hv.DynamicMap(fn, kdims=['A','B'])
+        assert_element_equal(dmap['Test', 1], hv.Scatter([(1, 2)], label='Test'))
 
 
     def test_dynamic_streams_only_kwargs(self):
         def fn(x=1, y=2):
-            return Scatter([(x,y)], label='default')
+            return hv.Scatter([(x,y)], label='default')
 
-        xy = streams.PointerXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=[], streams=[xy])
-        assert_element_equal(dmap[:], Scatter([(1, 2)], label='default'))
+        xy = hv.streams.PointerXY(x=1, y=2)
+        dmap = hv.DynamicMap(fn, kdims=[], streams=[xy])
+        assert_element_equal(dmap[:], hv.Scatter([(1, 2)], label='default'))
 
 
     def test_dynamic_streams_only_keywords(self):
         def fn(**kwargs):
-            return Scatter([(kwargs['x'],kwargs['y'])], label='default')
+            return hv.Scatter([(kwargs['x'],kwargs['y'])], label='default')
 
-        xy = streams.PointerXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=[], streams=[xy])
-        assert_element_equal(dmap[:], Scatter([(1, 2)], label='default'))
+        xy = hv.streams.PointerXY(x=1, y=2)
+        dmap = hv.DynamicMap(fn, kdims=[], streams=[xy])
+        assert_element_equal(dmap[:], hv.Scatter([(1, 2)], label='default'))
 
 
     def test_dynamic_split_kdims_and_streams(self):
         # Corresponds to the old style of kdims as posargs and streams
         # as kwargs
         def fn(A, x=1, y=2):
-            return Scatter([(x,y)], label=A)
+            return hv.Scatter([(x,y)], label=A)
 
-        xy = streams.PointerXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
-        assert_element_equal(dmap['Test'], Scatter([(1, 2)], label='Test'))
+        xy = hv.streams.PointerXY(x=1, y=2)
+        dmap = hv.DynamicMap(fn, kdims=['A'], streams=[xy])
+        assert_element_equal(dmap['Test'], hv.Scatter([(1, 2)], label='Test'))
 
     def test_dynamic_split_kdims_and_streams_invalid(self):
         # Corresponds to the old style of kdims as posargs and streams
         # as kwargs. Pointeral arg names don't have to match
         def fn(x=1, y=2, B='default'):
-            return Scatter([(x,y)], label=B)
+            return hv.Scatter([(x,y)], label=B)
 
-        xy = streams.PointerXY(x=1, y=2)
+        xy = hv.streams.PointerXY(x=1, y=2)
         regexp = "Callback 'fn' signature over (.+?) does not accommodate required kdims"
         with pytest.raises(KeyError, match=regexp):
-            DynamicMap(fn, kdims=['A'], streams=[xy])
+            hv.DynamicMap(fn, kdims=['A'], streams=[xy])
 
     def test_dynamic_split_mismatched_kdims(self):
         # Corresponds to the old style of kdims as posargs and streams
         # as kwargs. Pointeral arg names don't have to match
         def fn(B, x=1, y=2):
-            return Scatter([(x,y)], label=B)
+            return hv.Scatter([(x,y)], label=B)
 
-        xy = streams.PointerXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
-        assert_element_equal(dmap['Test'], Scatter([(1, 2)], label='Test'))
+        xy = hv.streams.PointerXY(x=1, y=2)
+        dmap = hv.DynamicMap(fn, kdims=['A'], streams=[xy])
+        assert_element_equal(dmap['Test'], hv.Scatter([(1, 2)], label='Test'))
 
     def test_dynamic_split_mismatched_kdims_invalid(self):
         # Corresponds to the old style of kdims as posargs and streams
@@ -337,47 +336,47 @@ class TestDynamicMapInvocation:
         # stream parameters can be passed by position but *only* if they
         # come first
         def fn(x, y, B):
-            return Scatter([(x,y)], label=B)
+            return hv.Scatter([(x,y)], label=B)
 
-        xy = streams.PointerXY(x=1, y=2)
+        xy = hv.streams.PointerXY(x=1, y=2)
         regexp = ("Unmatched positional kdim arguments only allowed "
                   "at the start of the signature")
         with pytest.raises(KeyError, match=regexp):
-            DynamicMap(fn, kdims=['A'], streams=[xy])
+            hv.DynamicMap(fn, kdims=['A'], streams=[xy])
 
     def test_dynamic_split_args_and_kwargs(self):
         # Corresponds to the old style of kdims as posargs and streams
         # as kwargs, captured as *args and **kwargs
         def fn(*args, **kwargs):
-            return Scatter([(kwargs['x'],kwargs['y'])], label=args[0])
+            return hv.Scatter([(kwargs['x'],kwargs['y'])], label=args[0])
 
-        xy = streams.PointerXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
-        assert_element_equal(dmap['Test'], Scatter([(1, 2)], label='Test'))
+        xy = hv.streams.PointerXY(x=1, y=2)
+        dmap = hv.DynamicMap(fn, kdims=['A'], streams=[xy])
+        assert_element_equal(dmap['Test'], hv.Scatter([(1, 2)], label='Test'))
 
 
     def test_dynamic_all_keywords(self):
         def fn(A='default', x=1, y=2):
-            return Scatter([(x,y)], label=A)
+            return hv.Scatter([(x,y)], label=A)
 
-        xy = streams.PointerXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
-        assert_element_equal(dmap['Test'], Scatter([(1, 2)], label='Test'))
+        xy = hv.streams.PointerXY(x=1, y=2)
+        dmap = hv.DynamicMap(fn, kdims=['A'], streams=[xy])
+        assert_element_equal(dmap['Test'], hv.Scatter([(1, 2)], label='Test'))
 
 
     def test_dynamic_keywords_and_kwargs(self):
         def fn(A='default', x=1, y=2, **kws):
-            return Scatter([(x,y)], label=A)
+            return hv.Scatter([(x,y)], label=A)
 
-        xy = streams.PointerXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
-        assert_element_equal(dmap['Test'], Scatter([(1, 2)], label='Test'))
+        xy = hv.streams.PointerXY(x=1, y=2)
+        dmap = hv.DynamicMap(fn, kdims=['A'], streams=[xy])
+        assert_element_equal(dmap['Test'], hv.Scatter([(1, 2)], label='Test'))
 
 
     def test_dynamic_mixed_kwargs(self):
         def fn(x, A, y):
-            return Scatter([(x, y)], label=A)
+            return hv.Scatter([(x, y)], label=A)
 
-        xy = streams.PointerXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
-        assert_element_equal(dmap['Test'], Scatter([(1, 2)], label='Test'))
+        xy = hv.streams.PointerXY(x=1, y=2)
+        dmap = hv.DynamicMap(fn, kdims=['A'], streams=[xy])
+        assert_element_equal(dmap['Test'], hv.Scatter([(1, 2)], label='Test'))

--- a/holoviews/tests/core/test_collation.py
+++ b/holoviews/tests/core/test_collation.py
@@ -5,8 +5,7 @@ import itertools
 
 import numpy as np
 
-from holoviews.core import Collator, GridSpace, HoloMap, NdOverlay, Overlay
-from holoviews.element import Curve
+import holoviews as hv
 from holoviews.testing import assert_element_equal
 
 
@@ -16,10 +15,10 @@ class TestCollation:
         Bs = list(range(100))
         coords = itertools.product(*(range(n) for n in [alphas, betas, deltas]))
         mus=np.random.rand(alphas, betas, 100, 10)
-        self.phase_boundaries = {(a, b, d): Curve(zip(Bs, mus[a, b, :, i]*a+b, strict=True))
+        self.phase_boundaries = {(a, b, d): hv.Curve(zip(Bs, mus[a, b, :, i]*a+b, strict=True))
                                  for i in range(10) for a, b, d in coords}
         self.dimensions = ['alpha', 'beta', 'delta']
-        self.nesting_hmap = HoloMap(self.phase_boundaries, kdims=self.dimensions)
+        self.nesting_hmap = hv.HoloMap(self.phase_boundaries, kdims=self.dimensions)
         self.nested_hmap = self.nesting_hmap.groupby(['alpha'])
         self.nested_overlay = self.nesting_hmap.overlay(['delta'])
         self.nested_grid = self.nested_overlay.grid(['alpha', 'beta'])
@@ -33,27 +32,27 @@ class TestCollation:
         assert repr(collated) == repr(self.nesting_hmap)
 
     def test_collate_ndoverlay(self):
-        collated = self.nested_overlay.collate(NdOverlay)
-        ndoverlay = NdOverlay(self.phase_boundaries, kdims=self.dimensions)
+        collated = self.nested_overlay.collate(hv.NdOverlay)
+        ndoverlay = hv.NdOverlay(self.phase_boundaries, kdims=self.dimensions)
         assert collated.kdims == ndoverlay.kdims
         assert collated.keys() == ndoverlay.keys()
         assert repr(collated) == repr(ndoverlay)
 
     def test_collate_gridspace_ndoverlay(self):
-        grid = self.nesting_hmap.groupby(['delta']).collate(NdOverlay).grid(['alpha', 'beta'])
+        grid = self.nesting_hmap.groupby(['delta']).collate(hv.NdOverlay).grid(['alpha', 'beta'])
         assert grid.dimensions() == self.nested_grid.dimensions()
         assert grid.keys() == self.nested_grid.keys()
         assert repr(grid) == repr(self.nested_grid)
 
     def test_collate_ndlayout_ndoverlay(self):
-        layout = self.nesting_hmap.groupby(['delta']).collate(NdOverlay).layout(['alpha', 'beta'])
+        layout = self.nesting_hmap.groupby(['delta']).collate(hv.NdOverlay).layout(['alpha', 'beta'])
         assert layout.dimensions() == self.nested_layout.dimensions()
         assert layout.keys() == self.nested_layout.keys()
         assert repr(layout) == repr(self.nested_layout)
 
     def test_collate_layout_overlay(self):
         layout = self.nested_overlay + self.nested_overlay
-        collated = Collator(kdims=['alpha', 'beta'])
+        collated = hv.Collator(kdims=['alpha', 'beta'])
         for k, v in self.nested_overlay.items():
             collated[k] = v + v
         collated = collated()
@@ -61,7 +60,7 @@ class TestCollation:
 
     def test_collate_layout_hmap(self):
         layout = self.nested_overlay + self.nested_overlay
-        collated = Collator(kdims=['delta'], merge_type=NdOverlay)
+        collated = hv.Collator(kdims=['delta'], merge_type=hv.NdOverlay)
         for k, v in self.nesting_hmap.groupby(['delta']).items():
             collated[k] = v + v
         collated = collated()
@@ -69,12 +68,12 @@ class TestCollation:
         assert collated.dimensions() == layout.dimensions()
 
     def test_overlay_hmap_collate(self):
-        hmap = HoloMap({i: Curve(np.arange(10)*i) for i in range(3)})
-        overlaid = Overlay([hmap, hmap, hmap]).collate()
+        hmap = hv.HoloMap({i: hv.Curve(np.arange(10)*i) for i in range(3)})
+        overlaid = hv.Overlay([hmap, hmap, hmap]).collate()
         assert_element_equal(overlaid, hmap*hmap*hmap)
 
     def test_overlay_gridspace_collate(self):
-        grid = GridSpace({(i,j): Curve(np.arange(10)*i) for i in range(3)
+        grid = hv.GridSpace({(i,j): hv.Curve(np.arange(10)*i) for i in range(3)
                           for j in range(3)})
-        overlaid = Overlay([grid, grid, grid]).collate()
+        overlaid = hv.Overlay([grid, grid, grid]).collate()
         assert_element_equal(overlaid, grid*grid*grid)

--- a/holoviews/tests/core/test_composites.py
+++ b/holoviews/tests/core/test_composites.py
@@ -6,24 +6,24 @@ import re
 
 import pytest
 
-from holoviews import Element, HoloMap, Layout, Overlay
+import holoviews as hv
 from holoviews.testing import assert_element_equal
 
 
 class ElementTestCase:
 
     def setup_method(self):
-        self.el1 = Element('data1')
-        self.el2 = Element('data2')
-        self.el3 = Element('data3')
-        self.el4 = Element('data4', group='ValA')
-        self.el5 = Element('data5', group='ValB')
-        self.el6 = Element('data6', label='LabelA')
-        self.el7 = Element('data7', group='ValA', label='LabelA')
-        self.el8 = Element('data8', group='ValA', label='LabelB')
+        self.el1 = hv.Element('data1')
+        self.el2 = hv.Element('data2')
+        self.el3 = hv.Element('data3')
+        self.el4 = hv.Element('data4', group='ValA')
+        self.el5 = hv.Element('data5', group='ValB')
+        self.el6 = hv.Element('data6', label='LabelA')
+        self.el7 = hv.Element('data7', group='ValA', label='LabelA')
+        self.el8 = hv.Element('data8', group='ValA', label='LabelB')
 
     def test_element_init(self):
-        Element('data1')
+        hv.Element('data1')
 
 
 class LayoutTestCase(ElementTestCase):
@@ -33,12 +33,12 @@ class LayoutTestCase(ElementTestCase):
         assert t.keys() == [('Element', 'I',), ('Element', 'II',)]
 
     def test_layouttree_keys_2(self):
-        t = Layout([self.el1, self.el2])
+        t = hv.Layout([self.el1, self.el2])
         assert t.keys() == [('Element', 'I',), ('Element', 'II',)]
 
     def test_layouttree_deduplicate(self):
         for i in range(2, 10):
-            l = Layout([Element([], label='0') for _ in range(i)])
+            l = hv.Layout([hv.Element([], label='0') for _ in range(i)])
             assert len(l) == i
 
     def test_layouttree_values_1(self):
@@ -46,7 +46,7 @@ class LayoutTestCase(ElementTestCase):
         assert t.values() == [self.el1, self.el2]
 
     def test_layouttree_values_2(self):
-        t = Layout([self.el1, self.el2])
+        t = hv.Layout([self.el1, self.el2])
         assert t.values() == [self.el1, self.el2]
 
     def test_triple_layouttree_keys(self):
@@ -105,16 +105,16 @@ class LayoutTestCase(ElementTestCase):
         assert t2.keys() == t3.keys()
 
     def test_layouttree_constructor1(self):
-        t = Layout([self.el1])
+        t = hv.Layout([self.el1])
         assert t.keys() == [('Element', 'I')]
 
     def test_layouttree_constructor2(self):
-        t = Layout([self.el8])
+        t = hv.Layout([self.el8])
         assert t.keys() == [('ValA', 'LabelB')]
 
     def test_layouttree_group(self):
         t1 = (self.el1 + self.el2)
-        t2 = Layout(list(t1.relabel(group='NewValue')))
+        t2 = hv.Layout(list(t1.relabel(group='NewValue')))
         assert t2.keys() == [('NewValue', 'I'), ('NewValue', 'II')]
 
     def test_layouttree_quadruple_1(self):
@@ -129,13 +129,13 @@ class LayoutTestCase(ElementTestCase):
     def test_layout_constructor_with_layouts(self):
         layout1 = self.el1 + self.el4
         layout2 = self.el2 + self.el5
-        paths = Layout([layout1, layout2]).keys()
+        paths = hv.Layout([layout1, layout2]).keys()
         assert paths == [('Element', 'I',), ('ValA', 'I',), ('Element', 'II',), ('ValB', 'I',)]
 
     def test_layout_constructor_with_mixed_types(self):
         layout1 = self.el1 + self.el4 + self.el7
         layout2 = self.el2 + self.el5 + self.el8
-        paths = Layout([layout1, layout2, self.el3]).keys()
+        paths = hv.Layout([layout1, layout2, self.el3]).keys()
         expected = [
             ('Element', 'I',), ('ValA', 'I'),
             ('ValA', 'LabelA'), ('Element', 'II'),
@@ -145,13 +145,13 @@ class LayoutTestCase(ElementTestCase):
         assert paths == expected
 
     def test_layout_constructor_retains_custom_path(self):
-        layout = Layout([('Custom', self.el1)])
-        paths = Layout([layout, self.el2]).keys()
+        layout = hv.Layout([('Custom', self.el1)])
+        paths = hv.Layout([layout, self.el2]).keys()
         assert paths == [('Custom', 'I'), ('Element', 'I')]
 
     def test_layout_constructor_retains_custom_path_with_label(self):
-        layout = Layout([('Custom', self.el6)])
-        paths = Layout([layout, self.el2]).keys()
+        layout = hv.Layout([('Custom', self.el6)])
+        paths = hv.Layout([layout, self.el2]).keys()
         assert paths == [('Custom', 'LabelA'), ('Element', 'I')]
 
     def test_layout_integer_index(self):
@@ -161,30 +161,30 @@ class LayoutTestCase(ElementTestCase):
 
     def test_layout_overlay_element(self):
         t = (self.el1 + self.el2) * self.el3
-        assert_element_equal(t, Layout([self.el1*self.el3, self.el2*self.el3]))
+        assert_element_equal(t, hv.Layout([self.el1*self.el3, self.el2*self.el3]))
 
     def test_layout_overlay_element_reverse(self):
         t = self.el3 * (self.el1 + self.el2)
-        assert_element_equal(t, Layout([self.el3*self.el1, self.el3*self.el2]))
+        assert_element_equal(t, hv.Layout([self.el3*self.el1, self.el3*self.el2]))
 
     def test_layout_overlay_overlay(self):
         t = (self.el1 + self.el2) * (self.el3 * self.el4)
-        assert_element_equal(t, Layout([self.el1*self.el3*self.el4, self.el2*self.el3*self.el4]))
+        assert_element_equal(t, hv.Layout([self.el1*self.el3*self.el4, self.el2*self.el3*self.el4]))
 
     def test_layout_overlay_overlay_reverse(self):
         t = (self.el3 * self.el4) * (self.el1 + self.el2)
-        assert_element_equal(t, Layout([self.el3*self.el4*self.el1,
+        assert_element_equal(t, hv.Layout([self.el3*self.el4*self.el1,
                                     self.el3*self.el4*self.el2]))
 
     def test_layout_overlay_holomap(self):
-        t = (self.el1 + self.el2) * HoloMap({0: self.el3})
-        assert_element_equal(t, Layout([HoloMap({0: self.el1*self.el3}),
-                                    HoloMap({0: self.el2*self.el3})]))
+        t = (self.el1 + self.el2) * hv.HoloMap({0: self.el3})
+        assert_element_equal(t, hv.Layout([hv.HoloMap({0: self.el1*self.el3}),
+                                    hv.HoloMap({0: self.el2*self.el3})]))
 
     def test_layout_overlay_holomap_reverse(self):
-        t = HoloMap({0: self.el3}) * (self.el1 + self.el2)
-        assert_element_equal(t, Layout([HoloMap({0: self.el3*self.el1}),
-                                    HoloMap({0: self.el3*self.el2})]))
+        t = hv.HoloMap({0: self.el3}) * (self.el1 + self.el2)
+        assert_element_equal(t, hv.Layout([hv.HoloMap({0: self.el3*self.el1}),
+                                    hv.HoloMap({0: self.el3*self.el2})]))
 
 
 
@@ -200,7 +200,7 @@ class OverlayTestCase(ElementTestCase):
         assert t.keys() == [('Element', 'I'), ('Element', 'II')]
 
     def test_overlay_keys_2(self):
-        t = Overlay([self.el1, self.el2])
+        t = hv.Overlay([self.el1, self.el2])
         assert t.keys() == [('Element', 'I',), ('Element', 'II',)]
 
     def test_overlay_values(self):
@@ -208,7 +208,7 @@ class OverlayTestCase(ElementTestCase):
         assert t.values() == [self.el1, self.el2]
 
     def test_overlay_values_2(self):
-        t = Overlay([self.el1, self.el2])
+        t = hv.Overlay([self.el1, self.el2])
         assert t.values() == [self.el1, self.el2]
 
     def test_triple_overlay_keys(self):
@@ -286,16 +286,16 @@ class OverlayTestCase(ElementTestCase):
         assert o2.keys() == o3.keys()
 
     def test_overlay_constructor1(self):
-        t = Overlay([self.el1])
+        t = hv.Overlay([self.el1])
         assert t.keys() ==  [('Element', 'I')]
 
     def test_overlay_constructor2(self):
-        t = Overlay([self.el8])
+        t = hv.Overlay([self.el8])
         assert t.keys() ==  [('ValA', 'LabelB')]
 
     def test_overlay_group(self):
         t1 = (self.el1 * self.el2)
-        t2 = Overlay(list(t1.relabel(group='NewValue', depth=1)))
+        t2 = hv.Overlay(list(t1.relabel(group='NewValue', depth=1)))
         assert t2.keys() == [('NewValue', 'I'), ('NewValue', 'II')]
 
     def test_overlay_quadruple_1(self):
@@ -316,13 +316,13 @@ class OverlayTestCase(ElementTestCase):
     def test_overlay_constructor_with_layouts(self):
         layout1 = self.el1 + self.el4
         layout2 = self.el2 + self.el5
-        paths = Layout([layout1, layout2]).keys()
+        paths = hv.Layout([layout1, layout2]).keys()
         assert paths == [('Element', 'I'), ('ValA', 'I'),  ('Element', 'II'), ('ValB', 'I')]
 
     def test_overlay_constructor_with_mixed_types(self):
         overlay1 = self.el1 + self.el4 + self.el7
         overlay2 = self.el2 + self.el5 + self.el8
-        paths = Layout([overlay1, overlay2, self.el3]).keys()
+        paths = hv.Layout([overlay1, overlay2, self.el3]).keys()
         expected = [
             ('Element', 'I'), ('ValA', 'I'),
             ('ValA', 'LabelA'), ('Element', 'II'),
@@ -332,22 +332,22 @@ class OverlayTestCase(ElementTestCase):
         assert paths == expected
 
     def test_overlay_constructor_retains_custom_path(self):
-        overlay = Overlay([('Custom', self.el1)])
-        paths = Overlay([overlay, self.el2]).keys()
+        overlay = hv.Overlay([('Custom', self.el1)])
+        paths = hv.Overlay([overlay, self.el2]).keys()
         assert paths == [('Custom', 'I'), ('Element', 'I')]
 
     def test_overlay_constructor_retains_custom_path_with_label(self):
-        overlay = Overlay([('Custom', self.el6)])
-        paths = Overlay([overlay, self.el2]).keys()
+        overlay = hv.Overlay([('Custom', self.el6)])
+        paths = hv.Overlay([overlay, self.el2]).keys()
         assert paths == [('Custom', 'LabelA'), ('Element', 'I')]
 
     def test_overlay_with_holomap(self):
-        overlay = Overlay([('Custom', self.el6)])
-        composite = overlay * HoloMap({0: Element(None, group='HoloMap')})
+        overlay = hv.Overlay([('Custom', self.el6)])
+        composite = overlay * hv.HoloMap({0: hv.Element(None, group='HoloMap')})
         assert composite.last.keys() == [('Custom', 'LabelA'), ('HoloMap', 'I')]
 
     def test_overlay_id_inheritance(self):
-        overlay = Overlay([], id=1)
+        overlay = hv.Overlay([], id=1)
         assert overlay.clone().id == 1
         assert overlay.clone()._plot_id == overlay._plot_id
         assert overlay.clone([])._plot_id != overlay._plot_id

--- a/holoviews/tests/core/test_datasetproperty.py
+++ b/holoviews/tests/core/test_datasetproperty.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews import Curve, Dataset, Dimension, Distribution, Scatter
+import holoviews as hv
 from holoviews.core import Apply, Redim
 from holoviews.operation import function, histogram
 from holoviews.testing import assert_element_equal
@@ -29,41 +29,41 @@ class DatasetPropertyTestCase:
             'd': [-1, -2, -3, -4, -5, -6, -7, -8]
         })
 
-        self.ds = Dataset(
+        self.ds = hv.Dataset(
             self.df,
             kdims=[
-                Dimension('a', label="The a Column"),
-                Dimension('b', label="The b Column"),
-                Dimension('c', label="The c Column"),
-                Dimension('d', label="The d Column"),
+                hv.Dimension('a', label="The a Column"),
+                hv.Dimension('b', label="The b Column"),
+                hv.Dimension('c', label="The c Column"),
+                hv.Dimension('d', label="The d Column"),
             ]
         )
 
-        self.ds2 = Dataset(
+        self.ds2 = hv.Dataset(
             self.df.iloc[2:],
             kdims=[
-                Dimension('a', label="The a Column"),
-                Dimension('b', label="The b Column"),
-                Dimension('c', label="The c Column"),
-                Dimension('d', label="The d Column"),
+                hv.Dimension('a', label="The a Column"),
+                hv.Dimension('b', label="The b Column"),
+                hv.Dimension('c', label="The c Column"),
+                hv.Dimension('d', label="The d Column"),
             ]
         )
 
 
 class ConstructorTestCase(DatasetPropertyTestCase):
     def test_constructors_dataset(self):
-        ds = Dataset(self.df)
+        ds = hv.Dataset(self.df)
         assert ds is ds.dataset
 
         # Check pipeline
         ops = ds.pipeline.operations
         assert len(ops) == 1
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert_element_equal(ds, ds.pipeline(ds.dataset))
 
     def test_constructor_curve(self):
-        element = Curve(self.df)
-        expected = Dataset(
+        element = hv.Curve(self.df)
+        expected = hv.Dataset(
             self.df,
             kdims=self.df.columns[0],
             vdims=self.df.columns[1:].tolist(),
@@ -73,28 +73,28 @@ class ConstructorTestCase(DatasetPropertyTestCase):
         # Check pipeline
         pipeline = element.pipeline
         assert len(pipeline.operations) == 1
-        assert pipeline.operations[0].output_type is Curve
+        assert pipeline.operations[0].output_type is hv.Curve
         assert_element_equal(element, element.pipeline(element.dataset))
 
 
 class ToTestCase(DatasetPropertyTestCase):
 
     def test_to_element(self):
-        curve = self.ds.to(Curve, 'a', 'b', groupby=[])
-        curve2 = self.ds2.to(Curve, 'a', 'b', groupby=[])
+        curve = self.ds.to(hv.Curve, 'a', 'b', groupby=[])
+        curve2 = self.ds2.to(hv.Curve, 'a', 'b', groupby=[])
         with pytest.raises(AssertionError):
             assert_element_equal(curve, curve2)
 
         assert_element_equal(curve.dataset, self.ds)
 
-        scatter = curve.to(Scatter)
+        scatter = curve.to(hv.Scatter)
         assert_element_equal(scatter.dataset, self.ds)
 
         # Check pipeline
         ops = curve.pipeline.operations
         assert len(ops) == 2
-        assert ops[0].output_type is Dataset
-        assert ops[1].output_type is Curve
+        assert ops[0].output_type is hv.Dataset
+        assert ops[1].output_type is hv.Curve
 
         # Execute pipeline
         assert_element_equal(curve.pipeline(curve.dataset), curve)
@@ -103,7 +103,7 @@ class ToTestCase(DatasetPropertyTestCase):
         )
 
     def test_to_holomap(self):
-        curve_hmap = self.ds.to(Curve, 'a', 'b', groupby=['c'])
+        curve_hmap = self.ds.to(hv.Curve, 'a', 'b', groupby=['c'])
 
         # Check HoloMap element datasets
         for v in self.df.c.drop_duplicates():
@@ -121,17 +121,17 @@ class ToTestCase(DatasetPropertyTestCase):
     def test_to_holomap_dask(self):
         with dask.config.set({"dataframe.convert-string": False}):
             ddf = dd.from_pandas(self.df, npartitions=2)
-        dds = Dataset(
+        dds = hv.Dataset(
             ddf,
             kdims=[
-                Dimension('a', label="The a Column"),
-                Dimension('b', label="The b Column"),
-                Dimension('c', label="The c Column"),
-                Dimension('d', label="The d Column"),
+                hv.Dimension('a', label="The a Column"),
+                hv.Dimension('b', label="The b Column"),
+                hv.Dimension('c', label="The c Column"),
+                hv.Dimension('d', label="The d Column"),
             ]
         )
 
-        curve_hmap = dds.to(Curve, 'a', 'b', groupby=['c'])
+        curve_hmap = dds.to(hv.Curve, 'a', 'b', groupby=['c'])
 
         # Check HoloMap element datasets
         for v in self.df.c.drop_duplicates():
@@ -187,7 +187,7 @@ class ReindexTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = ds_ab.pipeline.operations
         assert len(ops) == 2
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert ops[1].method_name == 'reindex'
         assert ops[1].args == []
         assert ops[1].kwargs == dict(kdims=['a'], vdims=['b'])
@@ -214,7 +214,7 @@ class ReindexTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = ds_ab.pipeline.operations
         assert len(ops) == 3
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert ops[1].method_name == 'reindex'
         assert ops[1].args == []
         assert ops[1].kwargs == dict(kdims=['a'], vdims=['b', 'c'])
@@ -228,10 +228,10 @@ class ReindexTestCase(DatasetPropertyTestCase):
 
     def test_reindex_curve(self):
         curve_ba = self.ds.to(
-            Curve, 'a', 'b', groupby=[]
+            hv.Curve, 'a', 'b', groupby=[]
         ).reindex(kdims='b', vdims='a')
         curve2_ba = self.ds2.to(
-            Curve, 'a', 'b', groupby=[]
+            hv.Curve, 'a', 'b', groupby=[]
         ).reindex(kdims='b', vdims='a')
 
         with pytest.raises(AssertionError):
@@ -241,8 +241,8 @@ class ReindexTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = curve_ba.pipeline.operations
         assert len(ops) == 3
-        assert ops[0].output_type is Dataset
-        assert ops[1].output_type is Curve
+        assert ops[0].output_type is hv.Dataset
+        assert ops[1].output_type is hv.Curve
         assert ops[2].method_name == 'reindex'
         assert ops[2].args == []
         assert ops[2].kwargs == dict(kdims='b', vdims='a')
@@ -253,10 +253,10 @@ class ReindexTestCase(DatasetPropertyTestCase):
 
     def test_double_reindex_curve(self):
         curve_ba = self.ds.to(
-            Curve, 'a', ['b', 'c'], groupby=[]
+            hv.Curve, 'a', ['b', 'c'], groupby=[]
         ).reindex(kdims='a', vdims='b').reindex(kdims='b', vdims='a')
         curve2_ba = self.ds2.to(
-            Curve, 'a', ['b', 'c'], groupby=[]
+            hv.Curve, 'a', ['b', 'c'], groupby=[]
         ).reindex(kdims='a', vdims='b').reindex(kdims='b', vdims='a')
 
         with pytest.raises(AssertionError):
@@ -267,8 +267,8 @@ class ReindexTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = curve_ba.pipeline.operations
         assert len(ops) == 4
-        assert ops[0].output_type is Dataset
-        assert ops[1].output_type is Curve
+        assert ops[0].output_type is hv.Dataset
+        assert ops[1].output_type is hv.Curve
         assert ops[2].method_name == 'reindex'
         assert ops[2].args == []
         assert ops[2].kwargs == dict(kdims='a', vdims='b')
@@ -294,7 +294,7 @@ class IlocTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = ds_iloc.pipeline.operations
         assert len(ops) == 2
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert ops[1].method_name == '_perform_getitem'
         assert ops[1].args == [[0, 2]]
         assert ops[1].kwargs == {}
@@ -316,8 +316,8 @@ class IlocTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = curve_iloc.pipeline.operations
         assert len(ops) == 3
-        assert ops[0].output_type is Dataset
-        assert ops[1].output_type is Curve
+        assert ops[0].output_type is hv.Dataset
+        assert ops[1].output_type is hv.Curve
         assert ops[2].method_name == '_perform_getitem'
         assert ops[2].args == [[0, 2]]
         assert ops[2].kwargs == {}
@@ -331,7 +331,7 @@ class NdlocTestCase(DatasetPropertyTestCase):
 
     def setup_method(self):
         super().setup_method()
-        self.ds_grid = Dataset(
+        self.ds_grid = hv.Dataset(
             (np.arange(4),
              np.arange(3),
              np.array([[1, 2, 3, 4],
@@ -341,7 +341,7 @@ class NdlocTestCase(DatasetPropertyTestCase):
             vdims='z'
         )
 
-        self.ds2_grid = Dataset(
+        self.ds2_grid = hv.Dataset(
             (np.arange(3),
              np.arange(3),
              np.array([[1, 2, 4],
@@ -367,7 +367,7 @@ class NdlocTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = ds_grid_ndloc.pipeline.operations
         assert len(ops) == 2
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert ops[1].method_name == '_perform_getitem'
         assert ops[1].args == [(slice(0, 2, None), slice(1, 3, None),)]
         assert ops[1].kwargs == {}
@@ -395,7 +395,7 @@ class SelectTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = ds_select.pipeline.operations
         assert len(ops) == 2
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert ops[1].method_name == 'select'
         assert ops[1].args == []
         assert ops[1].kwargs == {'b': 10}
@@ -416,8 +416,8 @@ class SelectTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = curve_select.pipeline.operations
         assert len(ops) == 3
-        assert ops[0].output_type is Dataset
-        assert ops[1].output_type is Curve
+        assert ops[0].output_type is hv.Dataset
+        assert ops[1].output_type is hv.Curve
         assert ops[2].method_name == 'select'
         assert ops[2].args == []
         assert ops[2].kwargs == {'b': 10}
@@ -445,8 +445,8 @@ class SortTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = curve_sorted.pipeline.operations
         assert len(ops) == 3
-        assert ops[0].output_type is Dataset
-        assert ops[1].output_type is Curve
+        assert ops[0].output_type is hv.Dataset
+        assert ops[1].output_type is hv.Curve
         assert ops[2].method_name == 'sort'
         assert ops[2].args == ['a']
         assert ops[2].kwargs == {}
@@ -474,8 +474,8 @@ class SampleTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = curve_sampled.pipeline.operations
         assert len(ops) == 3
-        assert ops[0].output_type is Dataset
-        assert ops[1].output_type is Curve
+        assert ops[0].output_type is hv.Dataset
+        assert ops[1].output_type is hv.Curve
         assert ops[2].method_name == 'sample'
         assert ops[2].args == [[1, 2]]
         assert ops[2].kwargs == {}
@@ -507,7 +507,7 @@ class ReduceTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = ds_reduced.pipeline.operations
         assert len(ops) == 3
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert ops[1].method_name == 'reindex'
         assert ops[2].method_name == 'reduce'
         assert ops[2].args == ['c']
@@ -537,7 +537,7 @@ class AggregateTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = ds_aggregated.pipeline.operations
         assert len(ops) == 3
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert ops[1].method_name == 'reindex'
         assert ops[2].method_name == 'aggregate'
         assert ops[2].args == ['b']
@@ -572,7 +572,7 @@ class GroupbyTestCase(DatasetPropertyTestCase):
             # Check pipeline
             ops = ds_group.pipeline.operations
             assert len(ops) == 4
-            assert ops[0].output_type is Dataset
+            assert ops[0].output_type is hv.Dataset
             assert ops[1].method_name == 'reindex'
             assert ops[2].method_name == 'groupby'
             assert ops[2].args == ['b']
@@ -599,7 +599,7 @@ class AddDimensionTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = ds_dim_added.pipeline.operations
         assert len(ops) == 2
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert ops[1].method_name == 'add_dimension'
         assert ops[1].args == ['new', 1, 17]
         assert ops[1].kwargs == {}
@@ -634,7 +634,7 @@ class HistogramTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = sub_hist.pipeline.operations
         assert len(ops) == 4
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert ops[1].output_type is Apply
         assert ops[2].method_name == '__call__'
         assert isinstance(ops[2].args[0], histogram)
@@ -662,7 +662,7 @@ class HistogramTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = sub_hist.pipeline.operations
         assert len(ops) == 4
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert ops[1].output_type is Apply
         assert ops[2].method_name == '__call__'
         assert isinstance(ops[2].args[0], histogram)
@@ -680,11 +680,11 @@ class HistogramTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = curve.pipeline.operations
         assert len(ops) == 4
-        assert ops[0].output_type is Dataset
+        assert ops[0].output_type is hv.Dataset
         assert ops[1].output_type is Apply
         assert ops[2].method_name == '__call__'
         assert isinstance(ops[2].args[0], histogram)
-        assert ops[3].output_type is Curve
+        assert ops[3].output_type is hv.Curve
 
         # Execute pipeline
         assert_element_equal(curve.pipeline(curve.dataset), curve)
@@ -694,7 +694,7 @@ class DistributionTestCase(DatasetPropertyTestCase):
 
     def setup_method(self):
         super().setup_method()
-        self.distribution = self.ds.to(Distribution, kdims='a', groupby=[])
+        self.distribution = self.ds.to(hv.Distribution, kdims='a', groupby=[])
 
     def test_distribution_dataset(self):
         assert_element_equal(self.distribution.dataset, self.ds)
@@ -711,10 +711,10 @@ class DatashaderTestCase(DatasetPropertyTestCase):
 
     def test_rasterize_curve(self):
         img = rasterize(
-            self.ds.to(Curve, 'a', 'b', groupby=[]), dynamic=False
+            self.ds.to(hv.Curve, 'a', 'b', groupby=[]), dynamic=False
         )
         img2 = rasterize(
-            self.ds2.to(Curve, 'a', 'b', groupby=[]), dynamic=False
+            self.ds2.to(hv.Curve, 'a', 'b', groupby=[]), dynamic=False
         )
         with pytest.raises(AssertionError):
             assert_element_equal(img, img2)
@@ -725,8 +725,8 @@ class DatashaderTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = img.pipeline.operations
         assert len(ops) == 3
-        assert ops[0].output_type is Dataset
-        assert ops[1].output_type is Curve
+        assert ops[0].output_type is hv.Dataset
+        assert ops[1].output_type is hv.Curve
         assert isinstance(ops[2], rasterize)
 
         # Execute pipeline
@@ -735,10 +735,10 @@ class DatashaderTestCase(DatasetPropertyTestCase):
 
     def test_datashade_curve(self):
         rgb = dynspread(datashade(
-            self.ds.to(Curve, 'a', 'b', groupby=[]), dynamic=False
+            self.ds.to(hv.Curve, 'a', 'b', groupby=[]), dynamic=False
         ), dynamic=False)
         rgb2 = dynspread(datashade(
-            self.ds2.to(Curve, 'a', 'b', groupby=[]), dynamic=False
+            self.ds2.to(hv.Curve, 'a', 'b', groupby=[]), dynamic=False
         ), dynamic=False)
 
         with pytest.raises(AssertionError):
@@ -750,8 +750,8 @@ class DatashaderTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = rgb.pipeline.operations
         assert len(ops) == 4
-        assert ops[0].output_type is Dataset
-        assert ops[1].output_type is Curve
+        assert ops[0].output_type is hv.Dataset
+        assert ops[1].output_type is hv.Curve
         assert isinstance(ops[2], datashade)
         assert isinstance(ops[3], dynspread)
 
@@ -763,10 +763,10 @@ class DatashaderTestCase(DatasetPropertyTestCase):
 class AccessorTestCase(DatasetPropertyTestCase):
     def test_apply_curve(self):
         curve = self.ds.to.curve('a', 'b', groupby=[]).apply(
-            lambda c: Scatter(c.select(b=(20, None)).data)
+            lambda c: hv.Scatter(c.select(b=(20, None)).data)
         )
         curve2 = self.ds2.to.curve('a', 'b', groupby=[]).apply(
-            lambda c: Scatter(c.select(b=(20, None)).data)
+            lambda c: hv.Scatter(c.select(b=(20, None)).data)
         )
         with pytest.raises(AssertionError):
             assert_element_equal(curve, curve2)
@@ -774,8 +774,8 @@ class AccessorTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = curve.pipeline.operations
         assert len(ops) == 4
-        assert ops[0].output_type is Dataset
-        assert ops[1].output_type is Curve
+        assert ops[0].output_type is hv.Dataset
+        assert ops[1].output_type is hv.Curve
         assert ops[2].output_type is Apply
         assert ops[2].kwargs == {'mode': None}
         assert ops[3].method_name == '__call__'
@@ -798,8 +798,8 @@ class AccessorTestCase(DatasetPropertyTestCase):
         # Check pipeline
         ops = curve.pipeline.operations
         assert len(ops) == 4
-        assert ops[0].output_type is Dataset
-        assert ops[1].output_type is Curve
+        assert ops[0].output_type is hv.Dataset
+        assert ops[1].output_type is hv.Curve
         assert ops[2].output_type is Redim
         assert ops[2].kwargs == {'mode': 'dataset'}
         assert ops[3].method_name == '__call__'

--- a/holoviews/tests/core/test_decollation.py
+++ b/holoviews/tests/core/test_decollation.py
@@ -1,7 +1,6 @@
 import param
 
-from holoviews.core import DynamicMap, GridSpace, HoloMap, NdOverlay, Overlay
-from holoviews.element import Points
+import holoviews as hv
 from holoviews.streams import PlotSize, RangeXY, Stream
 from holoviews.testing import assert_element_equal
 from holoviews.tests.utils import optional_dependencies
@@ -26,35 +25,35 @@ class TestDecollation:
         from holoviews.tests.test_streams import Sum, Val
 
         # kdims: a and b
-        self.dmap_ab = DynamicMap(
-            lambda a, b: Points([a, b]),
+        self.dmap_ab = hv.DynamicMap(
+            lambda a, b: hv.Points([a, b]),
             kdims=['a', 'b']
         ).redim.range(a=(0.0, 10.0), b=(0.0, 10.0))
 
         # kdims: b
-        self.dmap_b = DynamicMap(
-            lambda b: Points([b, b]),
+        self.dmap_b = hv.DynamicMap(
+            lambda b: hv.Points([b, b]),
             kdims=['b']
         ).redim.range(b=(0.0, 10.0))
 
         # no kdims, XY stream
         self.xy_stream = XY()
-        self.dmap_xy = DynamicMap(
-            lambda x, y: Points([x, y]), streams=[self.xy_stream]
+        self.dmap_xy = hv.DynamicMap(
+            lambda x, y: hv.Points([x, y]), streams=[self.xy_stream]
         )
 
         # no kdims, Z stream
         self.z_stream = Z()
-        self.dmap_z = DynamicMap(
-            lambda z: Points([z, z]), streams=[self.z_stream]
+        self.dmap_z = hv.DynamicMap(
+            lambda z: hv.Points([z, z]), streams=[self.z_stream]
         )
 
         # DynamicMap of a derived stream
         self.stream_val1 = Val()
         self.stream_val2 = Val()
         self.stream_val3 = Val()
-        self.dmap_derived = DynamicMap(
-            lambda v: Points([v, v]),
+        self.dmap_derived = hv.DynamicMap(
+            lambda v: hv.Points([v, v]),
             streams=[
                 Sum([self.stream_val1, Sum([self.stream_val2, self.stream_val3])])
             ]
@@ -66,7 +65,7 @@ class TestDecollation:
         # dmap produced by chained datashade and shade
         self.px_stream = PX()
         self.dmap_spread_points = spread(
-            datashade(Points([0.0, 1.0])), streams=[self.px_stream]
+            datashade(hv.Points([0.0, 1.0])), streams=[self.px_stream]
         )
 
         # data shaded with kdims: a, b
@@ -76,21 +75,21 @@ class TestDecollation:
     def test_decollate_layout_kdims(self):
         layout = self.dmap_ab + self.dmap_b
         decollated = layout.decollate()
-        assert isinstance(decollated, DynamicMap)
+        assert isinstance(decollated, hv.DynamicMap)
         assert decollated.kdims == self.dmap_ab.kdims
         assert_element_equal(
             decollated[2, 3],
-            Points([2, 3]) + Points([3, 3])
+            hv.Points([2, 3]) + hv.Points([3, 3])
         )
         assert_element_equal(
             decollated.callback.callable(2, 3),
-            Points([2, 3]) + Points([3, 3])
+            hv.Points([2, 3]) + hv.Points([3, 3])
         )
 
     def test_decollate_layout_streams(self):
         layout = self.dmap_xy + self.dmap_z
         decollated = layout.decollate()
-        assert isinstance(decollated, DynamicMap)
+        assert isinstance(decollated, hv.DynamicMap)
         assert decollated.kdims == []
 
         # Update streams
@@ -98,35 +97,35 @@ class TestDecollation:
         decollated.streams[1].event(z=3.0)
         assert_element_equal(
             decollated[()],
-            Points([1.0, 2.0]) + Points([3.0, 3.0])
+            hv.Points([1.0, 2.0]) + hv.Points([3.0, 3.0])
         )
         assert_element_equal(
             decollated.callback.callable(dict(x=1.0, y=2.0), dict(z=3.0)),
-            Points([1.0, 2.0]) + Points([3.0, 3.0])
+            hv.Points([1.0, 2.0]) + hv.Points([3.0, 3.0])
         )
 
     def test_decollate_layout_kdims_and_streams(self):
         layout = self.dmap_ab + self.dmap_xy
         decollated = layout.decollate()
-        assert isinstance(decollated, DynamicMap)
+        assert isinstance(decollated, hv.DynamicMap)
         assert decollated.kdims == self.dmap_ab.kdims
 
         # Update streams
         decollated.streams[0].event(x=3.0, y=4.0)
         assert_element_equal(
             decollated[1.0, 2.0],
-            Points([1.0, 2.0]) + Points([3.0, 4.0])
+            hv.Points([1.0, 2.0]) + hv.Points([3.0, 4.0])
         )
 
         assert_element_equal(
             decollated.callback.callable(1.0, 2.0, dict(x=3.0, y=4.0)),
-            Points([1.0, 2.0]) + Points([3.0, 4.0])
+            hv.Points([1.0, 2.0]) + hv.Points([3.0, 4.0])
         )
 
     @ds_skip
     def test_decollate_spread(self):
         decollated = self.dmap_spread_points.decollate()
-        assert isinstance(decollated, DynamicMap)
+        assert isinstance(decollated, hv.DynamicMap)
 
         # Check top-level stream types
         assert [PlotSize, RangeXY, PX] == [type(s) for s in decollated.streams]
@@ -150,7 +149,7 @@ class TestDecollation:
     @ds_skip
     def test_decollate_datashade_kdims(self):
         decollated = self.dmap_datashade_kdim_points.decollate()
-        assert isinstance(decollated, DynamicMap)
+        assert isinstance(decollated, hv.DynamicMap)
 
         # Check kdims
         assert decollated.kdims == self.dmap_ab.kdims
@@ -180,7 +179,7 @@ class TestDecollation:
         layout = self.dmap_datashade_kdim_points + self.dmap_b
 
         decollated = layout.decollate()
-        assert isinstance(decollated, DynamicMap)
+        assert isinstance(decollated, hv.DynamicMap)
 
         # Check kdims
         assert decollated.kdims == self.dmap_ab.kdims
@@ -204,18 +203,18 @@ class TestDecollation:
         assert_element_equal(expected, result)
 
     def test_decollate_overlay_of_dmaps(self):
-        overlay = Overlay([
-            DynamicMap(lambda z: Points([z, z]), streams=[Z()]),
-            DynamicMap(lambda z: Points([z, z]), streams=[Z()]),
-            DynamicMap(lambda z: Points([z, z]), streams=[Z()]),
+        overlay = hv.Overlay([
+            hv.DynamicMap(lambda z: hv.Points([z, z]), streams=[Z()]),
+            hv.DynamicMap(lambda z: hv.Points([z, z]), streams=[Z()]),
+            hv.DynamicMap(lambda z: hv.Points([z, z]), streams=[Z()]),
         ])
 
         decollated = overlay.decollate()
-        assert isinstance(decollated, DynamicMap)
+        assert isinstance(decollated, hv.DynamicMap)
         assert len(decollated.streams) == 3
 
-        expected = Overlay([
-            Points([1.0, 1.0]), Points([2.0, 2.0]), Points([3.0, 3.0])
+        expected = hv.Overlay([
+            hv.Points([1.0, 1.0]), hv.Points([2.0, 2.0]), hv.Points([3.0, 3.0])
         ])
 
         # Build result by updating streams
@@ -231,13 +230,13 @@ class TestDecollation:
 
 
     def test_decollate_dmap_gridspace_kdims(self):
-        self.perform_decollate_dmap_container_kdims(GridSpace)
+        self.perform_decollate_dmap_container_kdims(hv.GridSpace)
 
     def test_decollate_dmap_ndoverlay_kdims(self):
-        self.perform_decollate_dmap_container_kdims(NdOverlay)
+        self.perform_decollate_dmap_container_kdims(hv.NdOverlay)
 
     def test_decollate_dmap_holomap_kdims(self):
-        self.perform_decollate_dmap_container_kdims(HoloMap)
+        self.perform_decollate_dmap_container_kdims(hv.HoloMap)
 
     def perform_decollate_dmap_container_kdims(self, ContainerType):
         # Create container of DynamicMaps, each with kdims a and b.
@@ -250,7 +249,7 @@ class TestDecollation:
 
         # Decollate container
         decollated = container.decollate()
-        assert isinstance(decollated, DynamicMap)
+        assert isinstance(decollated, hv.DynamicMap)
         assert decollated.kdims == self.dmap_ab.kdims
 
         # Check result of instantiating decollate DynamicMap for particular kdim values
@@ -261,28 +260,28 @@ class TestDecollation:
         assert_element_equal(expected, result)
 
     def test_decollate_dmap_gridspace_streams(self):
-        self.perform_decollate_dmap_container_streams(GridSpace)
+        self.perform_decollate_dmap_container_streams(hv.GridSpace)
 
     def test_decollate_dmap_ndoverlay_streams(self):
-        self.perform_decollate_dmap_container_streams(NdOverlay)
+        self.perform_decollate_dmap_container_streams(hv.NdOverlay)
 
     def test_decollate_dmap_holomap_streams(self):
-        self.perform_decollate_dmap_container_streams(HoloMap)
+        self.perform_decollate_dmap_container_streams(hv.HoloMap)
 
     def perform_decollate_dmap_container_streams(self, ContainerType):
         # Create container of DynamicMaps, each with kdims a and b.
         xy_stream = XY()
-        fn = lambda x, y: Points([x, y])
+        fn = lambda x, y: hv.Points([x, y])
         data = [
-            (0, DynamicMap(fn, streams=[xy_stream])),
-            (1, DynamicMap(fn, streams=[xy_stream])),
-            (2, DynamicMap(fn, streams=[xy_stream]))
+            (0, hv.DynamicMap(fn, streams=[xy_stream])),
+            (1, hv.DynamicMap(fn, streams=[xy_stream])),
+            (2, hv.DynamicMap(fn, streams=[xy_stream]))
         ]
         container = ContainerType(data, kdims=["c"])
 
         # Decollate container
         decollated = container.decollate()
-        assert isinstance(decollated, DynamicMap)
+        assert isinstance(decollated, hv.DynamicMap)
         assert len(decollated.kdims) == 0
         assert len(decollated.streams) == 1
 
@@ -300,7 +299,7 @@ class TestDecollation:
         decollated = self.dmap_derived.decollate()
 
         # Check decollated types
-        assert isinstance(decollated, DynamicMap)
+        assert isinstance(decollated, hv.DynamicMap)
         assert len(decollated.streams) == 3
         for stream in decollated.streams:
             assert isinstance(stream, Val)

--- a/holoviews/tests/core/test_dimensioned.py
+++ b/holoviews/tests/core/test_dimensioned.py
@@ -3,15 +3,13 @@ import pickle
 
 import pytest
 
-from holoviews.core.element import Element
-from holoviews.core.options import Keywords, Options, OptionTree, Store
-from holoviews.core.spaces import HoloMap
-from holoviews.element.chart import Curve
+import holoviews as hv
+from holoviews.core.options import Keywords, OptionTree
 
 from ..utils import LoggingComparison
 
 
-class ExampleElement(Element):
+class ExampleElement(hv.Element):
     pass
 
 
@@ -27,10 +25,10 @@ class CustomBackendTestCase(LoggingComparison):
     """
 
     def setup_method(self):
-        self.current_backend = Store.current_backend
+        self.current_backend = hv.Store.current_backend
         self.register_custom(ExampleElement, 'backend_1', ['plot_custom1'])
         self.register_custom(ExampleElement, 'backend_2', ['plot_custom2'])
-        Store.set_current_backend('backend_1')
+        hv.Store.set_current_backend('backend_1')
 
     @classmethod
     def register_custom(cls, objtype, backend, custom_plot=None, custom_style=None):
@@ -38,18 +36,18 @@ class CustomBackendTestCase(LoggingComparison):
             custom_style = []
         if custom_plot is None:
             custom_plot = []
-        groups = Options._option_groups
-        if backend not in Store._options:
-            Store._options[backend] = OptionTree([], groups=groups)
-            Store._custom_options[backend] = {}
+        groups = hv.Options._option_groups
+        if backend not in hv.Store._options:
+            hv.Store._options[backend] = OptionTree([], groups=groups)
+            hv.Store._custom_options[backend] = {}
         name = objtype.__name__
         style_opts = Keywords(['style_opt1', 'style_opt2', *custom_style], name)
         plot_opts = Keywords(['plot_opt1', 'plot_opt2', *custom_plot], name)
-        opt_groups = {'plot': Options(allowed_keywords=plot_opts),
-                      'style': Options(allowed_keywords=style_opts),
-                      'output': Options(allowed_keywords=['backend'])}
-        Store._options[backend][name] = opt_groups
-        Store.renderers[backend] = MockRenderer(backend)
+        opt_groups = {'plot': hv.Options(allowed_keywords=plot_opts),
+                      'style': hv.Options(allowed_keywords=style_opts),
+                      'output': hv.Options(allowed_keywords=['backend'])}
+        hv.Store._options[backend][name] = opt_groups
+        hv.Store.renderers[backend] = MockRenderer(backend)
 
 
 
@@ -57,7 +55,7 @@ class TestDimensioned_options(CustomBackendTestCase):
 
     def test_apply_options_current_backend_style(self):
         obj = ExampleElement([]).options(style_opt1='A')
-        opts = Store.lookup_options('backend_1', obj, 'style')
+        opts = hv.Store.lookup_options('backend_1', obj, 'style')
         assert opts.options == {'style_opt1': 'A'}
 
     def test_apply_options_current_backend_style_invalid(self):
@@ -102,64 +100,64 @@ class TestDimensioned_options(CustomBackendTestCase):
 
     def test_apply_options_current_backend_style_multiple(self):
         obj = ExampleElement([]).options(style_opt1='A', style_opt2='B')
-        opts = Store.lookup_options('backend_1', obj, 'style')
+        opts = hv.Store.lookup_options('backend_1', obj, 'style')
         assert opts.options == {'style_opt1': 'A', 'style_opt2': 'B'}
 
     def test_apply_options_current_backend_plot(self):
         obj = ExampleElement([]).options(plot_opt1='A')
-        opts = Store.lookup_options('backend_1', obj, 'plot')
+        opts = hv.Store.lookup_options('backend_1', obj, 'plot')
         assert opts.options == {'plot_opt1': 'A'}
 
     def test_apply_options_current_backend_plot_multiple(self):
         obj = ExampleElement([]).options(plot_opt1='A', plot_opt2='B')
-        opts = Store.lookup_options('backend_1', obj, 'plot')
+        opts = hv.Store.lookup_options('backend_1', obj, 'plot')
         assert opts.options == {'plot_opt1': 'A', 'plot_opt2': 'B'}
 
     def test_apply_options_current_backend_plot_and_style(self):
         obj = ExampleElement([]).options(style_opt1='A', plot_opt1='B')
-        plot_opts = Store.lookup_options('backend_1', obj, 'plot')
+        plot_opts = hv.Store.lookup_options('backend_1', obj, 'plot')
         assert plot_opts.options == {'plot_opt1': 'B'}
-        style_opts = Store.lookup_options('backend_1', obj, 'style')
+        style_opts = hv.Store.lookup_options('backend_1', obj, 'style')
         assert style_opts.options == {'style_opt1': 'A'}
 
     def test_apply_options_explicit_backend_style(self):
         obj = ExampleElement([]).options(style_opt1='A', backend='backend_2')
-        opts = Store.lookup_options('backend_2', obj, 'style')
+        opts = hv.Store.lookup_options('backend_2', obj, 'style')
         assert opts.options == {'style_opt1': 'A'}
 
     def test_apply_options_explicit_backend_style_multiple(self):
         obj = ExampleElement([]).options(style_opt1='A', style_opt2='B', backend='backend_2')
-        opts = Store.lookup_options('backend_2', obj, 'style')
+        opts = hv.Store.lookup_options('backend_2', obj, 'style')
         assert opts.options == {'style_opt1': 'A', 'style_opt2': 'B'}
 
     def test_apply_options_explicit_backend_plot(self):
         obj = ExampleElement([]).options(plot_opt1='A', backend='backend_2')
-        opts = Store.lookup_options('backend_2', obj, 'plot')
+        opts = hv.Store.lookup_options('backend_2', obj, 'plot')
         assert opts.options == {'plot_opt1': 'A'}
 
     def test_apply_options_explicit_backend_plot_multiple(self):
         obj = ExampleElement([]).options(plot_opt1='A', plot_opt2='B', backend='backend_2')
-        opts = Store.lookup_options('backend_2', obj, 'plot')
+        opts = hv.Store.lookup_options('backend_2', obj, 'plot')
         assert opts.options == {'plot_opt1': 'A', 'plot_opt2': 'B'}
 
     def test_apply_options_explicit_backend_plot_and_style(self):
         obj = ExampleElement([]).options(style_opt1='A', plot_opt1='B', backend='backend_2')
-        plot_opts = Store.lookup_options('backend_2', obj, 'plot')
+        plot_opts = hv.Store.lookup_options('backend_2', obj, 'plot')
         assert plot_opts.options == {'plot_opt1': 'B'}
-        style_opts = Store.lookup_options('backend_2', obj, 'style')
+        style_opts = hv.Store.lookup_options('backend_2', obj, 'style')
         assert style_opts.options == {'style_opt1': 'A'}
 
     def test_apply_options_not_cloned(self):
         obj1 = ExampleElement([])
         obj2 = obj1.options(style_opt1='A', clone=False)
-        opts = Store.lookup_options('backend_1', obj1, 'style')
+        opts = hv.Store.lookup_options('backend_1', obj1, 'style')
         assert opts.options == {'style_opt1': 'A'}
         assert obj1 is obj2
 
     def test_apply_options_cloned(self):
         obj1 = ExampleElement([])
         obj2 = obj1.options(style_opt1='A')
-        opts = Store.lookup_options('backend_1', obj2, 'style')
+        opts = hv.Store.lookup_options('backend_1', obj2, 'style')
         assert opts.options == {'style_opt1': 'A'}
         assert obj1 is not obj2
 
@@ -167,37 +165,37 @@ class TestDimensioned_options(CustomBackendTestCase):
         obj = ExampleElement([])
         obj.opts(style_opt1='A', plot_opt1='B', backend='backend_1')
         obj.opts(style_opt1='C', plot_opt1='D', backend='backend_2')
-        plot_opts = Store.lookup_options('backend_1', obj, 'plot')
+        plot_opts = hv.Store.lookup_options('backend_1', obj, 'plot')
         assert plot_opts.options == {'plot_opt1': 'B'}
-        style_opts = Store.lookup_options('backend_1', obj, 'style')
+        style_opts = hv.Store.lookup_options('backend_1', obj, 'style')
         assert style_opts.options == {'style_opt1': 'A'}
-        plot_opts = Store.lookup_options('backend_2', obj, 'plot')
+        plot_opts = hv.Store.lookup_options('backend_2', obj, 'plot')
         assert plot_opts.options == {'plot_opt1': 'D'}
-        style_opts = Store.lookup_options('backend_2', obj, 'style')
+        style_opts = hv.Store.lookup_options('backend_2', obj, 'style')
         assert style_opts.options == {'style_opt1': 'C'}
 
     def test_apply_options_explicit_backend_persists_other_backend_inverted(self):
         obj = ExampleElement([])
         obj.opts(style_opt1='A', plot_opt1='B', backend='backend_2')
         obj.opts(style_opt1='C', plot_opt1='D', backend='backend_1')
-        plot_opts = Store.lookup_options('backend_1', obj, 'plot')
+        plot_opts = hv.Store.lookup_options('backend_1', obj, 'plot')
         assert plot_opts.options == {'plot_opt1': 'D'}
-        style_opts = Store.lookup_options('backend_1', obj, 'style')
+        style_opts = hv.Store.lookup_options('backend_1', obj, 'style')
         assert style_opts.options == {'style_opt1': 'C'}
-        plot_opts = Store.lookup_options('backend_2', obj, 'plot')
+        plot_opts = hv.Store.lookup_options('backend_2', obj, 'plot')
         assert plot_opts.options == {'plot_opt1': 'B'}
-        style_opts = Store.lookup_options('backend_2', obj, 'style')
+        style_opts = hv.Store.lookup_options('backend_2', obj, 'style')
         assert style_opts.options == {'style_opt1': 'A'}
 
     def test_apply_options_when_backend_switched(self):
         obj = ExampleElement([])
-        Store.current_backend = 'backend_2'
+        hv.Store.current_backend = 'backend_2'
         obj.opts(style_opt1='A', plot_opt1='B')
-        Store.current_backend = 'backend_1'
+        hv.Store.current_backend = 'backend_1'
         obj.opts(style_opt1='C', plot_opt1='D', backend='backend_2')
-        plot_opts = Store.lookup_options('backend_2', obj, 'plot')
+        plot_opts = hv.Store.lookup_options('backend_2', obj, 'plot')
         assert plot_opts.options == {'plot_opt1': 'D'}
-        style_opts = Store.lookup_options('backend_2', obj, 'style')
+        style_opts = hv.Store.lookup_options('backend_2', obj, 'style')
         assert style_opts.options == {'style_opt1': 'C'}
 
 
@@ -206,13 +204,13 @@ class TestOptionsCleanup(CustomBackendTestCase):
 
     def test_opts_resassignment_cleans_unused_tree(self):
         obj = ExampleElement([]).opts(style_opt1='A').opts(plot_opt1='B')
-        custom_options = Store._custom_options['backend_1']
+        custom_options = hv.Store._custom_options['backend_1']
         assert obj.id in custom_options
         assert len(custom_options) == 1
 
     def test_opts_multiple_resassignment_cleans_unused_tree(self):
-        obj = HoloMap({0: ExampleElement([]), 1: ExampleElement([])}).opts(style_opt1='A').opts(plot_opt1='B')
-        custom_options = Store._custom_options['backend_1']
+        obj = hv.HoloMap({0: ExampleElement([]), 1: ExampleElement([])}).opts(style_opt1='A').opts(plot_opt1='B')
+        custom_options = hv.Store._custom_options['backend_1']
         assert obj.last.id in custom_options
         assert len(custom_options) == 2
         for o in obj:
@@ -221,10 +219,10 @@ class TestOptionsCleanup(CustomBackendTestCase):
 
     def test_opts_resassignment_cleans_unused_tree_cross_backend(self):
         obj = ExampleElement([]).opts(style_opt1='A').opts(plot_opt1='B', backend='backend_2')
-        custom_options = Store._custom_options['backend_1']
+        custom_options = hv.Store._custom_options['backend_1']
         assert obj.id in custom_options
         assert len(custom_options) == 1
-        custom_options = Store._custom_options['backend_2']
+        custom_options = hv.Store._custom_options['backend_2']
         assert obj.id in custom_options
         assert len(custom_options) == 1
 
@@ -232,14 +230,14 @@ class TestOptionsCleanup(CustomBackendTestCase):
         obj = ExampleElement([]).opts(style_opt1='A')
         del obj
         gc.collect()
-        custom_options = Store._custom_options['backend_1']
+        custom_options = hv.Store._custom_options['backend_1']
         assert len(custom_options) == 0
 
     def test_partial_garbage_collect_does_not_clear_tree(self):
-        obj = HoloMap({0: ExampleElement([]), 1: ExampleElement([])}).opts(style_opt1='A')
+        obj = hv.HoloMap({0: ExampleElement([]), 1: ExampleElement([])}).opts(style_opt1='A')
         obj.pop(0)
         gc.collect()
-        custom_options = Store._custom_options['backend_1']
+        custom_options = hv.Store._custom_options['backend_1']
         assert obj.last.id in custom_options
         assert len(custom_options) == 1
         obj.pop(1)
@@ -248,13 +246,13 @@ class TestOptionsCleanup(CustomBackendTestCase):
 
     def test_opts_clear_cleans_unused_tree(self):
         ExampleElement([]).opts(style_opt1='A').opts.clear()
-        custom_options = Store._custom_options['backend_1']
+        custom_options = hv.Store._custom_options['backend_1']
         assert len(custom_options) == 0
 
 class TestGetSetState:
 
     def test_pickle_roundtrip(self):
-        curve = Curve([0, 1, 2], kdims=["XAXIS"])
+        curve = hv.Curve([0, 1, 2], kdims=["XAXIS"])
         roundtrip_curve = pickle.loads(pickle.dumps(curve))
         assert curve.kdims == roundtrip_curve.kdims
         assert curve.vdims == roundtrip_curve.vdims

--- a/holoviews/tests/core/test_dimensions.py
+++ b/holoviews/tests/core/test_dimensions.py
@@ -79,7 +79,7 @@ class DimensionReprTest:
 
     def test_name_dimension_repr_eval_equality(self):
         dim = hv.Dimension('test')
-        assert eval(repr(dim)) == dim
+        assert eval(repr(dim), {"Dimension": hv.Dimension}) == dim
 
     def test_name_dimension_repr_tuple(self):
         dim = hv.Dimension(('test', 'Test Dimension'))
@@ -87,7 +87,7 @@ class DimensionReprTest:
 
     def test_name_dimension_repr_tuple_eval_equality(self):
         dim = hv.Dimension(('test', 'Test Dimension'))
-        assert eval(repr(dim)) == dim
+        assert eval(repr(dim), {"Dimension": hv.Dimension}) == dim
 
     def test_name_dimension_repr_params(self):
         dim = hv.Dimension('test', label='Test Dimension', unit='m')
@@ -95,7 +95,7 @@ class DimensionReprTest:
 
     def test_name_dimension_repr_params_eval_equality(self):
         dim = hv.Dimension('test', label='Test Dimension', unit='m')
-        assert eval(repr(dim)) == dim
+        assert eval(repr(dim), {"Dimension": hv.Dimension}) == dim
 
     def test_pprint_value_boolean(self):
         # https://github.com/holoviz/holoviews/issues/5378

--- a/holoviews/tests/core/test_dimensions.py
+++ b/holoviews/tests/core/test_dimensions.py
@@ -5,7 +5,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core import Dimension, Dimensioned
+import holoviews as hv
+from holoviews.core import Dimensioned
 from holoviews.core.util import NUMPY_GE_2_0_0
 from holoviews.testing import assert_element_equal
 
@@ -15,46 +16,46 @@ from ..utils import LoggingComparison
 class DimensionNameLabelTest(LoggingComparison):
 
     def test_dimension_name(self):
-        dim = Dimension('test')
+        dim = hv.Dimension('test')
         assert dim.name == 'test'
 
     def test_dimension_name_and_label(self):
-        dim = Dimension('test')
+        dim = hv.Dimension('test')
         assert dim.name == 'test'
         assert dim.label == 'test'
 
     def test_dimension_name_tuple(self):
-        dim = Dimension(('test', 'A test'))
+        dim = hv.Dimension(('test', 'A test'))
         assert dim.name == 'test'
 
     def test_dimension_label_tuple(self):
-        dim = Dimension(('test', 'A test'))
+        dim = hv.Dimension(('test', 'A test'))
         assert dim.label == 'A test'
 
     def test_dimension_label_kwarg(self):
-        dim = Dimension('test', label='A test')
+        dim = hv.Dimension('test', label='A test')
         assert dim.label == 'A test'
 
     def test_dimension_dict_empty(self):
         with pytest.raises(ValueError, match='must contain a "name" key'):
-            Dimension({})
+            hv.Dimension({})
 
     def test_dimension_dict_label(self):
         with pytest.raises(ValueError, match='must contain a "name" key'):
-            Dimension(dict(label='A test'))
+            hv.Dimension(dict(label='A test'))
 
     def test_dimension_dict_name(self):
-        dim = Dimension(dict(name='test'))
+        dim = hv.Dimension(dict(name='test'))
         assert dim.name == 'test'
         assert dim.label == 'test'
 
     def test_dimension_dict_name_and_label(self):
-        dim = Dimension(dict(name='test', label='A test'))
+        dim = hv.Dimension(dict(name='test', label='A test'))
         assert dim.name == 'test'
         assert dim.label == 'A test'
 
     def test_dimension_label_kwarg_and_tuple(self):
-        dim = Dimension(('test', 'A test'), label='Another test')
+        dim = hv.Dimension(('test', 'A test'), label='Another test')
         substr = "Using label as supplied by keyword ('Another test'), ignoring tuple value 'A test'"
         self.log_handler.assert_endswith('WARNING', substr)
         assert dim.label == 'Another test'
@@ -62,86 +63,86 @@ class DimensionNameLabelTest(LoggingComparison):
     def test_dimension_invalid_name(self):
         regexp = 'Dimension name must only be passed as the positional argument'
         with pytest.raises(KeyError, match=regexp):
-            Dimension('test', name='something else')
+            hv.Dimension('test', name='something else')
 
     def test_dimension_invalid_name_tuple(self):
         regexp = 'Dimension name must only be passed as the positional argument'
         with pytest.raises(KeyError, match=regexp):
-            Dimension(('test', 'test dimension'), name='something else')
+            hv.Dimension(('test', 'test dimension'), name='something else')
 
 
 class DimensionReprTest:
 
     def test_name_dimension_repr(self):
-        dim = Dimension('test')
+        dim = hv.Dimension('test')
         assert repr(dim) == "Dimension('test')"
 
     def test_name_dimension_repr_eval_equality(self):
-        dim = Dimension('test')
+        dim = hv.Dimension('test')
         assert eval(repr(dim)) == dim
 
     def test_name_dimension_repr_tuple(self):
-        dim = Dimension(('test', 'Test Dimension'))
+        dim = hv.Dimension(('test', 'Test Dimension'))
         assert repr(dim) == "Dimension('test', label='Test Dimension')"
 
     def test_name_dimension_repr_tuple_eval_equality(self):
-        dim = Dimension(('test', 'Test Dimension'))
+        dim = hv.Dimension(('test', 'Test Dimension'))
         assert eval(repr(dim)) == dim
 
     def test_name_dimension_repr_params(self):
-        dim = Dimension('test', label='Test Dimension', unit='m')
+        dim = hv.Dimension('test', label='Test Dimension', unit='m')
         assert repr(dim) == "Dimension('test', label='Test Dimension', unit='m')"
 
     def test_name_dimension_repr_params_eval_equality(self):
-        dim = Dimension('test', label='Test Dimension', unit='m')
+        dim = hv.Dimension('test', label='Test Dimension', unit='m')
         assert eval(repr(dim)) == dim
 
     def test_pprint_value_boolean(self):
         # https://github.com/holoviz/holoviews/issues/5378
-        dim = Dimension('test')
+        dim = hv.Dimension('test')
         assert dim.pprint_value(True) == 'True'
         assert dim.pprint_value(False) == 'False'
 
 
 class DimensionEqualityTest:
     def test_simple_dim_equality(self):
-        dim1 = Dimension('test')
-        dim2 = Dimension('test')
+        dim1 = hv.Dimension('test')
+        dim2 = hv.Dimension('test')
         assert dim1==dim2
 
     def test_simple_str_equality(self):
-        dim1 = Dimension('test')
-        dim2 = Dimension('test')
+        dim1 = hv.Dimension('test')
+        dim2 = hv.Dimension('test')
         assert dim1==str(dim2)
 
     def test_simple_dim_inequality(self):
-        dim1 = Dimension('test1')
-        dim2 = Dimension('test2')
+        dim1 = hv.Dimension('test1')
+        dim2 = hv.Dimension('test2')
         assert not dim1==dim2
 
     def test_simple_str_inequality(self):
-        dim1 = Dimension('test1')
-        dim2 = Dimension('test2')
+        dim1 = hv.Dimension('test1')
+        dim2 = hv.Dimension('test2')
         assert not dim1==str(dim2)
 
     def test_label_dim_inequality(self):
-        dim1 = Dimension(('test', 'label1'))
-        dim2 = Dimension(('test', 'label2'))
+        dim1 = hv.Dimension(('test', 'label1'))
+        dim2 = hv.Dimension(('test', 'label2'))
         assert not dim1==dim2
 
     def test_label_str_equality(self):
-        dim1 = Dimension(('test', 'label1'))
-        dim2 = Dimension(('test', 'label2'))
+        dim1 = hv.Dimension(('test', 'label1'))
+        dim2 = hv.Dimension(('test', 'label2'))
         assert dim1==str(dim2)
 
     def test_weak_dim_equality(self):
-        dim1 = Dimension('test', cyclic=True, unit='m', type=float)
-        dim2 = Dimension('test', cyclic=False, unit='km', type=int)
+        dim1 = hv.Dimension('test', cyclic=True, unit='m', type=float)
+        dim2 = hv.Dimension('test', cyclic=False, unit='km', type=int)
         assert dim1==dim2
 
     def test_weak_str_equality(self):
-        dim1 = Dimension('test', cyclic=True, unit='m', type=float)
-        dim2 = Dimension('test', cyclic=False, unit='km', type=int)
+        dim1 = hv.Dimension('test', cyclic=True, unit='m', type=float)
+        dim2 = hv.Dimension('test', cyclic=False, unit='km', type=int)
         assert dim1==str(dim2)
 
 
@@ -155,82 +156,82 @@ class DimensionValuesTest:
         self.duplicates2 = ['a','b','b','a','c','a','c','d','d']
 
     def test_dimension_values_list1(self):
-        dim = Dimension('test', values=self.values1)
+        dim = hv.Dimension('test', values=self.values1)
         assert dim.values == self.values1
 
     def test_dimension_values_list2(self):
-        dim = Dimension('test', values=self.values2)
+        dim = hv.Dimension('test', values=self.values2)
         assert dim.values == self.values2
 
     def test_dimension_values_list_duplicates1(self):
-        dim = Dimension('test', values=self.duplicates1)
+        dim = hv.Dimension('test', values=self.duplicates1)
         assert dim.values == self.values1
 
     def test_dimension_values_list_duplicates2(self):
-        dim = Dimension('test', values=self.duplicates2)
+        dim = hv.Dimension('test', values=self.duplicates2)
         assert dim.values == self.values2
 
     def test_dimension_values_array1(self):
-        dim = Dimension('test', values=np.array(self.values1))
+        dim = hv.Dimension('test', values=np.array(self.values1))
         assert dim.values == self.values1
 
     def test_dimension_values_array2(self):
-        dim = Dimension('test', values=np.array(self.values2))
+        dim = hv.Dimension('test', values=np.array(self.values2))
         assert dim.values == self.values2
 
     def test_dimension_values_array_duplicates1(self):
-        dim = Dimension('test', values=np.array(self.duplicates1))
+        dim = hv.Dimension('test', values=np.array(self.duplicates1))
         assert dim.values == self.values1
 
     def test_dimension_values_array_duplicates2(self):
-        dim = Dimension('test', values=np.array(self.duplicates2))
+        dim = hv.Dimension('test', values=np.array(self.duplicates2))
         assert dim.values == self.values2
 
     def test_dimension_values_series1(self):
         df = pd.DataFrame({'col':self.values1})
-        dim = Dimension('test', values=df['col'])
+        dim = hv.Dimension('test', values=df['col'])
         assert dim.values == self.values1
 
     def test_dimension_values_series2(self):
         df = pd.DataFrame({'col':self.values2})
-        dim = Dimension('test', values=df['col'])
+        dim = hv.Dimension('test', values=df['col'])
         assert dim.values == self.values2
 
 
     def test_dimension_values_series_duplicates1(self):
         df = pd.DataFrame({'col':self.duplicates1})
-        dim = Dimension('test', values=df['col'])
+        dim = hv.Dimension('test', values=df['col'])
         assert dim.values == self.values1
 
     def test_dimension_values_series_duplicates2(self):
         df = pd.DataFrame({'col':self.duplicates2})
-        dim = Dimension('test', values=df['col'])
+        dim = hv.Dimension('test', values=df['col'])
         assert dim.values == self.values2
 
 
 class DimensionCloneTest:
 
     def test_simple_clone(self):
-        dim = Dimension('test')
+        dim = hv.Dimension('test')
         assert dim.name == 'test'
         assert dim.clone('bar').name == 'bar'
 
     def test_simple_label_clone(self):
-        dim = Dimension('test')
+        dim = hv.Dimension('test')
         assert dim.name == 'test'
         clone = dim.clone(label='label')
         assert clone.name == 'test'
         assert clone.label == 'label'
 
     def test_simple_values_clone(self):
-        dim = Dimension('test', values=[1,2,3])
+        dim = hv.Dimension('test', values=[1,2,3])
         assert dim.values == [1,2,3]
         clone = dim.clone(values=[4,5,6])
         assert clone.name == 'test'
         assert clone.values == [4,5,6]
 
     def test_tuple_clone(self):
-        dim = Dimension('test')
+        dim = hv.Dimension('test')
         assert dim.name == 'test'
         clone = dim.clone(('test', 'A test'))
         assert clone.name == 'test'
@@ -245,12 +246,12 @@ class DimensionDefaultTest:
         else:
             msg = r"Dimension\('A'\) default 1\.1 not found in declared values: \[0, 1\]"
         with pytest.raises(ValueError, match=msg):
-            Dimension('A', values=[0, 1], default=1.1)
+            hv.Dimension('A', values=[0, 1], default=1.1)
 
     def test_validate_default_against_range(self):
         msg = r"Dimension\('A'\) default 1\.1 not in declared range: \(0, 1\)"
         with pytest.raises(ValueError, match=msg):
-            Dimension('A', range=(0, 1), default=1.1)
+            hv.Dimension('A', range=(0, 1), default=1.1)
 
 
 class DimensionedTest:
@@ -285,7 +286,7 @@ class DimensionedTest:
     def test_dimensioned_redim_dimension(self):
         dimensioned = Dimensioned('Arbitrary Data', kdims=['x'])
         redimensioned = dimensioned.clone(kdims=['Test'])
-        assert_element_equal(redimensioned, dimensioned.redim(x=Dimension('Test')))
+        assert_element_equal(redimensioned, dimensioned.redim(x=hv.Dimension('Test')))
 
     def test_dimensioned_redim_dict(self):
         dimensioned = Dimensioned('Arbitrary Data', kdims=['x'])

--- a/holoviews/tests/core/test_dynamic.py
+++ b/holoviews/tests/core/test_dynamic.py
@@ -6,10 +6,7 @@ import numpy as np
 import param
 import pytest
 
-from holoviews import Dimension, GridSpace, Layout, NdLayout, NdOverlay
-from holoviews.core.options import Store
-from holoviews.core.spaces import Callable, DynamicMap, HoloMap
-from holoviews.element import Curve, Image, Points, Scatter, Text
+import holoviews as hv
 from holoviews.operation import histogram
 from holoviews.plotting.util import initialize_dynamic
 from holoviews.streams import (
@@ -46,270 +43,270 @@ class ExampleParameterized(param.Parameterized):
 class TestDynamicMapConstructor:
 
     def test_simple_constructor_kdims(self):
-        DynamicMap(lambda x: x, kdims=['test'])
+        hv.DynamicMap(lambda x: x, kdims=['test'])
 
     def test_simple_constructor_invalid_no_kdims(self):
         regexp = ("Callable '<lambda>' accepts more positional arguments than there are "
                   "kdims and stream parameters")
         with pytest.raises(KeyError, match=regexp):
-            DynamicMap(lambda x: x)
+            hv.DynamicMap(lambda x: x)
 
     def test_simple_constructor_invalid(self):
         regexp = (r"Callback '<lambda>' signature over \['x'\] does not accommodate "
                   r"required kdims \['x', 'y'\]")
         with pytest.raises(KeyError, match=regexp):
-            DynamicMap(lambda x: x, kdims=['x','y'])
+            hv.DynamicMap(lambda x: x, kdims=['x','y'])
 
     def test_simple_constructor_streams(self):
-        DynamicMap(lambda x: x, streams=[PointerX()])
+        hv.DynamicMap(lambda x: x, streams=[PointerX()])
 
     def test_simple_constructor_streams_dict(self):
         pointerx = PointerX()
-        DynamicMap(lambda x: x, streams=dict(x=pointerx.param.x))
+        hv.DynamicMap(lambda x: x, streams=dict(x=pointerx.param.x))
 
     def test_simple_constructor_streams_dict_panel_widget(self):
         import panel as pn
-        DynamicMap(lambda x: x, streams=dict(x=pn.widgets.FloatSlider()))
+        hv.DynamicMap(lambda x: x, streams=dict(x=pn.widgets.FloatSlider()))
 
     def test_simple_constructor_streams_dict_parameter(self):
         test = ExampleParameterized()
-        DynamicMap(lambda x: x, streams=dict(x=test.param.example))
+        hv.DynamicMap(lambda x: x, streams=dict(x=test.param.example))
 
     def test_simple_constructor_streams_dict_class_parameter(self):
-        DynamicMap(lambda x: x, streams=dict(x=ExampleParameterized.param.example))
+        hv.DynamicMap(lambda x: x, streams=dict(x=ExampleParameterized.param.example))
 
     def test_simple_constructor_streams_dict_invalid(self):
         regexp = "Cannot handle 'x' value 3 in streams dictionary"
         with pytest.raises(TypeError, match=regexp):
-            DynamicMap(lambda x: x, streams=dict(x=3))
+            hv.DynamicMap(lambda x: x, streams=dict(x=3))
 
     def test_simple_constructor_streams_invalid_uninstantiated(self):
         regexp = ("The supplied streams list contains objects "
                   "that are not Stream instances:(.+?)")
         with pytest.raises(TypeError, match=regexp):
-            DynamicMap(lambda x: x, streams=[PointerX])
+            hv.DynamicMap(lambda x: x, streams=[PointerX])
 
     def test_simple_constructor_streams_invalid_type(self):
         regexp = ("The supplied streams list contains objects "
                   "that are not Stream instances:(.+?)")
         with pytest.raises(TypeError, match=regexp):
-            DynamicMap(lambda x: x, streams=[3])
+            hv.DynamicMap(lambda x: x, streams=[3])
 
     def test_simple_constructor_streams_invalid_mismatch(self):
         regexp = "Callable '<lambda>' missing keywords to accept stream parameters: y"
         with pytest.raises(KeyError, match=regexp):
-            DynamicMap(lambda x: x, streams=[PointerXY()])
+            hv.DynamicMap(lambda x: x, streams=[PointerXY()])
 
     def test_simple_constructor_positional_stream_args(self):
-        DynamicMap(lambda v: v, streams=[PointerXY()], positional_stream_args=True)
+        hv.DynamicMap(lambda v: v, streams=[PointerXY()], positional_stream_args=True)
 
     def test_simple_constructor_streams_invalid_mismatch_named(self):
 
         def foo(x): return x
         regexp = "Callable 'foo' missing keywords to accept stream parameters: y"
         with pytest.raises(KeyError, match=regexp):
-            DynamicMap(foo, streams=[PointerXY()])
+            hv.DynamicMap(foo, streams=[PointerXY()])
 
 
 class TestDynamicMapPositionalStreamArgs:
     def test_positional_stream_args_without_streams(self):
-        fn = lambda i: Curve([i, i])
-        dmap = DynamicMap(fn, kdims=['i'], positional_stream_args=True)
-        assert_element_equal(dmap[0], Curve([0, 0]))
+        fn = lambda i: hv.Curve([i, i])
+        dmap = hv.DynamicMap(fn, kdims=['i'], positional_stream_args=True)
+        assert_element_equal(dmap[0], hv.Curve([0, 0]))
 
     def test_positional_stream_args_with_only_stream(self):
-        fn = lambda s: Curve([s['x'], s['y']])
+        fn = lambda s: hv.Curve([s['x'], s['y']])
         xy_stream = XY(x=1, y=2)
-        dmap = DynamicMap(fn, streams=[xy_stream], positional_stream_args=True)
-        assert_element_equal(dmap[()], Curve([1, 2]))
+        dmap = hv.DynamicMap(fn, streams=[xy_stream], positional_stream_args=True)
+        assert_element_equal(dmap[()], hv.Curve([1, 2]))
 
         # Update stream values
         xy_stream.event(x=5, y=7)
-        assert_element_equal(dmap[()], Curve([5, 7]))
+        assert_element_equal(dmap[()], hv.Curve([5, 7]))
 
     def test_positional_stream_args_with_single_kdim_and_stream(self):
-        fn = lambda i, s: Points([i, i]) + Curve([s['x'], s['y']])
+        fn = lambda i, s: hv.Points([i, i]) + hv.Curve([s['x'], s['y']])
         xy_stream = XY(x=1, y=2)
-        dmap = DynamicMap(
+        dmap = hv.DynamicMap(
             fn, kdims=['i'], streams=[xy_stream], positional_stream_args=True
         )
-        assert_element_equal(dmap[6], Points([6, 6]) + Curve([1, 2]))
+        assert_element_equal(dmap[6], hv.Points([6, 6]) + hv.Curve([1, 2]))
 
         # Update stream values
         xy_stream.event(x=5, y=7)
-        assert_element_equal(dmap[3], Points([3, 3]) + Curve([5, 7]))
+        assert_element_equal(dmap[3], hv.Points([3, 3]) + hv.Curve([5, 7]))
 
     def test_positional_stream_args_with_multiple_kdims_and_stream(self):
-        fn = lambda i, j, s1, s2: Points([i, j]) + Curve([s1['x'], s2['y']])
+        fn = lambda i, j, s1, s2: hv.Points([i, j]) + hv.Curve([s1['x'], s2['y']])
         x_stream = X(x=2)
         y_stream = Y(y=3)
 
-        dmap = DynamicMap(
+        dmap = hv.DynamicMap(
             fn,
             kdims=['i', 'j'],
             streams=[x_stream, y_stream],
             positional_stream_args=True
         )
-        assert_element_equal(dmap[0, 1], Points([0, 1]) + Curve([2, 3]))
+        assert_element_equal(dmap[0, 1], hv.Points([0, 1]) + hv.Curve([2, 3]))
 
         # Update stream values
         x_stream.event(x=5)
         y_stream.event(y=6)
-        assert_element_equal(dmap[3, 4], Points([3, 4]) + Curve([5, 6]))
+        assert_element_equal(dmap[3, 4], hv.Points([3, 4]) + hv.Curve([5, 6]))
 
     def test_initialize_with_overlapping_stream_params(self):
         fn = lambda xy0, xy1: \
-             Points([xy0['x'], xy0['y']]) + Curve([xy1['x'], xy1['y']])
+             hv.Points([xy0['x'], xy0['y']]) + hv.Curve([xy1['x'], xy1['y']])
         xy_stream0 = XY(x=1, y=2)
         xy_stream1 = XY(x=3, y=4)
-        dmap = DynamicMap(
+        dmap = hv.DynamicMap(
             fn, streams=[xy_stream0, xy_stream1], positional_stream_args=True
         )
-        assert_element_equal(dmap[()], Points([1, 2]) + Curve([3, 4]))
+        assert_element_equal(dmap[()], hv.Points([1, 2]) + hv.Curve([3, 4]))
 
 
 class TestDynamicMapMethods:
 
     def test_deep_relabel_label(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn, kdims=['i']).relabel(label='Test')
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap = hv.DynamicMap(fn, kdims=['i']).relabel(label='Test')
         assert dmap[0].label == 'Test'
 
     def test_deep_relabel_group(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn, kdims=['i']).relabel(group='Test')
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap = hv.DynamicMap(fn, kdims=['i']).relabel(group='Test')
         assert dmap[0].group == 'Test'
 
     def test_redim_dimension_name(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn, kdims=['i']).redim(i='New')
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap = hv.DynamicMap(fn, kdims=['i']).redim(i='New')
         assert dmap.kdims[0].name == 'New'
 
     def test_redim_dimension_range_aux(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn, kdims=['i']).redim.range(i=(0,1))
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap = hv.DynamicMap(fn, kdims=['i']).redim.range(i=(0,1))
         assert dmap.kdims[0].range == (0,1)
 
     def test_redim_dimension_values_cache_reset_1D(self):
         # Setting the values should drop mismatching keys from the cache
-        fn = lambda i: Curve([i,i])
-        dmap = DynamicMap(fn, kdims=['i'])[{0,1,2,3,4,5}]
+        fn = lambda i: hv.Curve([i,i])
+        dmap = hv.DynamicMap(fn, kdims=['i'])[{0,1,2,3,4,5}]
         assert dmap.keys() == [0,1,2,3,4,5]
         redimmed = dmap.redim.values(i=[2,3,5,6,8])
         assert redimmed.keys() == [2,3,5]
 
     def test_redim_dimension_values_cache_reset_2D_single(self):
         # Setting the values should drop mismatching keys from the cache
-        fn = lambda i,j: Curve([i,j])
+        fn = lambda i,j: hv.Curve([i,j])
         keys = [(0,1),(1,0),(2,2),(2,5), (3,3)]
-        dmap = DynamicMap(fn, kdims=['i','j'])[keys]
+        dmap = hv.DynamicMap(fn, kdims=['i','j'])[keys]
         assert dmap.keys() == keys
         redimmed = dmap.redim.values(i=[2,10,50])
         assert redimmed.keys() == [(2,2),(2,5)]
 
     def test_redim_dimension_values_cache_reset_2D_multi(self):
         # Setting the values should drop mismatching keys from the cache
-        fn = lambda i,j: Curve([i,j])
+        fn = lambda i,j: hv.Curve([i,j])
         keys = [(0,1),(1,0),(2,2),(2,5), (3,3)]
-        dmap = DynamicMap(fn, kdims=['i','j'])[keys]
+        dmap = hv.DynamicMap(fn, kdims=['i','j'])[keys]
         assert dmap.keys() == keys
         redimmed = dmap.redim.values(i=[2,10,50], j=[5,50,100])
         assert redimmed.keys() == [(2,5)]
 
 
     def test_redim_dimension_unit_aux(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn, kdims=['i']).redim.unit(i='m/s')
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap = hv.DynamicMap(fn, kdims=['i']).redim.unit(i='m/s')
         assert dmap.kdims[0].unit == 'm/s'
 
     def test_redim_dimension_type_aux(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn, kdims=['i']).redim.type(i=int)
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap = hv.DynamicMap(fn, kdims=['i']).redim.type(i=int)
         assert dmap.kdims[0].type is int
 
     def test_deep_redim_dimension_name(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn, kdims=['i']).redim(x='X')
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap = hv.DynamicMap(fn, kdims=['i']).redim(x='X')
         assert dmap[0].kdims[0].name == 'X'
 
     def test_deep_redim_dimension_name_with_spec(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn, kdims=['i']).redim(Image, x='X')
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap = hv.DynamicMap(fn, kdims=['i']).redim(hv.Image, x='X')
         assert dmap[0].kdims[0].name == 'X'
 
     def test_deep_getitem_bounded_kdims(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         assert_element_equal(dmap[:, 5:10][10], fn(10)[5:10])
 
     def test_deep_getitem_bounded_kdims_and_vdims(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         assert_element_equal(dmap[:, 5:10, 0:5][10], fn(10)[5:10, 0:5])
 
     def test_deep_getitem_cross_product_and_slice(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         assert_element_equal(dmap[[10, 11, 12], 5:10],
                          dmap.clone([(i, fn(i)[5:10]) for i in range(10, 13)]))
 
     def test_deep_getitem_index_and_slice(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         assert_element_equal(dmap[10, 5:10], fn(10)[5:10])
 
     def test_deep_getitem_cache_sliced(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         dmap[10] # Add item to cache
         assert_element_equal(dmap[:, 5:10][10], fn(10)[5:10])
 
     def test_deep_select_slice_kdim(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         assert_element_equal(dmap.select(x=(5, 10))[10], fn(10)[5:10])
 
     def test_deep_select_slice_kdim_and_vdims(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         assert_element_equal(dmap.select(x=(5, 10), y=(0, 5))[10], fn(10)[5:10, 0:5])
 
     def test_deep_select_slice_kdim_no_match(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
-        assert_element_equal(dmap.select(DynamicMap, x=(5, 10))[10], fn(10))
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
+        assert_element_equal(dmap.select(hv.DynamicMap, x=(5, 10))[10], fn(10))
 
     def test_deep_apply_element_function(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         mapped = dmap.apply(lambda x: x.clone(x.data*2))
         curve = fn(10)
         assert_element_equal(mapped[10], curve.clone(curve.data*2))
 
     def test_deep_apply_element_param_function(self):
-        fn = lambda i: Curve(np.arange(i))
+        fn = lambda i: hv.Curve(np.arange(i))
         class Test(param.Parameterized):
             a = param.Integer(default=1)
         test = Test()
         @param.depends(test.param.a)
         def op(obj, a):
             return obj.clone(obj.data*2)
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         mapped = dmap.apply(op)
         test.a = 2
         curve = fn(10)
         assert_element_equal(mapped[10], curve.clone(curve.data*2))
 
     def test_deep_apply_element_function_with_kwarg(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         mapped = dmap.apply(lambda x, label: x.relabel(label), label='New label')
         assert_element_equal(mapped[10], fn(10).relabel('New label'))
 
     def test_deep_map_apply_element_function_with_stream_kwarg(self):
         stream = Stream.define('Test', label='New label')()
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         mapped = dmap.apply(lambda x, label: x.relabel(label), streams=[stream])
         assert_element_equal(mapped[10], fn(10).relabel('New label'))
 
@@ -323,8 +320,8 @@ class TestDynamicMapMethods:
                 return self.label.title()
 
         test = Test()
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         mapped = dmap.apply(lambda x, label: x.relabel(label), label=test.value)
         curve = fn(10)
         assert_element_equal(mapped[10], curve.relabel('Label'))
@@ -341,8 +338,8 @@ class TestDynamicMapMethods:
                 return obj.relabel(self.label.title())
 
         test = Test()
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         mapped = dmap.apply(test.relabel)
         curve = fn(10)
         assert_element_equal(mapped[10], curve.relabel('Label'))
@@ -359,8 +356,8 @@ class TestDynamicMapMethods:
                 return obj.relabel(self.label.title(), group)
 
         test = Test()
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         mapped = dmap.apply(test.relabel, group='Group')
         curve = fn(10)
         assert_element_equal(mapped[10], curve.relabel('Label', 'Group'))
@@ -368,53 +365,53 @@ class TestDynamicMapMethods:
         assert_element_equal(mapped[10], curve.relabel('New Label', 'Group'))
 
     def test_deep_map_transform_element_type(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         dmap[10]
-        mapped = dmap.map(Scatter, Curve)
+        mapped = dmap.map(hv.Scatter, hv.Curve)
         area = mapped[11]
-        assert_element_equal(area, Scatter(fn(11)))
+        assert_element_equal(area, hv.Scatter(fn(11)))
 
     def test_deep_apply_transform_element_type(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         dmap[10]
-        mapped = dmap.apply(Scatter)
+        mapped = dmap.apply(hv.Scatter)
         area = mapped[11]
-        assert_element_equal(area, Scatter(fn(11)))
+        assert_element_equal(area, hv.Scatter(fn(11)))
 
     def test_deep_map_apply_dmap_function(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap1 = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
-        dmap2 = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
-        mapped = (dmap1 + dmap2).map(lambda x: x[10], DynamicMap)
-        assert_element_equal(mapped, Layout([('DynamicMap.I', fn(10)),
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap1 = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
+        dmap2 = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
+        mapped = (dmap1 + dmap2).map(lambda x: x[10], hv.DynamicMap)
+        assert_element_equal(mapped, hv.Layout([('DynamicMap.I', fn(10)),
                                          ('DynamicMap.II', fn(10))]))
 
     def test_deep_map_apply_dmap_function_no_clone(self):
-        fn = lambda i: Curve(np.arange(i))
-        dmap1 = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
-        dmap2 = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        fn = lambda i: hv.Curve(np.arange(i))
+        dmap1 = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
+        dmap2 = hv.DynamicMap(fn, kdims=[hv.Dimension('Test', range=(10, 20))])
         layout = (dmap1 + dmap2)
-        mapped = layout.map(lambda x: x[10], DynamicMap, clone=False)
+        mapped = layout.map(lambda x: x[10], hv.DynamicMap, clone=False)
         assert mapped is layout
 
     def test_dynamic_reindex_reorder(self):
         history = deque(maxlen=10)
         def history_callback(x, y):
             history.append((x, y))
-            return Points(list(history))
-        dmap = DynamicMap(history_callback, kdims=['x', 'y'])
+            return hv.Points(list(history))
+        dmap = hv.DynamicMap(history_callback, kdims=['x', 'y'])
         reindexed = dmap.reindex(['y', 'x'])
         points = reindexed[2, 1]
-        assert_element_equal(points, Points([(1, 2)]))
+        assert_element_equal(points, hv.Points([(1, 2)]))
 
     def test_dynamic_reindex_drop_raises_exception(self):
         history = deque(maxlen=10)
         def history_callback(x, y):
             history.append((x, y))
-            return Points(list(history))
-        dmap = DynamicMap(history_callback, kdims=['x', 'y'])
+            return hv.Points(list(history))
+        dmap = hv.DynamicMap(history_callback, kdims=['x', 'y'])
         exception = ("DynamicMap does not allow dropping dimensions, "
                      "reindex may only be used to reorder dimensions.")
         with pytest.raises(ValueError, match=exception):
@@ -422,68 +419,68 @@ class TestDynamicMapMethods:
 
     def test_dynamic_groupby_kdims_and_streams(self):
         def plot_function(mydim, data):
-            return Scatter(data[data[:, 2]==mydim])
+            return hv.Scatter(data[data[:, 2]==mydim])
 
         buff = Buffer(data=np.empty((0, 3)))
-        dmap = DynamicMap(plot_function, streams=[buff], kdims='mydim').redim.values(mydim=[0, 1, 2])
-        ndlayout = dmap.groupby('mydim', container_type=NdLayout)
-        assert isinstance(ndlayout[0], DynamicMap)
+        dmap = hv.DynamicMap(plot_function, streams=[buff], kdims='mydim').redim.values(mydim=[0, 1, 2])
+        ndlayout = dmap.groupby('mydim', container_type=hv.NdLayout)
+        assert isinstance(ndlayout[0], hv.DynamicMap)
         data = np.array([(0, 0, 0), (1, 1, 1), (2, 2, 2)])
         buff.send(data)
         assert ndlayout[0].callback.inputs[0] is dmap
         assert ndlayout[1].callback.inputs[0] is dmap
         assert ndlayout[2].callback.inputs[0] is dmap
-        assert_element_equal(ndlayout[0][()], Scatter([(0, 0)]))
-        assert_element_equal(ndlayout[1][()], Scatter([(1, 1)]))
-        assert_element_equal(ndlayout[2][()], Scatter([(2, 2)]))
+        assert_element_equal(ndlayout[0][()], hv.Scatter([(0, 0)]))
+        assert_element_equal(ndlayout[1][()], hv.Scatter([(1, 1)]))
+        assert_element_equal(ndlayout[2][()], hv.Scatter([(2, 2)]))
 
     def test_dynamic_split_overlays_on_ndoverlay(self):
-        dmap = DynamicMap(lambda: NdOverlay({i: Points([i]) for i in range(3)}))
+        dmap = hv.DynamicMap(lambda: hv.NdOverlay({i: hv.Points([i]) for i in range(3)}))
         initialize_dynamic(dmap)
         keys, dmaps = dmap._split_overlays()
         assert keys == [(0,), (1,), (2,)]
-        assert_element_equal(dmaps[0][()], Points([0]))
-        assert_element_equal(dmaps[1][()], Points([1]))
-        assert_element_equal(dmaps[2][()], Points([2]))
+        assert_element_equal(dmaps[0][()], hv.Points([0]))
+        assert_element_equal(dmaps[1][()], hv.Points([1]))
+        assert_element_equal(dmaps[2][()], hv.Points([2]))
 
     def test_dynamic_split_overlays_on_overlay(self):
-        dmap1 = DynamicMap(lambda: Points([]))
-        dmap2 = DynamicMap(lambda: Curve([]))
+        dmap1 = hv.DynamicMap(lambda: hv.Points([]))
+        dmap2 = hv.DynamicMap(lambda: hv.Curve([]))
         dmap = dmap1 * dmap2
         initialize_dynamic(dmap)
         keys, dmaps = dmap._split_overlays()
         assert keys == [('Points', 'I'), ('Curve', 'I')]
-        assert_element_equal(dmaps[0][()], Points([]))
-        assert_element_equal(dmaps[1][()], Curve([]))
+        assert_element_equal(dmaps[0][()], hv.Points([]))
+        assert_element_equal(dmaps[1][()], hv.Curve([]))
 
     def test_dynamic_split_overlays_on_varying_order_overlay(self):
         def cb(i):
             if i%2 == 0:
-                return Curve([]) * Points([])
+                return hv.Curve([]) * hv.Points([])
             else:
-                return Points([]) * Curve([])
-        dmap = DynamicMap(cb, kdims='i').redim.range(i=(0, 4))
+                return hv.Points([]) * hv.Curve([])
+        dmap = hv.DynamicMap(cb, kdims='i').redim.range(i=(0, 4))
         initialize_dynamic(dmap)
         keys, dmaps = dmap._split_overlays()
         assert keys == [('Curve', 'I'), ('Points', 'I')]
-        assert_element_equal(dmaps[0][0], Curve([]))
-        assert_element_equal(dmaps[0][1], Curve([]))
-        assert_element_equal(dmaps[1][0], Points([]))
-        assert_element_equal(dmaps[1][1], Points([]))
+        assert_element_equal(dmaps[0][0], hv.Curve([]))
+        assert_element_equal(dmaps[0][1], hv.Curve([]))
+        assert_element_equal(dmaps[1][0], hv.Points([]))
+        assert_element_equal(dmaps[1][1], hv.Points([]))
 
     def test_dynamic_split_overlays_on_missing_item_in_overlay(self):
         def cb(i):
             if i%2 == 0:
-                return Curve([]) * Points([])
+                return hv.Curve([]) * hv.Points([])
             else:
-                return Scatter([]) * Curve([])
-        dmap = DynamicMap(cb, kdims='i').redim.range(i=(0, 4))
+                return hv.Scatter([]) * hv.Curve([])
+        dmap = hv.DynamicMap(cb, kdims='i').redim.range(i=(0, 4))
         initialize_dynamic(dmap)
         keys, dmaps = dmap._split_overlays()
         assert keys == [('Curve', 'I'), ('Points', 'I')]
-        assert_element_equal(dmaps[0][0], Curve([]))
-        assert_element_equal(dmaps[0][1], Curve([]))
-        assert_element_equal(dmaps[1][0], Points([]))
+        assert_element_equal(dmaps[0][0], hv.Curve([]))
+        assert_element_equal(dmaps[0][1], hv.Curve([]))
+        assert_element_equal(dmaps[1][0], hv.Points([]))
         with pytest.raises(KeyError):
             dmaps[1][1]
 
@@ -492,29 +489,29 @@ class TestDynamicMapMethods:
 class DynamicMapOptionsTests(CustomBackendTestCase):
 
     def test_dynamic_options(self):
-        dmap = DynamicMap(lambda X: ExampleElement(None), kdims=['X']).redim.range(X=(0,10))
+        dmap = hv.DynamicMap(lambda X: ExampleElement(None), kdims=['X']).redim.range(X=(0,10))
         dmap = dmap.options(plot_opt1='red')
-        opts = Store.lookup_options('backend_1', dmap[0], 'plot')
+        opts = hv.Store.lookup_options('backend_1', dmap[0], 'plot')
         assert opts.options == {'plot_opt1': 'red'}
 
     def test_dynamic_options_no_clone(self):
-        dmap = DynamicMap(lambda X: ExampleElement(None), kdims=['X']).redim.range(X=(0,10))
+        dmap = hv.DynamicMap(lambda X: ExampleElement(None), kdims=['X']).redim.range(X=(0,10))
         dmap.options(plot_opt1='red', clone=False)
-        opts = Store.lookup_options('backend_1', dmap[0], 'plot')
+        opts = hv.Store.lookup_options('backend_1', dmap[0], 'plot')
         assert opts.options == {'plot_opt1': 'red'}
 
     def test_dynamic_opts_link_inputs(self):
         stream = LinkedStream()
-        inputs = [DynamicMap(lambda: None, streams=[stream])]
-        dmap = DynamicMap(Callable(lambda X: ExampleElement(None), inputs=inputs),
+        inputs = [hv.DynamicMap(lambda: None, streams=[stream])]
+        dmap = hv.DynamicMap(hv.Callable(lambda X: ExampleElement(None), inputs=inputs),
                           kdims=['X']).redim.range(X=(0,10))
         styled_dmap = dmap.options(plot_opt1='red', clone=False)
-        opts = Store.lookup_options('backend_1', dmap[0], 'plot')
+        opts = hv.Store.lookup_options('backend_1', dmap[0], 'plot')
         assert opts.options == {'plot_opt1': 'red'}
         assert styled_dmap is dmap
         assert dmap.callback.link_inputs
         unstyled_dmap = dmap.callback.inputs[0].callback.inputs[0]
-        opts = Store.lookup_options('backend_1', unstyled_dmap[0], 'plot')
+        opts = hv.Store.lookup_options('backend_1', unstyled_dmap[0], 'plot')
         assert opts.options == {}
         original_dmap = unstyled_dmap.callback.inputs[0]
         assert stream is original_dmap.streams[0]
@@ -523,46 +520,46 @@ class DynamicMapOptionsTests(CustomBackendTestCase):
 class TestDynamicMapUnboundedProperty:
 
     def test_callable_bounded_init(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, kdims=[Dimension('dim', range=(0,10))])
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap=hv.DynamicMap(fn, kdims=[hv.Dimension('dim', range=(0,10))])
         assert dmap.unbounded == []
 
     def test_callable_bounded_clone(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, kdims=[Dimension('dim', range=(0,10))])
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap=hv.DynamicMap(fn, kdims=[hv.Dimension('dim', range=(0,10))])
         assert_element_equal(dmap, dmap.clone())
         assert dmap.unbounded == []
 
     def test_sampled_unbounded_init(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, kdims=['i'])
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap=hv.DynamicMap(fn, kdims=['i'])
         assert dmap.unbounded == ['i']
 
     def test_sampled_unbounded_resample(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, kdims=['i'])
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap=hv.DynamicMap(fn, kdims=['i'])
         assert dmap[{0, 1, 2}].keys() == [0, 1, 2]
         assert dmap.unbounded == ['i']
 
     def test_mixed_kdim_streams_unbounded(self):
-        dmap=DynamicMap(lambda x,y,z: x+y, kdims=['z'], streams=[XY()])
+        dmap=hv.DynamicMap(lambda x,y,z: x+y, kdims=['z'], streams=[XY()])
         assert dmap.unbounded == ['z']
 
     def test_mixed_kdim_streams_bounded_redim(self):
-        dmap=DynamicMap(lambda x,y,z: x+y, kdims=['z'], streams=[XY()])
+        dmap=hv.DynamicMap(lambda x,y,z: x+y, kdims=['z'], streams=[XY()])
         assert dmap.redim.range(z=(-0.5,0.5)).unbounded == []
 
 
 class TestDynamicMapCurrentKeyProperty:
 
     def test_current_key_None_on_init(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn, kdims=[Dimension('dim', range=(0,10))])
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap = hv.DynamicMap(fn, kdims=[hv.Dimension('dim', range=(0,10))])
         assert dmap.current_key is None
 
     def test_current_key_one_dimension(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, kdims=[Dimension('dim', range=(0,10))])
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap=hv.DynamicMap(fn, kdims=[hv.Dimension('dim', range=(0,10))])
         dmap[0]
         assert dmap.current_key == 0
         dmap[1]
@@ -572,8 +569,8 @@ class TestDynamicMapCurrentKeyProperty:
         assert dmap.current_key != dmap.last_key
 
     def test_current_key_multiple_dimensions(self):
-        fn = lambda i, j: Curve([i, j])
-        dmap=DynamicMap(fn, kdims=[Dimension('i', range=(0,5)), Dimension('j', range=(0,5))])
+        fn = lambda i, j: hv.Curve([i, j])
+        dmap=hv.DynamicMap(fn, kdims=[hv.Dimension('i', range=(0,5)), hv.Dimension('j', range=(0,5))])
         dmap[0, 2]
         assert dmap.current_key == (0, 2)
         dmap[5, 5]
@@ -588,7 +585,7 @@ class TestDynamicTransferStreams:
     def setup_method(self):
         self.dimstream = PointerX(x=0)
         self.stream = PointerY(y=0)
-        self.dmap = DynamicMap(lambda x, y, z: Curve([x, y, z]),
+        self.dmap = hv.DynamicMap(lambda x, y, z: hv.Curve([x, y, z]),
                                kdims=['x', 'z'], streams=[self.stream, self.dimstream])
 
     def test_dynamic_redim_inherits_streams(self):
@@ -600,11 +597,11 @@ class TestDynamicTransferStreams:
         assert relabelled.streams == self.dmap.streams
 
     def test_dynamic_map_inherits_streams(self):
-        mapped = self.dmap.map(lambda x: x, Curve)
+        mapped = self.dmap.map(lambda x: x, hv.Curve)
         assert mapped.streams == self.dmap.streams
 
     def test_dynamic_select_inherits_streams(self):
-        selected = self.dmap.select(Curve, x=(0, 5))
+        selected = self.dmap.select(hv.Curve, x=(0, 5))
         assert selected.streams == self.dmap.streams
 
     def test_dynamic_hist_inherits_streams(self):
@@ -649,56 +646,56 @@ class TestDynamicTransferStreams:
 class DynamicTestOperation:
 
     def test_dynamic_operation(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, kdims=['i'])
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap=hv.DynamicMap(fn, kdims=['i'])
         dmap_with_fn = Dynamic(dmap, operation=lambda x: x.clone(x.data*2))
-        assert_element_equal(dmap_with_fn[5], Image(sine_array(0,5)*2))
+        assert_element_equal(dmap_with_fn[5], hv.Image(sine_array(0,5)*2))
 
     def test_dynamic_operation_on_hmap(self):
-        hmap = HoloMap({i: Image(sine_array(0,i)) for i in range(10)})
+        hmap = hv.HoloMap({i: hv.Image(sine_array(0,i)) for i in range(10)})
         dmap = Dynamic(hmap, operation=lambda x: x)
         assert dmap.kdims[0].name == hmap.kdims[0].name
         assert dmap.kdims[0].values == hmap.keys()
 
     def test_dynamic_operation_link_inputs_not_transferred_on_clone(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, kdims=['i'])
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap=hv.DynamicMap(fn, kdims=['i'])
         dmap_with_fn = Dynamic(dmap, link_inputs=False, operation=lambda x: x.clone(x.data*2))
         assert dmap_with_fn.clone().callback.link_inputs
 
     def test_dynamic_operation_on_element(self):
-        img = Image(sine_array(0,5))
+        img = hv.Image(sine_array(0,5))
         posxy = PointerXY(x=2, y=1)
         dmap_with_fn = Dynamic(img, operation=lambda obj, x, y: obj.clone(obj.data*x+y),
                                streams=[posxy])
         element = dmap_with_fn[()]
-        assert_element_equal(element, Image(sine_array(0,5)*2+1))
+        assert_element_equal(element, hv.Image(sine_array(0,5)*2+1))
         assert dmap_with_fn.streams == [posxy]
 
     def test_dynamic_operation_on_element_dict(self):
-        img = Image(sine_array(0,5))
+        img = hv.Image(sine_array(0,5))
         posxy = PointerXY(x=3, y=1)
         dmap_with_fn = Dynamic(img, operation=lambda obj, x, y: obj.clone(obj.data*x+y),
                                streams=dict(x=posxy.param.x, y=posxy.param.y))
         element = dmap_with_fn[()]
-        assert_element_equal(element, Image(sine_array(0,5)*3+1))
+        assert_element_equal(element, hv.Image(sine_array(0,5)*3+1))
 
     def test_dynamic_operation_with_kwargs(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, kdims=['i'])
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap=hv.DynamicMap(fn, kdims=['i'])
         def fn(x, multiplier=2):
             return x.clone(x.data*multiplier)
         dmap_with_fn = Dynamic(dmap, operation=fn, kwargs=dict(multiplier=3))
-        assert_element_equal(dmap_with_fn[5], Image(sine_array(0,5)*3))
+        assert_element_equal(dmap_with_fn[5], hv.Image(sine_array(0,5)*3))
 
     def test_dynamic_operation_init_renamed_stream_params(self):
-        img = Image(sine_array(0,5))
+        img = hv.Image(sine_array(0,5))
         stream = RangeX(rename={'x_range': 'bin_range'})
         histogram(img, bin_range=(0, 1), streams=[stream], dynamic=True)
         assert stream.x_range == (0, 1)
 
     def test_dynamic_operation_init_stream_params(self):
-        img = Image(sine_array(0,5))
+        img = hv.Image(sine_array(0,5))
         stream = Stream.define('TestStream', bin_range=None)()
         histogram(img, bin_range=(0, 1), streams=[stream], dynamic=True)
         assert stream.bin_range == (0, 1)
@@ -707,47 +704,47 @@ class DynamicTestOperation:
 class DynamicTestOverlay:
 
     def test_dynamic_element_overlay(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, kdims=['i'])
-        dynamic_overlay = dmap * Image(sine_array(0,10))
-        overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap=hv.DynamicMap(fn, kdims=['i'])
+        dynamic_overlay = dmap * hv.Image(sine_array(0,10))
+        overlaid = hv.Image(sine_array(0,5)) * hv.Image(sine_array(0,10))
         assert_element_equal(dynamic_overlay[5], overlaid)
 
     def test_dynamic_element_underlay(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, kdims=['i'])
-        dynamic_overlay = Image(sine_array(0,10)) * dmap
-        overlaid = Image(sine_array(0,10)) * Image(sine_array(0,5))
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap=hv.DynamicMap(fn, kdims=['i'])
+        dynamic_overlay = hv.Image(sine_array(0,10)) * dmap
+        overlaid = hv.Image(sine_array(0,10)) * hv.Image(sine_array(0,5))
         assert_element_equal(dynamic_overlay[5], overlaid)
 
     def test_dynamic_dynamicmap_overlay(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, kdims=['i'])
-        fn2 = lambda i: Image(sine_array(0,i*2))
-        dmap2=DynamicMap(fn2, kdims=['i'])
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap=hv.DynamicMap(fn, kdims=['i'])
+        fn2 = lambda i: hv.Image(sine_array(0,i*2))
+        dmap2=hv.DynamicMap(fn2, kdims=['i'])
         dynamic_overlay = dmap * dmap2
-        overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))
+        overlaid = hv.Image(sine_array(0,5)) * hv.Image(sine_array(0,10))
         assert_element_equal(dynamic_overlay[5], overlaid)
 
     def test_dynamic_holomap_overlay(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn, kdims=['i'])
-        hmap = HoloMap({i: Image(sine_array(0,i*2)) for i in range(10)}, kdims=['i'])
+        fn = lambda i: hv.Image(sine_array(0,i))
+        dmap = hv.DynamicMap(fn, kdims=['i'])
+        hmap = hv.HoloMap({i: hv.Image(sine_array(0,i*2)) for i in range(10)}, kdims=['i'])
         dynamic_overlay = dmap * hmap
-        overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))
+        overlaid = hv.Image(sine_array(0,5)) * hv.Image(sine_array(0,10))
         assert_element_equal(dynamic_overlay[5], overlaid)
 
     def test_dynamic_overlay_memoization(self):
         """Tests that Callable memoizes unchanged callbacks"""
         def fn(x, y):
-            return Scatter([(x, y)])
-        dmap = DynamicMap(fn, kdims=[], streams=[PointerXY()])
+            return hv.Scatter([(x, y)])
+        dmap = hv.DynamicMap(fn, kdims=[], streams=[PointerXY()])
 
         counter = [0]
         def fn2(x, y):
             counter[0] += 1
-            return Image(np.random.rand(10, 10))
-        dmap2 = DynamicMap(fn2, kdims=[], streams=[PointerXY()])
+            return hv.Image(np.random.rand(10, 10))
+        dmap2 = hv.DynamicMap(fn2, kdims=[], streams=[PointerXY()])
 
         overlaid = dmap * dmap2
         overlay = overlaid[()]
@@ -763,18 +760,18 @@ class DynamicTestOverlay:
     def test_dynamic_event_renaming_valid(self):
 
         def fn(x1, y1):
-            return Scatter([(x1, y1)])
+            return hv.Scatter([(x1, y1)])
 
         xy = PointerXY(rename={'x':'x1','y':'y1'})
-        dmap = DynamicMap(fn, kdims=[], streams=[xy])
+        dmap = hv.DynamicMap(fn, kdims=[], streams=[xy])
         dmap.event(x1=1, y1=2)
 
     def test_dynamic_event_renaming_invalid(self):
         def fn(x1, y1):
-            return Scatter([(x1, y1)])
+            return hv.Scatter([(x1, y1)])
 
         xy = PointerXY(rename={'x':'x1','y':'y1'})
-        dmap = DynamicMap(fn, kdims=[], streams=[xy])
+        dmap = hv.DynamicMap(fn, kdims=[], streams=[xy])
 
         regexp = '(.+?)do not correspond to stream parameters'
         with pytest.raises(KeyError, match=regexp):
@@ -784,16 +781,16 @@ class DynamicTestOverlay:
 class TestDynamicCallableMemoize:
 
     def test_dynamic_keydim_not_memoize(self):
-        dmap = DynamicMap(lambda x: Curve([(0, x)]), kdims=['x'])
-        assert_element_equal(dmap[0], Curve([(0, 0)]))
-        assert_element_equal(dmap[1], Curve([(0, 1)]))
+        dmap = hv.DynamicMap(lambda x: hv.Curve([(0, x)]), kdims=['x'])
+        assert_element_equal(dmap[0], hv.Curve([(0, 0)]))
+        assert_element_equal(dmap[1], hv.Curve([(0, 1)]))
 
     def test_dynamic_keydim_memoize(self):
-        dmap = DynamicMap(lambda x: Curve([(0, x)]), kdims=['x'])
+        dmap = hv.DynamicMap(lambda x: hv.Curve([(0, x)]), kdims=['x'])
         assert dmap[0] is dmap[0]
 
     def test_dynamic_keydim_memoize_disable(self):
-        dmap = DynamicMap(Callable(lambda x: Curve([(0, x)]), memoize=False), kdims=['x'])
+        dmap = hv.DynamicMap(hv.Callable(lambda x: hv.Curve([(0, x)]), memoize=False), kdims=['x'])
         first = dmap[0]
         del dmap.data[(0,)]
         second = dmap[0]
@@ -804,21 +801,21 @@ class TestDynamicCallableMemoize:
         history = deque(maxlen=10)
         def history_callback(x):
             history.append(x)
-            return Curve(list(history))
+            return hv.Curve(list(history))
 
         x = PointerX()
-        dmap = DynamicMap(history_callback, kdims=[], streams=[x])
+        dmap = hv.DynamicMap(history_callback, kdims=[], streams=[x])
 
         # Add stream subscriber mocking plot
         x.add_subscriber(lambda **kwargs: dmap[()])
 
         x.event(x=1)
         x.event(x=1)
-        assert_element_equal(dmap[()], Curve([1]))
+        assert_element_equal(dmap[()], hv.Curve([1]))
 
         x.event(x=2)
         x.event(x=2)
-        assert_element_equal(dmap[()], Curve([1, 2]))
+        assert_element_equal(dmap[()], hv.Curve([1, 2]))
 
 
     def test_dynamic_callable_disable_callable_memoize(self):
@@ -827,30 +824,30 @@ class TestDynamicCallableMemoize:
         history = deque(maxlen=10)
         def history_callback(x):
             history.append(x)
-            return Curve(list(history))
+            return hv.Curve(list(history))
 
         x = PointerX()
-        callable_obj = Callable(history_callback, memoize=False)
-        dmap = DynamicMap(callable_obj, kdims=[], streams=[x])
+        callable_obj = hv.Callable(history_callback, memoize=False)
+        dmap = hv.DynamicMap(callable_obj, kdims=[], streams=[x])
 
         # Add stream subscriber mocking plot
         x.add_subscriber(lambda **kwargs: dmap[()])
 
         x.event(x=1)
         x.event(x=1)
-        assert_element_equal(dmap[()], Curve([1, 1, 1]))
+        assert_element_equal(dmap[()], hv.Curve([1, 1, 1]))
 
         x.event(x=2)
         x.event(x=2)
-        assert_element_equal(dmap[()], Curve([1, 1, 1, 2, 2, 2]))
+        assert_element_equal(dmap[()], hv.Curve([1, 1, 1, 2, 2, 2]))
 
 
 class TestDynamicMapRX:
 
     def test_dynamic_rx(self):
         freq = param.rx(1)
-        rx_curve = param.rx(sine_array)(0, freq).rx.pipe(Curve)
-        dmap = DynamicMap(rx_curve)
+        rx_curve = param.rx(sine_array)(0, freq).rx.pipe(hv.Curve)
+        dmap = hv.DynamicMap(rx_curve)
         assert len(dmap.streams) == 1
         pstream = dmap.streams[0]
         assert isinstance(pstream, Params)
@@ -858,9 +855,9 @@ class TestDynamicMapRX:
         fn_param, freq_param = pstream.parameters
         assert getattr(fn_param.owner, fn_param.name) == sine_array
         assert getattr(freq_param.owner, freq_param.name) == 1
-        assert_element_equal(dmap[()], Curve(sine_array(0, 1)))
+        assert_element_equal(dmap[()], hv.Curve(sine_array(0, 1)))
         freq.rx.value = 2
-        assert_element_equal(dmap[()], Curve(sine_array(0, 2)))
+        assert_element_equal(dmap[()], hv.Curve(sine_array(0, 2)))
 
 
 class TestStreamSubscribersAddandClear:
@@ -913,21 +910,21 @@ class TestDynamicStreamReset:
         def history_callback(x):
             if x is not None:
                 history.append(x)
-            return Curve(list(history))
+            return hv.Curve(list(history))
 
         x = PointerX(transient=True)
-        dmap = DynamicMap(history_callback, kdims=[], streams=[x])
+        dmap = hv.DynamicMap(history_callback, kdims=[], streams=[x])
 
         # Add stream subscriber mocking plot
         x.add_subscriber(lambda **kwargs: dmap[()])
 
         x.event(x=1)
         x.event(x=1)
-        assert_element_equal(dmap[()], Curve([1, 1]))
+        assert_element_equal(dmap[()], hv.Curve([1, 1]))
 
         x.event(x=2)
         x.event(x=2)
-        assert_element_equal(dmap[()], Curve([1, 1, 2, 2]))
+        assert_element_equal(dmap[()], hv.Curve([1, 1, 2, 2]))
 
     def test_dynamic_stream_transients(self):
         # Ensure Stream reset option resets streams to default value
@@ -941,14 +938,14 @@ class TestDynamicStreamReset:
             if y is None:
                 history_callback.yresets += 1
 
-            return Curve(list(history))
+            return hv.Curve(list(history))
 
         history_callback.xresets = 0
         history_callback.yresets = 0
 
         x = PointerX(transient=True)
         y = PointerY(transient=True)
-        dmap = DynamicMap(history_callback, kdims=[], streams=[x, y])
+        dmap = hv.DynamicMap(history_callback, kdims=[], streams=[x, y])
 
         # Add stream subscriber mocking plot
         x.add_subscriber(lambda **kwargs: dmap[()])
@@ -970,7 +967,7 @@ class TestDynamicStreamReset:
         def history_callback(x):
             if x is not None:
                 history.append(x)
-            return Curve(list(history))
+            return hv.Curve(list(history))
 
         class NoMemoize(PointerX):
             x = param.ClassSelector(class_=pointer_types, default=None, constant=True)
@@ -978,18 +975,18 @@ class TestDynamicStreamReset:
             def hashkey(self): return {'hash': uuid.uuid4().hex}
 
         x = NoMemoize()
-        dmap = DynamicMap(history_callback, kdims=[], streams=[x])
+        dmap = hv.DynamicMap(history_callback, kdims=[], streams=[x])
 
         # Add stream subscriber mocking plot
         x.add_subscriber(lambda **kwargs: dmap[()])
 
         x.event(x=1)
         x.event(x=1)
-        assert_element_equal(dmap[()], Curve([1, 1, 1]))
+        assert_element_equal(dmap[()], hv.Curve([1, 1, 1]))
 
         x.event(x=2)
         x.event(x=2)
-        assert_element_equal(dmap[()], Curve([1, 1, 1, 2, 2, 2]))
+        assert_element_equal(dmap[()], hv.Curve([1, 1, 1, 2, 2, 2]))
 
 
 
@@ -1001,20 +998,20 @@ class TestPeriodicStreamUpdate:
                 self.count = 0
             def __call__(self):
                 self.count += 1
-                return Curve([1,2,3])
+                return hv.Curve([1,2,3])
 
         next_stream = Stream.define('Next')()
         counter = Counter()
-        dmap = DynamicMap(counter, streams=[next_stream])
+        dmap = hv.DynamicMap(counter, streams=[next_stream])
         # Add stream subscriber mocking plot
         next_stream.add_subscriber(lambda **kwargs: dmap[()])
         dmap.periodic(0.01, 100)
         assert counter.count == 100
 
     def test_periodic_param_fn_blocking(self):
-        def callback(x): return Curve([1,2,3])
+        def callback(x): return hv.Curve([1,2,3])
         xval = Stream.define('x',x=0)()
-        dmap = DynamicMap(callback, streams=[xval])
+        dmap = hv.DynamicMap(callback, streams=[xval])
         # Add stream subscriber mocking plot
         xval.add_subscriber(lambda **kwargs: dmap[()])
         dmap.periodic(0.01, 100, param_fn=lambda i: {'x':i})
@@ -1022,9 +1019,9 @@ class TestPeriodicStreamUpdate:
 
     @pytest.mark.flaky(reruns=3)
     def test_periodic_param_fn_non_blocking(self):
-        def callback(x): return Curve([1,2,3])
+        def callback(x): return hv.Curve([1,2,3])
         xval = Stream.define('x',x=0)()
-        dmap = DynamicMap(callback, streams=[xval])
+        dmap = hv.DynamicMap(callback, streams=[xval])
         # Add stream subscriber mocking plot
         xval.add_subscriber(lambda **kwargs: dmap[()])
 
@@ -1038,9 +1035,9 @@ class TestPeriodicStreamUpdate:
 
     def test_periodic_param_fn_blocking_period(self):
         def callback(x):
-            return Curve([1,2,3])
+            return hv.Curve([1,2,3])
         xval = Stream.define('x',x=0)()
-        dmap = DynamicMap(callback, streams=[xval])
+        dmap = hv.DynamicMap(callback, streams=[xval])
         # Add stream subscriber mocking plot
         xval.add_subscriber(lambda **kwargs: dmap[()])
         start = time.time()
@@ -1051,9 +1048,9 @@ class TestPeriodicStreamUpdate:
 
     def test_periodic_param_fn_blocking_timeout(self):
         def callback(x):
-            return Curve([1,2,3])
+            return hv.Curve([1,2,3])
         xval = Stream.define('x',x=0)()
-        dmap = DynamicMap(callback, streams=[xval])
+        dmap = hv.DynamicMap(callback, streams=[xval])
         # Add stream subscriber mocking plot
         xval.add_subscriber(lambda **kwargs: dmap[()])
         start = time.time()
@@ -1066,113 +1063,113 @@ class TestDynamicCollate(LoggingComparison):
 
     def test_dynamic_collate_layout(self):
         def callback():
-            return Image(np.array([[0, 1], [2, 3]])) + Text(0, 0, 'Test')
-        dmap = DynamicMap(callback, kdims=[])
+            return hv.Image(np.array([[0, 1], [2, 3]])) + hv.Text(0, 0, 'Test')
+        dmap = hv.DynamicMap(callback, kdims=[])
         layout = dmap.collate()
         assert list(layout.keys()) == [('Image', 'I'), ('Text', 'I')]
-        assert_element_equal(layout.Image.I[()], Image(np.array([[0, 1], [2, 3]])))
+        assert_element_equal(layout.Image.I[()], hv.Image(np.array([[0, 1], [2, 3]])))
 
     def test_dynamic_collate_layout_raise_no_remapping_error(self):
         def callback(x, y):
-            return Image(np.array([[0, 1], [2, 3]])) + Text(0, 0, 'Test')
+            return hv.Image(np.array([[0, 1], [2, 3]])) + hv.Text(0, 0, 'Test')
         stream = PointerXY()
-        cb_callable = Callable(callback)
-        dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
+        cb_callable = hv.Callable(callback)
+        dmap = hv.DynamicMap(cb_callable, kdims=[], streams=[stream])
         with pytest.raises(ValueError, match='The following streams are set to be automatically linked'):
             dmap.collate()
 
     def test_dynamic_collate_layout_raise_ambiguous_remapping_error(self):
         def callback(x, y):
-            return Image(np.array([[0, 1], [2, 3]])) + Image(np.array([[0, 1], [2, 3]]))
+            return hv.Image(np.array([[0, 1], [2, 3]])) + hv.Image(np.array([[0, 1], [2, 3]]))
         stream = PointerXY()
-        cb_callable = Callable(callback, stream_mapping={'Image': [stream]})
-        dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
+        cb_callable = hv.Callable(callback, stream_mapping={'Image': [stream]})
+        dmap = hv.DynamicMap(cb_callable, kdims=[], streams=[stream])
         with pytest.raises(ValueError, match='The stream_mapping supplied on the Callable is ambiguous'):
             dmap.collate()
 
     def test_dynamic_collate_layout_with_integer_stream_mapping(self):
         def callback(x, y):
-            return Image(np.array([[0, 1], [2, 3]])) + Text(0, 0, 'Test')
+            return hv.Image(np.array([[0, 1], [2, 3]])) + hv.Text(0, 0, 'Test')
         stream = PointerXY()
-        cb_callable = Callable(callback, stream_mapping={0: [stream]})
-        dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
+        cb_callable = hv.Callable(callback, stream_mapping={0: [stream]})
+        dmap = hv.DynamicMap(cb_callable, kdims=[], streams=[stream])
         layout = dmap.collate()
         assert list(layout.keys()) == [('Image', 'I'), ('Text', 'I')]
         assert stream.source is layout.Image.I
 
     def test_dynamic_collate_layout_with_spec_stream_mapping(self):
         def callback(x, y):
-            return Image(np.array([[0, 1], [2, 3]])) + Text(0, 0, 'Test')
+            return hv.Image(np.array([[0, 1], [2, 3]])) + hv.Text(0, 0, 'Test')
         stream = PointerXY()
-        cb_callable = Callable(callback, stream_mapping={'Image': [stream]})
-        dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
+        cb_callable = hv.Callable(callback, stream_mapping={'Image': [stream]})
+        dmap = hv.DynamicMap(cb_callable, kdims=[], streams=[stream])
         layout = dmap.collate()
         assert list(layout.keys()) == [('Image', 'I'), ('Text', 'I')]
         assert stream.source is layout.Image.I
 
     def test_dynamic_collate_ndlayout(self):
         def callback():
-            return NdLayout({i: Image(np.array([[i, 1], [2, 3]])) for i in range(1, 3)})
-        dmap = DynamicMap(callback, kdims=[])
+            return hv.NdLayout({i: hv.Image(np.array([[i, 1], [2, 3]])) for i in range(1, 3)})
+        dmap = hv.DynamicMap(callback, kdims=[])
         layout = dmap.collate()
         assert list(layout.keys()) == [1, 2]
-        assert_element_equal(layout[1][()], Image(np.array([[1, 1], [2, 3]])))
+        assert_element_equal(layout[1][()], hv.Image(np.array([[1, 1], [2, 3]])))
 
     def test_dynamic_collate_ndlayout_with_integer_stream_mapping(self):
         def callback(x, y):
-            return NdLayout({i: Image(np.array([[i, 1], [2, 3]])) for i in range(1, 3)})
+            return hv.NdLayout({i: hv.Image(np.array([[i, 1], [2, 3]])) for i in range(1, 3)})
         stream = PointerXY()
-        cb_callable = Callable(callback, stream_mapping={0: [stream]})
-        dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
+        cb_callable = hv.Callable(callback, stream_mapping={0: [stream]})
+        dmap = hv.DynamicMap(cb_callable, kdims=[], streams=[stream])
         layout = dmap.collate()
         assert list(layout.keys()) == [1, 2]
         assert stream.source is layout[1]
 
     def test_dynamic_collate_ndlayout_with_key_stream_mapping(self):
         def callback(x, y):
-            return NdLayout({i: Image(np.array([[i, 1], [2, 3]])) for i in range(1, 3)})
+            return hv.NdLayout({i: hv.Image(np.array([[i, 1], [2, 3]])) for i in range(1, 3)})
         stream = PointerXY()
-        cb_callable = Callable(callback, stream_mapping={(1,): [stream]})
-        dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
+        cb_callable = hv.Callable(callback, stream_mapping={(1,): [stream]})
+        dmap = hv.DynamicMap(cb_callable, kdims=[], streams=[stream])
         layout = dmap.collate()
         assert list(layout.keys()) == [1, 2]
         assert stream.source is layout[1]
 
     def test_dynamic_collate_grid(self):
         def callback():
-            return GridSpace({(i, j): Image(np.array([[i, j], [2, 3]]))
+            return hv.GridSpace({(i, j): hv.Image(np.array([[i, j], [2, 3]]))
                               for i in range(1, 3) for j in range(1, 3)})
-        dmap = DynamicMap(callback, kdims=[])
+        dmap = hv.DynamicMap(callback, kdims=[])
         grid = dmap.collate()
         assert list(grid.keys()) == [(i, j,) for i in range(1, 3) for j in range(1, 3)]
-        assert_element_equal(grid[(0, 1)][()], Image(np.array([[1, 1], [2, 3]])))
+        assert_element_equal(grid[(0, 1)][()], hv.Image(np.array([[1, 1], [2, 3]])))
 
     def test_dynamic_collate_grid_with_integer_stream_mapping(self):
         def callback():
-            return GridSpace({(i, j): Image(np.array([[i, j], [2, 3]]))
+            return hv.GridSpace({(i, j): hv.Image(np.array([[i, j], [2, 3]]))
                               for i in range(1, 3) for j in range(1, 3)})
         stream = PointerXY()
-        cb_callable = Callable(callback, stream_mapping={1: [stream]})
-        dmap = DynamicMap(cb_callable, kdims=[])
+        cb_callable = hv.Callable(callback, stream_mapping={1: [stream]})
+        dmap = hv.DynamicMap(cb_callable, kdims=[])
         grid = dmap.collate()
         assert list(grid.keys()) == [(i, j,) for i in range(1, 3) for j in range(1, 3)]
         assert_element_equal(stream.source, grid[(1, 2)])
 
     def test_dynamic_collate_grid_with_key_stream_mapping(self):
         def callback():
-            return GridSpace({(i, j): Image(np.array([[i, j], [2, 3]]))
+            return hv.GridSpace({(i, j): hv.Image(np.array([[i, j], [2, 3]]))
                               for i in range(1, 3) for j in range(1, 3)})
         stream = PointerXY()
-        cb_callable = Callable(callback, stream_mapping={(1, 2): [stream]})
-        dmap = DynamicMap(cb_callable, kdims=[])
+        cb_callable = hv.Callable(callback, stream_mapping={(1, 2): [stream]})
+        dmap = hv.DynamicMap(cb_callable, kdims=[])
         grid = dmap.collate()
         assert list(grid.keys()) == [(i, j,) for i in range(1, 3) for j in range(1, 3)]
         assert_element_equal(stream.source, grid[(1, 2)])
 
     def test_dynamic_collate_layout_with_changing_label(self):
         def callback(i):
-            return Layout([Curve([], label=str(j)) for j in range(i, i+2)])
-        dmap = DynamicMap(callback, kdims=['i']).redim.range(i=(0, 10))
+            return hv.Layout([hv.Curve([], label=str(j)) for j in range(i, i+2)])
+        dmap = hv.DynamicMap(callback, kdims=['i']).redim.range(i=(0, 10))
         layout = dmap.collate()
         dmap1, dmap2 = layout.values()
         el1, el2 = dmap1[2], dmap2[2]
@@ -1181,8 +1178,8 @@ class TestDynamicCollate(LoggingComparison):
 
     def test_dynamic_collate_ndlayout_with_changing_keys(self):
         def callback(i):
-            return NdLayout({j: Curve([], label=str(j)) for j in range(i, i+2)})
-        dmap = DynamicMap(callback, kdims=['i']).redim.range(i=(0, 10))
+            return hv.NdLayout({j: hv.Curve([], label=str(j)) for j in range(i, i+2)})
+        dmap = hv.DynamicMap(callback, kdims=['i']).redim.range(i=(0, 10))
         layout = dmap.collate()
         dmap1, dmap2 = layout.values()
         el1, el2 = dmap1[2], dmap2[2]
@@ -1191,8 +1188,8 @@ class TestDynamicCollate(LoggingComparison):
 
     def test_dynamic_collate_gridspace_with_changing_keys(self):
         def callback(i):
-            return GridSpace({j: Curve([], label=str(j)) for j in range(i, i+2)}, 'X')
-        dmap = DynamicMap(callback, kdims=['i']).redim.range(i=(0, 10))
+            return hv.GridSpace({j: hv.Curve([], label=str(j)) for j in range(i, i+2)}, 'X')
+        dmap = hv.DynamicMap(callback, kdims=['i']).redim.range(i=(0, 10))
         layout = dmap.collate()
         dmap1, dmap2 = layout.values()
         el1, el2 = dmap1[2], dmap2[2]
@@ -1201,8 +1198,8 @@ class TestDynamicCollate(LoggingComparison):
 
     def test_dynamic_collate_gridspace_with_changing_items_raises(self):
         def callback(i):
-            return GridSpace({j: Curve([], label=str(j)) for j in range(i)}, 'X')
-        dmap = DynamicMap(callback, kdims=['i']).redim.range(i=(2, 10))
+            return hv.GridSpace({j: hv.Curve([], label=str(j)) for j in range(i)}, 'X')
+        dmap = hv.DynamicMap(callback, kdims=['i']).redim.range(i=(2, 10))
         layout = dmap.collate()
         dmap1, _dmap2 = layout.values()
         err = 'Collated DynamicMaps must return GridSpace with consistent number of items.'
@@ -1212,9 +1209,9 @@ class TestDynamicCollate(LoggingComparison):
 
     def test_dynamic_collate_gridspace_with_changing_item_types_raises(self):
         def callback(i):
-            eltype = Image if i%2 else Curve
-            return GridSpace({j: eltype([], label=str(j)) for j in range(i, i+2)}, 'X')
-        dmap = DynamicMap(callback, kdims=['i']).redim.range(i=(2, 10))
+            eltype = hv.Image if i%2 else hv.Curve
+            return hv.GridSpace({j: eltype([], label=str(j)) for j in range(i, i+2)}, 'X')
+        dmap = hv.DynamicMap(callback, kdims=['i']).redim.range(i=(2, 10))
         layout = dmap.collate()
         dmap1, _dmap2 = layout.values()
         err = ('The objects in a GridSpace returned by a DynamicMap must '

--- a/holoviews/tests/core/test_element.py
+++ b/holoviews/tests/core/test_element.py
@@ -1,19 +1,21 @@
-from holoviews.core import Dimension, Element
+
+
+import holoviews as hv
 
 
 class ElementTests:
 
     def setup_method(self):
-        self.element = Element([], kdims=['A', 'B'], vdims=['C'])
+        self.element = hv.Element([], kdims=['A', 'B'], vdims=['C'])
 
     def test_key_dimension_in_element(self):
-        assert Dimension('A') in self.element
+        assert hv.Dimension('A') in self.element
 
     def test_value_dimension_in_element(self):
-        assert Dimension('C') in self.element
+        assert hv.Dimension('C') in self.element
 
     def test_dimension_not_in_element(self):
-        assert Dimension('D') not in self.element
+        assert hv.Dimension('D') not in self.element
 
     def test_key_dimension_string_in_element(self):
         assert 'A' in self.element

--- a/holoviews/tests/core/test_element.py
+++ b/holoviews/tests/core/test_element.py
@@ -1,5 +1,3 @@
-
-
 import holoviews as hv
 
 

--- a/holoviews/tests/core/test_importexport.py
+++ b/holoviews/tests/core/test_importexport.py
@@ -4,7 +4,7 @@ Unit test of the (non-rendering) exporters and importers.
 
 import numpy as np
 
-from holoviews import Image, Layout
+import holoviews as hv
 from holoviews.core.io import Deserializer, Pickler, Serializer, Unpickler
 from holoviews.testing import assert_element_equal
 
@@ -16,8 +16,8 @@ class TestSerialization:
     """
 
     def setup_method(self):
-        self.image1 = Image(np.array([[1,2],[4,5]]))
-        self.image2 = Image(np.array([[5,4],[3,2]]))
+        self.image1 = hv.Image(np.array([[1,2],[4,5]]))
+        self.image2 = hv.Image(np.array([[5,4],[3,2]]))
 
     def test_serializer_save(self, tmp_path):
         Serializer.save(self.image1, tmp_path / 'test_serializer_save.pkl',
@@ -69,8 +69,8 @@ class TestBasicPickler:
     """
 
     def setup_method(self):
-        self.image1 = Image(np.array([[1,2],[4,5]]))
-        self.image2 = Image(np.array([[5,4],[3,2]]))
+        self.image1 = hv.Image(np.array([[1,2],[4,5]]))
+        self.image2 = hv.Image(np.array([[5,4],[3,2]]))
 
     def test_pickler_save(self, tmp_path) -> None:
         Pickler.save(self.image1, tmp_path / 'test_pickler_save.hvz',
@@ -121,8 +121,8 @@ class TestPicklerAdvanced:
     """
 
     def setup_method(self):
-        self.image1 = Image(np.array([[1,2],[4,5]]))
-        self.image2 = Image(np.array([[5,4],[3,2]]))
+        self.image1 = hv.Image(np.array([[1,2],[4,5]]))
+        self.image2 = hv.Image(np.array([[5,4],[3,2]]))
 
     def test_pickler_save_layout(self, tmp_path):
         Pickler.save(self.image1+self.image2, tmp_path / 'test_pickler_save_layout',
@@ -159,7 +159,7 @@ class TestPicklerAdvanced:
         assert_element_equal(loaded, self.image2)
 
     def test_pickler_save_load_single_layout(self, tmp_path):
-        single_layout = Layout([self.image1])
+        single_layout = hv.Layout([self.image1])
         Pickler.save(single_layout, tmp_path / 'test_pickler_save_load_single_layout',
                         info={'info':'example'}, key={1:2})
 

--- a/holoviews/tests/core/test_layers.py
+++ b/holoviews/tests/core/test_layers.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from holoviews import Curve, Element, NdOverlay, Overlay
+import holoviews as hv
 from holoviews.testing import assert_element_equal
 
 
@@ -12,27 +12,27 @@ class OverlayTest:
         self.data2 = np.ones((10, 2))
         self.data3 = np.ones((10, 2)) * 2
 
-        self.view1 = Element(self.data1, label='view1')
-        self.view2 = Element(self.data2, label='view2')
-        self.view3 = Element(self.data3, label='view3')
+        self.view1 = hv.Element(self.data1, label='view1')
+        self.view2 = hv.Element(self.data2, label='view2')
+        self.view3 = hv.Element(self.data3, label='view3')
 
     def test_overlay(self):
-        NdOverlay(list(enumerate([self.view1, self.view2, self.view3])))
+        hv.NdOverlay(list(enumerate([self.view1, self.view2, self.view3])))
 
     def test_overlay_iter(self):
         views = [self.view1, self.view2, self.view3]
-        overlay = NdOverlay(list(enumerate(views)))
+        overlay = hv.NdOverlay(list(enumerate(views)))
         for el, v in zip(overlay, views, strict=True):
             assert_element_equal(el, v)
 
     def test_overlay_iterable(self):
         # Related to https://github.com/holoviz/holoviews/issues/5315
-        c1 = Curve([0, 1])
-        c2 = Curve([10, 20])
-        Overlay({'a': c1, 'b': c2}.values())
+        c1 = hv.Curve([0, 1])
+        c2 = hv.Curve([10, 20])
+        hv.Overlay({'a': c1, 'b': c2}.values())
 
     def test_overlay_integer_indexing(self):
-        overlay = NdOverlay(list(enumerate([self.view1, self.view2, self.view3])))
+        overlay = hv.NdOverlay(list(enumerate([self.view1, self.view2, self.view3])))
         assert_element_equal(overlay[0], self.view1)
         assert_element_equal(overlay[1], self.view2)
         assert_element_equal(overlay[2], self.view3)

--- a/holoviews/tests/core/test_layouts.py
+++ b/holoviews/tests/core/test_layouts.py
@@ -4,16 +4,7 @@ Tests of Layout and related classes
 import numpy as np
 import pytest
 
-from holoviews import (
-    AdjointLayout,
-    Element,
-    GridSpace,
-    HoloMap,
-    Layout,
-    NdLayout,
-    Overlay,
-)
-from holoviews.element import Curve, HLine, Image
+import holoviews as hv
 from holoviews.testing import assert_element_equal
 
 
@@ -25,17 +16,17 @@ class CompositeTest:
         self.data2 = 'Another example...'
         self.data3 = 'A third example.'
 
-        self.view1 = Element(self.data1, label='View1')
-        self.view2 = Element(self.data2, label='View2')
-        self.view3 = Element(self.data3, label='View3')
-        self.hmap = HoloMap({0: self.view1, 1: self.view2, 2: self.view3})
+        self.view1 = hv.Element(self.data1, label='View1')
+        self.view2 = hv.Element(self.data2, label='View2')
+        self.view3 = hv.Element(self.data3, label='View3')
+        self.hmap = hv.HoloMap({0: self.view1, 1: self.view2, 2: self.view3})
 
     def test_add_operator(self):
-        assert type(self.view1 + self.view2) is Layout
+        assert type(self.view1 + self.view2) is hv.Layout
 
     def test_add_unicode(self):
         "Test to avoid regression of #3403 where unicode characters don't capitalize"
-        layout = Curve([-1,-2,-3]) + Curve([1,2,3]) .relabel('𝜗_1 vs th_2')
+        layout = hv.Curve([-1,-2,-3]) + hv.Curve([1,2,3]) .relabel('𝜗_1 vs th_2')
         elements = list(layout)
         assert len(elements) == 2
 
@@ -49,7 +40,7 @@ class CompositeTest:
 class AdjointLayoutTest(CompositeTest):
 
     def test_adjointlayout_single(self):
-        layout = AdjointLayout([self.view1])
+        layout = hv.AdjointLayout([self.view1])
         assert_element_equal(layout.main, self.view1)
 
     def test_adjointlayout_double(self):
@@ -71,7 +62,7 @@ class AdjointLayoutTest(CompositeTest):
     def test_adjointlayout_add_operator(self):
         layout1 = self.view3 << self.view2
         layout2 = self.view2 << self.view1
-        assert type(layout1 + layout2) is Layout
+        assert type(layout1 + layout2) is hv.Layout
 
     def test_adjointlayout_overlay_main(self):
         layout = (self.view1 << self.view2) * self.view3
@@ -134,81 +125,81 @@ class AdjointLayoutTest(CompositeTest):
 
     @pytest.mark.usefixtures("mpl_backend")
     def test_histogram_image_hline_overlay(self):
-        image = Image(np.arange(100).reshape(10, 10))
-        overlay = image * HLine(y=0)
+        image = hv.Image(np.arange(100).reshape(10, 10))
+        overlay = image * hv.HLine(y=0)
         element = overlay.hist()
 
-        assert isinstance(element, AdjointLayout)
+        assert isinstance(element, hv.AdjointLayout)
         assert element.main == overlay
 
 class NdLayoutTest(CompositeTest):
 
     def test_ndlayout_init(self):
-        grid = NdLayout([(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)])
+        grid = hv.NdLayout([(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)])
         assert grid.shape == (1,4)
 
     def test_ndlayout_overlay_element(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
-        grid = NdLayout(items)
-        hline = HLine(0)
+        grid = hv.NdLayout(items)
+        hline = hv.HLine(0)
         overlaid_grid = grid * hline
-        expected = NdLayout([(k, v*hline) for k, v in items])
+        expected = hv.NdLayout([(k, v*hline) for k, v in items])
         assert_element_equal(overlaid_grid, expected)
 
     def test_ndlayout_overlay_reverse(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
-        grid = NdLayout(items)
-        hline = HLine(0)
+        grid = hv.NdLayout(items)
+        hline = hv.HLine(0)
         overlaid_grid = hline * grid
-        expected = NdLayout([(k, hline*v) for k, v in items])
+        expected = hv.NdLayout([(k, hline*v) for k, v in items])
         assert_element_equal(overlaid_grid, expected)
 
     def test_ndlayout_overlay_ndlayout(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
-        grid = NdLayout(items)
+        grid = hv.NdLayout(items)
         items2 = [(0, self.view2), (1, self.view1), (2, self.view2), (3, self.view3)]
-        grid2 = NdLayout(items2)
+        grid2 = hv.NdLayout(items2)
 
         expected_items = [(0, self.view1*self.view2), (1, self.view2*self.view1),
                           (2, self.view3*self.view2), (3, self.view2*self.view3)]
-        expected = NdLayout(expected_items)
+        expected = hv.NdLayout(expected_items)
         assert_element_equal(grid*grid2, expected)
 
     def test_ndlayout_overlay_ndlayout_reverse(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
-        grid = NdLayout(items)
+        grid = hv.NdLayout(items)
         items2 = [(0, self.view2), (1, self.view1), (2, self.view2), (3, self.view3)]
-        grid2 = NdLayout(items2)
+        grid2 = hv.NdLayout(items2)
 
         expected_items = [(0, self.view2*self.view1), (1, self.view1*self.view2),
                           (2, self.view2*self.view3), (3, self.view3*self.view2)]
-        expected = NdLayout(expected_items)
+        expected = hv.NdLayout(expected_items)
         assert_element_equal(grid2*grid, expected)
 
     def test_ndlayout_overlay_ndlayout_partial(self):
         items = [(0, self.view1), (1, self.view2), (3, self.view2)]
-        grid = NdLayout(items, 'X')
+        grid = hv.NdLayout(items, 'X')
         items2 = [(0, self.view2), (2, self.view2), (3, self.view3)]
-        grid2 = NdLayout(items2, 'X')
+        grid2 = hv.NdLayout(items2, 'X')
 
-        expected_items = [(0, Overlay([self.view1, self.view2])),
-                          (1, Overlay([self.view2])),
-                          (2, Overlay([self.view2])),
-                          (3, Overlay([self.view2, self.view3]))]
-        expected = NdLayout(expected_items, 'X')
+        expected_items = [(0, hv.Overlay([self.view1, self.view2])),
+                          (1, hv.Overlay([self.view2])),
+                          (2, hv.Overlay([self.view2])),
+                          (3, hv.Overlay([self.view2, self.view3]))]
+        expected = hv.NdLayout(expected_items, 'X')
         assert_element_equal(grid*grid2, expected)
 
     def test_ndlayout_overlay_ndlayout_partial_reverse(self):
         items = [(0, self.view1), (1, self.view2), (3, self.view2)]
-        grid = NdLayout(items, 'X')
+        grid = hv.NdLayout(items, 'X')
         items2 = [(0, self.view2), (2, self.view2), (3, self.view3)]
-        grid2 = NdLayout(items2, 'X')
+        grid2 = hv.NdLayout(items2, 'X')
 
-        expected_items = [(0, Overlay([self.view2, self.view1])),
-                          (1, Overlay([self.view2])),
-                          (2, Overlay([self.view2])),
-                          (3, Overlay([self.view3, self.view2]))]
-        expected = NdLayout(expected_items, 'X')
+        expected_items = [(0, hv.Overlay([self.view2, self.view1])),
+                          (1, hv.Overlay([self.view2])),
+                          (2, hv.Overlay([self.view2])),
+                          (3, hv.Overlay([self.view3, self.view2]))]
+        expected = hv.NdLayout(expected_items, 'X')
         assert_element_equal(grid2*grid, expected)
 
 
@@ -217,87 +208,87 @@ class GridTest(CompositeTest):
     def test_grid_init(self):
         vals = [self.view1, self.view2, self.view3, self.view2]
         keys = [(0,0), (0,1), (1,0), (1,1)]
-        grid = GridSpace(zip(keys, vals, strict=True))
+        grid = hv.GridSpace(zip(keys, vals, strict=True))
         assert grid.shape == (2,2)
 
     def test_grid_index_snap(self):
         vals = [self.view1, self.view2, self.view3, self.view2]
         keys = [(0,0), (0,1), (1,0), (1,1)]
-        grid = GridSpace(zip(keys, vals, strict=True))
+        grid = hv.GridSpace(zip(keys, vals, strict=True))
         assert_element_equal(grid[0.1, 0.1], self.view1)
 
     def test_grid_index_strings(self):
         vals = [self.view1, self.view2, self.view3, self.view2]
         keys = [('A', 0), ('B', 1), ('C', 0), ('D', 1)]
-        grid = GridSpace(zip(keys, vals, strict=True))
+        grid = hv.GridSpace(zip(keys, vals, strict=True))
         assert_element_equal(grid['B', 1], self.view2)
 
     def test_grid_index_one_axis(self):
         vals = [self.view1, self.view2, self.view3, self.view2]
         keys = [('A', 0), ('B', 1), ('C', 0), ('D', 1)]
-        grid = GridSpace(zip(keys, vals, strict=True))
-        assert_element_equal(grid[:, 0], GridSpace([(('A', 0), self.view1), (('C', 0), self.view3)]))
+        grid = hv.GridSpace(zip(keys, vals, strict=True))
+        assert_element_equal(grid[:, 0], hv.GridSpace([(('A', 0), self.view1), (('C', 0), self.view3)]))
 
     def test_gridspace_overlay_element(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
-        grid = GridSpace(items, 'X')
-        hline = HLine(0)
+        grid = hv.GridSpace(items, 'X')
+        hline = hv.HLine(0)
         overlaid_grid = grid * hline
-        expected = GridSpace([(k, v*hline) for k, v in items], 'X')
+        expected = hv.GridSpace([(k, v*hline) for k, v in items], 'X')
         assert_element_equal(overlaid_grid, expected)
 
     def test_gridspace_overlay_reverse(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
-        grid = GridSpace(items, 'X')
-        hline = HLine(0)
+        grid = hv.GridSpace(items, 'X')
+        hline = hv.HLine(0)
         overlaid_grid = hline * grid
-        expected = GridSpace([(k, hline*v) for k, v in items], 'X')
+        expected = hv.GridSpace([(k, hline*v) for k, v in items], 'X')
         assert_element_equal(overlaid_grid, expected)
 
     def test_gridspace_overlay_gridspace(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
-        grid = GridSpace(items, 'X')
+        grid = hv.GridSpace(items, 'X')
         items2 = [(0, self.view2), (1, self.view1), (2, self.view2), (3, self.view3)]
-        grid2 = GridSpace(items2, 'X')
+        grid2 = hv.GridSpace(items2, 'X')
 
         expected_items = [(0, self.view1*self.view2), (1, self.view2*self.view1),
                           (2, self.view3*self.view2), (3, self.view2*self.view3)]
-        expected = GridSpace(expected_items, 'X')
+        expected = hv.GridSpace(expected_items, 'X')
         assert_element_equal(grid*grid2, expected)
 
     def test_gridspace_overlay_gridspace_reverse(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
-        grid = GridSpace(items, 'X')
+        grid = hv.GridSpace(items, 'X')
         items2 = [(0, self.view2), (1, self.view1), (2, self.view2), (3, self.view3)]
-        grid2 = GridSpace(items2, 'X')
+        grid2 = hv.GridSpace(items2, 'X')
 
         expected_items = [(0, self.view2*self.view1), (1, self.view1*self.view2),
                           (2, self.view2*self.view3), (3, self.view3*self.view2)]
-        expected = GridSpace(expected_items, 'X')
+        expected = hv.GridSpace(expected_items, 'X')
         assert_element_equal(grid2*grid, expected)
 
     def test_gridspace_overlay_gridspace_partial(self):
         items = [(0, self.view1), (1, self.view2), (3, self.view2)]
-        grid = GridSpace(items, 'X')
+        grid = hv.GridSpace(items, 'X')
         items2 = [(0, self.view2), (2, self.view2), (3, self.view3)]
-        grid2 = GridSpace(items2, 'X')
+        grid2 = hv.GridSpace(items2, 'X')
 
-        expected_items = [(0, Overlay([self.view1, self.view2])),
-                          (1, Overlay([self.view2])),
-                          (2, Overlay([self.view2])),
-                          (3, Overlay([self.view2, self.view3]))]
-        expected = GridSpace(expected_items, 'X')
+        expected_items = [(0, hv.Overlay([self.view1, self.view2])),
+                          (1, hv.Overlay([self.view2])),
+                          (2, hv.Overlay([self.view2])),
+                          (3, hv.Overlay([self.view2, self.view3]))]
+        expected = hv.GridSpace(expected_items, 'X')
         assert_element_equal(grid*grid2, expected)
 
     def test_gridspace_overlay_gridspace_partial_reverse(self):
         items = [(0, self.view1), (1, self.view2), (3, self.view2)]
-        grid = GridSpace(items, 'X')
+        grid = hv.GridSpace(items, 'X')
         items2 = [(0, self.view2), (2, self.view2), (3, self.view3)]
-        grid2 = GridSpace(items2, 'X')
+        grid2 = hv.GridSpace(items2, 'X')
 
-        expected_items = [(0, Overlay([self.view2, self.view1])),
-                          (1, Overlay([self.view2])),
-                          (2, Overlay([self.view2])),
-                          (3, Overlay([self.view3, self.view2]))]
-        expected = GridSpace(expected_items, 'X')
+        expected_items = [(0, hv.Overlay([self.view2, self.view1])),
+                          (1, hv.Overlay([self.view2])),
+                          (2, hv.Overlay([self.view2])),
+                          (3, hv.Overlay([self.view3, self.view2]))]
+        expected = hv.GridSpace(expected_items, 'X')
         assert_element_equal(grid2*grid, expected)

--- a/holoviews/tests/core/test_ndmapping.py
+++ b/holoviews/tests/core/test_ndmapping.py
@@ -1,27 +1,20 @@
 import numpy as np
 
-from holoviews import Dataset, HoloMap
-from holoviews.core import Dimension
-from holoviews.core.ndmapping import (
-    MultiDimensionalMapping,
-    NdMapping,
-    UniformNdMapping,
-)
-from holoviews.core.overlay import Overlay
-from holoviews.element import Curve
+import holoviews as hv
+from holoviews.core.ndmapping import MultiDimensionalMapping, UniformNdMapping
 from holoviews.testing import assert_data_equal, assert_element_equal
 
 
 class DimensionTest:
 
     def test_dimension_init(self):
-        Dimension('Test dimension')
-        Dimension('Test dimension', cyclic=True)
-        Dimension('Test dimension', cyclic=True, type=int)
-        Dimension('Test dimension', cyclic=True, type=int, unit='Twilight zones')
+        hv.Dimension('Test dimension')
+        hv.Dimension('Test dimension', cyclic=True)
+        hv.Dimension('Test dimension', cyclic=True, type=int)
+        hv.Dimension('Test dimension', cyclic=True, type=int, unit='Twilight zones')
 
     def test_dimension_clone(self):
-        dim1 = Dimension('Test dimension')
+        dim1 = hv.Dimension('Test dimension')
         dim2 = dim1.clone(cyclic=True)
         assert dim2.cyclic is True
 
@@ -30,7 +23,7 @@ class DimensionTest:
         assert dim3.unit == 'scovilles'
 
     def test_dimension_pprint(self):
-        dim = Dimension('Test dimension', cyclic=True, type=float, unit='Twilight zones')
+        dim = hv.Dimension('Test dimension', cyclic=True, type=float, unit='Twilight zones')
         assert dim.pprint_value_string(3.23451) == 'Test dimension: 3.2345 Twilight zones'
         assert dim.pprint_value_string(4.23441) == 'Test dimension: 4.2344 Twilight zones'
         assert dim.pprint_value(3.23451, print_unit=True) == '3.2345 Twilight zones'
@@ -44,9 +37,9 @@ class NdIndexableMappingTest:
         self.init_item_list = [((1, 2.0), 'a'), ((5, 3.0), 'b')]
         self.init_item_odict = dict([((1, 2.0), 'a'), ((5, 3.0), 'b')])
         self.dimension_labels = ['intdim', 'floatdim']
-        self.dim1 = Dimension('intdim', type=int)
-        self.dim2 = Dimension('floatdim', type=float)
-        self.time_dimension = Dimension
+        self.dim1 = hv.Dimension('intdim', type=int)
+        self.dim2 = hv.Dimension('floatdim', type=float)
+        self.time_dimension = hv.Dimension
 
     def test_idxmapping_init(self):
         MultiDimensionalMapping()
@@ -103,35 +96,35 @@ class NdIndexableMappingTest:
         assert list(nested_ndmap[1.5].values()) == ['e', 'f']
 
     def test_ndmapping_slice_lower_bound_inclusive_int(self):
-        ndmap = NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
+        ndmap = hv.NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
         assert ndmap[1:].keys() == [(1, 2.0), (5, 3.0)]
 
     def test_ndmapping_slice_lower_bound_inclusive2_int(self):
-        ndmap = NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
+        ndmap = hv.NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
         assert ndmap[1:6].keys() == [(1, 2.0), (5, 3.0)]
 
     def test_ndmapping_slice_upper_bound_exclusive_int(self):
-        ndmap = NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
+        ndmap = hv.NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
         assert ndmap[1:5].keys() == [(1, 2.0)]
 
     def test_ndmapping_slice_upper_bound_exclusive2_int(self):
-        ndmap = NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
+        ndmap = hv.NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
         assert ndmap[:5].keys() == [(1, 2.0)]
 
     def test_ndmapping_slice_lower_bound_inclusive_float(self):
-        ndmap = NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
+        ndmap = hv.NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
         assert ndmap[:, 2.0:].keys() == [(1, 2.0), (5, 3.0)]
 
     def test_ndmapping_slice_lower_bound_inclusive2_float(self):
-        ndmap = NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
+        ndmap = hv.NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
         assert ndmap[:, 2.0:5.0].keys() == [(1, 2.0), (5, 3.0)]
 
     def test_ndmapping_slice_upper_bound_exclusive_float(self):
-        ndmap = NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
+        ndmap = hv.NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
         assert ndmap[:, :3.0].keys() == [(1, 2.0)]
 
     def test_ndmapping_slice_upper_bound_exclusive2_float(self):
-        ndmap = NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
+        ndmap = hv.NdMapping(self.init_item_odict, kdims=[self.dim1, self.dim2])
         assert ndmap[:, 0.0:3.0].keys() == [(1, 2.0)]
 
     def test_idxmapping_unsorted(self):
@@ -146,7 +139,7 @@ class NdIndexableMappingTest:
 
     def test_idxmapping_groupby_unsorted(self):
         data = [(('B', 2), 1), (('C', 2), 2), (('A', 1), 3)]
-        grouped = NdMapping(data, sort=False, kdims=['X', 'Y']).groupby('Y')
+        grouped = hv.NdMapping(data, sort=False, kdims=['X', 'Y']).groupby('Y')
         assert grouped.keys() == [2, 1]
         assert grouped.values()[0].keys() == ['B', 'C']
         assert grouped.last.keys() == ['A']
@@ -164,19 +157,19 @@ class NdIndexableMappingTest:
         data = [((0, 0.5), 'a'), ((1, 0.5), 'b')]
         ndmap = MultiDimensionalMapping(data, kdims=[self.dim1, self.dim2])
         redimmed = ndmap.redim(intdim='Integer')
-        assert redimmed.kdims == [Dimension('Integer', type=int), Dimension('floatdim', type=float)]
+        assert redimmed.kdims == [hv.Dimension('Integer', type=int), hv.Dimension('floatdim', type=float)]
 
     def test_idxmapping_redim_range_aux(self):
         data = [((0, 0.5), 'a'), ((1, 0.5), 'b')]
         ndmap = MultiDimensionalMapping(data, kdims=[self.dim1, self.dim2])
         redimmed = ndmap.redim.range(intdim=(-9,9))
-        assert redimmed.kdims == [Dimension('intdim', type=int, range=(-9, 9,)), Dimension('floatdim', type=float)]
+        assert redimmed.kdims == [hv.Dimension('intdim', type=int, range=(-9, 9,)), hv.Dimension('floatdim', type=float)]
 
     def test_idxmapping_redim_type_aux(self):
         data = [((0, 0.5), 'a'), ((1, 0.5), 'b')]
         ndmap = MultiDimensionalMapping(data, kdims=[self.dim1, self.dim2])
         redimmed = ndmap.redim.type(intdim=str)
-        assert redimmed.kdims == [Dimension('intdim', type=str), Dimension('floatdim', type=float)]
+        assert redimmed.kdims == [hv.Dimension('intdim', type=str), hv.Dimension('floatdim', type=float)]
 
 
     def test_idxmapping_add_dimension(self):
@@ -212,11 +205,11 @@ class NdIndexableMappingTest:
 class UniformNdMappingTest:
 
     def test_collapse_nested(self):
-        inner1 = UniformNdMapping({1: Dataset([(1, 2)], ['x', 'y'])}, 'Y')
-        inner2 = UniformNdMapping({1: Dataset([(3, 4)], ['x', 'y'])}, 'Y')
+        inner1 = UniformNdMapping({1: hv.Dataset([(1, 2)], ['x', 'y'])}, 'Y')
+        inner2 = UniformNdMapping({1: hv.Dataset([(3, 4)], ['x', 'y'])}, 'Y')
         outer = UniformNdMapping({1: inner1, 2: inner2}, 'X')
         collapsed = outer.collapse()
-        expected = Dataset([(1, 1, 1, 2), (2, 1, 3, 4)], ['X', 'Y', 'x', 'y'])
+        expected = hv.Dataset([(1, 1, 1, 2), (2, 1, 3, 4)], ['X', 'Y', 'x', 'y'])
         assert_element_equal(collapsed, expected)
 
 
@@ -226,28 +219,28 @@ class HoloMapTest:
         self.xs = range(11)
         self.y_ints = [i*2 for i in range(11)]
         self.ys = np.linspace(0, 1, 11)
-        self.columns = Dataset(np.column_stack([self.xs, self.y_ints]),
+        self.columns = hv.Dataset(np.column_stack([self.xs, self.y_ints]),
                                kdims=['x'], vdims=['y'])
 
     def test_holomap_redim(self):
-        hmap = HoloMap({i: Dataset({'x':self.xs, 'y': self.ys * i},
+        hmap = hv.HoloMap({i: hv.Dataset({'x':self.xs, 'y': self.ys * i},
                                    kdims=['x'], vdims=['y'])
                         for i in range(10)}, kdims=['z'])
         redimmed = hmap.redim(x='Time')
         assert redimmed.dimensions('all', True) == ['z', 'Time', 'y']
 
     def test_holomap_redim_nested(self):
-        hmap = HoloMap({i: Dataset({'x':self.xs, 'y': self.ys * i},
+        hmap = hv.HoloMap({i: hv.Dataset({'x':self.xs, 'y': self.ys * i},
                                    kdims=['x'], vdims=['y'])
                         for i in range(10)}, kdims=['z'])
         redimmed = hmap.redim(x='Time', z='Magnitude')
         assert redimmed.dimensions('all', True) == ['Magnitude', 'Time', 'y']
 
     def test_columns_collapse_heterogeneous(self):
-        collapsed = HoloMap({i: Dataset({'x':self.xs, 'y': self.ys * i},
+        collapsed = hv.HoloMap({i: hv.Dataset({'x':self.xs, 'y': self.ys * i},
                                         kdims=['x'], vdims=['y'])
                              for i in range(10)}, kdims=['z']).collapse('z', np.mean)
-        expected = Dataset({'x':self.xs, 'y': self.ys * 4.5}, kdims=['x'], vdims=['y'])
+        expected = hv.Dataset({'x':self.xs, 'y': self.ys * 4.5}, kdims=['x'], vdims=['y'])
         assert_element_equal(collapsed, expected)
 
     def test_columns_sample_homogeneous(self):
@@ -255,14 +248,14 @@ class HoloMapTest:
         assert_data_equal(samples, np.array([0, 10, 20]))
 
     def test_holomap_map_with_none(self):
-        hmap = HoloMap({i: Dataset({'x':self.xs, 'y': self.ys * i},
+        hmap = hv.HoloMap({i: hv.Dataset({'x':self.xs, 'y': self.ys * i},
                                    kdims=['x'], vdims=['y'])
                         for i in range(10)}, kdims=['z'])
-        mapped = hmap.map(lambda x: x if x.range(1)[1] > 0 else None, Dataset)
+        mapped = hmap.map(lambda x: x if x.range(1)[1] > 0 else None, hv.Dataset)
         assert_element_equal(hmap[1:10], mapped)
 
     def test_holomap_hist_two_dims(self):
-        hmap = HoloMap({i: Dataset({'x':self.xs, 'y': self.ys * i},
+        hmap = hv.HoloMap({i: hv.Dataset({'x':self.xs, 'y': self.ys * i},
                                    kdims=['x'], vdims=['y'])
                         for i in range(10)}, kdims=['z'])
         hists = hmap.hist(dimension=['x', 'y'])
@@ -270,18 +263,18 @@ class HoloMapTest:
         assert hists['top'].last.kdims == ['x']
 
     def test_holomap_collapse_overlay_no_function(self):
-        hmap = HoloMap({
-            (1,0): Curve(np.arange(8)) * Curve(-np.arange(8)),
-            (2,0): Curve(np.arange(8)**2) * Curve(-np.arange(8)**3)
+        hmap = hv.HoloMap({
+            (1,0): hv.Curve(np.arange(8)) * hv.Curve(-np.arange(8)),
+            (2,0): hv.Curve(np.arange(8)**2) * hv.Curve(-np.arange(8)**3)
         }, kdims=["A","B"])
-        assert_element_equal(hmap.collapse(), Overlay([
-            (('Curve', 'I'), Dataset({
+        assert_element_equal(hmap.collapse(), hv.Overlay([
+            (('Curve', 'I'), hv.Dataset({
                 'A': np.concatenate([np.ones(8), np.ones(8)*2]),
                 'B': np.zeros(16),
                 'x': np.tile(np.arange(8), 2),
                 'y': np.concatenate([np.arange(8), np.arange(8)**2])
             }, kdims=['A', 'B', 'x'], vdims=['y'])),
-            (('Curve', 'II'), Dataset({
+            (('Curve', 'II'), hv.Dataset({
                 'A': np.concatenate([np.ones(8), np.ones(8)*2]),
                 'B': np.zeros(16),
                 'x': np.tile(np.arange(8), 2),
@@ -290,16 +283,16 @@ class HoloMapTest:
         ]))
 
     def test_holomap_collapse_overlay_max(self):
-        hmap = HoloMap({
-            (1,0): Curve(np.arange(8)) * Curve(-np.arange(8)),
-            (2,0): Curve(np.arange(8)**2) * Curve(-np.arange(8)**3)
+        hmap = hv.HoloMap({
+            (1,0): hv.Curve(np.arange(8)) * hv.Curve(-np.arange(8)),
+            (2,0): hv.Curve(np.arange(8)**2) * hv.Curve(-np.arange(8)**3)
         }, kdims=["A","B"])
-        assert_element_equal(hmap.collapse(function=np.max), Overlay([
-            (('Curve', 'I'), Curve({
+        assert_element_equal(hmap.collapse(function=np.max), hv.Overlay([
+            (('Curve', 'I'), hv.Curve({
                 'x': np.arange(8),
                 'y': np.arange(8)**2
             }, kdims=['x'], vdims=['y'])),
-            (('Curve', 'II'), Curve({
+            (('Curve', 'II'), hv.Curve({
                 'x': np.arange(8),
                 'y': -np.arange(8)
             }, kdims=['x'], vdims=['y']))

--- a/holoviews/tests/core/test_operation.py
+++ b/holoviews/tests/core/test_operation.py
@@ -1,12 +1,11 @@
 import param
 
-from holoviews.core.operation import Operation
-from holoviews.element import Curve
+import holoviews as hv
 from holoviews.streams import Params, Stream
 from holoviews.testing import assert_element_equal
 
 
-class ExampleOperation(Operation):
+class ExampleOperation(hv.Operation):
 
     label = param.String()
 
@@ -26,19 +25,19 @@ class ParamClass(param.Parameterized):
 class TestOperationBroadcast:
 
     def test_element_dynamic_with_streams(self):
-        curve = Curve([1, 2, 3])
-        applied = Operation(curve, dynamic=True, streams=[Stream])
+        curve = hv.Curve([1, 2, 3])
+        applied = hv.Operation(curve, dynamic=True, streams=[Stream])
         assert len(applied.streams) == 1
         assert isinstance(applied.streams[0], Stream)
         assert_element_equal(applied[()], curve)
 
     def test_element_not_dynamic_despite_streams(self):
-        curve = Curve([1, 2, 3])
-        applied = Operation(curve, dynamic=False, streams=[Stream])
+        curve = hv.Curve([1, 2, 3])
+        applied = hv.Operation(curve, dynamic=False, streams=[Stream])
         assert_element_equal(applied, curve)
 
     def test_element_dynamic_with_instance_param(self):
-        curve = Curve([1, 2, 3])
+        curve = hv.Curve([1, 2, 3])
         inst = ParamClass(label='Test')
         applied = ExampleOperation(curve, label=inst.param.label)
         assert len(applied.streams) == 1
@@ -47,7 +46,7 @@ class TestOperationBroadcast:
         assert_element_equal(applied[()], curve.relabel('Test'))
 
     def test_element_dynamic_with_param_method(self):
-        curve = Curve([1, 2, 3])
+        curve = hv.Curve([1, 2, 3])
         inst = ParamClass(label='Test')
         applied = ExampleOperation(curve, label=inst.dynamic_label)
         assert len(applied.streams) == 1
@@ -58,13 +57,13 @@ class TestOperationBroadcast:
         assert_element_equal(applied[()], curve.relabel('New label!'))
 
     def test_element_not_dynamic_with_instance_param(self):
-        curve = Curve([1, 2, 3])
+        curve = hv.Curve([1, 2, 3])
         inst = ParamClass(label='Test')
         applied = ExampleOperation(curve, dynamic=False, label=inst.param.label)
         assert_element_equal(applied, curve.relabel('Test'))
 
     def test_element_not_dynamic_with_param_method(self):
-        curve = Curve([1, 2, 3])
+        curve = hv.Curve([1, 2, 3])
         inst = ParamClass(label='Test')
         applied = ExampleOperation(curve, dynamic=False, label=inst.dynamic_label)
         assert_element_equal(applied, curve.relabel('Test!'))

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -4,31 +4,15 @@ import re
 import numpy as np
 import pytest
 
-from holoviews import (
-    Curve,
-    DynamicMap,
-    Histogram,
-    Image,
-    Points,
-    Store,
-    opts,
-    plotting,
-    util,
-)
-from holoviews.core.options import (
-    Cycle,
-    OptionError,
-    Options,
-    OptionTree,
-    StoreOptions,
-    options_policy,
-)
+import holoviews as hv
+from holoviews import plotting
+from holoviews.core.options import OptionError, OptionTree, options_policy
 from holoviews.plotting import bokeh  # noqa: F401
 from holoviews.testing import assert_element_equal
 
 from ..utils import optional_dependencies
 
-Options.skip_invalid = False
+hv.Options.skip_invalid = False
 
 mpl, mpl_skip = optional_dependencies("matplotlib")
 plotly, plotly_skip = optional_dependencies("plotly")
@@ -37,86 +21,86 @@ if mpl:
     import holoviews.plotting.mpl
 
 if plotly:
-    import holoviews.plotting.plotly  # noqa: F401
+    import holoviews.plotting.plotly
 
 
 class TestOptions:
 
     def setup_method(self):
-        self.original_option_groups = Options._option_groups
-        Options._option_groups = ['test']
+        self.original_option_groups = hv.Options._option_groups
+        hv.Options._option_groups = ['test']
 
     def teardown_method(self):
-        Options._option_groups = self.original_option_groups
+        hv.Options._option_groups = self.original_option_groups
 
     def test_options_init(self):
-        Options('test')
+        hv.Options('test')
 
     def test_options_valid_keywords1(self):
-        opts = Options('test', allowed_keywords=['kw1'], kw1='value')
+        opts = hv.Options('test', allowed_keywords=['kw1'], kw1='value')
         assert opts.kwargs == {'kw1':'value'}
 
     def test_options_valid_keywords2(self):
-        opts = Options('test', allowed_keywords=['kw1', 'kw2'], kw1='value')
+        opts = hv.Options('test', allowed_keywords=['kw1', 'kw2'], kw1='value')
         assert opts.kwargs == {'kw1':'value'}
 
     def test_options_valid_keywords3(self):
-        opts = Options('test', allowed_keywords=['kw1', 'kw2'], kw1='value1', kw2='value2')
+        opts = hv.Options('test', allowed_keywords=['kw1', 'kw2'], kw1='value1', kw2='value2')
         assert opts.kwargs == {'kw1':'value1', 'kw2':'value2'}
 
     def test_options_any_keywords3(self):
-        opts = Options('test', kw1='value1', kw2='value3')
+        opts = hv.Options('test', kw1='value1', kw2='value3')
         assert opts.kwargs == {'kw1':'value1', 'kw2':'value3'}
 
     def test_options_invalid_keywords1(self):
         msg = "Invalid option 'kw', valid options are: ['kw1']."
         with pytest.raises(OptionError, match=re.escape(msg)):
-            Options('test', allowed_keywords=['kw1'], kw='value')
+            hv.Options('test', allowed_keywords=['kw1'], kw='value')
 
     def test_options_invalid_keywords2(self):
         msg = "Invalid option 'kw3', valid options are: ['kw2']."
         with pytest.raises(OptionError, match=re.escape(msg)):
-            Options('test', allowed_keywords=['kw2'], kw2='value', kw3='value')
+            hv.Options('test', allowed_keywords=['kw2'], kw2='value', kw3='value')
 
     def test_options_invalid_keywords_skip1(self):
         with options_policy(skip_invalid=True, warn_on_skip=False):
-            opts = Options('test', allowed_keywords=['kw1'], kw='value')
+            opts = hv.Options('test', allowed_keywords=['kw1'], kw='value')
         assert opts.kwargs == {}
 
     def test_options_invalid_keywords_skip2(self):
         with options_policy(skip_invalid=True, warn_on_skip=False):
-            opts = Options('test', allowed_keywords=['kw1'], kw1='value', kw2='val')
+            opts = hv.Options('test', allowed_keywords=['kw1'], kw1='value', kw2='val')
         assert opts.kwargs == {'kw1':'value'}
 
 
     def test_options_record_invalid(self):
-        StoreOptions.start_recording_skipped()
+        hv.StoreOptions.start_recording_skipped()
         with options_policy(skip_invalid=True, warn_on_skip=False):
-            Options('test', allowed_keywords=['kw1'], kw1='value', kw2='val')
-        errors = StoreOptions.stop_recording_skipped()
+            hv.Options('test', allowed_keywords=['kw1'], kw1='value', kw2='val')
+        errors = hv.StoreOptions.stop_recording_skipped()
         assert len(errors) == 1
         assert errors[0].invalid_keyword == 'kw2'
 
 
     def test_options_get_options(self):
-        opts = Options('test', allowed_keywords=['kw2', 'kw3'],
+        opts = hv.Options('test', allowed_keywords=['kw2', 'kw3'],
                        kw2='value', kw3='value').options
         assert opts == dict(kw2='value', kw3='value')
 
     def test_options_get_options_cyclic1(self):
-        opts = Options('test', allowed_keywords=['kw2', 'kw3'],
+        opts = hv.Options('test', allowed_keywords=['kw2', 'kw3'],
                        kw2='value', kw3='value')
         for i in range(16):
             assert opts[i] == dict(kw2='value', kw3='value')
 
     def test_options_keys(self):
-        opts = Options('test', allowed_keywords=['kw3', 'kw2'],
+        opts = hv.Options('test', allowed_keywords=['kw3', 'kw2'],
                        kw2='value', kw3='value')
         assert opts.keys() == ['kw2', 'kw3']
 
     def test_options_inherit(self):
         original_kws = dict(kw2='value', kw3='value')
-        opts = Options('test', **original_kws)
+        opts = hv.Options('test', **original_kws)
         new_kws = dict(kw4='val4', kw5='val5')
         new_opts = opts(**new_kws)
 
@@ -124,7 +108,7 @@ class TestOptions:
 
     def test_options_inherit_invalid_keywords(self):
         original_kws = dict(kw2='value', kw3='value')
-        opts = Options('test', allowed_keywords=['kw3', 'kw2'], **original_kws)
+        opts = hv.Options('test', allowed_keywords=['kw3', 'kw2'], **original_kws)
         new_kws = dict(kw4='val4', kw5='val5')
         msg = re.escape(r"Invalid option 'kw4', valid options are: ['kw2', 'kw3'].")
         with pytest.raises(OptionError, match=msg):
@@ -134,22 +118,22 @@ class TestOptions:
 class TestCycle:
 
     def setup_method(self):
-        self.original_option_groups = Options._option_groups
-        Options._option_groups = ['test']
+        self.original_option_groups = hv.Options._option_groups
+        hv.Options._option_groups = ['test']
 
     def teardown_method(self):
-        Options._option_groups = self.original_option_groups
+        hv.Options._option_groups = self.original_option_groups
 
     def test_cycle_init(self):
-        Cycle(values=['a', 'b', 'c'])
-        Cycle(values=[1, 2, 3])
+        hv.Cycle(values=['a', 'b', 'c'])
+        hv.Cycle(values=[1, 2, 3])
 
 
     def test_cycle_expansion(self):
-        cycle1 = Cycle(values=['a', 'b', 'c'])
-        cycle2 = Cycle(values=[1, 2, 3])
+        cycle1 = hv.Cycle(values=['a', 'b', 'c'])
+        cycle2 = hv.Cycle(values=[1, 2, 3])
 
-        opts = Options('test', one=cycle1, two=cycle2)
+        opts = hv.Options('test', one=cycle1, two=cycle2)
         assert opts[0] == {'one': 'a', 'two': 1}
         assert opts[1] == {'one': 'b', 'two': 2}
         assert opts[2] == {'one': 'c', 'two': 3}
@@ -159,10 +143,10 @@ class TestCycle:
 
 
     def test_cycle_expansion_unequal(self):
-        cycle1 = Cycle(values=['a', 'b', 'c', 'd'])
-        cycle2 = Cycle(values=[1, 2, 3])
+        cycle1 = hv.Cycle(values=['a', 'b', 'c', 'd'])
+        cycle2 = hv.Cycle(values=[1, 2, 3])
 
-        opts = Options('test', one=cycle1, two=cycle2)
+        opts = hv.Options('test', one=cycle1, two=cycle2)
         assert opts[0] == {'one': 'a', 'two': 1}
         assert opts[1] == {'one': 'b', 'two': 2}
         assert opts[2] == {'one': 'c', 'two': 3}
@@ -172,10 +156,10 @@ class TestCycle:
 
 
     def test_cycle_slice(self):
-        cycle1 = Cycle(values=['a', 'b', 'c'])[2]
-        cycle2 = Cycle(values=[1, 2, 3])
+        cycle1 = hv.Cycle(values=['a', 'b', 'c'])[2]
+        cycle2 = hv.Cycle(values=[1, 2, 3])
 
-        opts = Options('test', one=cycle1, two=cycle2)
+        opts = hv.Options('test', one=cycle1, two=cycle2)
         assert opts[0] == {'one': 'a', 'two': 1}
         assert opts[1] == {'one': 'b', 'two': 2}
         assert opts[2] == {'one': 'a', 'two': 3}
@@ -183,18 +167,18 @@ class TestCycle:
 
 
     def test_cyclic_property_true(self):
-        cycle1 = Cycle(values=['a', 'b', 'c'])
-        opts = Options('test', one=cycle1, two='two')
+        cycle1 = hv.Cycle(values=['a', 'b', 'c'])
+        opts = hv.Options('test', one=cycle1, two='two')
         assert opts.cyclic is True
 
     def test_cyclic_property_false(self):
-        opts = Options('test', one='one', two='two')
+        opts = hv.Options('test', one='one', two='two')
         assert opts.cyclic is False
 
 
     def test_options_property_disabled(self):
-        cycle1 = Cycle(values=['a', 'b', 'c'])
-        opts = Options('test', one=cycle1)
+        cycle1 = hv.Cycle(values=['a', 'b', 'c'])
+        opts = hv.Options('test', one=cycle1)
         msg = r"The options property may only be used with non-cyclic Options\."
         with pytest.raises(Exception, match=msg):
             opts.options  # noqa: B018
@@ -204,11 +188,11 @@ class TestCycle:
 class TestOptionTree:
 
     def setup_method(self):
-        self.original_option_groups = Options._option_groups[:]
-        Options._option_groups = ['group1', 'group2']
+        self.original_option_groups = hv.Options._option_groups[:]
+        hv.Options._option_groups = ['group1', 'group2']
 
     def teardown_method(self):
-        Options._option_groups = self.original_option_groups
+        hv.Options._option_groups = self.original_option_groups
 
     def test_optiontree_init_1(self):
         OptionTree(groups=['group1', 'group2'])
@@ -218,7 +202,7 @@ class TestOptionTree:
 
     def test_optiontree_setter_getter(self):
         options = OptionTree(groups=['group1', 'group2'])
-        opts = Options('group1', kw1='value')
+        opts = hv.Options('group1', kw1='value')
         options.MyType = opts
         assert_element_equal(options.MyType['group1'], opts)
         assert options.MyType['group1'].options == {'kw1':'value'}
@@ -226,8 +210,8 @@ class TestOptionTree:
     def test_optiontree_dict_setter_getter(self):
         options = OptionTree(groups=['group1', 'group2'])
 
-        opts1 = Options(kw1='value1')
-        opts2 = Options(kw2='value2')
+        opts1 = hv.Options(kw1='value1')
+        opts2 = hv.Options(kw2='value2')
         options.MyType = {'group1':opts1, 'group2':opts2}
 
         assert_element_equal(options.MyType['group1'], opts1)
@@ -239,12 +223,12 @@ class TestOptionTree:
     def test_optiontree_inheritance(self):
         options = OptionTree(groups=['group1', 'group2'])
 
-        opts1 = Options(kw1='value1')
-        opts2 = Options(kw2='value2')
+        opts1 = hv.Options(kw1='value1')
+        opts2 = hv.Options(kw2='value2')
         options.MyType = {'group1':opts1, 'group2':opts2}
 
-        opts3 = Options(kw3='value3')
-        opts4 = Options(kw4='value4')
+        opts3 = hv.Options(kw3='value3')
+        opts4 = hv.Options(kw4='value4')
         options.MyType.Child = {'group1':opts3, 'group2':opts4}
 
         assert options.MyType.Child.options('group1').kwargs == {'kw1':'value1', 'kw3':'value3'}
@@ -257,12 +241,12 @@ class TestOptionTree:
         """
         options = OptionTree(groups=['group1', 'group2'])
 
-        opts3 = Options(kw3='value3')
-        opts4 = Options(kw4='value4')
+        opts3 = hv.Options(kw3='value3')
+        opts4 = hv.Options(kw4='value4')
         options.MyType.Child = {'group1':opts3, 'group2':opts4}
 
-        opts1 = Options(kw1='value1')
-        opts2 = Options(kw2='value2')
+        opts1 = hv.Options(kw1='value1')
+        opts2 = hv.Options(kw2='value2')
         options.MyType = {'group1':opts1, 'group2':opts2}
 
         assert options.MyType.Child.options('group1').kwargs == {'kw1':'value1', 'kw3':'value3'}
@@ -278,30 +262,30 @@ class TestStoreInheritanceDynamic:
 
     def setup_method(self):
         self.backend = 'matplotlib'
-        Store.set_current_backend(self.backend)
-        options = Store.options()
+        hv.Store.set_current_backend(self.backend)
+        options = hv.Store.options()
         self.store_copy = OptionTree(sorted(options.items()),
-                                     groups=Options._option_groups,
+                                     groups=hv.Options._option_groups,
                                      backend=options.backend)
 
     def teardown_method(self):
-        Store.options(val=self.store_copy)
+        hv.Store.options(val=self.store_copy)
 
     def initialize_option_tree(self):
-        Store.options(val=OptionTree(groups=['plot', 'style']))
-        options = Store.options()
-        options.Image = Options('style', cmap='hot', interpolation='nearest')
+        hv.Store.options(val=OptionTree(groups=['plot', 'style']))
+        options = hv.Store.options()
+        options.Image = hv.Options('style', cmap='hot', interpolation='nearest')
         return options
 
     def test_empty_group(self):
         "Test to prevent regression of issue fixed in #5131"
         ls = np.linspace(0, 10, 200)
         xx, yy = np.meshgrid(ls, ls)
-        util.render(Image(np.sin(xx)*np.cos(yy), group="").opts(cmap="greys"))
+        hv.util.render(hv.Image(np.sin(xx)*np.cos(yy), group="").opts(cmap="greys"))
 
     def test_merge_keywords(self):
         options = self.initialize_option_tree()
-        options.Image = Options('style', clims=(0, 0.5))
+        options.Image = hv.Options('style', clims=(0, 0.5))
 
         expected = {'clims': (0, 0.5), 'cmap': 'hot', 'interpolation': 'nearest'}
         direct_kws = options.Image.groups['style'].kwargs
@@ -311,7 +295,7 @@ class TestStoreInheritanceDynamic:
 
     def test_merge_keywords_disabled(self):
         options = self.initialize_option_tree()
-        options.Image = Options('style', clims=(0, 0.5), merge_keywords=False)
+        options.Image = hv.Options('style', clims=(0, 0.5), merge_keywords=False)
 
         expected = {'clims': (0, 0.5)}
         direct_kws = options.Image.groups['style'].kwargs
@@ -326,13 +310,13 @@ class TestStoreInheritanceDynamic:
         """
         options = self.initialize_option_tree()
 
-        obj = Image(np.random.rand(10,10), group='SomeGroup')
+        obj = hv.Image(np.random.rand(10,10), group='SomeGroup')
 
-        options.Image = Options('style', cmap='viridis')
-        options.Image.SomeGroup = Options('style', alpha=0.2)
+        options.Image = hv.Options('style', cmap='viridis')
+        options.Image.SomeGroup = hv.Options('style', alpha=0.2)
 
         expected = {'alpha': 0.2, 'cmap': 'viridis', 'interpolation': 'nearest'}
-        lookup = Store.lookup_options('matplotlib', obj, 'style')
+        lookup = hv.Store.lookup_options('matplotlib', obj, 'style')
 
         assert lookup.kwargs == expected
         # Check the tree is structured as expected
@@ -350,13 +334,13 @@ class TestStoreInheritanceDynamic:
         """
         options = self.initialize_option_tree()
 
-        obj = Image(np.random.rand(10,10), group='SomeGroup', label='SomeLabel')
+        obj = hv.Image(np.random.rand(10,10), group='SomeGroup', label='SomeLabel')
 
-        options.Image = Options('style', cmap='viridis')
-        options.Image.SomeGroup.SomeLabel = Options('style', alpha=0.2)
+        options.Image = hv.Options('style', cmap='viridis')
+        options.Image.SomeGroup.SomeLabel = hv.Options('style', alpha=0.2)
 
         expected = {'alpha': 0.2, 'cmap': 'viridis', 'interpolation': 'nearest'}
-        lookup = Store.lookup_options('matplotlib', obj, 'style')
+        lookup = hv.Store.lookup_options('matplotlib', obj, 'style')
 
         assert lookup.kwargs == expected
         # Check the tree is structured as expected
@@ -372,13 +356,13 @@ class TestStoreInheritanceDynamic:
         then specifying a general one
         """
         options = self.initialize_option_tree()
-        options.Image.SomeGroup = Options('style', alpha=0.2)
+        options.Image.SomeGroup = hv.Options('style', alpha=0.2)
 
-        obj = Image(np.random.rand(10,10), group='SomeGroup')
-        options.Image = Options('style', cmap='viridis')
+        obj = hv.Image(np.random.rand(10,10), group='SomeGroup')
+        options.Image = hv.Options('style', cmap='viridis')
 
         expected = {'alpha': 0.2, 'cmap': 'viridis', 'interpolation': 'nearest'}
-        lookup = Store.lookup_options('matplotlib', obj, 'style')
+        lookup = hv.Store.lookup_options('matplotlib', obj, 'style')
 
         assert lookup.kwargs == expected
         # Check the tree is structured as expected
@@ -395,12 +379,12 @@ class TestStoreInheritanceDynamic:
         to specific
         """
         options = self.initialize_option_tree()
-        options.Image.SomeGroup.SomeLabel = Options('style', alpha=0.2)
-        obj = Image(np.random.rand(10,10), group='SomeGroup', label='SomeLabel')
+        options.Image.SomeGroup.SomeLabel = hv.Options('style', alpha=0.2)
+        obj = hv.Image(np.random.rand(10,10), group='SomeGroup', label='SomeLabel')
 
-        options.Image = Options('style', cmap='viridis')
+        options.Image = hv.Options('style', cmap='viridis')
         expected = {'alpha': 0.2, 'cmap': 'viridis', 'interpolation': 'nearest'}
-        lookup = Store.lookup_options('matplotlib', obj, 'style')
+        lookup = hv.Store.lookup_options('matplotlib', obj, 'style')
 
         assert lookup.kwargs == expected
         # Check the tree is structured as expected
@@ -416,17 +400,17 @@ class TestStoreInheritanceDynamic:
         using .opts.
         """
         options = self.initialize_option_tree()
-        options.Image.A.B = Options('style', alpha=0.2)
+        options.Image.A.B = hv.Options('style', alpha=0.2)
 
-        obj = Image(np.random.rand(10, 10), group='A', label='B')
+        obj = hv.Image(np.random.rand(10, 10), group='A', label='B')
         expected_obj =  {'alpha': 0.2, 'cmap': 'hot', 'interpolation': 'nearest'}
-        obj_lookup = Store.lookup_options('matplotlib', obj, 'style')
+        obj_lookup = hv.Store.lookup_options('matplotlib', obj, 'style')
         assert obj_lookup.kwargs == expected_obj
 
         # Customize this particular object
-        custom_obj = opts.apply_groups(obj, style=dict(clims=(0, 0.5)))
+        custom_obj = hv.opts.apply_groups(obj, style=dict(clims=(0, 0.5)))
         expected_custom_obj =  dict(clims=(0,0.5), **expected_obj)
-        custom_obj_lookup = Store.lookup_options('matplotlib', custom_obj, 'style')
+        custom_obj_lookup = hv.Store.lookup_options('matplotlib', custom_obj, 'style')
         assert custom_obj_lookup.kwargs == expected_custom_obj
 
     def test_custom_magic_to_default_inheritance(self):
@@ -435,23 +419,23 @@ class TestStoreInheritanceDynamic:
         simulating the %%opts cell magic.
         """
         options = self.initialize_option_tree()
-        options.Image.A.B = Options('style', alpha=0.2)
+        options.Image.A.B = hv.Options('style', alpha=0.2)
 
-        obj = Image(np.random.rand(10, 10), group='A', label='B')
+        obj = hv.Image(np.random.rand(10, 10), group='A', label='B')
 
         # Before customizing...
         expected_obj =  {'alpha': 0.2, 'cmap': 'hot', 'interpolation': 'nearest'}
-        obj_lookup = Store.lookup_options('matplotlib', obj, 'style')
+        obj_lookup = hv.Store.lookup_options('matplotlib', obj, 'style')
         assert obj_lookup.kwargs == expected_obj
 
-        custom_tree = {0: OptionTree(groups=Options._option_groups,
+        custom_tree = {0: OptionTree(groups=hv.Options._option_groups,
                                      style={'Image' : dict(clims=(0, 0.5))})}
-        Store._custom_options['matplotlib'] = custom_tree
+        hv.Store._custom_options['matplotlib'] = custom_tree
         obj.id = 0 # Manually set the id to point to the tree above
 
         # Customize this particular object
         expected_custom_obj =  dict(clims=(0,0.5), **expected_obj)
-        custom_obj_lookup = Store.lookup_options('matplotlib', obj, 'style')
+        custom_obj_lookup = hv.Store.lookup_options('matplotlib', obj, 'style')
         assert custom_obj_lookup.kwargs == expected_custom_obj
 
 
@@ -464,30 +448,30 @@ class TestStoreInheritance:
 
     def setup_method(self):
         self.backend = 'matplotlib'
-        Store.set_current_backend(self.backend)
-        self.store_copy = OptionTree(sorted(Store.options().items()),
-                                     groups=Options._option_groups)
-        Store.options(val=OptionTree(
+        hv.Store.set_current_backend(self.backend)
+        self.store_copy = OptionTree(sorted(hv.Store.options().items()),
+                                     groups=hv.Options._option_groups)
+        hv.Store.options(val=OptionTree(
             groups=['plot', 'style'], backend=self.backend
         ))
 
-        options = Store.options()
+        options = hv.Store.options()
 
         self.default_plot = dict(plot1='plot1', plot2='plot2')
-        options.Histogram = Options('plot', **self.default_plot)
+        options.Histogram = hv.Options('plot', **self.default_plot)
 
         self.default_style = dict(style1='style1', style2='style2')
-        options.Histogram = Options('style', **self.default_style)
+        options.Histogram = hv.Options('style', **self.default_style)
 
         data = [np.random.normal() for i in range(10000)]
         frequencies, edges = np.histogram(data, 20)
-        self.hist = Histogram((edges, frequencies))
+        self.hist = hv.Histogram((edges, frequencies))
 
     def teardown_method(self):
-        Store.options(val=self.store_copy)
+        hv.Store.options(val=self.store_copy)
 
     def lookup_options(self, obj, group):
-        return Store.lookup_options(self.backend, obj, group)
+        return hv.Store.lookup_options(self.backend, obj, group)
 
     def test_original_style_options(self):
         assert self.lookup_options(self.hist, 'style').options == self.default_style
@@ -497,39 +481,39 @@ class TestStoreInheritance:
 
     def test_plot_inheritance_addition(self):
         "Adding an element"
-        hist2 = opts.apply_groups(self.hist, plot={'plot3':'plot3'})
+        hist2 = hv.opts.apply_groups(self.hist, plot={'plot3':'plot3'})
         assert self.lookup_options(hist2, 'plot').options == dict(plot1='plot1', plot2='plot2', plot3='plot3')
         # Check style works as expected
         assert self.lookup_options(hist2, 'style').options == self.default_style
 
     def test_plot_inheritance_override(self):
         "Overriding an element"
-        hist2 = opts.apply_groups(self.hist, plot={'plot1':'plot_child'})
+        hist2 = hv.opts.apply_groups(self.hist, plot={'plot1':'plot_child'})
         assert self.lookup_options(hist2, 'plot').options == dict(plot1='plot_child', plot2='plot2')
         # Check style works as expected
         assert self.lookup_options(hist2, 'style').options == self.default_style
 
     def test_style_inheritance_addition(self):
         "Adding an element"
-        hist2 = opts.apply_groups(self.hist, style={'style3':'style3'})
+        hist2 = hv.opts.apply_groups(self.hist, style={'style3':'style3'})
         assert self.lookup_options(hist2, 'style').options == dict(style1='style1', style2='style2', style3='style3')
         # Check plot options works as expected
         assert self.lookup_options(hist2, 'plot').options == self.default_plot
 
     def test_style_inheritance_override(self):
         "Overriding an element"
-        hist2 = opts.apply_groups(self.hist, style={'style1':'style_child'})
+        hist2 = hv.opts.apply_groups(self.hist, style={'style1':'style_child'})
         assert self.lookup_options(hist2, 'style').options == dict(style1='style_child', style2='style2')
         # Check plot options works as expected
         assert self.lookup_options(hist2, 'plot').options == self.default_plot
 
     def test_style_transfer(self):
-        hist = opts.apply_groups(self.hist, style={'style1':'style_child'})
+        hist = hv.opts.apply_groups(self.hist, style={'style1':'style_child'})
         hist2 = self.hist.opts()
-        opts_kwargs = Store.lookup_options('matplotlib', hist2, 'style').kwargs
+        opts_kwargs = hv.Store.lookup_options('matplotlib', hist2, 'style').kwargs
         assert opts_kwargs == {'style1': 'style1', 'style2': 'style2'}
-        Store.transfer_options(hist, hist2, 'matplotlib')
-        opts_kwargs = Store.lookup_options('matplotlib', hist2, 'style').kwargs
+        hv.Store.transfer_options(hist, hist2, 'matplotlib')
+        opts_kwargs = hv.Store.lookup_options('matplotlib', hist2, 'style').kwargs
         assert opts_kwargs == {'style1': 'style_child', 'style2': 'style2'}
 
 
@@ -539,41 +523,41 @@ class TestOptionsMethod:
 
     def setup_method(self):
         self.backend = 'matplotlib'
-        Store.set_current_backend(self.backend)
-        self.store_copy = OptionTree(sorted(Store.options().items()),
-                                     groups=Options._option_groups)
+        hv.Store.set_current_backend(self.backend)
+        self.store_copy = OptionTree(sorted(hv.Store.options().items()),
+                                     groups=hv.Options._option_groups)
 
     def teardown_method(self):
-        Store.options(val=self.store_copy)
+        hv.Store.options(val=self.store_copy)
 
     def lookup_options(self, obj, group):
-        return Store.lookup_options(self.backend, obj, group)
+        return hv.Store.lookup_options(self.backend, obj, group)
 
     def test_plot_options_keywords(self):
-        im = Image(np.random.rand(10,10))
+        im = hv.Image(np.random.rand(10,10))
         styled_im = im.options(interpolation='nearest', cmap='jet')
         assert self.lookup_options(im, 'plot').options == {}
         assert self.lookup_options(styled_im, 'style').options == dict(cmap='jet', interpolation='nearest')
 
     def test_plot_options_one_object(self):
-        im = Image(np.random.rand(10,10))
-        imopts = opts.Image(interpolation='nearest', cmap='jet')
+        im = hv.Image(np.random.rand(10,10))
+        imopts = hv.opts.Image(interpolation='nearest', cmap='jet')
         styled_im = im.options(imopts)
         assert self.lookup_options(im, 'plot').options == {}
         assert self.lookup_options(styled_im, 'style').options == dict(cmap='jet', interpolation='nearest')
 
     def test_plot_options_two_object(self):
-        im = Image(np.random.rand(10,10))
-        imopts1 = opts.Image(interpolation='nearest')
-        imopts2 = opts.Image(cmap='hsv')
+        im = hv.Image(np.random.rand(10,10))
+        imopts1 = hv.opts.Image(interpolation='nearest')
+        imopts2 = hv.opts.Image(cmap='hsv')
         styled_im = im.options(imopts1,imopts2)
         assert self.lookup_options(im, 'plot').options == {}
         assert self.lookup_options(styled_im, 'style').options == dict(cmap='hsv', interpolation='nearest')
 
     def test_plot_options_object_list(self):
-        im = Image(np.random.rand(10,10))
-        imopts1 = opts.Image(interpolation='nearest')
-        imopts2 = opts.Image(cmap='summer')
+        im = hv.Image(np.random.rand(10,10))
+        imopts1 = hv.opts.Image(interpolation='nearest')
+        imopts2 = hv.opts.Image(cmap='summer')
         styled_im = im.options([imopts1,imopts2])
         assert self.lookup_options(im, 'plot').options == {}
         assert self.lookup_options(styled_im, 'style').options == dict(cmap='summer', interpolation='nearest')
@@ -584,18 +568,18 @@ class TestOptsMethod:
 
     def setup_method(self):
         self.backend = 'matplotlib'
-        Store.set_current_backend(self.backend)
-        self.store_copy = OptionTree(sorted(Store.options().items()),
-                                     groups=Options._option_groups)
+        hv.Store.set_current_backend(self.backend)
+        self.store_copy = OptionTree(sorted(hv.Store.options().items()),
+                                     groups=hv.Options._option_groups)
 
     def teardown_method(self):
-        Store.options(val=self.store_copy)
+        hv.Store.options(val=self.store_copy)
 
     def lookup_options(self, obj, group):
-        return Store.lookup_options(self.backend, obj, group)
+        return hv.Store.lookup_options(self.backend, obj, group)
 
     def test_simple_clone_disabled(self):
-        im = Image(np.random.rand(10,10))
+        im = hv.Image(np.random.rand(10,10))
         styled_im = im.opts(interpolation='nearest', cmap='jet', clone=False)
 
         assert self.lookup_options(im, 'plot').options == {}
@@ -605,7 +589,7 @@ class TestOptsMethod:
         assert self.lookup_options(im, 'style').options == {'cmap': 'jet', 'interpolation': 'nearest'}
 
     def test_simple_opts_clone_enabled(self):
-        im = Image(np.random.rand(10,10))
+        im = hv.Image(np.random.rand(10,10))
         styled_im = im.opts(interpolation='nearest', cmap='jet', clone=True)
 
         assert self.lookup_options(im, 'plot').options == {}
@@ -618,23 +602,23 @@ class TestOptsMethod:
         assert styled_im_lookup['cmap'] == 'jet'
 
     def test_opts_method_with_utility(self):
-        im = Image(np.random.rand(10,10))
-        imopts = opts.Image(cmap='Blues')
+        im = hv.Image(np.random.rand(10,10))
+        imopts = hv.opts.Image(cmap='Blues')
         styled_im = im.opts(imopts)
 
         assert styled_im is im
         assert self.lookup_options(im, 'style').options == {'cmap': 'Blues', 'interpolation': 'nearest'}
 
     def test_opts_method_dynamicmap_grouped(self):
-        dmap = DynamicMap(lambda X: Curve([1, 2, X]),
+        dmap = hv.DynamicMap(lambda X: hv.Curve([1, 2, X]),
                           kdims=['X']).redim.range(X=(0, 3))
         retval = dmap.opts(padding=1, clone=True)
         assert retval is not dmap
         assert self.lookup_options(retval[0], 'plot').options == {'padding':1}
 
     def test_opts_clear(self):
-        im = Image(np.random.rand(10,10))
-        styled_im = opts.apply_groups(im, style=dict(cmap='jet', interpolation='nearest',
+        im = hv.Image(np.random.rand(10,10))
+        styled_im = hv.opts.apply_groups(im, style=dict(cmap='jet', interpolation='nearest',
                                        option1='A', option2='B'), clone=False)
         expected = {'cmap': 'jet', 'interpolation': 'nearest', 'option1':'A', 'option2':'B'}
         assert self.lookup_options(im, 'style').options == expected
@@ -645,8 +629,8 @@ class TestOptsMethod:
         assert not any(k in ['option1', 'option2'] for k in cleared_options.keys())
 
     def test_opts_clear_clone(self):
-        im = Image(np.random.rand(10,10))
-        styled_im = opts.apply_groups(im, style=dict(cmap='jet', interpolation='nearest',
+        im = hv.Image(np.random.rand(10,10))
+        styled_im = hv.opts.apply_groups(im, style=dict(cmap='jet', interpolation='nearest',
                                        option1='A', option2='B'), clone=False)
         expected = {'cmap': 'jet', 'interpolation': 'nearest', 'option1':'A', 'option2':'B'}
         assert self.lookup_options(im, 'style').options == expected
@@ -661,15 +645,15 @@ class TestOptsMethod:
 class TestOptionTreeFind:
 
     def setup_method(self):
-        self.original_option_groups = Options._option_groups[:]
-        Options._option_groups = ['group']
+        self.original_option_groups = hv.Options._option_groups[:]
+        hv.Options._option_groups = ['group']
         options = OptionTree(groups=['group'])
-        self.opts1 = Options('group', kw1='value1')
-        self.opts2 = Options('group', kw2='value2')
-        self.opts3 = Options('group', kw3='value3')
-        self.opts4 = Options('group', kw4='value4')
-        self.opts5 = Options('group', kw5='value5')
-        self.opts6 = Options('group', kw6='value6')
+        self.opts1 = hv.Options('group', kw1='value1')
+        self.opts2 = hv.Options('group', kw2='value2')
+        self.opts3 = hv.Options('group', kw3='value3')
+        self.opts4 = hv.Options('group', kw4='value4')
+        self.opts5 = hv.Options('group', kw5='value5')
+        self.opts6 = hv.Options('group', kw6='value6')
 
         options.MyType = self.opts1
         options.XType = self.opts2
@@ -679,12 +663,12 @@ class TestOptionTreeFind:
         options.XType.Bar = self.opts6
 
         self.options = options
-        self.original_options=Store.options()
-        Store.options(val=OptionTree(groups=['group']))
+        self.original_options=hv.Store.options()
+        hv.Store.options(val=OptionTree(groups=['group']))
 
     def teardown_method(self):
-        Options._option_groups = self.original_option_groups
-        Store.options(val=self.original_options)
+        hv.Options._option_groups = self.original_option_groups
+        hv.Store.options(val=self.original_options)
 
     def test_optiontree_find1(self):
         assert self.options.find('MyType').options('group').options == dict(kw1='value1')
@@ -726,104 +710,104 @@ class TestCrossBackendOptions:
 
     def setup_method(self):
         # Some tests require that plotly isn't loaded
-        self.plotly_options = Store._options.pop('plotly', None)
+        self.plotly_options = hv.Store._options.pop('plotly', None)
         self.store_mpl = OptionTree(
-            sorted(Store.options(backend='matplotlib').items()),
-            groups=Options._option_groups,
+            sorted(hv.Store.options(backend='matplotlib').items()),
+            groups=hv.Options._option_groups,
             backend='matplotlib'
         )
         self.store_bokeh = OptionTree(
-            sorted(Store.options(backend='bokeh').items()),
-            groups=Options._option_groups,
+            sorted(hv.Store.options(backend='bokeh').items()),
+            groups=hv.Options._option_groups,
             backend='bokeh'
         )
         self.clear_options()
 
     def clear_options(self):
         # Clear global options..
-        Store.options(val=OptionTree(groups=['plot', 'style'], backend='matplotlib'),
+        hv.Store.options(val=OptionTree(groups=['plot', 'style'], backend='matplotlib'),
                       backend='matplotlib')
-        Store.options(val=OptionTree(groups=['plot', 'style'], backend='bokeh'),
+        hv.Store.options(val=OptionTree(groups=['plot', 'style'], backend='bokeh'),
                       backend='bokeh')
         # ... and custom options
-        Store.custom_options({}, backend='matplotlib')
-        Store.custom_options({}, backend='bokeh')
+        hv.Store.custom_options({}, backend='matplotlib')
+        hv.Store.custom_options({}, backend='bokeh')
 
     def teardown_method(self):
-        Store.options(val=self.store_mpl, backend='matplotlib')
-        Store.options(val=self.store_bokeh, backend='bokeh')
-        Store.current_backend = 'matplotlib'
+        hv.Store.options(val=self.store_mpl, backend='matplotlib')
+        hv.Store.options(val=self.store_bokeh, backend='bokeh')
+        hv.Store.current_backend = 'matplotlib'
 
         if self.plotly_options is not None:
-            Store._options['plotly'] = self.plotly_options
+            hv.Store._options['plotly'] = self.plotly_options
 
     def test_mpl_bokeh_mpl(self):
-        img = Image(np.random.rand(10,10))
+        img = hv.Image(np.random.rand(10,10))
         # Use blue in matplotlib
-        Store.current_backend = 'matplotlib'
-        StoreOptions.set_options(img, style={'Image':{'cmap':'Blues'}})
-        mpl_opts = Store.lookup_options('matplotlib', img, 'style').options
+        hv.Store.current_backend = 'matplotlib'
+        hv.StoreOptions.set_options(img, style={'Image':{'cmap':'Blues'}})
+        mpl_opts = hv.Store.lookup_options('matplotlib', img, 'style').options
         assert mpl_opts == {'cmap':'Blues'}
         # Use purple in bokeh
-        Store.current_backend = 'bokeh'
-        StoreOptions.set_options(img, style={'Image':{'cmap':'Purple'}})
-        bokeh_opts = Store.lookup_options('bokeh', img, 'style').options
+        hv.Store.current_backend = 'bokeh'
+        hv.StoreOptions.set_options(img, style={'Image':{'cmap':'Purple'}})
+        bokeh_opts = hv.Store.lookup_options('bokeh', img, 'style').options
         assert bokeh_opts == {'cmap':'Purple'}
         # Check it is still blue in matplotlib...
-        Store.current_backend = 'matplotlib'
-        mpl_opts = Store.lookup_options('matplotlib', img, 'style').options
+        hv.Store.current_backend = 'matplotlib'
+        mpl_opts = hv.Store.lookup_options('matplotlib', img, 'style').options
         assert mpl_opts == {'cmap':'Blues'}
         # And purple in bokeh..
-        Store.current_backend = 'bokeh'
-        bokeh_opts = Store.lookup_options('bokeh', img, 'style').options
+        hv.Store.current_backend = 'bokeh'
+        bokeh_opts = hv.Store.lookup_options('bokeh', img, 'style').options
         assert bokeh_opts == {'cmap':'Purple'}
 
     def test_mpl_bokeh_offset_mpl(self):
-        img = Image(np.random.rand(10,10))
+        img = hv.Image(np.random.rand(10,10))
         # Use blue in matplotlib
-        Store.current_backend = 'matplotlib'
-        StoreOptions.set_options(img, style={'Image':{'cmap':'Blues'}})
-        mpl_opts = Store.lookup_options('matplotlib', img, 'style').options
+        hv.Store.current_backend = 'matplotlib'
+        hv.StoreOptions.set_options(img, style={'Image':{'cmap':'Blues'}})
+        mpl_opts = hv.Store.lookup_options('matplotlib', img, 'style').options
         assert mpl_opts == {'cmap':'Blues'}
         # Switch to bokeh and style a random object...
-        Store.current_backend = 'bokeh'
-        img2 = Image(np.random.rand(10,10))
-        StoreOptions.set_options(img2, style={'Image':{'cmap':'Reds'}})
-        img2_opts = Store.lookup_options('bokeh', img2, 'style').options
+        hv.Store.current_backend = 'bokeh'
+        img2 = hv.Image(np.random.rand(10,10))
+        hv.StoreOptions.set_options(img2, style={'Image':{'cmap':'Reds'}})
+        img2_opts = hv.Store.lookup_options('bokeh', img2, 'style').options
         assert img2_opts == {'cmap':'Reds'}
         # Use purple in bokeh on the object...
-        StoreOptions.set_options(img, style={'Image':{'cmap':'Purple'}})
-        bokeh_opts = Store.lookup_options('bokeh', img, 'style').options
+        hv.StoreOptions.set_options(img, style={'Image':{'cmap':'Purple'}})
+        bokeh_opts = hv.Store.lookup_options('bokeh', img, 'style').options
         assert bokeh_opts == {'cmap':'Purple'}
         # Check it is still blue in matplotlib...
-        Store.current_backend = 'matplotlib'
-        mpl_opts = Store.lookup_options('matplotlib', img, 'style').options
+        hv.Store.current_backend = 'matplotlib'
+        mpl_opts = hv.Store.lookup_options('matplotlib', img, 'style').options
         assert mpl_opts == {'cmap':'Blues'}
         # And purple in bokeh..
-        Store.current_backend = 'bokeh'
-        bokeh_opts = Store.lookup_options('bokeh', img, 'style').options
+        hv.Store.current_backend = 'bokeh'
+        bokeh_opts = hv.Store.lookup_options('bokeh', img, 'style').options
         assert bokeh_opts == {'cmap':'Purple'}
 
     def test_builder_backend_switch_signature(self):
-        Store.options(val=self.store_mpl, backend='matplotlib')
-        Store.options(val=self.store_bokeh, backend='bokeh')
-        Store.set_current_backend('bokeh')
-        assert opts.Curve.__signature__ is not None
-        sigkeys = opts.Curve.__signature__.parameters
+        hv.Store.options(val=self.store_mpl, backend='matplotlib')
+        hv.Store.options(val=self.store_bokeh, backend='bokeh')
+        hv.Store.set_current_backend('bokeh')
+        assert hv.opts.Curve.__signature__ is not None
+        sigkeys = hv.opts.Curve.__signature__.parameters
         assert 'color' in sigkeys
         assert 'line_width' in sigkeys
-        Store.set_current_backend('matplotlib')
-        assert opts.Curve.__signature__ is not None
-        sigkeys = opts.Curve.__signature__.parameters
+        hv.Store.set_current_backend('matplotlib')
+        assert hv.opts.Curve.__signature__ is not None
+        sigkeys = hv.opts.Curve.__signature__.parameters
         assert 'color' in sigkeys
         assert 'linewidth' in sigkeys
 
     def test_builder_cross_backend_validation(self):
-        Store.options(val=self.store_mpl, backend='matplotlib')
-        Store.options(val=self.store_bokeh, backend='bokeh')
-        Store.set_current_backend('bokeh')
-        opts.Curve(line_dash='dotted') # Bokeh keyword
-        opts.Curve(linewidth=10)       # MPL keyword
+        hv.Store.options(val=self.store_mpl, backend='matplotlib')
+        hv.Store.options(val=self.store_bokeh, backend='bokeh')
+        hv.Store.set_current_backend('bokeh')
+        hv.opts.Curve(line_dash='dotted') # Bokeh keyword
+        hv.opts.Curve(linewidth=10)       # MPL keyword
 
         err = (
             "In opts.Curve(...), keywords supplied are mixed across backends. "
@@ -831,35 +815,35 @@ class TestCrossBackendOptions:
             "'line_dash' are invalid for matplotlib"
         )
         with pytest.raises(ValueError, match=re.escape(err)):
-            opts.Curve(linewidth=10, line_dash='dotted') # Bokeh and MPL
+            hv.opts.Curve(linewidth=10, line_dash='dotted') # Bokeh and MPL
 
         # Non-existent keyword across backends (bokeh active)
         err = ("In opts.Curve(...), unexpected option 'foobar' for Curve type "
                "across all extensions. Similar options for current "
                "extension ('bokeh') are: ['toolbar'].")
         with pytest.raises(ValueError, match=re.escape(err)):
-            opts.Curve(foobar=3)
+            hv.opts.Curve(foobar=3)
 
         # Non-existent keyword across backends (matplotlib active)
-        Store.set_current_backend('matplotlib')
+        hv.Store.set_current_backend('matplotlib')
 
         err = ("In opts.Curve(...), unexpected option 'foobar' for Curve "
                "type across all extensions. No similar options found.")
         with pytest.raises(ValueError, match=re.escape(err)):
-            opts.Curve(foobar=3)
+            hv.opts.Curve(foobar=3)
 
     def test_apply_opts_with_non_active_backend(self):
-        Store.options(val=self.store_mpl, backend='matplotlib')
-        Store.options(val=self.store_bokeh, backend='bokeh')
-        Store.set_current_backend('bokeh')
+        hv.Store.options(val=self.store_mpl, backend='matplotlib')
+        hv.Store.options(val=self.store_bokeh, backend='bokeh')
+        hv.Store.set_current_backend('bokeh')
 
-        opts.defaults(
-            opts.Curve(linewidth=5),
+        hv.opts.defaults(
+            hv.opts.Curve(linewidth=5),
             backend="matplotlib",
         )
 
-        Store.set_current_backend('matplotlib')
-        assert Curve([]).opts.get().kwargs["linewidth"] == 5
+        hv.Store.set_current_backend('matplotlib')
+        assert hv.Curve([]).opts.get().kwargs["linewidth"] == 5
 
 
 @mpl_skip
@@ -867,25 +851,25 @@ class TestCrossBackendOptions:
 class TestLookupOptions:
 
     def test_lookup_options_honors_backend(self):
-        points = Points([[1, 2], [3, 4]])
+        points = hv.Points([[1, 2], [3, 4]])
 
-        backends = Store.loaded_backends()
+        backends = hv.Store.loaded_backends()
 
         # Lookup points style options with matplotlib and plotly backends while current
         # backend is bokeh
         if 'bokeh' in backends:
-            Store.set_current_backend('bokeh')
+            hv.Store.set_current_backend('bokeh')
             if 'matplotlib' in backends:
-                options_matplotlib = Store.lookup_options("matplotlib", points, "style")
+                options_matplotlib = hv.Store.lookup_options("matplotlib", points, "style")
             if 'plotly' in backends:
-                options_plotly = Store.lookup_options("plotly", points, "style")
+                options_plotly = hv.Store.lookup_options("plotly", points, "style")
 
         # Lookup points style options with bokeh backend while current
         # backend is matplotlib
         if 'matplotlib' in backends:
-            Store.set_current_backend('matplotlib')
+            hv.Store.set_current_backend('matplotlib')
             if 'bokeh' in backends:
-                options_bokeh = Store.lookup_options("bokeh", points, "style")
+                options_bokeh = hv.Store.lookup_options("bokeh", points, "style")
 
         # Check matplotlib style options
         if 'matplotlib' in backends:
@@ -914,154 +898,154 @@ class TestCrossBackendOptionSpecification:
 
     def setup_method(self):
         # Some tests require that plotly isn't loaded
-        self.plotly_options = Store._options.pop('plotly', None)
+        self.plotly_options = hv.Store._options.pop('plotly', None)
         self.store_mpl = OptionTree(
-            sorted(Store.options(backend='matplotlib').items()),
-            groups=Options._option_groups, backend='matplotlib'
+            sorted(hv.Store.options(backend='matplotlib').items()),
+            groups=hv.Options._option_groups, backend='matplotlib'
         )
         self.store_bokeh = OptionTree(
-            sorted(Store.options(backend='bokeh').items()),
-            groups=Options._option_groups, backend='bokeh'
+            sorted(hv.Store.options(backend='bokeh').items()),
+            groups=hv.Options._option_groups, backend='bokeh'
         )
 
     def teardown_method(self):
-        Store.options(val=self.store_mpl, backend='matplotlib')
-        Store.options(val=self.store_bokeh, backend='bokeh')
-        Store.current_backend = 'matplotlib'
+        hv.Store.options(val=self.store_mpl, backend='matplotlib')
+        hv.Store.options(val=self.store_bokeh, backend='bokeh')
+        hv.Store.current_backend = 'matplotlib'
 
         if self.plotly_options is not None:
-            Store._options['plotly'] = self.plotly_options
+            hv.Store._options['plotly'] = self.plotly_options
 
     def assert_output_options_group_empty(self, obj):
-        mpl_output_lookup = Store.lookup_options('matplotlib', obj, 'output').options
+        mpl_output_lookup = hv.Store.lookup_options('matplotlib', obj, 'output').options
         assert mpl_output_lookup == {}
-        bokeh_output_lookup = Store.lookup_options('bokeh', obj, 'output').options
+        bokeh_output_lookup = hv.Store.lookup_options('bokeh', obj, 'output').options
         assert bokeh_output_lookup == {}
 
     def test_mpl_bokeh_mpl_via_option_objects_opts_method(self):
-        img = Image(np.random.rand(10,10))
-        mpl_opts = Options('Image', cmap='Blues', backend='matplotlib')
-        bokeh_opts = Options('Image', cmap='Purple', backend='bokeh')
+        img = hv.Image(np.random.rand(10,10))
+        mpl_opts = hv.Options('Image', cmap='Blues', backend='matplotlib')
+        bokeh_opts = hv.Options('Image', cmap='Purple', backend='bokeh')
         assert mpl_opts.kwargs['backend'] == 'matplotlib'
         assert bokeh_opts.kwargs['backend'] == 'bokeh'
         img.opts(mpl_opts, bokeh_opts)
-        mpl_lookup = Store.lookup_options('matplotlib', img, 'style').options
+        mpl_lookup = hv.Store.lookup_options('matplotlib', img, 'style').options
         assert mpl_lookup['cmap'] == 'Blues'
-        bokeh_lookup = Store.lookup_options('bokeh', img, 'style').options
+        bokeh_lookup = hv.Store.lookup_options('bokeh', img, 'style').options
         assert bokeh_lookup['cmap'] == 'Purple'
         self.assert_output_options_group_empty(img)
 
     def test_mpl_bokeh_mpl_via_builders_opts_method(self):
-        img = Image(np.random.rand(10,10))
-        mpl_opts = opts.Image(cmap='Blues', backend='matplotlib')
-        bokeh_opts = opts.Image(cmap='Purple', backend='bokeh')
+        img = hv.Image(np.random.rand(10,10))
+        mpl_opts = hv.opts.Image(cmap='Blues', backend='matplotlib')
+        bokeh_opts = hv.opts.Image(cmap='Purple', backend='bokeh')
         assert mpl_opts.kwargs['backend'] == 'matplotlib'
         assert bokeh_opts.kwargs['backend'] == 'bokeh'
         img.opts(mpl_opts, bokeh_opts)
-        mpl_lookup = Store.lookup_options('matplotlib', img, 'style').options
+        mpl_lookup = hv.Store.lookup_options('matplotlib', img, 'style').options
         assert mpl_lookup['cmap'] == 'Blues'
-        bokeh_lookup = Store.lookup_options('bokeh', img, 'style').options
+        bokeh_lookup = hv.Store.lookup_options('bokeh', img, 'style').options
         assert bokeh_lookup['cmap'] == 'Purple'
         self.assert_output_options_group_empty(img)
 
 
     def test_mpl_bokeh_mpl_via_dict_backend_keyword(self):
-        curve = Curve([1,2,3])
+        curve = hv.Curve([1,2,3])
         styled_mpl = curve.opts({'Curve': dict(color='red')}, backend='matplotlib')
         styled = styled_mpl.opts({'Curve': dict(color='green')}, backend='bokeh')
-        mpl_lookup = Store.lookup_options('matplotlib', styled, 'style')
+        mpl_lookup = hv.Store.lookup_options('matplotlib', styled, 'style')
         assert mpl_lookup.kwargs['color'] == 'red'
-        bokeh_lookup = Store.lookup_options('bokeh', styled, 'style')
+        bokeh_lookup = hv.Store.lookup_options('bokeh', styled, 'style')
         assert bokeh_lookup.kwargs['color'] == 'green'
 
     def test_mpl_bokeh_mpl_via_builders_opts_method_implicit_backend(self):
-        img = Image(np.random.rand(10,10))
-        Store.set_current_backend('matplotlib')
-        mpl_opts = opts.Image(cmap='Blues')
-        bokeh_opts = opts.Image(cmap='Purple', backend='bokeh')
+        img = hv.Image(np.random.rand(10,10))
+        hv.Store.set_current_backend('matplotlib')
+        mpl_opts = hv.opts.Image(cmap='Blues')
+        bokeh_opts = hv.opts.Image(cmap='Purple', backend='bokeh')
         assert 'backend' not in mpl_opts.kwargs
         assert bokeh_opts.kwargs['backend'] == 'bokeh'
         img.opts(mpl_opts, bokeh_opts)
-        mpl_lookup = Store.lookup_options('matplotlib', img, 'style').options
+        mpl_lookup = hv.Store.lookup_options('matplotlib', img, 'style').options
         assert mpl_lookup['cmap'] == 'Blues'
-        bokeh_lookup = Store.lookup_options('bokeh', img, 'style').options
+        bokeh_lookup = hv.Store.lookup_options('bokeh', img, 'style').options
         assert bokeh_lookup['cmap'] == 'Purple'
         self.assert_output_options_group_empty(img)
 
 
     def test_mpl_bokeh_mpl_via_builders_opts_method_literal_implicit_backend(self):
-        img = Image(np.random.rand(10,10))
-        curve = Curve([1,2,3])
+        img = hv.Image(np.random.rand(10,10))
+        curve = hv.Curve([1,2,3])
         overlay = img * curve
-        Store.set_current_backend('matplotlib')
+        hv.Store.set_current_backend('matplotlib')
 
         literal = {'Curve': dict(color='orange'),
                    'Image': dict(cmap='jet', backend='bokeh'),
                    }
         styled = overlay.opts(literal)
-        mpl_curve_lookup = Store.lookup_options('matplotlib', styled.Curve.I, 'style')
+        mpl_curve_lookup = hv.Store.lookup_options('matplotlib', styled.Curve.I, 'style')
         assert mpl_curve_lookup.kwargs['color'] == 'orange'
 
-        mpl_img_lookup = Store.lookup_options('matplotlib', styled.Image.I, 'style')
+        mpl_img_lookup = hv.Store.lookup_options('matplotlib', styled.Image.I, 'style')
         assert mpl_img_lookup.kwargs['cmap'] != 'jet'
 
-        bokeh_curve_lookup = Store.lookup_options('bokeh', styled.Curve.I, 'style')
+        bokeh_curve_lookup = hv.Store.lookup_options('bokeh', styled.Curve.I, 'style')
         assert bokeh_curve_lookup.kwargs['color'] != 'orange'
 
-        bokeh_img_lookup = Store.lookup_options('bokeh', styled.Image.I, 'style')
+        bokeh_img_lookup = hv.Store.lookup_options('bokeh', styled.Image.I, 'style')
         assert bokeh_img_lookup.kwargs['cmap'] == 'jet'
 
 
     def test_mpl_bokeh_mpl_via_builders_opts_method_literal_explicit_backend(self):
-        img = Image(np.random.rand(10,10))
-        curve = Curve([1,2,3])
+        img = hv.Image(np.random.rand(10,10))
+        curve = hv.Curve([1,2,3])
         overlay = img * curve
-        Store.set_current_backend('matplotlib')
+        hv.Store.set_current_backend('matplotlib')
 
         literal = {'Curve': dict(color='orange', backend='matplotlib'),
                    'Image': dict(cmap='jet', backend='bokeh')
                    }
         styled = overlay.opts(literal)
-        mpl_curve_lookup = Store.lookup_options('matplotlib', styled.Curve.I, 'style')
+        mpl_curve_lookup = hv.Store.lookup_options('matplotlib', styled.Curve.I, 'style')
         assert mpl_curve_lookup.kwargs['color'] == 'orange'
 
-        mpl_img_lookup = Store.lookup_options('matplotlib', styled.Image.I, 'style')
+        mpl_img_lookup = hv.Store.lookup_options('matplotlib', styled.Image.I, 'style')
         assert mpl_img_lookup.kwargs['cmap'] != 'jet'
 
-        bokeh_curve_lookup = Store.lookup_options('bokeh', styled.Curve.I, 'style')
+        bokeh_curve_lookup = hv.Store.lookup_options('bokeh', styled.Curve.I, 'style')
         assert bokeh_curve_lookup.kwargs['color'] != 'orange'
 
-        bokeh_img_lookup = Store.lookup_options('bokeh', styled.Image.I, 'style')
+        bokeh_img_lookup = hv.Store.lookup_options('bokeh', styled.Image.I, 'style')
         assert bokeh_img_lookup.kwargs['cmap'] == 'jet'
 
 
     def test_mpl_bokeh_output_options_group_expandable(self):
-        original_allowed_kws = Options._output_allowed_kws[:]
-        Options._output_allowed_kws = ['backend', 'file_format_example']
+        original_allowed_kws = hv.Options._output_allowed_kws[:]
+        hv.Options._output_allowed_kws = ['backend', 'file_format_example']
         # Re-register
-        Store.register({Curve: plotting.mpl.CurvePlot}, 'matplotlib')
-        Store.register({Curve: plotting.bokeh.CurvePlot}, 'bokeh')
+        hv.Store.register({hv.Curve: plotting.mpl.CurvePlot}, 'matplotlib')
+        hv.Store.register({hv.Curve: plotting.bokeh.CurvePlot}, 'bokeh')
 
-        curve_bk = Options('Curve', backend='bokeh', color='blue')
-        curve_mpl = Options('Curve', backend='matplotlib', color='red',
+        curve_bk = hv.Options('Curve', backend='bokeh', color='blue')
+        curve_mpl = hv.Options('Curve', backend='matplotlib', color='red',
                             file_format_example='SVG')
-        c = Curve([1,2,3])
+        c = hv.Curve([1,2,3])
         styled = c.opts(curve_bk, curve_mpl)
-        assert Store.lookup_options('matplotlib', styled, 'output').kwargs == {'backend':'matplotlib', 'file_format_example':'SVG'}
+        assert hv.Store.lookup_options('matplotlib', styled, 'output').kwargs == {'backend':'matplotlib', 'file_format_example':'SVG'}
 
-        assert Store.lookup_options('bokeh', styled, 'output').kwargs == {}
-        Options._output_allowed_kws = original_allowed_kws
+        assert hv.Store.lookup_options('bokeh', styled, 'output').kwargs == {}
+        hv.Options._output_allowed_kws = original_allowed_kws
 
 
 class TestCrossBackendOptionPickling(TestCrossBackendOptions):
 
     def setup_method(self):
         super().setup_method()
-        self.raw = Image(np.random.rand(10,10))
-        Store.current_backend = 'matplotlib'
-        StoreOptions.set_options(self.raw, style={'Image':{'cmap':'Blues'}})
-        Store.current_backend = 'bokeh'
-        StoreOptions.set_options(self.raw, style={'Image':{'cmap':'Purple'}})
+        self.raw = hv.Image(np.random.rand(10,10))
+        hv.Store.current_backend = 'matplotlib'
+        hv.StoreOptions.set_options(self.raw, style={'Image':{'cmap':'Blues'}})
+        hv.Store.current_backend = 'bokeh'
+        hv.StoreOptions.set_options(self.raw, style={'Image':{'cmap':'Purple'}})
 
     def test_raw_pickle(self, tmp_path):
         """
@@ -1078,11 +1062,11 @@ class TestCrossBackendOptionPickling(TestCrossBackendOptions):
         assert_element_equal(self.raw, img)
         # But the styles will be lost without using Store.load/Store.dump
         pickle.current_backend = 'matplotlib'
-        mpl_opts = Store.lookup_options('matplotlib', img, 'style').options
+        mpl_opts = hv.Store.lookup_options('matplotlib', img, 'style').options
         assert mpl_opts == {}
         # ... across all backends
-        Store.current_backend = 'bokeh'
-        bokeh_opts = Store.lookup_options('bokeh', img, 'style').options
+        hv.Store.current_backend = 'bokeh'
+        bokeh_opts = hv.Store.lookup_options('bokeh', img, 'style').options
         assert bokeh_opts == {}
 
 
@@ -1092,17 +1076,17 @@ class TestCrossBackendOptionPickling(TestCrossBackendOptions):
         """
         fname = tmp_path / 'test_pickle_mpl_bokeh.pkl'
         with open(fname,'wb') as handle:
-            Store.dump(self.raw, handle)
+            hv.Store.dump(self.raw, handle)
         self.clear_options()
         with open(fname,'rb') as handle:
-            img = Store.load(handle)
+            img = hv.Store.load(handle)
         # Data should match
         assert_element_equal(self.raw, img)
         # Check it is still blue in matplotlib...
-        Store.current_backend = 'matplotlib'
-        mpl_opts = Store.lookup_options('matplotlib', img, 'style').options
+        hv.Store.current_backend = 'matplotlib'
+        mpl_opts = hv.Store.lookup_options('matplotlib', img, 'style').options
         assert mpl_opts == {'cmap':'Blues'}
         # And purple in bokeh..
-        Store.current_backend = 'bokeh'
-        bokeh_opts = Store.lookup_options('bokeh', img, 'style').options
+        hv.Store.current_backend = 'bokeh'
+        bokeh_opts = hv.Store.lookup_options('bokeh', img, 'style').options
         assert bokeh_opts == {'cmap':'Purple'}

--- a/holoviews/tests/core/test_prettyprint.py
+++ b/holoviews/tests/core/test_prettyprint.py
@@ -3,7 +3,7 @@ Test cases for the pretty printing system.
 """
 
 
-from holoviews import Curve, Element, Layout, Overlay, Store
+import holoviews as hv
 from holoviews.core.pprint import PrettyPrinter
 
 from .test_dimensioned import CustomBackendTestCase, ExampleElement
@@ -12,8 +12,8 @@ from .test_dimensioned import CustomBackendTestCase, ExampleElement
 class PrettyPrintTest:
 
     def setup_method(self):
-        self.element1 = Element(None, group='Value', label='Label')
-        self.element2 = Element(None, group='Value', label='')
+        self.element1 = hv.Element(None, group='Value', label='Label')
+        self.element2 = hv.Element(None, group='Value', label='')
 
     def test_element_repr1(self):
         r = PrettyPrinter.pprint(self.element1)
@@ -28,7 +28,7 @@ class PrettyPrintTest:
     def test_curve_pprint_repr(self):
         # Ensure it isn't a bytes object with the 'b' prefix
         expected = "':Curve   [x]   (y)'"
-        r = PrettyPrinter.pprint(Curve([1,2,3]))
+        r = PrettyPrinter.pprint(hv.Curve([1,2,3]))
         assert repr(r) == expected
 
 
@@ -36,13 +36,13 @@ class PrettyPrintOptionsTest(CustomBackendTestCase):
 
     def setup_method(self):
         super().setup_method()
-        self.current_backend = Store.current_backend
+        self.current_backend = hv.Store.current_backend
         self.pprinter = PrettyPrinter(show_options=True)
         self.register_custom(ExampleElement, 'backend_1', ['plot_custom1'], ['style_custom1'])
-        self.register_custom(Overlay, 'backend_1', ['plot_custom1'])
-        self.register_custom(Layout, 'backend_1', ['plot_custom1'])
+        self.register_custom(hv.Overlay, 'backend_1', ['plot_custom1'])
+        self.register_custom(hv.Layout, 'backend_1', ['plot_custom1'])
         self.register_custom(ExampleElement, 'backend_2', ['plot_custom2'])
-        Store.current_backend = 'backend_1'
+        hv.Store.current_backend = 'backend_1'
 
     def test_element_options(self):
         element = ExampleElement(None).opts(style_opt1='A', backend='backend_1')

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -4,39 +4,38 @@ Store as used by the %opts magic.
 """
 import numpy as np
 
-from holoviews import Curve, HoloMap, Image, Overlay
-from holoviews.core.options import Store, StoreOptions
+import holoviews as hv
 from holoviews.plotting import bokeh  # noqa: F401
 
 from ..utils import optional_dependencies
 
 mpl, mpl_skip = optional_dependencies("matplotlib")
 if mpl:
-    import holoviews.plotting.mpl  # noqa: F401
+    import holoviews.plotting.mpl
 
 
 @mpl_skip
 class TestStoreOptionsMerge:
 
     def setup_method(self):
-        Store.current_backend = 'matplotlib'
+        hv.Store.current_backend = 'matplotlib'
         self.expected = {'Image': {'plot': {'fig_size': 150},
                                    'style': {'cmap': 'Blues'}}}
 
     def test_full_spec_format(self):
-        out = StoreOptions.merge_options(['plot', 'style'],
+        out = hv.StoreOptions.merge_options(['plot', 'style'],
                options={ 'Image':{'plot':dict(fig_size=150),
                                   'style': dict(cmap='Blues')}})
         assert out == self.expected
 
     def test_options_partitioned_format(self):
-        out = StoreOptions.merge_options(['plot', 'style'],
+        out = hv.StoreOptions.merge_options(['plot', 'style'],
             options = dict(plot={'Image':dict(fig_size=150)},
                            style={'Image':dict(cmap='Blues')}))
         assert out == self.expected
 
     def test_partitioned_format(self):
-        out = StoreOptions.merge_options(['plot', 'style'],
+        out = hv.StoreOptions.merge_options(['plot', 'style'],
             plot={'Image':dict(fig_size=150)},
             style={'Image':dict(cmap='Blues')})
         assert out == self.expected
@@ -50,62 +49,62 @@ class TestStoreOptsMethod:
     """
 
     def setup_method(self):
-        Store.current_backend = 'matplotlib'
+        hv.Store.current_backend = 'matplotlib'
 
     def test_overlay_options_partitioned(self):
         """
         The new style introduced in #73
         """
         data = [zip(range(10),range(10), strict=True), zip(range(5),range(5), strict=True)]
-        o = Overlay([Curve(c) for c in data]).opts(
+        o = hv.Overlay([hv.Curve(c) for c in data]).opts(
             {'Curve.Curve': {'show_grid': False, 'color':'k'}}
         )
 
-        assert not Store.lookup_options('matplotlib', o.Curve.I, 'plot').kwargs['show_grid']
-        assert not Store.lookup_options('matplotlib', o.Curve.II, 'plot').kwargs['show_grid']
-        assert Store.lookup_options('matplotlib', o.Curve.I, 'style').kwargs['color'] == 'k'
-        assert Store.lookup_options('matplotlib', o.Curve.II, 'style').kwargs['color'] == 'k'
+        assert not hv.Store.lookup_options('matplotlib', o.Curve.I, 'plot').kwargs['show_grid']
+        assert not hv.Store.lookup_options('matplotlib', o.Curve.II, 'plot').kwargs['show_grid']
+        assert hv.Store.lookup_options('matplotlib', o.Curve.I, 'style').kwargs['color'] == 'k'
+        assert hv.Store.lookup_options('matplotlib', o.Curve.II, 'style').kwargs['color'] == 'k'
 
     def test_overlay_options_complete(self):
         """
         Complete specification style.
         """
         data = [zip(range(10),range(10), strict=True), zip(range(5),range(5), strict=True)]
-        o = Overlay([Curve(c) for c in data]).opts(
+        o = hv.Overlay([hv.Curve(c) for c in data]).opts(
             {'Curve.Curve': {'show_grid':True, 'color':'b'}})
 
-        assert Store.lookup_options('matplotlib', o.Curve.I, 'plot').kwargs['show_grid']
-        assert Store.lookup_options('matplotlib', o.Curve.II, 'plot').kwargs['show_grid']
-        assert Store.lookup_options('matplotlib', o.Curve.I, 'style').kwargs['color'] == 'b'
-        assert Store.lookup_options('matplotlib', o.Curve.II, 'style').kwargs['color'] == 'b'
+        assert hv.Store.lookup_options('matplotlib', o.Curve.I, 'plot').kwargs['show_grid']
+        assert hv.Store.lookup_options('matplotlib', o.Curve.II, 'plot').kwargs['show_grid']
+        assert hv.Store.lookup_options('matplotlib', o.Curve.I, 'style').kwargs['color'] == 'b'
+        assert hv.Store.lookup_options('matplotlib', o.Curve.II, 'style').kwargs['color'] == 'b'
 
     def test_layout_options_short_style(self):
         """
         Short __call__ syntax.
         """
-        im = Image(np.random.rand(10,10))
+        im = hv.Image(np.random.rand(10,10))
         layout = (im + im).opts({'Layout':dict({'hspace':5})})
-        assert Store.lookup_options('matplotlib', layout, 'plot').kwargs['hspace'] == 5
+        assert hv.Store.lookup_options('matplotlib', layout, 'plot').kwargs['hspace'] == 5
 
     def test_layout_options_long_style(self):
         """
         The old (longer) syntax in __call__
         """
-        im = Image(np.random.rand(10,10))
+        im = hv.Image(np.random.rand(10,10))
         layout = (im + im).opts({'Layout':dict({'hspace':10})})
-        assert Store.lookup_options('matplotlib',
+        assert hv.Store.lookup_options('matplotlib',
             layout, 'plot').kwargs['hspace'] == 10
 
     def test_holomap_opts(self):
-        hmap = HoloMap({0: Image(np.random.rand(10,10))}).opts(xaxis=None)
-        opts = Store.lookup_options('matplotlib', hmap.last, 'plot')
+        hmap = hv.HoloMap({0: hv.Image(np.random.rand(10,10))}).opts(xaxis=None)
+        opts = hv.Store.lookup_options('matplotlib', hmap.last, 'plot')
         assert opts.kwargs['xaxis'] is None
 
     def test_holomap_options(self):
-        hmap = HoloMap({0: Image(np.random.rand(10,10))}).options(xaxis=None)
-        opts = Store.lookup_options('matplotlib', hmap.last, 'plot')
+        hmap = hv.HoloMap({0: hv.Image(np.random.rand(10,10))}).options(xaxis=None)
+        opts = hv.Store.lookup_options('matplotlib', hmap.last, 'plot')
         assert opts.kwargs['xaxis'] is None
 
 
     def test_holomap_options_empty_no_exception(self):
-        HoloMap({0: Image(np.random.rand(10,10))}).options()
+        hv.HoloMap({0: hv.Image(np.random.rand(10,10))}).options()

--- a/holoviews/tests/core/test_traversal.py
+++ b/holoviews/tests/core/test_traversal.py
@@ -1,43 +1,43 @@
 import pytest
 
-from holoviews import Curve, DynamicMap, HoloMap
+import holoviews as hv
 from holoviews.core.traversal import unique_dimkeys
 
 
 class TestUniqueDimKeys:
 
     def test_unique_keys_complete_overlap(self):
-        hmap1 = HoloMap({i: Curve(range(10)) for i in range(5)})
-        hmap2 = HoloMap({i: Curve(range(10)) for i in range(3, 10)})
+        hmap1 = hv.HoloMap({i: hv.Curve(range(10)) for i in range(5)})
+        hmap2 = hv.HoloMap({i: hv.Curve(range(10)) for i in range(3, 10)})
         dims, keys = unique_dimkeys(hmap1+hmap2)
         assert hmap1.kdims == dims
         assert keys == [(i,) for i in range(10)]
 
     def test_unique_keys_partial_overlap(self):
-        hmap1 = HoloMap({(i, j): Curve(range(10)) for i in range(5) for j in range(3)}, kdims=['A', 'B'])
-        hmap2 = HoloMap({i: Curve(range(10)) for i in range(5)}, kdims=['A'])
+        hmap1 = hv.HoloMap({(i, j): hv.Curve(range(10)) for i in range(5) for j in range(3)}, kdims=['A', 'B'])
+        hmap2 = hv.HoloMap({i: hv.Curve(range(10)) for i in range(5)}, kdims=['A'])
         dims, keys = unique_dimkeys(hmap1+hmap2)
         assert hmap1.kdims == dims
         assert keys == [(i, j) for i in range(5) for j in list(range(3))]
 
     def test_unique_keys_no_overlap_exception(self):
-        hmap1 = HoloMap({i: Curve(range(10)) for i in range(5)}, kdims=['A'])
-        hmap2 = HoloMap({i: Curve(range(10)) for i in range(3, 10)})
+        hmap1 = hv.HoloMap({i: hv.Curve(range(10)) for i in range(5)}, kdims=['A'])
+        hmap2 = hv.HoloMap({i: hv.Curve(range(10)) for i in range(3, 10)})
         exception = ('When combining HoloMaps into a composite plot '
                      'their dimensions must be subsets of each other.')
         with pytest.raises(Exception, match=exception):
             unique_dimkeys(hmap1+hmap2)
 
     def test_unique_keys_no_overlap_dynamicmap_uninitialized(self):
-        dmap1 = DynamicMap(lambda A: Curve(range(10)), kdims=['A'])
-        dmap2 = DynamicMap(lambda B: Curve(range(10)), kdims=['B'])
+        dmap1 = hv.DynamicMap(lambda A: hv.Curve(range(10)), kdims=['A'])
+        dmap2 = hv.DynamicMap(lambda B: hv.Curve(range(10)), kdims=['B'])
         dims, keys = unique_dimkeys(dmap1+dmap2)
         assert dims == dmap1.kdims+dmap2.kdims
         assert keys == []
 
     def test_unique_keys_no_overlap_dynamicmap_initialized(self):
-        dmap1 = DynamicMap(lambda A: Curve(range(10)), kdims=['A'])
-        dmap2 = DynamicMap(lambda B: Curve(range(10)), kdims=['B'])
+        dmap1 = hv.DynamicMap(lambda A: hv.Curve(range(10)), kdims=['A'])
+        dmap2 = hv.DynamicMap(lambda B: hv.Curve(range(10)), kdims=['B'])
         dmap1[0]
         dmap2[1]
         dims, keys = unique_dimkeys(dmap1+dmap2)

--- a/holoviews/tests/core/test_utils.py
+++ b/holoviews/tests/core/test_utils.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews import Dimension, Element
+import holoviews as hv
 from holoviews.core import util
 from holoviews.core.util import (
     _minmax_finite,
@@ -582,25 +582,25 @@ class TestWrapTupleStreams:
 
     def test_no_streams_two_kdims(self):
         result = wrap_tuple_streams((1,2),
-                                    [Dimension('x'), Dimension('y')],
+                                    [hv.Dimension('x'), hv.Dimension('y')],
                                     [])
         assert result == (1,2)
 
     def test_no_streams_none_value(self):
         result = wrap_tuple_streams((1,None),
-                                    [Dimension('x'), Dimension('y')],
+                                    [hv.Dimension('x'), hv.Dimension('y')],
                                     [])
         assert result == (1,None)
 
     def test_no_streams_one_stream_substitution(self):
         result = wrap_tuple_streams((None,3),
-                                    [Dimension('x'), Dimension('y')],
+                                    [hv.Dimension('x'), hv.Dimension('y')],
                                     [PointerXY(x=-5,y=10)])
         assert result == (-5,3)
 
     def test_no_streams_two_stream_substitution(self):
         result = wrap_tuple_streams((None,None),
-                                    [Dimension('x'), Dimension('y')],
+                                    [hv.Dimension('x'), hv.Dimension('y')],
                                     [PointerXY(x=0,y=5)])
         assert result == (0,5)
 
@@ -608,44 +608,44 @@ class TestWrapTupleStreams:
 class TestMergeDimensions:
 
     def test_merge_dimensions(self):
-        dimensions = merge_dimensions([[Dimension('A')], [Dimension('A'), Dimension('B')]])
-        assert dimensions == [Dimension('A'), Dimension('B')]
+        dimensions = merge_dimensions([[hv.Dimension('A')], [hv.Dimension('A'), hv.Dimension('B')]])
+        assert dimensions == [hv.Dimension('A'), hv.Dimension('B')]
 
     def test_merge_dimensions_with_values(self):
-        dimensions = merge_dimensions([[Dimension('A', values=[0, 1])],
-                                       [Dimension('A', values=[1, 2]), Dimension('B')]])
-        assert dimensions == [Dimension('A'), Dimension('B')]
+        dimensions = merge_dimensions([[hv.Dimension('A', values=[0, 1])],
+                                       [hv.Dimension('A', values=[1, 2]), hv.Dimension('B')]])
+        assert dimensions == [hv.Dimension('A'), hv.Dimension('B')]
         assert dimensions[0].values == [0, 1, 2]
 
 
 class TestTreePathUtils:
 
     def test_get_path_with_label(self):
-        path = get_path(Element('Test', label='A'))
+        path = get_path(hv.Element('Test', label='A'))
         assert path == ('Element', 'A')
 
     def test_get_path_without_label(self):
-        path = get_path(Element('Test'))
+        path = get_path(hv.Element('Test'))
         assert path == ('Element',)
 
     def test_get_path_with_custom_group(self):
-        path = get_path(Element('Test', group='Custom Group'))
+        path = get_path(hv.Element('Test', group='Custom Group'))
         assert path == ('Custom_Group',)
 
     def test_get_path_with_custom_group_and_label(self):
-        path = get_path(Element('Test', group='Custom Group', label='A'))
+        path = get_path(hv.Element('Test', group='Custom Group', label='A'))
         assert path == ('Custom_Group', 'A')
 
     def test_get_path_from_item_with_custom_group(self):
-        path = get_path((('Custom',), Element('Test')))
+        path = get_path((('Custom',), hv.Element('Test')))
         assert path == ('Custom',)
 
     def test_get_path_from_item_with_custom_group_and_label(self):
-        path = get_path((('Custom', 'Path'), Element('Test')))
+        path = get_path((('Custom', 'Path'), hv.Element('Test')))
         assert path == ('Custom',)
 
     def test_get_path_from_item_with_custom_group_and_matching_label(self):
-        path = get_path((('Custom', 'Path'), Element('Test', label='Path')))
+        path = get_path((('Custom', 'Path'), hv.Element('Test', label='Path')))
         assert path == ('Custom', 'Path')
 
     def test_make_path_unique_no_clash(self):

--- a/holoviews/tests/core/test_utils.py
+++ b/holoviews/tests/core/test_utils.py
@@ -16,7 +16,7 @@ import pytest
 import holoviews as hv
 from holoviews.core import util
 from holoviews.core.util import (
-    _minmax_finite,
+     _minmax_finite,
     closest_match,
     compute_density,
     compute_edges,
@@ -50,16 +50,16 @@ sanitize_identifier = sanitize_identifier_fn.instance()
 
 @pytest.fixture
 def with_pandas(request, monkeypatch):
-  """Fixture to control pandas availability"""
-  if request.param:
-      pytest.importorskip("pandas")
-  else:
-      monkeypatch.setattr(util, 'pd', None)
+    """Fixture to control pandas availability"""
+    if request.param:
+        pytest.importorskip("pandas")
+    else:
+        monkeypatch.setattr(util, 'pd', None)
 
 
 def with_and_without_pandas(func):
-  """Decorator to test both with and without pandas"""
-  return pytest.mark.parametrize("with_pandas", [True, False], indirect=True, ids=["with_pandas", "without_pandas"])(func)
+    """Decorator to test both with and without pandas"""
+    return pytest.mark.parametrize("with_pandas", [True, False], indirect=True, ids=["with_pandas", "without_pandas"])(func)
 
 
 class TestDeepHash:

--- a/holoviews/tests/element/test_annotations.py
+++ b/holoviews/tests/element/test_annotations.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
 
-from holoviews import Annotation, Arrow, HLine, Spline, Text, VLine
-from holoviews.element import Points
+import holoviews as hv
 from holoviews.testing import assert_data_equal, assert_element_equal
 
 
@@ -15,60 +14,60 @@ class AnnotationTests:
     def test_hline_invalid_constructor(self):
         msg = r"ClassSelector parameter 'HLine\.y' value must be an instance of"
         with pytest.raises(ValueError, match=msg):
-            HLine(None)
+            hv.HLine(None)
 
     def test_text_string_position(self):
-        text = Text('A', 1, 'A')
-        Points([('A', 1)]) * text
+        text = hv.Text('A', 1, 'A')
+        hv.Points([('A', 1)]) * text
         assert text.x == 'A'
 
     def test_hline_dimension_values(self):
-        hline = HLine(0)
+        hline = hv.HLine(0)
         assert all(not np.isfinite(v) for v in hline.range(0))
         assert hline.range(1) == (0, 0)
 
         # Testing numpy inputs
-        hline = HLine(np.array([0]))
+        hline = hv.HLine(np.array([0]))
         assert all(not np.isfinite(v) for v in hline.range(0))
         assert hline.range(1) == (0, 0)
 
-        hline = HLine(np.array(0))
+        hline = hv.HLine(np.array(0))
         assert all(not np.isfinite(v) for v in hline.range(0))
         assert hline.range(1) == (0, 0)
 
     def test_vline_dimension_values(self):
-        vline = VLine(0)
+        vline = hv.VLine(0)
         assert vline.range(0) == (0, 0)
         assert all(not np.isfinite(v) for v in vline.range(1))
 
         # Testing numpy inputs
-        vline = VLine(np.array([0]))
+        vline = hv.VLine(np.array([0]))
         assert vline.range(0) == (0, 0)
         assert all(not np.isfinite(v) for v in vline.range(1))
 
-        vline = VLine(np.array(0))
+        vline = hv.VLine(np.array(0))
         assert vline.range(0) == (0, 0)
         assert all(not np.isfinite(v) for v in vline.range(1))
 
     def test_arrow_redim_range_aux(self):
-        annotations = Arrow(0, 0)
+        annotations = hv.Arrow(0, 0)
         redimmed = annotations.redim.range(x=(-0.5,0.5))
         assert redimmed.kdims[0].range == (-0.5,0.5)
 
     def test_deep_clone_map_select_redim(self):
-        annotations = (Text(0, 0, 'A') + Arrow(0, 0) + HLine(0) + VLine(0))
+        annotations = (hv.Text(0, 0, 'A') + hv.Arrow(0, 0) + hv.HLine(0) + hv.VLine(0))
         selected = annotations.select(x=(0, 5))
         redimmed = selected.redim(x='z')
         relabelled = redimmed.relabel(label='foo', depth=5)
-        mapped = relabelled.map(lambda x: x.clone(group='bar'), Annotation)
+        mapped = relabelled.map(lambda x: x.clone(group='bar'), hv.Annotation)
         kwargs = dict(label='foo', group='bar', extents=(0, None, 5, None), kdims=['z', 'y'])
-        assert_element_equal(mapped.Text.I, Text(0, 0, 'A', **kwargs))
-        assert_element_equal(mapped.Arrow.I, Arrow(0, 0, **kwargs))
-        assert_element_equal(mapped.HLine.I, HLine(0, **kwargs))
-        assert_element_equal(mapped.VLine.I, VLine(0, **kwargs))
+        assert_element_equal(mapped.Text.I, hv.Text(0, 0, 'A', **kwargs))
+        assert_element_equal(mapped.Arrow.I, hv.Arrow(0, 0, **kwargs))
+        assert_element_equal(mapped.HLine.I, hv.HLine(0, **kwargs))
+        assert_element_equal(mapped.VLine.I, hv.VLine(0, **kwargs))
 
     def test_spline_clone(self):
         points = [(-0.3, -0.3), (0,0), (0.25, -0.25), (0.3, 0.3)]
-        spline = Spline((points,[])).clone()
+        spline = hv.Spline((points,[])).clone()
         assert_data_equal(spline.dimension_values(0), np.array([-0.3, 0, 0.25, 0.3]))
         assert_data_equal(spline.dimension_values(1), np.array([-0.3, 0, -0.25, 0.3]))

--- a/holoviews/tests/element/test_apiconsistency.py
+++ b/holoviews/tests/element/test_apiconsistency.py
@@ -3,20 +3,19 @@ Tests to make sure all components follow the appropriate API
 """
 import pytest
 
-from holoviews import element
-from holoviews.element import elements_list
+import holoviews as hv
 
 
-@pytest.mark.parametrize("element_name", sorted(elements_list))
+@pytest.mark.parametrize("element_name", sorted(hv.elements_list))
 def test_element_group_parameter_declared_constant(element_name):
-    el = getattr(element, element_name)
+    el = getattr(hv.element, element_name)
     assert el.param['group'].constant
 
 
-@pytest.mark.parametrize("element_name", sorted(elements_list))
+@pytest.mark.parametrize("element_name", sorted(hv.elements_list))
 def test_element_label_parameter_declared_constant(element_name):
     """
     Checking all elements in case LabelledData.label is redefined
     """
-    el = getattr(element, element_name)
+    el = getattr(hv.element, element_name)
     assert el.param['label'].constant

--- a/holoviews/tests/element/test_comparisonchart.py
+++ b/holoviews/tests/element/test_comparisonchart.py
@@ -4,7 +4,7 @@ Test cases for the Comparisons class over the Chart elements
 
 import numpy as np
 
-from holoviews import Bars, Curve, Dimension, Histogram, Points, Scatter, VectorField
+import holoviews as hv
 from holoviews.element.comparison import ComparisonTestCase
 
 
@@ -13,8 +13,8 @@ class CurveComparisonTest(ComparisonTestCase):
     def setUp(self):
         "Variations on the constructors in the Elements notebook"
 
-        self.curve1 = Curve([(0.1*i, np.sin(0.1*i)) for i in range(100)])
-        self.curve2 = Curve([(0.1*i, np.sin(0.1*i)) for i in range(101)])
+        self.curve1 = hv.Curve([(0.1*i, np.sin(0.1*i)) for i in range(100)])
+        self.curve2 = hv.Curve([(0.1*i, np.sin(0.1*i)) for i in range(101)])
 
     def test_curves_equal(self):
         self.assertEqual(self.curve1, self.curve1)
@@ -33,14 +33,14 @@ class BarsComparisonTest(ComparisonTestCase):
     def setUp(self):
         "Variations on the constructors in the Elements notebook"
 
-        key_dims1=[Dimension('Car occupants')]
-        key_dims2=[Dimension('Cyclists')]
+        key_dims1=[hv.Dimension('Car occupants')]
+        key_dims2=[hv.Dimension('Cyclists')]
         value_dims1=['Count']
-        self.bars1 = Bars([('one',8),('two', 10), ('three', 16)],
+        self.bars1 = hv.Bars([('one',8),('two', 10), ('three', 16)],
                           kdims=key_dims1, vdims=value_dims1)
-        self.bars2 = Bars([('one',8),('two', 10), ('three', 17)],
+        self.bars2 = hv.Bars([('one',8),('two', 10), ('three', 17)],
                           kdims=key_dims1, vdims=value_dims1)
-        self.bars3 = Bars([('one',8),('two', 10), ('three', 16)],
+        self.bars3 = hv.Bars([('one',8),('two', 10), ('three', 16)],
                           kdims=key_dims2, vdims=value_dims1)
 
     def test_bars_equal_1(self):
@@ -75,12 +75,12 @@ class HistogramComparisonTest(ComparisonTestCase):
 
         np.random.seed(1)
         frequencies1, edges1 = np.histogram([np.random.normal() for i in range(1000)], 20)
-        self.hist1 = Histogram((edges1, frequencies1))
+        self.hist1 = hv.Histogram((edges1, frequencies1))
         np.random.seed(2)
         frequencies2, edges2 =  np.histogram([np.random.normal() for i in range(1000)], 20)
-        self.hist2 = Histogram((edges2, frequencies2))
-        self.hist3 = Histogram((edges2, frequencies1))
-        self.hist4 = Histogram((edges1, frequencies2))
+        self.hist2 = hv.Histogram((edges2, frequencies2))
+        self.hist3 = hv.Histogram((edges2, frequencies1))
+        self.hist4 = hv.Histogram((edges1, frequencies2))
 
     def test_histograms_equal_1(self):
         self.assertEqual(self.hist1, self.hist1)
@@ -107,9 +107,9 @@ class ScatterComparisonTest(ComparisonTestCase):
     def setUp(self):
         "Variations on the constructors in the Elements notebook"
 
-        self.scatter1 = Scatter([(1, i) for i in range(20)])
-        self.scatter2 = Scatter([(1, i) for i in range(21)])
-        self.scatter3 = Scatter([(1, i*2) for i in range(20)])
+        self.scatter1 = hv.Scatter([(1, i) for i in range(20)])
+        self.scatter2 = hv.Scatter([(1, i) for i in range(21)])
+        self.scatter3 = hv.Scatter([(1, i*2) for i in range(20)])
 
 
     def test_scatter_equal_1(self):
@@ -142,9 +142,9 @@ class PointsComparisonTest(ComparisonTestCase):
     def setUp(self):
         "Variations on the constructors in the Elements notebook"
 
-        self.points1 = Points([(1, i) for i in range(20)])
-        self.points2 = Points([(1, i) for i in range(21)])
-        self.points3 = Points([(1, i*2) for i in range(20)])
+        self.points1 = hv.Points([(1, i) for i in range(20)])
+        self.points2 = hv.Points([(1, i) for i in range(21)])
+        self.points3 = hv.Points([(1, i*2) for i in range(20)])
 
 
     def test_points_equal_1(self):
@@ -182,8 +182,8 @@ class VectorFieldComparisonTest(ComparisonTestCase):
         exp_falloff1 = 1/np.exp((x**2+y**2)/8)
         exp_falloff2 = 1/np.exp((x**2+y**2)/9)
 
-        self.vfield1 = VectorField([x,y,sine_rings, exp_falloff1])
-        self.vfield2 = VectorField([x,y,sine_rings, exp_falloff2])
+        self.vfield1 = hv.VectorField([x,y,sine_rings, exp_falloff1])
+        self.vfield2 = hv.VectorField([x,y,sine_rings, exp_falloff2])
 
 
     def test_vfield_equal_1(self):

--- a/holoviews/tests/element/test_comparisoncomposite.py
+++ b/holoviews/tests/element/test_comparisoncomposite.py
@@ -7,18 +7,18 @@ Overlay    (the * operator)
 HoloMaps are not tested in this file.
 """
 
-from holoviews import Element
+import holoviews as hv
 from holoviews.element.comparison import ComparisonTestCase
 
 
 class CompositeComparisonTestCase(ComparisonTestCase):
 
     def setUp(self):
-        self.el1 = Element('data1')
-        self.el2 = Element('data2')
-        self.el3 = Element('data3')
-        self.el4 = Element('data5', group='ValB')
-        self.el5 = Element('data6', label='LabelA')
+        self.el1 = hv.Element('data1')
+        self.el2 = hv.Element('data2')
+        self.el3 = hv.Element('data3')
+        self.el4 = hv.Element('data5', group='ValB')
+        self.el5 = hv.Element('data6', label='LabelA')
 
     #========================#
     # Tests for layout trees #

--- a/holoviews/tests/element/test_comparisondimension.py
+++ b/holoviews/tests/element/test_comparisondimension.py
@@ -1,7 +1,8 @@
 """
 Test cases for Dimension and Dimensioned object comparison.
 """
-from holoviews.core import Dimension, Dimensioned
+import holoviews as hv
+from holoviews.core import Dimensioned
 from holoviews.core.util import NUMPY_GE_2_0_0
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -10,30 +11,30 @@ class DimensionsComparisonTestCase(ComparisonTestCase):
 
     def setUp(self):
         super().setUp()
-        self.dimension1 = Dimension('dim1', range=(0,1))
-        self.dimension2 = Dimension('dim2', range=(0,1))
-        self.dimension3 = Dimension('dim1', range=(0,2))
-        self.dimension4 = Dimension('dim1')
-        self.dimension5 = Dimension('dim1', cyclic=True)
-        self.dimension6 = Dimension('dim1', cyclic=True, range=(0,1))
-        self.dimension7 = Dimension('dim1', cyclic=True, range=(0,1), unit='ms')
-        self.dimension8 = Dimension('dim1', values=['a', 'b'])
-        self.dimension9 = Dimension('dim1', type=int)
-        self.dimension10 = Dimension('dim1', type=float)
-        self.dimension11 = Dimension(('dim1','Test Dimension'), range=(0,1))
-        self.dimension12 = Dimension('dim1', value_format=lambda x: x)
-        self.dimension13 = Dimension('dim1', value_format=lambda x: x)
+        self.dimension1 = hv.Dimension('dim1', range=(0,1))
+        self.dimension2 = hv.Dimension('dim2', range=(0,1))
+        self.dimension3 = hv.Dimension('dim1', range=(0,2))
+        self.dimension4 = hv.Dimension('dim1')
+        self.dimension5 = hv.Dimension('dim1', cyclic=True)
+        self.dimension6 = hv.Dimension('dim1', cyclic=True, range=(0,1))
+        self.dimension7 = hv.Dimension('dim1', cyclic=True, range=(0,1), unit='ms')
+        self.dimension8 = hv.Dimension('dim1', values=['a', 'b'])
+        self.dimension9 = hv.Dimension('dim1', type=int)
+        self.dimension10 = hv.Dimension('dim1', type=float)
+        self.dimension11 = hv.Dimension(('dim1','Test Dimension'), range=(0,1))
+        self.dimension12 = hv.Dimension('dim1', value_format=lambda x: x)
+        self.dimension13 = hv.Dimension('dim1', value_format=lambda x: x)
 
     def test_dimension_comparison_equal1(self):
         self.assertEqual(self.dimension1, self.dimension1)
 
     def test_dimension_comparison_equal2(self):
         self.assertEqual(self.dimension1,
-                         Dimension('dim1', range=(0,1)))
+                         hv.Dimension('dim1', range=(0,1)))
 
     def test_dimension_comparison_equal3(self):
         self.assertEqual(self.dimension7,
-                         Dimension('dim1', cyclic=True, range=(0,1), unit='ms'))
+                         hv.Dimension('dim1', cyclic=True, range=(0,1), unit='ms'))
 
     def test_dimension_comparison_names_unequal(self):
         try:
@@ -99,11 +100,11 @@ class DimensionedComparisonTestCase(ComparisonTestCase):
     def setUp(self):
         super().setUp()
         # Value dimension lists
-        self.value_list1 = [Dimension('val1')]
-        self.value_list2 = [Dimension('val2')]
+        self.value_list1 = [hv.Dimension('val1')]
+        self.value_list2 = [hv.Dimension('val2')]
         # Key dimension lists
-        self.key_list1 = [Dimension('key1')]
-        self.key_list2 = [Dimension('key2')]
+        self.key_list1 = [hv.Dimension('key1')]
+        self.key_list2 = [hv.Dimension('key2')]
         # Dimensioned instances
         self.dimensioned1 = Dimensioned('data1', vdims=self.value_list1,
                                         kdims=self.key_list1)

--- a/holoviews/tests/element/test_comparisonpath.py
+++ b/holoviews/tests/element/test_comparisonpath.py
@@ -2,36 +2,36 @@
 Test cases for the Comparisons class over the Path elements
 """
 
-from holoviews import Bounds, Box, Contours, Ellipse, Path
+import holoviews as hv
 from holoviews.element.comparison import ComparisonTestCase
 
 
 class PathComparisonTest(ComparisonTestCase):
 
     def setUp(self):
-        self.path1 = Path([(-0.3, 0.4), (-0.3, 0.3), (-0.2, 0.3),
+        self.path1 = hv.Path([(-0.3, 0.4), (-0.3, 0.3), (-0.2, 0.3),
                            (-0.2, 0.4),(-0.3, 0.4)])
 
-        self.path2 = Path([(-0.3, 0.4), (-0.3, 0.3), (-0.2, 0.3),
+        self.path2 = hv.Path([(-0.3, 0.4), (-0.3, 0.3), (-0.2, 0.3),
                            (-0.2, 0.4),(-3, 4)])
 
-        self.contours1 = Contours([(-0.3, 0.4, 1), (-0.3, 0.3, 1), (-0.2, 0.3, 1),
+        self.contours1 = hv.Contours([(-0.3, 0.4, 1), (-0.3, 0.3, 1), (-0.2, 0.3, 1),
                                    (-0.2, 0.4, 1),(-0.3, 0.4, 1)], vdims='Level')
 
-        self.contours2 = Contours([(-0.3, 0.4, 1), (-0.3, 0.3, 1), (-0.2, 0.3, 1),
+        self.contours2 = hv.Contours([(-0.3, 0.4, 1), (-0.3, 0.3, 1), (-0.2, 0.3, 1),
                                    (-0.2, 0.4, 1), (-3, 4, 1)], vdims='Level')
 
-        self.contours3 = Contours([(-0.3, 0.4, 2), (-0.3, 0.3, 2), (-0.2, 0.3, 2),
+        self.contours3 = hv.Contours([(-0.3, 0.4, 2), (-0.3, 0.3, 2), (-0.2, 0.3, 2),
                                    (-0.2, 0.4, 2), (-0.3, 0.4, 2)], vdims='Level')
 
-        self.bounds1 = Bounds(0.3)
-        self.bounds2 = Bounds(0.4)
+        self.bounds1 = hv.Bounds(0.3)
+        self.bounds2 = hv.Bounds(0.4)
 
-        self.box1 = Box(-0.25, 0.3, 0.3)
-        self.box2 = Box(-0.25, 0.3, 0.4)
+        self.box1 = hv.Box(-0.25, 0.3, 0.3)
+        self.box2 = hv.Box(-0.25, 0.3, 0.4)
 
-        self.ellipse1 = Ellipse(-0.25, 0.3, 0.3)
-        self.ellipse2 = Ellipse(-0.25, 0.3, 0.4)
+        self.ellipse1 = hv.Ellipse(-0.25, 0.3, 0.3)
+        self.ellipse2 = hv.Ellipse(-0.25, 0.3, 0.4)
 
     def test_paths_equal(self):
         self.assertEqual(self.path1, self.path1)

--- a/holoviews/tests/element/test_comparisonraster.py
+++ b/holoviews/tests/element/test_comparisonraster.py
@@ -3,9 +3,7 @@ Test cases for the Comparisons class over the Raster types.
 """
 import numpy as np
 
-from holoviews import Image
-from holoviews.core import BoundingBox, Dimension
-from holoviews.core.element import HoloMap
+import holoviews as hv
 from holoviews.element.comparison import ComparisonTestCase
 
 
@@ -16,12 +14,12 @@ class RasterTestCase(ComparisonTestCase):
         self.arr2 = np.array([[10,2], [3,4]])
         self.arr3 = np.array([[10,2], [3,40]])
         # Varying arrays, default bounds
-        self.mat1 = Image(self.arr1, bounds=BoundingBox())
-        self.mat2 = Image(self.arr2, bounds=BoundingBox())
-        self.mat3 = Image(self.arr3, bounds=BoundingBox())
+        self.mat1 = hv.Image(self.arr1, bounds=hv.BoundingBox())
+        self.mat2 = hv.Image(self.arr2, bounds=hv.BoundingBox())
+        self.mat3 = hv.Image(self.arr3, bounds=hv.BoundingBox())
         # Varying arrays, different bounds
-        self.mat4 = Image(self.arr1, bounds=BoundingBox(radius=0.3))
-        self.mat5 = Image(self.arr2, bounds=BoundingBox(radius=0.3))
+        self.mat4 = hv.Image(self.arr1, bounds=hv.BoundingBox(radius=0.3))
+        self.mat5 = hv.Image(self.arr2, bounds=hv.BoundingBox(radius=0.3))
 
 
 class RasterOverlayTestCase(RasterTestCase):
@@ -42,45 +40,45 @@ class RasterMapTestCase(RasterOverlayTestCase):
     def setUp(self):
         super().setUp()
         # Example 1D map
-        self.map1_1D = HoloMap(kdims=['int'])
+        self.map1_1D = hv.HoloMap(kdims=['int'])
         self.map1_1D[0] = self.mat1
         self.map1_1D[1] = self.mat2
         # Changed keys...
-        self.map2_1D = HoloMap(kdims=['int'])
+        self.map2_1D = hv.HoloMap(kdims=['int'])
         self.map2_1D[1] = self.mat1
         self.map2_1D[2] = self.mat2
         # Changed number of keys...
-        self.map3_1D = HoloMap(kdims=['int'])
+        self.map3_1D = hv.HoloMap(kdims=['int'])
         self.map3_1D[1] = self.mat1
         self.map3_1D[2] = self.mat2
         self.map3_1D[3] = self.mat3
         # Changed values...
-        self.map4_1D = HoloMap(kdims=['int'])
+        self.map4_1D = hv.HoloMap(kdims=['int'])
         self.map4_1D[0] = self.mat1
         self.map4_1D[1] = self.mat3
         # Changed bounds...
-        self.map5_1D = HoloMap(kdims=['int'])
+        self.map5_1D = hv.HoloMap(kdims=['int'])
         self.map5_1D[0] = self.mat4
         self.map5_1D[1] = self.mat5
         # Example dimension label
-        self.map6_1D = HoloMap(kdims=['int_v2'])
+        self.map6_1D = hv.HoloMap(kdims=['int_v2'])
         self.map6_1D[0] = self.mat1
         self.map6_1D[1] = self.mat2
         # A HoloMap of Overlays
-        self.map7_1D = HoloMap(kdims=['int'])
+        self.map7_1D = hv.HoloMap(kdims=['int'])
         self.map7_1D[0] =  self.overlay1_depth2
         self.map7_1D[1] =  self.overlay2_depth2
         # A different HoloMap of Overlays
-        self.map8_1D = HoloMap(kdims=['int'])
+        self.map8_1D = hv.HoloMap(kdims=['int'])
         self.map8_1D[0] =  self.overlay2_depth2
         self.map8_1D[1] =  self.overlay1_depth2
 
         # Example 2D map
-        self.map1_2D = HoloMap(kdims=['int', Dimension('float')])
+        self.map1_2D = hv.HoloMap(kdims=['int', hv.Dimension('float')])
         self.map1_2D[0, 0.5] = self.mat1
         self.map1_2D[1, 1.0] = self.mat2
         # Changed 2D keys...
-        self.map2_2D = HoloMap(kdims=['int', Dimension('float')])
+        self.map2_2D = hv.HoloMap(kdims=['int', hv.Dimension('float')])
         self.map2_2D[0, 1.0] = self.mat1
         self.map2_2D[1, 1.5] = self.mat2
 

--- a/holoviews/tests/element/test_comparisonsimple.py
+++ b/holoviews/tests/element/test_comparisonsimple.py
@@ -6,7 +6,7 @@ Int, float, numpy array and BoundingBox comparisons are tested.
 
 import numpy as np
 
-from holoviews.core import BoundingBox
+import holoviews as hv
 from holoviews.element.comparison import ComparisonTestCase
 
 
@@ -87,25 +87,25 @@ class SimpleComparisonTest(ComparisonTestCase):
                             raise self.failureException("Float array mismatch error not raised.")
 
     def test_bounds_equal(self):
-        self.assertEqual(BoundingBox(radius=0.5),
-                         BoundingBox(radius=0.5))
+        self.assertEqual(hv.BoundingBox(radius=0.5),
+                         hv.BoundingBox(radius=0.5))
 
     def test_bounds_unequal(self):
         try:
-            self.assertEqual(BoundingBox(radius=0.5),
-                             BoundingBox(radius=0.7))
+            self.assertEqual(hv.BoundingBox(radius=0.5),
+                             hv.BoundingBox(radius=0.7))
         except AssertionError as e:
             self.assertEqual(str(e), "BoundingBox(radius=0.5) != BoundingBox(radius=0.7)")
 
 
     def test_bounds_equal_lbrt(self):
-        self.assertEqual(BoundingBox(points=((-1,-1),(3,4.5))),
-                         BoundingBox(points=((-1,-1),(3,4.5))))
+        self.assertEqual(hv.BoundingBox(points=((-1,-1),(3,4.5))),
+                         hv.BoundingBox(points=((-1,-1),(3,4.5))))
 
     def test_bounds_unequal_lbrt(self):
         try:
-            self.assertEqual(BoundingBox(points=((-1,-1),(3,4.5))),
-                             BoundingBox(points=((-1,-1),(3,5.0))))
+            self.assertEqual(hv.BoundingBox(points=((-1,-1),(3,4.5))),
+                             hv.BoundingBox(points=((-1,-1),(3,5.0))))
         except AssertionError as e:
             msg = 'BoundingBox(points=((-1,-1),(3,4.5))) != BoundingBox(points=((-1,-1),(3,5.0)))'
             self.assertEqual(str(e), msg)

--- a/holoviews/tests/element/test_elementconstructors.py
+++ b/holoviews/tests/element/test_elementconstructors.py
@@ -2,34 +2,7 @@ import numpy as np
 import pandas as pd
 import param
 
-from holoviews import (
-    RGB,
-    Annotation,
-    Area,
-    Bars,
-    BoxWhisker,
-    Contours,
-    Curve,
-    Dataset,
-    Dimension,
-    Div,
-    Element,
-    ErrorBars,
-    Graph,
-    HeatMap,
-    Histogram,
-    Image,
-    Path,
-    Points,
-    Polygons,
-    QuadMesh,
-    Raster,
-    Scatter,
-    Spikes,
-    Tiles,
-    TriMesh,
-    VectorField,
-)
+import holoviews as hv
 from holoviews.element.path import BaseShape
 from holoviews.testing import assert_data_equal, assert_element_equal
 
@@ -47,15 +20,15 @@ class ElementConstructorTest:
         self.cos = np.cos(self.xs)
         sine_data = np.column_stack((self.xs, self.sin))
         cos_data = np.column_stack((self.xs, self.cos))
-        self.curve = Curve(sine_data)
-        self.path = Path([sine_data, cos_data])
-        self.histogram = Histogram((self.hxs, self.sin))
+        self.curve = hv.Curve(sine_data)
+        self.path = hv.Path([sine_data, cos_data])
+        self.histogram = hv.Histogram((self.hxs, self.sin))
 
     def test_empty_element_constructor(self):
         failed_elements = []
-        for name, el in param.concrete_descendents(Element).items():
+        for name, el in param.concrete_descendents(hv.Element).items():
             if name == 'Sankey': continue
-            if issubclass(el, (Annotation, BaseShape, Div, Tiles)):
+            if issubclass(el, (hv.Annotation, BaseShape, hv.Div, hv.Tiles)):
                 continue
             try:
                 el([])
@@ -64,59 +37,59 @@ class ElementConstructorTest:
         assert failed_elements == []
 
     def test_chart_zipconstruct(self):
-        assert_element_equal(Curve(zip(self.xs, self.sin, strict=True)), self.curve)
+        assert_element_equal(hv.Curve(zip(self.xs, self.sin, strict=True)), self.curve)
 
     def test_chart_tuple_construct(self):
-        assert_element_equal(Curve((self.xs, self.sin)), self.curve)
+        assert_element_equal(hv.Curve((self.xs, self.sin)), self.curve)
 
     def test_path_tuple_construct(self):
-        assert_element_equal(Path((self.xs, np.column_stack((self.sin, self.cos)))), self.path)
+        assert_element_equal(hv.Path((self.xs, np.column_stack((self.sin, self.cos)))), self.path)
 
     def test_path_tuplelist_construct(self):
-        assert_element_equal(Path([(self.xs, self.sin), (self.xs, self.cos)]), self.path)
+        assert_element_equal(hv.Path([(self.xs, self.sin), (self.xs, self.cos)]), self.path)
 
     def test_path_ziplist_construct(self):
-        assert_element_equal(Path([list(zip(self.xs, self.sin, strict=True)), list(zip(self.xs, self.cos, strict=True))]), self.path)
+        assert_element_equal(hv.Path([list(zip(self.xs, self.sin, strict=True)), list(zip(self.xs, self.cos, strict=True))]), self.path)
 
     def test_hist_zip_construct(self):
-        assert_element_equal(Histogram(list(zip(self.hxs, self.sin, strict=True))), self.histogram)
+        assert_element_equal(hv.Histogram(list(zip(self.hxs, self.sin, strict=True))), self.histogram)
 
     def test_hist_array_construct(self):
-        assert_element_equal(Histogram(np.column_stack((self.hxs, self.sin))), self.histogram)
+        assert_element_equal(hv.Histogram(np.column_stack((self.hxs, self.sin))), self.histogram)
 
     def test_hist_yvalues_construct(self):
-        assert_element_equal(Histogram(self.sin), self.histogram)
+        assert_element_equal(hv.Histogram(self.sin), self.histogram)
 
     def test_hist_curve_construct(self):
-        hist = Histogram(Curve(([0.1, 0.3, 0.5], [2.1, 2.2, 3.3])))
+        hist = hv.Histogram(hv.Curve(([0.1, 0.3, 0.5], [2.1, 2.2, 3.3])))
         values = hist.dimension_values(1)
         edges = hist.edges
         assert_data_equal(values, np.array([2.1, 2.2, 3.3]))
         assert_data_equal(edges, np.array([0, 0.2, 0.4, 0.6]))
 
     def test_hist_curve_int_edges_construct(self):
-        hist = Histogram(Curve(range(3)))
+        hist = hv.Histogram(hv.Curve(range(3)))
         values = hist.dimension_values(1)
         edges = hist.edges
         assert_data_equal(values, np.arange(3))
         assert_data_equal(edges, np.array([-.5, .5, 1.5, 2.5]))
 
     def test_heatmap_construct(self):
-        hmap = HeatMap([('A', 'a', 1), ('B', 'b', 2)])
-        dataset = Dataset({'x': ['A', 'B'], 'y': ['a', 'b'], 'z': [[1, np.nan], [np.nan, 2]]},
+        hmap = hv.HeatMap([('A', 'a', 1), ('B', 'b', 2)])
+        dataset = hv.Dataset({'x': ['A', 'B'], 'y': ['a', 'b'], 'z': [[1, np.nan], [np.nan, 2]]},
                           kdims=['x', 'y'], vdims=['z'], label='unique')
         assert_element_equal(hmap.gridded, dataset)
 
     def test_heatmap_construct_unsorted(self):
-        hmap = HeatMap([('B', 'b', 2), ('A', 'a', 1)])
-        dataset = Dataset({'x': ['B', 'A'], 'y': ['b', 'a'], 'z': [[2, np.nan], [np.nan, 1]]},
+        hmap = hv.HeatMap([('B', 'b', 2), ('A', 'a', 1)])
+        dataset = hv.Dataset({'x': ['B', 'A'], 'y': ['b', 'a'], 'z': [[2, np.nan], [np.nan, 1]]},
                           kdims=['x', 'y'], vdims=['z'], label='unique')
         assert_element_equal(hmap.gridded, dataset)
 
     def test_heatmap_construct_partial_sorted(self):
         data = [(chr(65+i),chr(97+j), i*j) for i in range(3) for j in [2, 0, 1] if i!=j]
-        hmap = HeatMap(data)
-        dataset = Dataset({
+        hmap = hv.HeatMap(data)
+        dataset = hv.Dataset({
             'x': ['A', 'B', 'C'],
             'y': ['b', 'a', 'c'],
             'z': [[0, np.nan, 2], [np.nan, 0, 0], [0, 2, np.nan]]
@@ -125,8 +98,8 @@ class ElementConstructorTest:
 
     def test_heatmap_construct_and_sort(self):
         data = [(chr(65+i),chr(97+j), i*j) for i in range(3) for j in [2, 0, 1] if i!=j]
-        hmap = HeatMap(data).sort()
-        dataset = Dataset({'x': ['A', 'B', 'C'], 'y': ['a', 'b', 'c'],
+        hmap = hv.HeatMap(data).sort()
+        dataset = hv.Dataset({'x': ['A', 'B', 'C'], 'y': ['a', 'b', 'c'],
                            'z': [[np.nan, 0, 0], [0, np.nan, 2], [0, 2, np.nan]]},
                           kdims=['x', 'y'], vdims=['z'], label='unique')
         assert_element_equal(hmap.gridded, dataset)
@@ -139,57 +112,57 @@ class ElementSignatureTest:
     """
 
     def test_curve_string_signature(self):
-        curve = Curve([], 'a', 'b')
-        assert curve.kdims == [Dimension('a')]
-        assert curve.vdims == [Dimension('b')]
+        curve = hv.Curve([], 'a', 'b')
+        assert curve.kdims == [hv.Dimension('a')]
+        assert curve.vdims == [hv.Dimension('b')]
 
     def test_area_string_signature(self):
-        area = Area([], 'a', 'b')
-        assert area.kdims == [Dimension('a')]
-        assert area.vdims == [Dimension('b')]
+        area = hv.Area([], 'a', 'b')
+        assert area.kdims == [hv.Dimension('a')]
+        assert area.vdims == [hv.Dimension('b')]
 
     def test_errorbars_string_signature(self):
-        errorbars = ErrorBars([], 'a', ['b', 'c'])
-        assert errorbars.kdims == [Dimension('a')]
-        assert errorbars.vdims == [Dimension('b'), Dimension('c')]
+        errorbars = hv.ErrorBars([], 'a', ['b', 'c'])
+        assert errorbars.kdims == [hv.Dimension('a')]
+        assert errorbars.vdims == [hv.Dimension('b'), hv.Dimension('c')]
 
     def test_bars_string_signature(self):
-        bars = Bars([], 'a', 'b')
-        assert bars.kdims == [Dimension('a')]
-        assert bars.vdims == [Dimension('b')]
+        bars = hv.Bars([], 'a', 'b')
+        assert bars.kdims == [hv.Dimension('a')]
+        assert bars.vdims == [hv.Dimension('b')]
 
     def test_boxwhisker_string_signature(self):
-        boxwhisker = BoxWhisker([], 'a', 'b')
-        assert boxwhisker.kdims == [Dimension('a')]
-        assert boxwhisker.vdims == [Dimension('b')]
+        boxwhisker = hv.BoxWhisker([], 'a', 'b')
+        assert boxwhisker.kdims == [hv.Dimension('a')]
+        assert boxwhisker.vdims == [hv.Dimension('b')]
 
     def test_scatter_string_signature(self):
-        scatter = Scatter([], 'a', 'b')
-        assert scatter.kdims == [Dimension('a')]
-        assert scatter.vdims == [Dimension('b')]
+        scatter = hv.Scatter([], 'a', 'b')
+        assert scatter.kdims == [hv.Dimension('a')]
+        assert scatter.vdims == [hv.Dimension('b')]
 
     def test_points_string_signature(self):
-        points = Points([], ['a', 'b'], 'c')
-        assert points.kdims == [Dimension('a'), Dimension('b')]
-        assert points.vdims == [Dimension('c')]
+        points = hv.Points([], ['a', 'b'], 'c')
+        assert points.kdims == [hv.Dimension('a'), hv.Dimension('b')]
+        assert points.vdims == [hv.Dimension('c')]
 
     def test_vectorfield_string_signature(self):
-        vectorfield = VectorField([], ['a', 'b'], ['c', 'd'])
-        assert vectorfield.kdims == [Dimension('a'), Dimension('b')]
-        assert vectorfield.vdims == [Dimension('c'), Dimension('d')]
+        vectorfield = hv.VectorField([], ['a', 'b'], ['c', 'd'])
+        assert vectorfield.kdims == [hv.Dimension('a'), hv.Dimension('b')]
+        assert vectorfield.vdims == [hv.Dimension('c'), hv.Dimension('d')]
 
     def test_vectorfield_from_uv(self):
         x = np.linspace(-1, 1, 4)
         X, Y = np.meshgrid(x, x)
         U, V = 3 * X, 4 * Y
-        vectorfield = VectorField.from_uv((X, Y, U, V))
+        vectorfield = hv.VectorField.from_uv((X, Y, U, V))
 
         angle = np.arctan2(V, U)
         mag = np.hypot(U, V)
-        kdims = [Dimension('x'), Dimension('y')]
+        kdims = [hv.Dimension('x'), hv.Dimension('y')]
         vdims = [
-            Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
-            Dimension('Magnitude')
+            hv.Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
+            hv.Dimension('Magnitude')
         ]
         assert vectorfield.kdims == kdims
         assert vectorfield.vdims == vdims
@@ -208,14 +181,14 @@ class ElementSignatureTest:
             "u": U.flatten(),
             "v": V.flatten(),
         })
-        vectorfield = VectorField.from_uv(df, ["x", "y"], ["u", "v"])
+        vectorfield = hv.VectorField.from_uv(df, ["x", "y"], ["u", "v"])
 
         angle = np.arctan2(V, U)
         mag = np.hypot(U, V)
-        kdims = [Dimension('x'), Dimension('y')]
+        kdims = [hv.Dimension('x'), hv.Dimension('y')]
         vdims = [
-            Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
-            Dimension('Magnitude')
+            hv.Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
+            hv.Dimension('Magnitude')
         ]
         assert vectorfield.kdims == kdims
         assert vectorfield.vdims == vdims
@@ -223,45 +196,45 @@ class ElementSignatureTest:
         np.testing.assert_equal(vectorfield.dimension_values(3, flat=False), mag.flat)
 
     def test_path_string_signature(self):
-        path = Path([], ['a', 'b'])
-        assert path.kdims == [Dimension('a'), Dimension('b')]
+        path = hv.Path([], ['a', 'b'])
+        assert path.kdims == [hv.Dimension('a'), hv.Dimension('b')]
 
     def test_spikes_string_signature(self):
-        spikes = Spikes([], 'a')
-        assert spikes.kdims == [Dimension('a')]
+        spikes = hv.Spikes([], 'a')
+        assert spikes.kdims == [hv.Dimension('a')]
 
     def test_contours_string_signature(self):
-        contours = Contours([], ['a', 'b'])
-        assert contours.kdims == [Dimension('a'), Dimension('b')]
+        contours = hv.Contours([], ['a', 'b'])
+        assert contours.kdims == [hv.Dimension('a'), hv.Dimension('b')]
 
     def test_polygons_string_signature(self):
-        polygons = Polygons([], ['a', 'b'])
-        assert polygons.kdims == [Dimension('a'), Dimension('b')]
+        polygons = hv.Polygons([], ['a', 'b'])
+        assert polygons.kdims == [hv.Dimension('a'), hv.Dimension('b')]
 
     def test_heatmap_string_signature(self):
-        heatmap = HeatMap([], ['a', 'b'], 'c')
-        assert heatmap.kdims == [Dimension('a'), Dimension('b')]
-        assert heatmap.vdims == [Dimension('c')]
+        heatmap = hv.HeatMap([], ['a', 'b'], 'c')
+        assert heatmap.kdims == [hv.Dimension('a'), hv.Dimension('b')]
+        assert heatmap.vdims == [hv.Dimension('c')]
 
     def test_raster_string_signature(self):
-        raster = Raster(np.array([[0]]), ['a', 'b'], 'c')
-        assert raster.kdims == [Dimension('a'), Dimension('b')]
-        assert raster.vdims == [Dimension('c')]
+        raster = hv.Raster(np.array([[0]]), ['a', 'b'], 'c')
+        assert raster.kdims == [hv.Dimension('a'), hv.Dimension('b')]
+        assert raster.vdims == [hv.Dimension('c')]
 
     def test_image_string_signature(self):
-        img = Image(np.array([[0, 1], [0, 1]]), ['a', 'b'], 'c')
-        assert img.kdims == [Dimension('a'), Dimension('b')]
-        assert img.vdims == [Dimension('c')]
+        img = hv.Image(np.array([[0, 1], [0, 1]]), ['a', 'b'], 'c')
+        assert img.kdims == [hv.Dimension('a'), hv.Dimension('b')]
+        assert img.vdims == [hv.Dimension('c')]
 
     def test_rgb_string_signature(self):
-        img = RGB(np.zeros((2, 2, 3)), ['a', 'b'], ['R', 'G', 'B'])
-        assert img.kdims == [Dimension('a'), Dimension('b')]
-        assert img.vdims == [Dimension('R'), Dimension('G'), Dimension('B')]
+        img = hv.RGB(np.zeros((2, 2, 3)), ['a', 'b'], ['R', 'G', 'B'])
+        assert img.kdims == [hv.Dimension('a'), hv.Dimension('b')]
+        assert img.vdims == [hv.Dimension('R'), hv.Dimension('G'), hv.Dimension('B')]
 
     def test_quadmesh_string_signature(self):
-        qmesh = QuadMesh(([0, 1], [0, 1], np.array([[0, 1], [0, 1]])), ['a', 'b'], 'c')
-        assert qmesh.kdims == [Dimension('a'), Dimension('b')]
-        assert qmesh.vdims == [Dimension('c')]
+        qmesh = hv.QuadMesh(([0, 1], [0, 1], np.array([[0, 1], [0, 1]])), ['a', 'b'], 'c')
+        assert qmesh.kdims == [hv.Dimension('a'), hv.Dimension('b')]
+        assert qmesh.vdims == [hv.Dimension('c')]
 
 
 class ElementCastingTests:
@@ -273,17 +246,17 @@ class ElementCastingTests:
     """
 
     def test_image_casting(self):
-        img = Image([], bounds=2)
-        assert_element_equal(img, Image(img))
+        img = hv.Image([], bounds=2)
+        assert_element_equal(img, hv.Image(img))
 
     def test_rgb_casting(self):
-        rgb = RGB([], bounds=2)
-        assert_element_equal(rgb, RGB(rgb))
+        rgb = hv.RGB([], bounds=2)
+        assert_element_equal(rgb, hv.RGB(rgb))
 
     def test_graph_casting(self):
-        graph = Graph(([(0, 1)], [(0, 0, 0), (0, 1, 1)]))
-        assert_element_equal(graph, Graph(graph))
+        graph = hv.Graph(([(0, 1)], [(0, 0, 0), (0, 1, 1)]))
+        assert_element_equal(graph, hv.Graph(graph))
 
     def test_trimesh_casting(self):
-        trimesh = TriMesh(([(0, 1, 2)], [(0, 0, 0), (0, 1, 1), (1, 1, 2)]))
-        assert_element_equal(trimesh, TriMesh(trimesh))
+        trimesh = hv.TriMesh(([(0, 1, 2)], [(0, 0, 0), (0, 1, 1), (1, 1, 2)]))
+        assert_element_equal(trimesh, hv.TriMesh(trimesh))

--- a/holoviews/tests/element/test_elementranges.py
+++ b/holoviews/tests/element/test_elementranges.py
@@ -2,8 +2,6 @@
 Test cases for computing ranges on elements which are not simply
 the (min, max) of the dimension values array.
 """
-
-
 import holoviews as hv
 
 

--- a/holoviews/tests/element/test_elementranges.py
+++ b/holoviews/tests/element/test_elementranges.py
@@ -2,47 +2,49 @@
 Test cases for computing ranges on elements which are not simply
 the (min, max) of the dimension values array.
 """
-from holoviews import Dimension, ErrorBars, Histogram
+
+
+import holoviews as hv
 
 
 class HistogramRangeTests:
 
     def test_histogram_range_x(self):
-        r = Histogram(([0, 1, 2, 3], [1, 2, 3])).range(0)
+        r = hv.Histogram(([0, 1, 2, 3], [1, 2, 3])).range(0)
         assert r == (0., 3.0)
 
     def test_histogram_range_x_explicit(self):
-        r = Histogram(([0, 1, 2, 3], [1, 2, 3]),
-                      kdims=[Dimension('x', range=(-1, 4.))]).range(0)
+        r = hv.Histogram(([0, 1, 2, 3], [1, 2, 3]),
+                      kdims=[hv.Dimension('x', range=(-1, 4.))]).range(0)
         assert r == (-1., 4.)
 
     def test_histogram_range_x_explicit_upper(self):
-        r = Histogram(([0, 1, 2, 3], [1, 2, 3]),
-                      kdims=[Dimension('x', range=(None, 4.))]).range(0)
+        r = hv.Histogram(([0, 1, 2, 3], [1, 2, 3]),
+                      kdims=[hv.Dimension('x', range=(None, 4.))]).range(0)
         assert r == (0, 4.)
 
     def test_histogram_range_x_explicit_lower(self):
-        r = Histogram(([0, 1, 2, 3], [1, 2, 3]),
-                      kdims=[Dimension('x', range=(-1, None))]).range(0)
+        r = hv.Histogram(([0, 1, 2, 3], [1, 2, 3]),
+                      kdims=[hv.Dimension('x', range=(-1, None))]).range(0)
         assert r == (-1., 3.)
 
     def test_histogram_range_y(self):
-        r = Histogram(([0, 1, 2, 3], [1, 2, 3])).range(1)
+        r = hv.Histogram(([0, 1, 2, 3], [1, 2, 3])).range(1)
         assert r == (1., 3.0)
 
     def test_histogram_range_y_explicit(self):
-        r = Histogram(([0, 1, 2, 3], [1, 2, 3]),
-                      vdims=[Dimension('y', range=(0, 4.))]).range(1)
+        r = hv.Histogram(([0, 1, 2, 3], [1, 2, 3]),
+                      vdims=[hv.Dimension('y', range=(0, 4.))]).range(1)
         assert r == (0., 4.)
 
     def test_histogram_range_y_explicit_upper(self):
-        r = Histogram(([0, 1, 2, 3], [1, 2, 3]),
-                      vdims=[Dimension('y', range=(None, 4.))]).range(1)
+        r = hv.Histogram(([0, 1, 2, 3], [1, 2, 3]),
+                      vdims=[hv.Dimension('y', range=(None, 4.))]).range(1)
         assert r == (1., 4.)
 
     def test_histogram_range_y_explicit_lower(self):
-        r = Histogram(([0, 1, 2, 3], [1, 2, 3]),
-                      vdims=[Dimension('y', range=(0., None))]).range(1)
+        r = hv.Histogram(([0, 1, 2, 3], [1, 2, 3]),
+                      vdims=[hv.Dimension('y', range=(0., None))]).range(1)
         assert r == (0., 3.)
 
 
@@ -50,51 +52,51 @@ class HistogramRangeTests:
 class ErrorBarsRangeTests:
 
     def test_errorbars_range_x(self):
-        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5])).range(0)
+        r = hv.ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5])).range(0)
         assert r == (1., 3.0)
 
     def test_errorbars_range_x_explicit(self):
-        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
-                      kdims=[Dimension('x', range=(-1, 4.))]).range(0)
+        r = hv.ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      kdims=[hv.Dimension('x', range=(-1, 4.))]).range(0)
         assert r == (-1., 4.)
 
     def test_errorbars_range_x_explicit_upper(self):
-        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
-                      kdims=[Dimension('x', range=(None, 4.))]).range(0)
+        r = hv.ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      kdims=[hv.Dimension('x', range=(None, 4.))]).range(0)
         assert r == (1, 4.)
 
     def test_errorbars_range_x_explicit_lower(self):
-        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
-                      kdims=[Dimension('x', range=(-1, None))]).range(0)
+        r = hv.ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      kdims=[hv.Dimension('x', range=(-1, None))]).range(0)
         assert r == (-1., 3.)
 
     def test_errorbars_range_y(self):
-        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5])).range(1)
+        r = hv.ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5])).range(1)
         assert r == (1.5, 4.5)
 
     def test_errorbars_range_y_explicit(self):
-        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
-                      vdims=[Dimension('y', range=(0, 4.)), 'yerr']).range(1)
+        r = hv.ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      vdims=[hv.Dimension('y', range=(0, 4.)), 'yerr']).range(1)
         assert r == (0., 4.)
 
     def test_errorbars_range_y_explicit_upper(self):
-        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
-                      vdims=[Dimension('y', range=(None, 4.)), 'yerr']).range(1)
+        r = hv.ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      vdims=[hv.Dimension('y', range=(None, 4.)), 'yerr']).range(1)
         assert r == (1.5, 4.)
 
     def test_errorbars_range_y_explicit_lower(self):
-        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
-                      vdims=[Dimension('y', range=(0., None)), 'yerr']).range(1)
+        r = hv.ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      vdims=[hv.Dimension('y', range=(0., None)), 'yerr']).range(1)
         assert r == (0., 4.5)
 
     def test_errorbars_range_horizontal(self):
-        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+        r = hv.ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
                       horizontal=True).range(0)
         assert r == (0.5, 3.5)
 
     def test_errorbars_range_explicit_horizontal(self):
-        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
-                      kdims=[Dimension('x', range=(-1, 4.))],
+        r = hv.ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      kdims=[hv.Dimension('x', range=(-1, 4.))],
                       vdims=['y', 'xerr'],
                       horizontal=True).range(0)
         assert r == (-1., 4.)

--- a/holoviews/tests/element/test_elementselect.py
+++ b/holoviews/tests/element/test_elementselect.py
@@ -5,29 +5,28 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core import HoloMap
-from holoviews.element import Contours, Curve, Image
+import holoviews as hv
 from holoviews.testing import assert_element_equal
 
 
 class DimensionedSelectionTest:
 
     def setup_method(self):
-        self.img_fn = lambda: Image(np.random.rand(10, 10))
-        self.contour_fn = lambda: Contours([np.random.rand(10, 2)
+        self.img_fn = lambda: hv.Image(np.random.rand(10, 10))
+        self.contour_fn = lambda: hv.Contours([np.random.rand(10, 2)
                                             for i in range(2)])
-        self.datetime_fn = lambda: Curve((
+        self.datetime_fn = lambda: hv.Curve((
             [dt.datetime(2000,1,1), dt.datetime(2000,1,2),
              dt.datetime(2000,1,3)],
             np.random.rand(3)
             ), 'time', 'x')
         params = [list(range(3)) for i in range(2)]
-        self.sanitized_map = HoloMap({i: Image(i*np.random.rand(10,10))
+        self.sanitized_map = hv.HoloMap({i: hv.Image(i*np.random.rand(10,10))
                                       for i in range(1,10)}, kdims=['A B'])
-        self.img_map = HoloMap({(i, j): self.img_fn()
+        self.img_map = hv.HoloMap({(i, j): self.img_fn()
                                 for i, j in product(*params)},
                                kdims=['a', 'b'])
-        self.contour_map = HoloMap({(i, j): self.contour_fn()
+        self.contour_map = hv.HoloMap({(i, j): self.contour_fn()
                                     for i, j in product(*params)},
                                    kdims=['a', 'b'])
         self.ndoverlay_map = self.img_map.overlay('b')
@@ -35,8 +34,8 @@ class DimensionedSelectionTest:
         self.layout_map = self.ndoverlay_map + self.contour_map
         self.duplicate_map = self.img_map.clone(kdims=['x', 'y'])
 
-        self.overlap1 = HoloMap({i: self.img_fn() for i in range(5)})
-        self.overlap2 = HoloMap({i: self.img_fn() for i in range(10)})
+        self.overlap1 = hv.HoloMap({i: self.img_fn() for i in range(5)})
+        self.overlap2 = hv.HoloMap({i: self.img_fn() for i in range(10)})
         self.overlap_layout = self.overlap1 + self.overlap2
 
 
@@ -73,7 +72,7 @@ class DimensionedSelectionTest:
 
     def test_deep_holooverlay_slice(self):
         map_slc = self.overlay_map[1:3, 1:3]
-        img_slc = map_slc.map(lambda x: x[0:0.5, 0:0.5], [Image, Contours])
+        img_slc = map_slc.map(lambda x: x[0:0.5, 0:0.5], [hv.Image, hv.Contours])
         selection = self.overlay_map.select(a=(1,3), b=(1, 3), x=(0, 0.5), y=(0, 0.5))
         assert_element_equal(selection, img_slc)
 
@@ -86,7 +85,7 @@ class DimensionedSelectionTest:
 
     def test_spec_duplicate_dim_select(self):
         selection = self.duplicate_map.select(
-            selection_specs=(HoloMap,), x=(0, 1), y=(1, 3)
+            selection_specs=(hv.HoloMap,), x=(0, 1), y=(1, 3)
         )
         assert_element_equal(selection, self.duplicate_map[0:1, 1:3])
 
@@ -117,4 +116,4 @@ class DimensionedSelectionTest:
         curve = self.datetime_fn()
         with pytest.raises(ValueError, match="Use the selection_specs keyword"
         ):
-            curve.select((Curve,), time=(s, e))
+            curve.select((hv.Curve,), time=(s, e))

--- a/holoviews/tests/element/test_graphelement.py
+++ b/holoviews/tests/element/test_graphelement.py
@@ -5,10 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core.data import Dataset
-from holoviews.element.chart import Points
-from holoviews.element.graphs import Chord, Graph, Nodes, TriMesh
-from holoviews.element.sankey import Sankey
+import holoviews as hv
 from holoviews.element.util import circular_layout, connect_edges, connect_edges_pd
 from holoviews.testing import assert_data_equal, assert_element_equal
 
@@ -25,16 +22,16 @@ class GraphTests:
         self.source = np.arange(N, dtype=np.int32)
         self.target = np.zeros(N, dtype=np.int32)
         self.edge_info = np.arange(N)
-        self.graph = Graph(((self.source, self.target),))
+        self.graph = hv.Graph(((self.source, self.target),))
 
     def test_basic_constructor(self):
-        graph = Graph(((self.source, self.target),))
-        nodes = Nodes(self.nodes)
+        graph = hv.Graph(((self.source, self.target),))
+        nodes = hv.Nodes(self.nodes)
         assert_element_equal(graph.nodes, nodes)
 
     def test_constructor_with_nodes(self):
-        graph = Graph(((self.source, self.target), self.nodes))
-        nodes = Nodes(self.nodes)
+        graph = hv.Graph(((self.source, self.target), self.nodes))
+        nodes = hv.Nodes(self.nodes)
         assert_element_equal(graph.nodes, nodes)
 
     def test_graph_edge_segments(self):
@@ -46,25 +43,25 @@ class GraphTests:
         np.testing.assert_equal(segments, paths)
 
     def test_graph_node_info_no_index(self):
-        node_info = Dataset(np.arange(8), vdims=['Label'])
-        graph = Graph(((self.source, self.target), node_info))
+        node_info = hv.Dataset(np.arange(8), vdims=['Label'])
+        graph = hv.Graph(((self.source, self.target), node_info))
         assert_data_equal(graph.nodes.dimension_values(3),
                          node_info.dimension_values(0))
 
     def test_graph_node_info_no_index_mismatch(self):
-        node_info = Dataset(np.arange(6), vdims=['Label'])
+        node_info = hv.Dataset(np.arange(6), vdims=['Label'])
         with pytest.raises(ValueError):  # noqa: PT011
-            Graph(((self.source, self.target), node_info))
+            hv.Graph(((self.source, self.target), node_info))
 
     def test_graph_node_info_merge_on_index(self):
-        node_info = Dataset((np.arange(8), np.arange(1,9)), 'index', 'label')
-        graph = Graph(((self.source, self.target), node_info))
+        node_info = hv.Dataset((np.arange(8), np.arange(1,9)), 'index', 'label')
+        graph = hv.Graph(((self.source, self.target), node_info))
         assert_data_equal(graph.nodes.dimension_values(3),
                          node_info.dimension_values(1))
 
     def test_graph_node_info_merge_on_index_partial(self):
-        node_info = Dataset((np.arange(5), np.arange(1,6)), 'index', 'label')
-        graph = Graph(((self.source, self.target), node_info))
+        node_info = hv.Dataset((np.arange(5), np.arange(1,6)), 'index', 'label')
+        graph = hv.Graph(((self.source, self.target), node_info))
         expected = np.array([1., 2., 3., 4., 5., np.nan, np.nan, np.nan])
         assert_data_equal(graph.nodes.dimension_values(3), expected)
 
@@ -77,56 +74,56 @@ class GraphTests:
         np.testing.assert_equal(segments, paths)
 
     def test_constructor_with_nodes_and_paths(self):
-        paths = Graph(((self.source, self.target), self.nodes)).edgepaths
-        graph = Graph(((self.source, self.target), self.nodes, paths.data))
+        paths = hv.Graph(((self.source, self.target), self.nodes)).edgepaths
+        graph = hv.Graph(((self.source, self.target), self.nodes, paths.data))
         assert_element_equal(graph._edgepaths, paths)
 
     def test_constructor_with_nodes_and_paths_dimension_mismatch(self):
-        paths = Graph(((self.source, self.target), self.nodes)).edgepaths
+        paths = hv.Graph(((self.source, self.target), self.nodes)).edgepaths
         exception = 'Ensure that the first two key dimensions on Nodes and EdgePaths match: x != x2'
         with pytest.raises(ValueError, match=exception):
-            Graph(((self.source, self.target), self.nodes, paths.redim(x='x2')))
+            hv.Graph(((self.source, self.target), self.nodes, paths.redim(x='x2')))
 
     def test_graph_clone_static_plot_id(self):
         assert self.graph.clone()._plot_id == self.graph._plot_id
 
     def test_select_by_node_in_edges_selection_mode(self):
-        graph = Graph(((self.source, self.target),))
-        selection = Graph(([(1, 0), (2, 0)], list(zip(*self.nodes, strict=True))[0:3]))
+        graph = hv.Graph(((self.source, self.target),))
+        selection = hv.Graph(([(1, 0), (2, 0)], list(zip(*self.nodes, strict=True))[0:3]))
         assert_element_equal(graph.select(index=(1, 3)), selection)
 
     def test_select_by_node_in_nodes_selection_mode(self):
-        graph = Graph(((self.source, self.source+1), self.nodes))
-        selection = Graph(([(1, 2)], list(zip(*self.nodes, strict=True))[1:3]))
+        graph = hv.Graph(((self.source, self.source+1), self.nodes))
+        selection = hv.Graph(([(1, 2)], list(zip(*self.nodes, strict=True))[1:3]))
         assert_element_equal(graph.select(index=(1, 3), selection_mode='nodes'), selection)
 
     def test_select_by_source(self):
-        graph = Graph(((self.source, self.target),))
-        selection = Graph(([(0,0), (1, 0)], list(zip(*self.nodes, strict=True))[:2]))
+        graph = hv.Graph(((self.source, self.target),))
+        selection = hv.Graph(([(0,0), (1, 0)], list(zip(*self.nodes, strict=True))[:2]))
         assert_element_equal(graph.select(start=(0, 2)), selection)
 
     def test_select_by_target(self):
-        graph = Graph(((self.source, self.target),))
-        selection = Graph(([(0,0), (1, 0)], list(zip(*self.nodes, strict=True))[:2]))
+        graph = hv.Graph(((self.source, self.target),))
+        selection = hv.Graph(([(0,0), (1, 0)], list(zip(*self.nodes, strict=True))[:2]))
         assert_element_equal(graph.select(start=(0, 2)), selection)
 
     def test_select_by_source_and_target(self):
-        graph = Graph(((self.source, self.source+1), self.nodes))
-        selection = Graph(([(0,1)], list(zip(*self.nodes, strict=True))[:2]))
+        graph = hv.Graph(((self.source, self.source+1), self.nodes))
+        selection = hv.Graph(([(0,1)], list(zip(*self.nodes, strict=True))[:2]))
         assert_element_equal(graph.select(start=(0, 3), end=1), selection)
 
     def test_select_by_edge_data(self):
-        graph = Graph(((self.target, self.source, self.edge_info),), vdims=['info'])
-        selection = Graph(([(0, 0, 0), (0, 1, 1)], list(zip(*self.nodes, strict=True))[:2]), vdims=['info'])
+        graph = hv.Graph(((self.target, self.source, self.edge_info),), vdims=['info'])
+        selection = hv.Graph(([(0, 0, 0), (0, 1, 1)], list(zip(*self.nodes, strict=True))[:2]), vdims=['info'])
         assert_element_equal(graph.select(info=(0, 2)), selection)
 
     def test_graph_node_range(self):
-        graph = Graph(((self.target, self.source),))
+        graph = hv.Graph(((self.target, self.source),))
         assert graph.range('x') == (-1, 1)
         assert graph.range('y') == (-1, 1)
 
     def test_graph_redim_nodes(self):
-        graph = Graph(((self.target, self.source),))
+        graph = hv.Graph(((self.target, self.source),))
         redimmed = graph.redim(x='x2', y='y2')
         assert_element_equal(redimmed.nodes, graph.nodes.redim(x='x2', y='y2'))
         assert_element_equal(redimmed.edgepaths, graph.edgepaths.redim(x='x2', y='y2'))
@@ -149,7 +146,7 @@ class TestFromSparse:
         data = np.array([1.0, 2.0, 3.0, 4.0])
         sparse_data = getattr(sp, sparse_func)((data, (row, col)), shape=(3, 3))
         nodes_data = {'x': [0.0, 1.0, 0.5], 'y': [0.0, 0.0, 1.0], 'index': [0, 1, 2]}
-        graph = Graph.from_sparse(sparse_data, nodes_data, **graph_kwargs)
+        graph = hv.Graph.from_sparse(sparse_data, nodes_data, **graph_kwargs)
 
         if kdims := graph_kwargs.get("kdims"):
             np.testing.assert_array_equal(graph.dimension_values(kdims[0]), row)
@@ -168,7 +165,7 @@ class TestFromSparse:
         nodes_data = {'x': [0.0, 1.0], 'y': [0.0, 1.0], 'index': [0, 1]}
 
         with pytest.raises(TypeError, match=r"edges expected to be a scipy.sparse array"):
-            Graph.from_sparse(regular_array, nodes_data)
+            hv.Graph.from_sparse(regular_array, nodes_data)
 
 
 @nx_skip
@@ -176,7 +173,7 @@ class FromNetworkXTests:
 
     def test_from_networkx_with_node_attrs(self):
         G = nx.karate_club_graph()
-        graph = Graph.from_networkx(G, nx.circular_layout)
+        graph = hv.Graph.from_networkx(G, nx.circular_layout)
         clubs = np.array([
             'Mr. Hi', 'Mr. Hi', 'Mr. Hi', 'Mr. Hi', 'Mr. Hi', 'Mr. Hi',
             'Mr. Hi', 'Mr. Hi', 'Mr. Hi', 'Officer', 'Mr. Hi', 'Mr. Hi',
@@ -191,7 +188,7 @@ class FromNetworkXTests:
         FG.add_node(1, test=[])
         FG.add_node(2, test=[])
         FG.add_edge(1, 2)
-        graph = Graph.from_networkx(FG, nx.circular_layout)
+        graph = hv.Graph.from_networkx(FG, nx.circular_layout)
         assert graph.nodes.vdims == []
         assert_data_equal(graph.nodes.dimension_values(2), np.array([1, 2]))
         assert_data_equal(graph.array(), np.array([(1, 2)]))
@@ -199,33 +196,33 @@ class FromNetworkXTests:
     def test_from_networkx_with_edge_attrs(self):
         FG = nx.Graph()
         FG.add_weighted_edges_from([(1,2,0.125), (1,3,0.75), (2,4,1.2), (3,4,0.375)])
-        graph = Graph.from_networkx(FG, nx.circular_layout)
+        graph = hv.Graph.from_networkx(FG, nx.circular_layout)
         assert_data_equal(graph.dimension_values('weight'), np.array([0.125, 0.75, 1.2, 0.375]))
 
     def test_from_networkx_with_invalid_edge_attrs(self):
         FG = nx.Graph()
         FG.add_weighted_edges_from([(1,2,[]), (1,3,[]), (2,4,[]), (3,4,[])])
-        graph = Graph.from_networkx(FG, nx.circular_layout)
+        graph = hv.Graph.from_networkx(FG, nx.circular_layout)
         assert graph.vdims == []
 
     def test_from_networkx_only_nodes(self):
         G = nx.Graph()
         G.add_nodes_from([1, 2, 3])
-        graph = Graph.from_networkx(G, nx.circular_layout)
+        graph = hv.Graph.from_networkx(G, nx.circular_layout)
         assert_data_equal(graph.nodes.dimension_values(2), np.array([1, 2, 3]))
 
     def test_from_networkx_custom_nodes(self):
         FG = nx.Graph()
         FG.add_weighted_edges_from([(1,2,0.125), (1,3,0.75), (2,4,1.2), (3,4,0.375)])
-        nodes = Dataset([(1, 'A'), (2, 'B'), (3, 'A'), (4, 'B')], 'index', 'some_attribute')
-        graph = Graph.from_networkx(FG, nx.circular_layout, nodes=nodes)
+        nodes = hv.Dataset([(1, 'A'), (2, 'B'), (3, 'A'), (4, 'B')], 'index', 'some_attribute')
+        graph = hv.Graph.from_networkx(FG, nx.circular_layout, nodes=nodes)
         assert_data_equal(graph.nodes.dimension_values('some_attribute'), np.array(['A', 'B', 'A', 'B']))
 
     def test_from_networkx_dictionary_positions(self):
         G = nx.Graph()
         G.add_nodes_from([1, 2, 3])
         positions = nx.circular_layout(G)
-        graph = Graph.from_networkx(G, positions)
+        graph = hv.Graph.from_networkx(G, positions)
         assert_data_equal(graph.nodes.dimension_values(2), np.array([1, 2, 3]))
 
 
@@ -236,32 +233,32 @@ class ChordTests:
         self.simplices = [(0, 1, 2), (1, 2, 3), (2, 3, 4)]
 
     def test_chord_constructor_no_vdims(self):
-        chord = Chord(self.simplices)
+        chord = hv.Chord(self.simplices)
         nodes = np.array([[0.8660254037844387, 0.49999999999999994, 0],
                           [-0.4999999999999998, 0.8660254037844388, 1],
                           [-0.5000000000000004, -0.8660254037844384, 2],
                           [0.8660254037844379, -0.5000000000000012, 3]])
-        assert_element_equal(chord.nodes, Nodes(nodes))
+        assert_element_equal(chord.nodes, hv.Nodes(nodes))
         assert_data_equal(chord.array(), np.array([s[:2] for s in self.simplices]))
 
     def test_chord_constructor_with_vdims(self):
-        chord = Chord(self.simplices, vdims=['z'])
+        chord = hv.Chord(self.simplices, vdims=['z'])
         nodes = np.array(
             [[0.9396926207859084, 0.3420201433256687, 0],
              [6.123233995736766e-17, 1.0, 1],
              [-0.8660254037844388, -0.4999999999999998, 2],
              [0.7660444431189779, -0.6427876096865396, 3]]
         )
-        assert_element_equal(chord.nodes, Nodes(nodes))
+        assert_element_equal(chord.nodes, hv.Nodes(nodes))
         assert_data_equal(chord.array(), np.array(self.simplices))
 
     def test_chord_constructor_self_reference(self):
-        chord = Chord([('A', 'B', 2), ('B', 'A', 3), ('A', 'A', 2)])
+        chord = hv.Chord([('A', 'B', 2), ('B', 'A', 3), ('A', 'A', 2)])
         nodes = pd.DataFrame(
             [[-0.5, 0.866025, "A"], [0.5, -0.866025, "B"]],
             columns=["x", "y", "index"]
         )
-        assert_element_equal(chord.nodes, Nodes(nodes))
+        assert_element_equal(chord.nodes, hv.Nodes(nodes))
 
 
 
@@ -273,59 +270,59 @@ class TriMeshTests:
 
     def test_trimesh_constructor(self):
         nodes = [n[:2] for n in self.nodes]
-        trimesh = TriMesh((self.simplices, nodes))
+        trimesh = hv.TriMesh((self.simplices, nodes))
         assert_data_equal(trimesh.array(), np.array(self.simplices))
         assert_data_equal(trimesh.nodes.array([0, 1]), np.array(nodes))
         assert_data_equal(trimesh.nodes.dimension_values(2), np.arange(4))
 
     def test_trimesh_empty(self):
-        trimesh = TriMesh([])
+        trimesh = hv.TriMesh([])
         assert_data_equal(trimesh.array(), np.empty((0, 3)))
         assert_data_equal(trimesh.nodes.array(), np.empty((0, 3)))
 
     def test_trimesh_empty_clone(self):
-        trimesh = TriMesh([]).clone()
+        trimesh = hv.TriMesh([]).clone()
         assert_data_equal(trimesh.array(), np.empty((0, 3)))
         assert_data_equal(trimesh.nodes.array(), np.empty((0, 3)))
 
     def test_trimesh_constructor_tuple_nodes(self):
         nodes = tuple(zip(*self.nodes, strict=True))[:2]
-        trimesh = TriMesh((self.simplices, nodes))
+        trimesh = hv.TriMesh((self.simplices, nodes))
         assert_data_equal(trimesh.array(), np.array(self.simplices))
         assert_data_equal(trimesh.nodes.array([0, 1]), np.array(nodes).T)
         assert_data_equal(trimesh.nodes.dimension_values(2), np.arange(4))
 
     def test_trimesh_constructor_df_nodes(self):
         nodes_df = pd.DataFrame(self.nodes, columns=['x', 'y', 'z'])
-        trimesh = TriMesh((self.simplices, nodes_df))
-        nodes = Nodes([(0, 0, 0, 0), (0.5, 1, 1, 1),
+        trimesh = hv.TriMesh((self.simplices, nodes_df))
+        nodes = hv.Nodes([(0, 0, 0, 0), (0.5, 1, 1, 1),
                        (1., 0, 2, 2), (1.5, 1, 3, 4)], vdims='z')
         assert_data_equal(trimesh.array(), np.array(self.simplices))
         assert_element_equal(trimesh.nodes, nodes)
 
     def test_trimesh_constructor_point_nodes(self):
         nodes = [n[:2] for n in self.nodes]
-        trimesh = TriMesh((self.simplices, Points(self.nodes)))
+        trimesh = hv.TriMesh((self.simplices, hv.Points(self.nodes)))
         assert_data_equal(trimesh.array(), np.array(self.simplices))
         assert_data_equal(trimesh.nodes.array([0, 1]), np.array(nodes))
         assert_data_equal(trimesh.nodes.dimension_values(2), np.arange(4))
 
     def test_trimesh_edgepaths(self):
-        trimesh = TriMesh((self.simplices, self.nodes))
+        trimesh = hv.TriMesh((self.simplices, self.nodes))
         paths = [np.array([(0, 0), (0.5, 1), (1, 0), (0, 0), (np.nan, np.nan),
                  (0.5, 1), (1, 0), (1.5, 1), (0.5, 1)])]
         for p1, p2 in zip(trimesh.edgepaths.split(datatype='array'), paths, strict=True):
             assert_data_equal(p1, p2)
 
     def test_trimesh_select(self):
-        trimesh = TriMesh((self.simplices, self.nodes)).select(x=(0.1, None))
+        trimesh = hv.TriMesh((self.simplices, self.nodes)).select(x=(0.1, None))
         assert_data_equal(trimesh.array(), np.array(self.simplices[1:]))
 
 
 class TestSankey:
 
     def test_single_edge_sankey(self):
-        sankey = Sankey([('A', 'B', 1)])
+        sankey = hv.Sankey([('A', 'B', 1)])
         links = list(sankey._sankey['links'])
         assert len(links) == 1
         del links[0]['source']['sourceLinks']

--- a/holoviews/tests/element/test_image.py
+++ b/holoviews/tests/element/test_image.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 import holoviews as hv
-from holoviews.element import Curve, Image
 from holoviews.testing import assert_element_equal
 
 from ..utils import LoggingComparison
@@ -18,39 +17,39 @@ class TestImage(LoggingComparison):
         self.array1 = np.array([(0, 1, 2), (3, 4, 5)])
 
     def test_image_init(self):
-        image = Image(self.array1)
+        image = hv.Image(self.array1)
         assert image.xdensity == 3
         assert image.ydensity == 2
 
     def test_image_index(self):
-        image = Image(self.array1)
+        image = hv.Image(self.array1)
         assert image[-.33, -0.25] == 3
 
 
     def test_image_sample(self):
-        image = Image(self.array1)
+        image = hv.Image(self.array1)
         assert_element_equal(image.sample(y=0.25),
-                         Curve(np.array([(-0.333333, 0), (0, 1), (0.333333, 2)]),
+                         hv.Curve(np.array([(-0.333333, 0), (0, 1), (0.333333, 2)]),
                                kdims=['x'], vdims=['z']))
 
     def test_image_range_masked(self):
         arr = np.random.rand(10,10)-0.5
         arr = np.ma.masked_where(arr<=0, arr)
-        rrange = Image(arr).range(2)
+        rrange = hv.Image(arr).range(2)
         assert rrange == (np.min(arr), np.max(arr))
 
     def test_empty_image(self):
-        Image([])
-        Image(None)
-        Image(np.array([]))
-        Image(np.zeros((0, 0)))
+        hv.Image([])
+        hv.Image(None)
+        hv.Image(np.array([]))
+        hv.Image(np.zeros((0, 0)))
 
     def test_image_rtol_failure(self):
         vals = np.random.rand(20,20)
         xs = np.linspace(0,10,20)
         ys = np.linspace(0,10,20)
         ys[-1] += 0.1
-        Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals')
+        hv.Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals')
         substr = ('set a higher tolerance on hv.config.image_rtol or '
                   'the rtol parameter in the Image constructor.')
         self.log_handler.assert_endswith('WARNING', substr)
@@ -60,7 +59,7 @@ class TestImage(LoggingComparison):
         xs = np.linspace(0,10,20)
         ys = np.linspace(0,10,20)
         ys[-1] += 0.01
-        Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals', rtol=10e-2)
+        hv.Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals', rtol=10e-2)
 
     def test_image_rtol_config(self):
         vals = np.random.rand(20,20)
@@ -69,7 +68,7 @@ class TestImage(LoggingComparison):
         ys[-1] += 0.001
         image_rtol = hv.config.image_rtol
         hv.config.image_rtol = 10e-3
-        Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals')
+        hv.Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals')
         hv.config.image_rtol = image_rtol
 
     def test_image_clone(self):
@@ -77,7 +76,7 @@ class TestImage(LoggingComparison):
         xs = np.linspace(0,10,20)
         ys = np.linspace(0,10,20)
         ys[-1] += 0.001
-        img = Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals', rtol=10e-3)
+        img = hv.Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals', rtol=10e-3)
         assert img.clone().rtol == 10e-3
 
     def test_image_curvilinear_coords_error(self):
@@ -86,4 +85,4 @@ class TestImage(LoggingComparison):
         X, Y = np.meshgrid(x, y)
         Z = np.sqrt(X**2 + Y**2) * np.cos(X)
         with pytest.raises(ValueError):  # noqa: PT011
-            Image((X, Y, Z))
+            hv.Image((X, Y, Z))

--- a/holoviews/tests/element/test_paths.py
+++ b/holoviews/tests/element/test_paths.py
@@ -4,7 +4,7 @@ Unit tests of Path types.
 import numpy as np
 import pytest
 
-from holoviews import Box, Dataset, Ellipse, Path, Polygons
+import holoviews as hv
 from holoviews.core.data.interface import DataError
 from holoviews.testing import assert_data_equal, assert_element_equal
 
@@ -12,7 +12,7 @@ from holoviews.testing import assert_data_equal, assert_element_equal
 class PathTests:
 
     def test_multi_path_list_constructor(self):
-        path = Path([[(0, 1), (1, 2)], [(2, 3), (3, 4)]])
+        path = hv.Path([[(0, 1), (1, 2)], [(2, 3), (3, 4)]])
         assert path.interface.multi
         assert_data_equal(path.dimension_values(0), np.array([
             0, 1, np.nan, 2, 3]))
@@ -20,8 +20,8 @@ class PathTests:
             1, 2, np.nan, 3, 4]))
 
     def test_multi_path_cast_path(self):
-        path = Path([[(0, 1), (1, 2)], [(2, 3), (3, 4)]])
-        path2 = Path(path)
+        path = hv.Path([[(0, 1), (1, 2)], [(2, 3), (3, 4)]])
+        path2 = hv.Path(path)
         assert path2.interface.multi
         assert_data_equal(path2.dimension_values(0), np.array([
             0, 1, np.nan, 2, 3]))
@@ -29,7 +29,7 @@ class PathTests:
             1, 2, np.nan, 3, 4]))
 
     def test_multi_path_tuple(self):
-        path = Path(([0, 1], [[1, 3], [2, 4]]))
+        path = hv.Path(([0, 1], [[1, 3], [2, 4]]))
         assert path.interface.multi
         assert_data_equal(path.dimension_values(0), np.array([
             0, 1, np.nan, 0, 1]))
@@ -37,7 +37,7 @@ class PathTests:
             1, 2, np.nan, 3, 4]))
 
     def test_multi_path_unpack_single_paths(self):
-        path = Path([Path([(0, 1), (1, 2)]), Path([(2, 3), (3, 4)])])
+        path = hv.Path([hv.Path([(0, 1), (1, 2)]), hv.Path([(2, 3), (3, 4)])])
         assert path.interface.multi
         assert_data_equal(path.dimension_values(0), np.array([
             0, 1, np.nan, 2, 3]))
@@ -45,8 +45,8 @@ class PathTests:
             1, 2, np.nan, 3, 4]))
 
     def test_multi_path_unpack_multi_paths(self):
-        path = Path([Path([[(0, 1), (1, 2)]]),
-                     Path([[(2, 3), (3, 4)], [(4, 5), (5, 6)]])])
+        path = hv.Path([hv.Path([[(0, 1), (1, 2)]]),
+                     hv.Path([[(2, 3), (3, 4)], [(4, 5), (5, 6)]])])
         assert path.interface.multi
         assert_data_equal(path.dimension_values(0), np.array([
             0, 1, np.nan, 2, 3, np.nan, 4, 5]))
@@ -54,36 +54,36 @@ class PathTests:
             1, 2, np.nan, 3, 4, np.nan, 5, 6]))
 
     def test_single_path_list_constructor(self):
-        path = Path([(0, 1), (1, 2), (2, 3), (3, 4)])
+        path = hv.Path([(0, 1), (1, 2), (2, 3), (3, 4)])
         assert_data_equal(path.dimension_values(0), np.array([
             0, 1, 2, 3]))
         assert_data_equal(path.dimension_values(1), np.array([
             1, 2, 3, 4]))
 
     def test_single_path_tuple_constructor(self):
-        path = Path(([0, 1, 2, 3], [1, 2, 3, 4]))
+        path = hv.Path(([0, 1, 2, 3], [1, 2, 3, 4]))
         assert_data_equal(path.dimension_values(0), np.array([
             0, 1, 2, 3]))
         assert_data_equal(path.dimension_values(1), np.array([
             1, 2, 3, 4]))
 
     def test_multi_path_list_split(self):
-        path = Path([[(0, 1), (1, 2)], [(2, 3), (3, 4)]])
+        path = hv.Path([[(0, 1), (1, 2)], [(2, 3), (3, 4)]])
         subpaths = path.split()
         assert len(subpaths) == 2
-        assert_element_equal(subpaths[0], Path([(0, 1), (1, 2)]))
-        assert_element_equal(subpaths[1], Path([(2, 3), (3, 4)]))
+        assert_element_equal(subpaths[0], hv.Path([(0, 1), (1, 2)]))
+        assert_element_equal(subpaths[1], hv.Path([(2, 3), (3, 4)]))
 
     def test_single_path_split(self):
-        path = Path(([0, 1, 2, 3], [1, 2, 3, 4]))
+        path = hv.Path(([0, 1, 2, 3], [1, 2, 3, 4]))
         assert_element_equal(path, path.split()[0])
 
     def test_dataset_groupby_path(self):
-        ds = Dataset([(0, 0, 1), (0, 1, 2), (1, 2, 3), (1, 3, 4)], ['group', 'x', 'y'])
-        subpaths = ds.groupby('group', group_type=Path)
+        ds = hv.Dataset([(0, 0, 1), (0, 1, 2), (1, 2, 3), (1, 3, 4)], ['group', 'x', 'y'])
+        subpaths = ds.groupby('group', group_type=hv.Path)
         assert len(subpaths) == 2
-        assert_element_equal(subpaths[0], Path([(0, 1), (1, 2)]))
-        assert_element_equal(subpaths[1], Path([(2, 3), (3, 4)]))
+        assert_element_equal(subpaths[0], hv.Path([(0, 1), (1, 2)]))
+        assert_element_equal(subpaths[1], hv.Path([(2, 3), (3, 4)]))
 
 
 class PolygonsTests:
@@ -92,7 +92,7 @@ class PolygonsTests:
         xs = [1, 2, 3]
         ys = [2, 0, 7]
         holes = [[[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]]]
-        self.single_poly = Polygons([{'x': xs, 'y': ys, 'holes': holes}])
+        self.single_poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes}])
 
         xs = [1, 2, 3, np.nan, 6, 7, 3]
         ys = [2, 0, 7, np.nan, 7, 5, 2]
@@ -100,10 +100,10 @@ class PolygonsTests:
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        self.multi_poly = Polygons([{'x': xs, 'y': ys, 'holes': holes}])
-        self.multi_poly_no_hole = Polygons([{'x': xs, 'y': ys}])
+        self.multi_poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes}])
+        self.multi_poly_no_hole = hv.Polygons([{'x': xs, 'y': ys}])
 
-        self.distinct_polys = Polygons([
+        self.distinct_polys = hv.Polygons([
             {'x': xs, 'y': ys, 'holes': holes, 'value': 0},
             {'x': [4, 6, 6], 'y': [0, 2, 1], 'value': 1}], vdims='value')
 
@@ -127,7 +127,7 @@ class PolygonsTests:
         assert len(holes[0][1]) == 0
 
     def test_multi_poly_empty_holes(self):
-        poly = Polygons([])
+        poly = hv.Polygons([])
         assert not poly.interface.has_holes(poly)
         assert poly.interface.holes(poly) == []
 
@@ -157,13 +157,13 @@ class PolygonsTests:
         xs = [1, 2, 3]
         ys = [2, 0, 7]
         with pytest.raises(DataError):
-            Polygons([{'x': xs, 'y': ys, 'holes': [[], []]}])
+            hv.Polygons([{'x': xs, 'y': ys, 'holes': [[], []]}])
 
     def test_multi_poly_hole_validation(self):
         xs = [1, 2, 3, np.nan, 6, 7, 3]
         ys = [2, 0, 7, np.nan, 7, 5, 2]
         with pytest.raises(DataError):
-            Polygons([{'x': xs, 'y': ys, 'holes': [[]]}])
+            hv.Polygons([{'x': xs, 'y': ys, 'holes': [[]]}])
 
 
 class EllipseTests:
@@ -185,19 +185,19 @@ class EllipseTests:
 
 
     def test_ellipse_simple_constructor(self):
-        ellipse = Ellipse(0,0,1, samples=100)
+        ellipse = hv.Ellipse(0,0,1, samples=100)
         assert len(ellipse.data[0]) == 100
 
     def test_ellipse_simple_constructor_pentagon(self):
-        ellipse = Ellipse(0,0,1, samples=6)
+        ellipse = hv.Ellipse(0,0,1, samples=6)
         assert np.allclose(ellipse.data[0], self.pentagon)
 
     def test_ellipse_tuple_constructor_squashed(self):
-        ellipse = Ellipse(0,0,(1,2), samples=6)
+        ellipse = hv.Ellipse(0,0,(1,2), samples=6)
         assert np.allclose(ellipse.data[0], self.squashed)
 
     def test_ellipse_simple_constructor_squashed_aspect(self):
-        ellipse = Ellipse(0,0,2, aspect=0.5, samples=6)
+        ellipse = hv.Ellipse(0,0,2, aspect=0.5, samples=6)
         assert np.allclose(ellipse.data[0], self.squashed)
 
 
@@ -217,13 +217,13 @@ class BoxTests:
                                       [-0.73253782, -0.8446232 ]])
 
     def test_box_simple_constructor_rotated(self):
-        box = Box(0,0,1, orientation=np.pi/8)
+        box = hv.Box(0,0,1, orientation=np.pi/8)
         assert np.allclose(box.data[0], self.rotated_square)
 
     def test_box_tuple_constructor_rotated(self):
-        box = Box(0,0,(2,1), orientation=np.pi/8)
+        box = hv.Box(0,0,(2,1), orientation=np.pi/8)
         assert np.allclose(box.data[0], self.rotated_rect)
 
     def test_box_aspect_constructor_rotated(self):
-        box = Box(0,0,1, aspect=2, orientation=np.pi/8)
+        box = hv.Box(0,0,1, aspect=2, orientation=np.pi/8)
         assert np.allclose(box.data[0], self.rotated_rect)

--- a/holoviews/tests/element/test_raster.py
+++ b/holoviews/tests/element/test_raster.py
@@ -5,7 +5,7 @@ Unit tests of Raster elements
 import numpy as np
 import pytest
 
-from holoviews.element import HSV, RGB, Curve, Image, QuadMesh, Raster
+import holoviews as hv
 from holoviews.testing import assert_data_equal, assert_element_equal
 
 
@@ -15,22 +15,22 @@ class TestRaster:
         self.array1 = np.array([(0, 1, 2), (3, 4, 5)])
 
     def test_raster_init(self):
-        Raster(self.array1)
+        hv.Raster(self.array1)
 
     def test_raster_index(self):
-        raster = Raster(self.array1)
+        raster = hv.Raster(self.array1)
         assert raster[0, 1] == 3
 
     def test_raster_sample(self):
-        raster = Raster(self.array1)
+        raster = hv.Raster(self.array1)
         assert_element_equal(raster.sample(y=0),
-                         Curve(np.array([(0, 0), (1, 1), (2, 2)]),
+                         hv.Curve(np.array([(0, 0), (1, 1), (2, 2)]),
                                kdims=['x'], vdims=['z']))
 
     def test_raster_range_masked(self):
         arr = np.random.rand(10,10)-0.5
         arr = np.ma.masked_where(arr<=0, arr)
-        rrange = Raster(arr).range(2)
+        rrange = hv.Raster(arr).range(2)
         assert rrange == (np.min(arr), np.max(arr))
 
 
@@ -40,11 +40,11 @@ class TestRGB:
         self.rgb_array = np.random.randint(0, 255, (3, 3, 4))
 
     def test_construct_from_array_with_alpha(self):
-        rgb = RGB(self.rgb_array)
+        rgb = hv.RGB(self.rgb_array)
         assert len(rgb.vdims) == 4
 
     def test_construct_from_tuple_with_alpha(self):
-        rgb = RGB(([0, 1, 2], [0, 1, 2], self.rgb_array))
+        rgb = hv.RGB(([0, 1, 2], [0, 1, 2], self.rgb_array))
         assert len(rgb.vdims) == 4
 
     def test_construct_from_xarray_dataset_with_alpha(self):
@@ -53,17 +53,17 @@ class TestRGB:
             data=self.rgb_array,
             coords={"y": [0, 1, 2], "x": [0, 1, 2], "band": list("RGBA")}
         ).to_dataset(dim="band")
-        rgb = RGB(xr_dataset)
+        rgb = hv.RGB(xr_dataset)
         assert str(rgb.alpha_dimension) in xr_dataset.data_vars
         assert len(rgb.vdims) == 4
 
     def test_construct_from_dict_with_alpha(self):
-        rgb = RGB({'x': [1, 2, 3], 'y': [1, 2, 3], ('R', 'G', 'B', 'A'): self.rgb_array})
+        rgb = hv.RGB({'x': [1, 2, 3], 'y': [1, 2, 3], ('R', 'G', 'B', 'A'): self.rgb_array})
         assert len(rgb.vdims) == 4
 
     def test_not_using_class_variables_vdims(self):
-        init_vdims = RGB(self.rgb_array).vdims
-        cls_vdims = RGB.vdims
+        init_vdims = hv.RGB(self.rgb_array).vdims
+        cls_vdims = hv.RGB.vdims
         assert len(init_vdims) == 4
         assert len(cls_vdims) == 3
         for i, c in zip(init_vdims, cls_vdims, strict=False):
@@ -73,7 +73,7 @@ class TestRGB:
     def test_nodata(self):
         N = 2
         rgb_d = np.linspace(0, 1, N * N * 3).reshape(N, N, 3)
-        rgb = RGB(rgb_d)
+        rgb = hv.RGB(rgb_d)
         assert sum(np.isnan(rgb["R"])) == 0
         assert sum(np.isnan(rgb["G"])) == 0
         assert sum(np.isnan(rgb["B"])) == 0
@@ -89,8 +89,8 @@ class TestHSV:
         self.hsv_array = np.random.randint(0, 255, (3, 3, 4))
 
     def test_not_using_class_variables_vdims(self):
-            init_vdims = HSV(self.hsv_array).vdims
-            cls_vdims = HSV.vdims
+            init_vdims = hv.HSV(self.hsv_array).vdims
+            cls_vdims = hv.HSV.vdims
             assert len(init_vdims) == 4
             assert len(cls_vdims) == 3
             for i, c in zip(init_vdims, cls_vdims, strict=False):
@@ -103,8 +103,8 @@ class TestQuadMesh:
         self.array1 = np.array([(0, 1, 2), (3, 4, 5)])
 
     def test_cast_image_to_quadmesh(self):
-        img = Image(self.array1, kdims=['a', 'b'], vdims=['c'], group='A', label='B')
-        qmesh = QuadMesh(img)
+        img = hv.Image(self.array1, kdims=['a', 'b'], vdims=['c'], group='A', label='B')
+        qmesh = hv.QuadMesh(img)
         assert_data_equal(qmesh.dimension_values(0, False), np.array([-0.333333, 0., 0.333333]))
         assert_data_equal(qmesh.dimension_values(1, False), np.array([-0.25, 0.25]))
         assert_data_equal(qmesh.dimension_values(2, flat=False), self.array1[::-1])
@@ -114,7 +114,7 @@ class TestQuadMesh:
         assert qmesh.label == img.label
 
     def test_quadmesh_to_trimesh(self):
-        qmesh = QuadMesh(([0, 1], [0, 1], np.array([[0, 1], [2, 3]])))
+        qmesh = hv.QuadMesh(([0, 1], [0, 1], np.array([[0, 1], [2, 3]])))
         trimesh = qmesh.trimesh()
         simplices = np.array([[0, 1, 3, 0],
                               [1, 2, 4, 2],

--- a/holoviews/tests/element/test_selection.py
+++ b/holoviews/tests/element/test_selection.py
@@ -6,29 +6,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core import NdOverlay
-from holoviews.core.options import Store
-from holoviews.element import (
-    RGB,
-    Area,
-    BoxWhisker,
-    Curve,
-    Distribution,
-    HSpan,
-    Image,
-    Path,
-    Points,
-    Polygons,
-    QuadMesh,
-    Rectangles,
-    Scatter,
-    Segments,
-    Violin,
-    VSpan,
-)
+import holoviews as hv
 from holoviews.element.selection import spatial_select_columnar
 from holoviews.testing import assert_data_equal, assert_dict_equal, assert_element_equal
-from holoviews.util.transform import dim
 
 from ..utils import optional_dependencies
 
@@ -42,59 +22,59 @@ class TestIndexExpr:
 
     def setup_method(self):
         import holoviews.plotting.bokeh # noqa
-        self._backend = Store.current_backend
-        Store.set_current_backend('bokeh')
+        self._backend = hv.Store.current_backend
+        hv.Store.set_current_backend('bokeh')
 
     def teardown_method(self):
-        Store.current_backend = self._backend
+        hv.Store.current_backend = self._backend
 
     def test_index_selection_on_id_column(self):
         # tests issue in https://github.com/holoviz/holoviews/pull/6336
         x, y = np.random.randn(2, 100)
         idx = np.arange(100)
 
-        points = Points(
+        points = hv.Points(
             {'x': x, 'y': y, 'id': idx}, kdims=['x', 'y'], vdims=['id'], datatype=['dataframe']
         )
         sel, _, _ = points._get_index_selection([3, 7], ['id'])
-        assert sel == dim('id').isin([3, 7])
+        assert sel == hv.dim('id').isin([3, 7])
 
 
 class TestSelection1DExpr:
 
     def setup_method(self):
         import holoviews.plotting.bokeh # noqa
-        self._backend = Store.current_backend
-        Store.set_current_backend('bokeh')
+        self._backend = hv.Store.current_backend
+        hv.Store.set_current_backend('bokeh')
 
     def teardown_method(self):
-        Store.current_backend = self._backend
+        hv.Store.current_backend = self._backend
 
     def test_area_selection_numeric(self):
-        area = Area([3, 2, 1, 3, 4])
+        area = hv.Area([3, 2, 1, 3, 4])
         expr, bbox, region = area._get_selection_expr_for_stream_value(bounds=(1, 0, 3, 2))
         assert bbox == {'x': (1, 3)}
         assert_data_equal(expr.apply(area), np.array([False, True, True, True, False]))
-        assert_element_equal(region, NdOverlay({0: VSpan(1, 3)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.VSpan(1, 3)}))
 
     def test_area_selection_numeric_inverted(self):
-        area = Area([3, 2, 1, 3, 4]).opts(invert_axes=True)
+        area = hv.Area([3, 2, 1, 3, 4]).opts(invert_axes=True)
         expr, bbox, region = area._get_selection_expr_for_stream_value(bounds=(0, 1, 2, 3))
         assert bbox == {'x': (1, 3)}
         assert_data_equal(expr.apply(area), np.array([False, True, True, True, False]))
-        assert_element_equal(region, NdOverlay({0: HSpan(1, 3)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.HSpan(1, 3)}))
 
     def test_area_selection_categorical(self):
-        area = Area((['B', 'A', 'C', 'D', 'E'], [3, 2, 1, 3, 4]))
+        area = hv.Area((['B', 'A', 'C', 'D', 'E'], [3, 2, 1, 3, 4]))
         expr, bbox, region = area._get_selection_expr_for_stream_value(
             bounds=(0, 1, 2, 3), x_selection=['B', 'A', 'C']
         )
         assert bbox == {'x': ['B', 'A', 'C']}
         assert_data_equal(expr.apply(area), np.array([True, True, True, False, False]))
-        assert_element_equal(region, NdOverlay({0: VSpan(0, 2)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.VSpan(0, 2)}))
 
     def test_area_selection_numeric_index_cols(self):
-        area = Area([3, 2, 1, 3, 2])
+        area = hv.Area([3, 2, 1, 3, 2])
         expr, bbox, region = area._get_selection_expr_for_stream_value(
             bounds=(1, 0, 3, 2), index_cols=['y']
         )
@@ -103,23 +83,23 @@ class TestSelection1DExpr:
         assert region is None
 
     def test_curve_selection_numeric(self):
-        curve = Curve([3, 2, 1, 3, 4])
+        curve = hv.Curve([3, 2, 1, 3, 4])
         expr, bbox, region = curve._get_selection_expr_for_stream_value(bounds=(1, 0, 3, 2))
         assert bbox == {'x': (1, 3)}
         assert_data_equal(expr.apply(curve), np.array([False, True, True, True, False]))
-        assert_element_equal(region, NdOverlay({0: VSpan(1, 3)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.VSpan(1, 3)}))
 
     def test_curve_selection_categorical(self):
-        curve = Curve((['B', 'A', 'C', 'D', 'E'], [3, 2, 1, 3, 4]))
+        curve = hv.Curve((['B', 'A', 'C', 'D', 'E'], [3, 2, 1, 3, 4]))
         expr, bbox, region = curve._get_selection_expr_for_stream_value(
             bounds=(0, 1, 2, 3), x_selection=['B', 'A', 'C']
         )
         assert bbox == {'x': ['B', 'A', 'C']}
         assert_data_equal(expr.apply(curve), np.array([True, True, True, False, False]))
-        assert_element_equal(region, NdOverlay({0: VSpan(0, 2)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.VSpan(0, 2)}))
 
     def test_curve_selection_numeric_index_cols(self):
-        curve = Curve([3, 2, 1, 3, 2])
+        curve = hv.Curve([3, 2, 1, 3, 2])
         expr, bbox, region = curve._get_selection_expr_for_stream_value(
             bounds=(1, 0, 3, 2), index_cols=['y']
         )
@@ -128,7 +108,7 @@ class TestSelection1DExpr:
         assert region is None
 
     def test_box_whisker_single(self):
-        box_whisker = BoxWhisker(list(range(10)))
+        box_whisker = hv.BoxWhisker(list(range(10)))
         expr, bbox, region = box_whisker._get_selection_expr_for_stream_value(
             bounds=(0, 3, 1, 7)
         )
@@ -136,10 +116,10 @@ class TestSelection1DExpr:
         assert_data_equal(expr.apply(box_whisker), np.array([
             False, False, False, True, True, True, True, True, False, False
         ]))
-        assert_element_equal(region, NdOverlay({0: HSpan(3, 7)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.HSpan(3, 7)}))
 
     def test_box_whisker_single_inverted(self):
-        box = BoxWhisker(list(range(10))).opts(invert_axes=True)
+        box = hv.BoxWhisker(list(range(10))).opts(invert_axes=True)
         expr, bbox, region = box._get_selection_expr_for_stream_value(
             bounds=(3, 0, 7, 1)
         )
@@ -147,10 +127,10 @@ class TestSelection1DExpr:
         assert_data_equal(expr.apply(box), np.array([
             False, False, False, True, True, True, True, True, False, False
         ]))
-        assert_element_equal(region, NdOverlay({0: VSpan(3, 7)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.VSpan(3, 7)}))
 
     def test_box_whisker_cats(self):
-        box_whisker = BoxWhisker((['A', 'A', 'A', 'B', 'B', 'C', 'C', 'C', 'C', 'C'], list(range(10))), 'x', 'y')
+        box_whisker = hv.BoxWhisker((['A', 'A', 'A', 'B', 'B', 'C', 'C', 'C', 'C', 'C'], list(range(10))), 'x', 'y')
         expr, bbox, region = box_whisker._get_selection_expr_for_stream_value(
             bounds=(0, 1, 2, 7), x_selection=['A', 'B']
         )
@@ -158,10 +138,10 @@ class TestSelection1DExpr:
         assert_data_equal(expr.apply(box_whisker), np.array([
             False, True, True, True, True, False, False, False, False, False
         ]))
-        assert_element_equal(region, NdOverlay({0: HSpan(1, 7)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.HSpan(1, 7)}))
 
     def test_box_whisker_cats_index_cols(self):
-        box_whisker = BoxWhisker((['A', 'A', 'A', 'B', 'B', 'C', 'C', 'C', 'C', 'C'], list(range(10))), 'x', 'y')
+        box_whisker = hv.BoxWhisker((['A', 'A', 'A', 'B', 'B', 'C', 'C', 'C', 'C', 'C'], list(range(10))), 'x', 'y')
         expr, bbox, region = box_whisker._get_selection_expr_for_stream_value(
             bounds=(0, 1, 2, 7), x_selection=['A', 'B'], index_cols=['x']
         )
@@ -172,7 +152,7 @@ class TestSelection1DExpr:
         assert region is None
 
     def test_violin_single(self):
-        violin = Violin(list(range(10)))
+        violin = hv.Violin(list(range(10)))
         expr, bbox, region = violin._get_selection_expr_for_stream_value(
             bounds=(0, 3, 1, 7)
         )
@@ -180,10 +160,10 @@ class TestSelection1DExpr:
         assert_data_equal(expr.apply(violin), np.array([
             False, False, False, True, True, True, True, True, False, False
         ]))
-        assert_element_equal(region, NdOverlay({0: HSpan(3, 7)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.HSpan(3, 7)}))
 
     def test_violin_single_inverted(self):
-        violin = Violin(list(range(10))).opts(invert_axes=True)
+        violin = hv.Violin(list(range(10))).opts(invert_axes=True)
         expr, bbox, region = violin._get_selection_expr_for_stream_value(
             bounds=(3, 0, 7, 1)
         )
@@ -191,10 +171,10 @@ class TestSelection1DExpr:
         assert_data_equal(expr.apply(violin), np.array([
             False, False, False, True, True, True, True, True, False, False
         ]))
-        assert_element_equal(region, NdOverlay({0: VSpan(3, 7)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.VSpan(3, 7)}))
 
     def test_violin_cats(self):
-        violin = Violin((['A', 'A', 'A', 'B', 'B', 'C', 'C', 'C', 'C', 'C'], list(range(10))), 'x', 'y')
+        violin = hv.Violin((['A', 'A', 'A', 'B', 'B', 'C', 'C', 'C', 'C', 'C'], list(range(10))), 'x', 'y')
         expr, bbox, region = violin._get_selection_expr_for_stream_value(
             bounds=(0, 1, 2, 7), x_selection=['A', 'B']
         )
@@ -202,10 +182,10 @@ class TestSelection1DExpr:
         assert_data_equal(expr.apply(violin), np.array([
             False, True, True, True, True, False, False, False, False, False
         ]))
-        assert_element_equal(region, NdOverlay({0: HSpan(1, 7)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.HSpan(1, 7)}))
 
     def test_violin_cats_index_cols(self):
-        violin = Violin((['A', 'A', 'A', 'B', 'B', 'C', 'C', 'C', 'C', 'C'], list(range(10))), 'x', 'y')
+        violin = hv.Violin((['A', 'A', 'A', 'B', 'B', 'C', 'C', 'C', 'C', 'C'], list(range(10))), 'x', 'y')
         expr, bbox, region = violin._get_selection_expr_for_stream_value(
             bounds=(0, 1, 2, 7), x_selection=['A', 'B'], index_cols=['x']
         )
@@ -216,7 +196,7 @@ class TestSelection1DExpr:
         assert region is None
 
     def test_distribution_single(self):
-        dist = Distribution(list(range(10)))
+        dist = hv.Distribution(list(range(10)))
         expr, bbox, region = dist._get_selection_expr_for_stream_value(
             bounds=(3, 0, 7, 1)
         )
@@ -224,10 +204,10 @@ class TestSelection1DExpr:
         assert_data_equal(expr.apply(dist), np.array([
             False, False, False, True, True, True, True, True, False, False
         ]))
-        assert_element_equal(region, NdOverlay({0: VSpan(3, 7)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.VSpan(3, 7)}))
 
     def test_distribution_single_inverted(self):
-        dist = Distribution(list(range(10))).opts(invert_axes=True)
+        dist = hv.Distribution(list(range(10))).opts(invert_axes=True)
         expr, bbox, region = dist._get_selection_expr_for_stream_value(
             bounds=(0, 3, 1, 7)
         )
@@ -235,32 +215,32 @@ class TestSelection1DExpr:
         assert_data_equal(expr.apply(dist), np.array([
             False, False, False, True, True, True, True, True, False, False
         ]))
-        assert_element_equal(region, NdOverlay({0: HSpan(3, 7)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.HSpan(3, 7)}))
 
 
 class TestSelection2DExpr:
 
     def setup_method(self):
         import holoviews.plotting.bokeh # noqa
-        self._backend = Store.current_backend
-        Store.set_current_backend('bokeh')
+        self._backend = hv.Store.current_backend
+        hv.Store.set_current_backend('bokeh')
 
     def teardown_method(self):
-        Store.current_backend = self._backend
+        hv.Store.current_backend = self._backend
 
     def test_points_selection_numeric(self):
-        points = Points([3, 2, 1, 3, 4])
+        points = hv.Points([3, 2, 1, 3, 4])
         expr, bbox, region = points._get_selection_expr_for_stream_value(bounds=(1, 0, 3, 2))
         assert bbox == {'x': (1, 3), 'y': (0, 2)}
         assert_data_equal(expr.apply(points), np.array([False, True, True, False, False]))
-        assert_element_equal(region, Rectangles([(1, 0, 3, 2)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(1, 0, 3, 2)]) * hv.Path([]))
 
     def test_points_selection_numeric_inverted(self):
-        points = Points([3, 2, 1, 3, 4]).opts(invert_axes=True)
+        points = hv.Points([3, 2, 1, 3, 4]).opts(invert_axes=True)
         expr, bbox, region = points._get_selection_expr_for_stream_value(bounds=(0, 1, 2, 3))
         assert bbox == {'x': (1, 3), 'y': (0, 2)}
         assert_data_equal(expr.apply(points), np.array([False, True, True, False, False]))
-        assert_element_equal(region, Rectangles([(0, 1, 2, 3)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0, 1, 2, 3)]) * hv.Path([]))
 
     @pytest.mark.parametrize("module", ["spatialpandas", "shapely"])
     def test_points_selection_geom(self, unimport, module):
@@ -269,13 +249,13 @@ class TestSelection2DExpr:
         import multiprocessing.resource_tracker  # noqa: F401
         pytest.importorskip(module)
         unimport("spatialpandas" if module == "shapely" else "shapely")
-        points = Points([3, 2, 1, 3, 4])
+        points = hv.Points([3, 2, 1, 3, 4])
         geom = np.array([(-0.1, -0.1), (1.4, 0), (1.4, 2.2), (-0.1, 2.2)])
         expr, bbox, region = points._get_selection_expr_for_stream_value(geometry=geom)
         assert_dict_equal(bbox, {'x': np.array([-0.1, 1.4, 1.4, -0.1]),
                                 'y': np.array([-0.1, 0, 2.2, 2.2])})
         assert_data_equal(expr.apply(points), np.array([False, True, False, False, False]))
-        assert_element_equal(region, Rectangles([]) * Path([[*geom, (-0.1, -0.1)]]))
+        assert_element_equal(region, hv.Rectangles([]) * hv.Path([[*geom, (-0.1, -0.1)]]))
 
     @pytest.mark.parametrize("module", ["spatialpandas", "shapely"])
     def test_points_selection_geom_inverted(self, unimport, module):
@@ -284,25 +264,25 @@ class TestSelection2DExpr:
         import multiprocessing.resource_tracker  # noqa: F401
         pytest.importorskip(module)
         unimport("spatialpandas" if module == "shapely" else "shapely")
-        points = Points([3, 2, 1, 3, 4]).opts(invert_axes=True)
+        points = hv.Points([3, 2, 1, 3, 4]).opts(invert_axes=True)
         geom = np.array([(-0.1, -0.1), (1.4, 0), (1.4, 2.2), (-0.1, 2.2)])
         expr, bbox, region = points._get_selection_expr_for_stream_value(geometry=geom)
         assert_dict_equal(bbox, {'y': np.array([-0.1, 1.4, 1.4, -0.1]),
                                 'x': np.array([-0.1, 0, 2.2, 2.2])})
         assert_data_equal(expr.apply(points), np.array([False, False, True, False, False]))
-        assert_element_equal(region, Rectangles([]) * Path([[*geom, (-0.1, -0.1)]]))
+        assert_element_equal(region, hv.Rectangles([]) * hv.Path([[*geom, (-0.1, -0.1)]]))
 
     def test_points_selection_categorical(self):
-        points = Points((['B', 'A', 'C', 'D', 'E'], [3, 2, 1, 3, 4]))
+        points = hv.Points((['B', 'A', 'C', 'D', 'E'], [3, 2, 1, 3, 4]))
         expr, bbox, region = points._get_selection_expr_for_stream_value(
             bounds=(0, 1, 2, 3), x_selection=['B', 'A', 'C'], y_selection=None
         )
         assert bbox == {'x': ['B', 'A', 'C'], 'y': (1, 3)}
         assert_data_equal(expr.apply(points), np.array([True, True, True, False, False]))
-        assert_element_equal(region, Rectangles([(0, 1, 2, 3)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0, 1, 2, 3)]) * hv.Path([]))
 
     def test_points_selection_numeric_index_cols(self):
-        points = Points([3, 2, 1, 3, 2])
+        points = hv.Points([3, 2, 1, 3, 2])
         expr, bbox, region = points._get_selection_expr_for_stream_value(
             bounds=(1, 0, 3, 2), index_cols=['y']
         )
@@ -311,30 +291,30 @@ class TestSelection2DExpr:
         assert region is None
 
     def test_scatter_selection_numeric(self):
-        scatter = Scatter([3, 2, 1, 3, 4])
+        scatter = hv.Scatter([3, 2, 1, 3, 4])
         expr, bbox, region = scatter._get_selection_expr_for_stream_value(bounds=(1, 0, 3, 2))
         assert bbox == {'x': (1, 3)}
         assert_data_equal(expr.apply(scatter), np.array([False, True, True, True, False]))
-        assert_element_equal(region, NdOverlay({0: VSpan(1, 3)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.VSpan(1, 3)}))
 
     def test_scatter_selection_numeric_inverted(self):
-        scatter = Scatter([3, 2, 1, 3, 4]).opts(invert_axes=True)
+        scatter = hv.Scatter([3, 2, 1, 3, 4]).opts(invert_axes=True)
         expr, bbox, region = scatter._get_selection_expr_for_stream_value(bounds=(0, 1, 2, 3))
         assert bbox == {'x': (1, 3)}
         assert_data_equal(expr.apply(scatter), np.array([False, True, True, True, False]))
-        assert_element_equal(region, NdOverlay({0: HSpan(1, 3)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.HSpan(1, 3)}))
 
     def test_scatter_selection_categorical(self):
-        scatter = Scatter((['B', 'A', 'C', 'D', 'E'], [3, 2, 1, 3, 4]))
+        scatter = hv.Scatter((['B', 'A', 'C', 'D', 'E'], [3, 2, 1, 3, 4]))
         expr, bbox, region = scatter._get_selection_expr_for_stream_value(
             bounds=(0, 1, 2, 3), x_selection=['B', 'A', 'C'], y_selection=None
         )
         assert bbox == {'x': ['B', 'A', 'C']}
         assert_data_equal(expr.apply(scatter), np.array([True, True, True, False, False]))
-        assert_element_equal(region, NdOverlay({0: VSpan(0, 2)}))
+        assert_element_equal(region, hv.NdOverlay({0: hv.VSpan(0, 2)}))
 
     def test_scatter_selection_numeric_index_cols(self):
-        scatter = Scatter([3, 2, 1, 3, 2])
+        scatter = hv.Scatter([3, 2, 1, 3, 2])
         expr, bbox, region = scatter._get_selection_expr_for_stream_value(
             bounds=(1, 0, 3, 2), index_cols=['y']
         )
@@ -343,7 +323,7 @@ class TestSelection2DExpr:
         assert region is None
 
     def test_image_selection_numeric(self):
-        img = Image(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3)))
+        img = hv.Image(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3)))
         expr, bbox, region = img._get_selection_expr_for_stream_value(bounds=(0.5, 1.5, 2.1, 3.1))
         assert bbox == {'x': (0.5, 2.1), 'y': (1.5, 3.1)}
         assert_data_equal(expr.apply(img, expanded=True, flat=False), np.array([
@@ -352,10 +332,10 @@ class TestSelection2DExpr:
             [False, True, True],
             [False, True, True]
         ]))
-        assert_element_equal(region, Rectangles([(0.5, 1.5, 2.1, 3.1)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0.5, 1.5, 2.1, 3.1)]) * hv.Path([]))
 
     def test_image_selection_numeric_inverted(self):
-        img = Image(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3))).opts(invert_axes=True)
+        img = hv.Image(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3))).opts(invert_axes=True)
         expr, bbox, region = img._get_selection_expr_for_stream_value(bounds=(1.5, 0.5, 3.1, 2.1))
         assert bbox == {'x': (0.5, 2.1), 'y': (1.5, 3.1)}
         assert_data_equal(expr.apply(img, expanded=True, flat=False), np.array([
@@ -364,12 +344,12 @@ class TestSelection2DExpr:
             [False, True, True],
             [False, True, True]
         ]))
-        assert_element_equal(region, Rectangles([(1.5, 0.5, 3.1, 2.1)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(1.5, 0.5, 3.1, 2.1)]) * hv.Path([]))
 
     @ds_skip
     @spd_skip
     def test_img_selection_geom(self):
-        img = Image(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3)))
+        img = hv.Image(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3)))
         geom = np.array([(-0.4, -0.1), (0.6, -0.1), (0.4, 1.7), (-0.1, 1.7)])
         expr, bbox, region = img._get_selection_expr_for_stream_value(geometry=geom)
         assert_dict_equal(bbox, {'x': np.array([-0.4, 0.6, 0.4, -0.1]),
@@ -380,11 +360,11 @@ class TestSelection2DExpr:
             [np.nan, np.nan, np.nan],
             [np.nan, np.nan, np.nan]
         ]))
-        assert_element_equal(region, Rectangles([]) * Path([[*geom, (-0.4, -0.1)]]))
+        assert_element_equal(region, hv.Rectangles([]) * hv.Path([[*geom, (-0.4, -0.1)]]))
 
     @ds_skip
     def test_img_selection_geom_inverted(self):
-        img = Image(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3))).opts(invert_axes=True)
+        img = hv.Image(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3))).opts(invert_axes=True)
         geom = np.array([(-0.4, -0.1), (0.6, -0.1), (0.4, 1.7), (-0.1, 1.7)])
         expr, bbox, region = img._get_selection_expr_for_stream_value(geometry=geom)
         assert_dict_equal(bbox, {'y': np.array([-0.4, 0.6, 0.4, -0.1]),
@@ -395,10 +375,10 @@ class TestSelection2DExpr:
             [ False,  False, False],
             [False, False, False]
         ]))
-        assert_element_equal(region, Rectangles([]) * Path([[*geom, (-0.4, -0.1)]]))
+        assert_element_equal(region, hv.Rectangles([]) * hv.Path([[*geom, (-0.4, -0.1)]]))
 
     def test_rgb_selection_numeric(self):
-        img = RGB(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3, 3)))
+        img = hv.RGB(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3, 3)))
         expr, bbox, region = img._get_selection_expr_for_stream_value(bounds=(0.5, 1.5, 2.1, 3.1))
         assert bbox == {'x': (0.5, 2.1), 'y': (1.5, 3.1)}
         assert_data_equal(expr.apply(img, expanded=True, flat=False), np.array([
@@ -407,10 +387,10 @@ class TestSelection2DExpr:
             [False, True, True],
             [False, True, True]
         ]))
-        assert_element_equal(region, Rectangles([(0.5, 1.5, 2.1, 3.1)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0.5, 1.5, 2.1, 3.1)]) * hv.Path([]))
 
     def test_rgb_selection_numeric_inverted(self):
-        img = RGB(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3, 3))).opts(invert_axes=True)
+        img = hv.RGB(([0, 1, 2], [0, 1, 2, 3], np.random.rand(4, 3, 3))).opts(invert_axes=True)
         expr, bbox, region = img._get_selection_expr_for_stream_value(bounds=(1.5, 0.5, 3.1, 2.1))
         assert bbox == {'x': (0.5, 2.1), 'y': (1.5, 3.1)}
         assert_data_equal(expr.apply(img, expanded=True, flat=False), np.array([
@@ -419,7 +399,7 @@ class TestSelection2DExpr:
             [False, True, True],
             [False, True, True]
         ]))
-        assert_element_equal(region, Rectangles([(1.5, 0.5, 3.1, 2.1)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(1.5, 0.5, 3.1, 2.1)]) * hv.Path([]))
 
     def test_quadmesh_selection(self):
         n = 4
@@ -428,7 +408,7 @@ class TestSelection2DExpr:
         Qx = np.cos(Y) - np.cos(X)
         Qy = np.sin(Y) + np.sin(X)
         Z = np.sqrt(X**2 + Y**2)
-        qmesh = QuadMesh((Qx, Qy, Z))
+        qmesh = hv.QuadMesh((Qx, Qy, Z))
         expr, bbox, region = qmesh._get_selection_expr_for_stream_value(bounds=(0, -0.5, 0.7, 1.5))
         assert bbox == {'x': (0, 0.7), 'y': (-0.5, 1.5)}
         assert_data_equal(expr.apply(qmesh, expanded=True, flat=False), np.array([
@@ -437,7 +417,7 @@ class TestSelection2DExpr:
             [False,  True,  True, False],
             [True,  False, False, False]
         ]))
-        assert_element_equal(region, Rectangles([(0, -0.5, 0.7, 1.5)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0, -0.5, 0.7, 1.5)]) * hv.Path([]))
 
     def test_quadmesh_selection_inverted(self):
         n = 4
@@ -446,7 +426,7 @@ class TestSelection2DExpr:
         Qx = np.cos(Y) - np.cos(X)
         Qy = np.sin(Y) + np.sin(X)
         Z = np.sqrt(X**2 + Y**2)
-        qmesh = QuadMesh((Qx, Qy, Z)).opts(invert_axes=True)
+        qmesh = hv.QuadMesh((Qx, Qy, Z)).opts(invert_axes=True)
         expr, bbox, region = qmesh._get_selection_expr_for_stream_value(bounds=(0, -0.5, 0.7, 1.5))
         assert bbox == {'x': (-0.5, 1.5), 'y': (0, 0.7)}
         assert_data_equal(expr.apply(qmesh, expanded=True, flat=False), np.array([
@@ -455,7 +435,7 @@ class TestSelection2DExpr:
             [False,  True, False, False],
             [True,  False, False, False]
         ]))
-        assert_element_equal(region, Rectangles([(0, -0.5, 0.7, 1.5)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0, -0.5, 0.7, 1.5)]) * hv.Path([]))
 
 
 
@@ -463,37 +443,37 @@ class TestSelectionGeomExpr:
 
     def setup_method(self):
         import holoviews.plotting.bokeh # noqa
-        self._backend = Store.current_backend
-        Store.set_current_backend('bokeh')
+        self._backend = hv.Store.current_backend
+        hv.Store.set_current_backend('bokeh')
 
     def teardown_method(self):
-        Store.current_backend = self._backend
+        hv.Store.current_backend = self._backend
 
     def test_rect_selection_numeric(self):
-        rect = Rectangles([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)])
+        rect = hv.Rectangles([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)])
         expr, bbox, region = rect._get_selection_expr_for_stream_value(bounds=(0.5, 0.9, 3.4, 4.9))
         assert bbox == {'x0': (0.5, 3.4), 'y0': (0.9, 4.9), 'x1': (0.5, 3.4), 'y1': (0.9, 4.9)}
         assert_data_equal(expr.apply(rect), np.array([False, True, False]))
-        assert_element_equal(region, Rectangles([(0.5, 0.9, 3.4, 4.9)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0.5, 0.9, 3.4, 4.9)]) * hv.Path([]))
         expr, bbox, region = rect._get_selection_expr_for_stream_value(bounds=(0, 0.9, 3.5, 4.9))
         assert bbox == {'x0': (0, 3.5), 'y0': (0.9, 4.9), 'x1': (0, 3.5), 'y1': (0.9, 4.9)}
         assert_data_equal(expr.apply(rect), np.array([True, True, True]))
-        assert_element_equal(region, Rectangles([(0, 0.9, 3.5, 4.9)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0, 0.9, 3.5, 4.9)]) * hv.Path([]))
 
     def test_rect_selection_numeric_inverted(self):
-        rect = Rectangles([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)]).opts(invert_axes=True)
+        rect = hv.Rectangles([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)]).opts(invert_axes=True)
         expr, bbox, region = rect._get_selection_expr_for_stream_value(bounds=(0.9, 0.5, 4.9, 3.4))
         assert bbox == {'x0': (0.5, 3.4), 'y0': (0.9, 4.9), 'x1': (0.5, 3.4), 'y1': (0.9, 4.9)}
         assert_data_equal(expr.apply(rect), np.array([False, True, False]))
-        assert_element_equal(region, Rectangles([(0.9, 0.5, 4.9, 3.4)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0.9, 0.5, 4.9, 3.4)]) * hv.Path([]))
         expr, bbox, region = rect._get_selection_expr_for_stream_value(bounds=(0.9, 0, 4.9, 3.5))
         assert bbox == {'x0': (0, 3.5), 'y0': (0.9, 4.9), 'x1': (0, 3.5), 'y1': (0.9, 4.9)}
         assert_data_equal(expr.apply(rect), np.array([True, True, True]))
-        assert_element_equal(region, Rectangles([(0.9, 0, 4.9, 3.5)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0.9, 0, 4.9, 3.5)]) * hv.Path([]))
 
     @shapely_skip
     def test_rect_geom_selection(self):
-        rect = Rectangles([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)])
+        rect = hv.Rectangles([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)])
         geom = np.array([(-0.4, -0.1), (2.2, -0.1), (2.2, 4.1), (-0.1, 4.2)])
         expr, bbox, region = rect._get_selection_expr_for_stream_value(geometry=geom)
         assert_dict_equal(bbox, {'x0': np.array([-0.4, 2.2, 2.2, -0.1]),
@@ -501,11 +481,11 @@ class TestSelectionGeomExpr:
                                 'x1': np.array([-0.4, 2.2, 2.2, -0.1]),
                                 'y1': np.array([-0.1, -0.1, 4.1, 4.2])})
         assert_data_equal(expr.apply(rect), np.array([True, True, False]))
-        assert_element_equal(region, Rectangles([]) * Path([[*geom, (-0.4, -0.1)]]))
+        assert_element_equal(region, hv.Rectangles([]) * hv.Path([[*geom, (-0.4, -0.1)]]))
 
     @shapely_skip
     def test_rect_geom_selection_inverted(self):
-        rect = Rectangles([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)]).opts(invert_axes=True)
+        rect = hv.Rectangles([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)]).opts(invert_axes=True)
         geom = np.array([(-0.4, -0.1), (3.2, -0.1), (3.2, 4.1), (-0.1, 4.2)])
         expr, bbox, region = rect._get_selection_expr_for_stream_value(geometry=geom)
         assert_dict_equal(bbox, {'y0': np.array([-0.4, 3.2, 3.2, -0.1]),
@@ -513,33 +493,33 @@ class TestSelectionGeomExpr:
                                 'y1': np.array([-0.4, 3.2, 3.2, -0.1]),
                                 'x1': np.array([-0.1, -0.1, 4.1, 4.2])})
         assert_data_equal(expr.apply(rect), np.array([True, False, False]))
-        assert_element_equal(region, Rectangles([]) * Path([[*geom, (-0.4, -0.1)]]))
+        assert_element_equal(region, hv.Rectangles([]) * hv.Path([[*geom, (-0.4, -0.1)]]))
 
     def test_segments_selection_numeric(self):
-        segs = Segments([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)])
+        segs = hv.Segments([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)])
         expr, bbox, region = segs._get_selection_expr_for_stream_value(bounds=(0.5, 0.9, 3.4, 4.9))
         assert bbox == {'x0': (0.5, 3.4), 'y0': (0.9, 4.9), 'x1': (0.5, 3.4), 'y1': (0.9, 4.9)}
         assert_data_equal(expr.apply(segs), np.array([False, True, False]))
-        assert_element_equal(region, Rectangles([(0.5, 0.9, 3.4, 4.9)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0.5, 0.9, 3.4, 4.9)]) * hv.Path([]))
         expr, bbox, region = segs._get_selection_expr_for_stream_value(bounds=(0, 0.9, 3.5, 4.9))
         assert bbox == {'x0': (0, 3.5), 'y0': (0.9, 4.9), 'x1': (0, 3.5), 'y1': (0.9, 4.9)}
         assert_data_equal(expr.apply(segs), np.array([True, True, True]))
-        assert_element_equal(region, Rectangles([(0, 0.9, 3.5, 4.9)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0, 0.9, 3.5, 4.9)]) * hv.Path([]))
 
     def test_segs_selection_numeric_inverted(self):
-        segs = Segments([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)]).opts(invert_axes=True)
+        segs = hv.Segments([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)]).opts(invert_axes=True)
         expr, bbox, region = segs._get_selection_expr_for_stream_value(bounds=(0.9, 0.5, 4.9, 3.4))
         assert bbox == {'x0': (0.5, 3.4), 'y0': (0.9, 4.9), 'x1': (0.5, 3.4), 'y1': (0.9, 4.9)}
         assert_data_equal(expr.apply(segs), np.array([False, True, False]))
-        assert_element_equal(region, Rectangles([(0.9, 0.5, 4.9, 3.4)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0.9, 0.5, 4.9, 3.4)]) * hv.Path([]))
         expr, bbox, region = segs._get_selection_expr_for_stream_value(bounds=(0.9, 0, 4.9, 3.5))
         assert bbox == {'x0': (0, 3.5), 'y0': (0.9, 4.9), 'x1': (0, 3.5), 'y1': (0.9, 4.9)}
         assert_data_equal(expr.apply(segs), np.array([True, True, True]))
-        assert_element_equal(region, Rectangles([(0.9, 0, 4.9, 3.5)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0.9, 0, 4.9, 3.5)]) * hv.Path([]))
 
     @shapely_skip
     def test_segs_geom_selection(self):
-        rect = Segments([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)])
+        rect = hv.Segments([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)])
         geom = np.array([(-0.4, -0.1), (2.2, -0.1), (2.2, 4.1), (-0.1, 4.2)])
         expr, bbox, region = rect._get_selection_expr_for_stream_value(geometry=geom)
         assert_dict_equal(bbox, {'x0': np.array([-0.4, 2.2, 2.2, -0.1]),
@@ -547,11 +527,11 @@ class TestSelectionGeomExpr:
                                 'x1': np.array([-0.4, 2.2, 2.2, -0.1]),
                                 'y1': np.array([-0.1, -0.1, 4.1, 4.2])})
         assert_data_equal(expr.apply(rect), np.array([True, True, False]))
-        assert_element_equal(region, Rectangles([]) * Path([[*geom, (-0.4, -0.1)]]))
+        assert_element_equal(region, hv.Rectangles([]) * hv.Path([[*geom, (-0.4, -0.1)]]))
 
     @shapely_skip
     def test_segs_geom_selection_inverted(self):
-        rect = Segments([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)]).opts(invert_axes=True)
+        rect = hv.Segments([(0, 1, 2, 3), (1, 3, 1.5, 4), (2.5, 4.2, 3.5, 4.8)]).opts(invert_axes=True)
         geom = np.array([(-0.4, -0.1), (3.2, -0.1), (3.2, 4.1), (-0.1, 4.2)])
         expr, bbox, region = rect._get_selection_expr_for_stream_value(geometry=geom)
         assert_dict_equal(bbox, {'y0': np.array([-0.4, 3.2, 3.2, -0.1]),
@@ -559,21 +539,21 @@ class TestSelectionGeomExpr:
                                 'y1': np.array([-0.4, 3.2, 3.2, -0.1]),
                                 'x1': np.array([-0.1, -0.1, 4.1, 4.2])})
         assert_data_equal(expr.apply(rect), np.array([True, False, False]))
-        assert_element_equal(region, Rectangles([]) * Path([[*geom, (-0.4, -0.1)]]))
+        assert_element_equal(region, hv.Rectangles([]) * hv.Path([[*geom, (-0.4, -0.1)]]))
 
 
 class TestSelectionPolyExpr:
 
     def setup_method(self):
         import holoviews.plotting.bokeh # noqa
-        self._backend = Store.current_backend
-        Store.set_current_backend('bokeh')
+        self._backend = hv.Store.current_backend
+        hv.Store.set_current_backend('bokeh')
 
     def teardown_method(self):
-        Store.current_backend = self._backend
+        hv.Store.current_backend = self._backend
 
     def test_poly_selection_numeric(self):
-        poly = Polygons([
+        poly = hv.Polygons([
             [(0, 0), (0.2, 0.1), (0.3, 0.4), (0.1, 0.2)],
             [(0.25, -.1), (0.4, 0.2), (0.6, 0.3), (0.5, 0.1)],
             [(0.3, 0.3), (0.5, 0.4), (0.6, 0.5), (0.35, 0.45)]
@@ -581,10 +561,10 @@ class TestSelectionPolyExpr:
         expr, bbox, region = poly._get_selection_expr_for_stream_value(bounds=(0.2, -0.2, 0.6, 0.6))
         assert bbox == {'x': (0.2, 0.6), 'y': (-0.2, 0.6)}
         assert_data_equal(expr.apply(poly, expanded=False), np.array([False, True, True]))
-        assert_element_equal(region, Rectangles([(0.2, -0.2, 0.6, 0.6)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0.2, -0.2, 0.6, 0.6)]) * hv.Path([]))
 
     def test_poly_selection_numeric_inverted(self):
-        poly = Polygons([
+        poly = hv.Polygons([
             [(0, 0), (0.2, 0.1), (0.3, 0.4), (0.1, 0.2)],
             [(0.25, -.1), (0.4, 0.2), (0.6, 0.3), (0.5, 0.1)],
             [(0.3, 0.3), (0.5, 0.4), (0.6, 0.5), (0.35, 0.45)]
@@ -592,11 +572,11 @@ class TestSelectionPolyExpr:
         expr, bbox, region = poly._get_selection_expr_for_stream_value(bounds=(0.2, -0.2, 0.6, 0.6))
         assert bbox == {'y': (0.2, 0.6), 'x': (-0.2, 0.6)}
         assert_data_equal(expr.apply(poly, expanded=False), np.array([False, False, True]))
-        assert_element_equal(region, Rectangles([(0.2, -0.2, 0.6, 0.6)]) * Path([]))
+        assert_element_equal(region, hv.Rectangles([(0.2, -0.2, 0.6, 0.6)]) * hv.Path([]))
 
     @shapely_skip
     def test_poly_geom_selection(self):
-        poly = Polygons([
+        poly = hv.Polygons([
             [(0, 0), (0.2, 0.1), (0.3, 0.4), (0.1, 0.2)],
             [(0.25, -.1), (0.4, 0.2), (0.6, 0.3), (0.5, 0.1)],
             [(0.3, 0.3), (0.5, 0.4), (0.6, 0.5), (0.35, 0.45)]
@@ -606,11 +586,11 @@ class TestSelectionPolyExpr:
         assert_dict_equal(bbox, {'x': np.array([0.2, 0.5, 0.75, 0.1]),
                                 'y': np.array([-0.15, 0, 0.6, 0.45])})
         assert_data_equal(expr.apply(poly, expanded=False), np.array([False, True, True]))
-        assert_element_equal(region, Rectangles([]) * Path([[*geom, (0.2, -0.15)]]))
+        assert_element_equal(region, hv.Rectangles([]) * hv.Path([[*geom, (0.2, -0.15)]]))
 
     @shapely_skip
     def test_poly_geom_selection_inverted(self):
-        poly = Polygons([
+        poly = hv.Polygons([
             [(0, 0), (0.2, 0.1), (0.3, 0.4), (0.1, 0.2)],
             [(0.25, -.1), (0.4, 0.2), (0.6, 0.3), (0.5, 0.1)],
             [(0.3, 0.3), (0.5, 0.4), (0.6, 0.5), (0.35, 0.45)]
@@ -620,7 +600,7 @@ class TestSelectionPolyExpr:
         assert_dict_equal(bbox, {'y': np.array([0.2, 0.5, 0.75, 0.1]),
                                 'x': np.array([-0.15, 0, 0.6, 0.6])})
         assert_data_equal(expr.apply(poly, expanded=False), np.array([False, False, True]))
-        assert_element_equal(region, Rectangles([]) * Path([[*geom, (0.2, -0.15)]]))
+        assert_element_equal(region, hv.Rectangles([]) * hv.Path([[*geom, (0.2, -0.15)]]))
 
 
 @pytest.mark.parametrize(("geometry", "pt_mask"), [

--- a/holoviews/tests/element/test_statselements.py
+++ b/holoviews/tests/element/test_statselements.py
@@ -2,112 +2,102 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core.dimension import Dimension
-from holoviews.core.options import Compositor, Store
-from holoviews.element import (
-    Area,
-    Bivariate,
-    Contours,
-    Curve,
-    Distribution,
-    Image,
-    Points,
-    Polygons,
-)
+import holoviews as hv
+from holoviews.core.options import Compositor
 
 
 class TestStatisticalElement:
 
     def test_distribution_array_constructor(self):
-        dist = Distribution(np.array([0, 1, 2]))
-        assert dist.kdims == [Dimension('Value')]
-        assert dist.vdims == [Dimension('Density')]
+        dist = hv.Distribution(np.array([0, 1, 2]))
+        assert dist.kdims == [hv.Dimension('Value')]
+        assert dist.vdims == [hv.Dimension('Density')]
 
     def test_distribution_dframe_constructor(self):
-        dist = Distribution(pd.DataFrame({'Value': [0, 1, 2]}))
-        assert dist.kdims == [Dimension('Value')]
-        assert dist.vdims == [Dimension('Density')]
+        dist = hv.Distribution(pd.DataFrame({'Value': [0, 1, 2]}))
+        assert dist.kdims == [hv.Dimension('Value')]
+        assert dist.vdims == [hv.Dimension('Density')]
 
     def test_distribution_series_constructor(self):
-        dist = Distribution(pd.Series([0, 1, 2], name='Value'))
-        assert dist.kdims == [Dimension('Value')]
-        assert dist.vdims == [Dimension('Density')]
+        dist = hv.Distribution(pd.Series([0, 1, 2], name='Value'))
+        assert dist.kdims == [hv.Dimension('Value')]
+        assert dist.vdims == [hv.Dimension('Density')]
 
     def test_distribution_dict_constructor(self):
-        dist = Distribution({'Value': [0, 1, 2]})
-        assert dist.kdims == [Dimension('Value')]
-        assert dist.vdims == [Dimension('Density')]
+        dist = hv.Distribution({'Value': [0, 1, 2]})
+        assert dist.kdims == [hv.Dimension('Value')]
+        assert dist.vdims == [hv.Dimension('Density')]
 
     def test_distribution_array_constructor_custom_vdim(self):
-        dist = Distribution(np.array([0, 1, 2]), vdims=['Test'])
-        assert dist.kdims == [Dimension('Value')]
-        assert dist.vdims == [Dimension('Test')]
+        dist = hv.Distribution(np.array([0, 1, 2]), vdims=['Test'])
+        assert dist.kdims == [hv.Dimension('Value')]
+        assert dist.vdims == [hv.Dimension('Test')]
 
     def test_bivariate_array_constructor(self):
-        dist = Bivariate(np.array([[0, 1, 2], [0, 1, 2]]))
-        assert dist.kdims == [Dimension('x'), Dimension('y')]
-        assert dist.vdims == [Dimension('Density')]
+        dist = hv.Bivariate(np.array([[0, 1, 2], [0, 1, 2]]))
+        assert dist.kdims == [hv.Dimension('x'), hv.Dimension('y')]
+        assert dist.vdims == [hv.Dimension('Density')]
 
     def test_bivariate_dframe_constructor(self):
-        dist = Bivariate(pd.DataFrame({'x': [0, 1, 2], 'y': [0, 1, 2]}, columns=['x', 'y']))
-        assert dist.kdims == [Dimension('x'), Dimension('y')]
-        assert dist.vdims == [Dimension('Density')]
+        dist = hv.Bivariate(pd.DataFrame({'x': [0, 1, 2], 'y': [0, 1, 2]}, columns=['x', 'y']))
+        assert dist.kdims == [hv.Dimension('x'), hv.Dimension('y')]
+        assert dist.vdims == [hv.Dimension('Density')]
 
     def test_bivariate_dict_constructor(self):
-        dist = Bivariate({'x': [0, 1, 2], 'y': [0, 1, 2]}, ['x', 'y'])
-        assert dist.kdims == [Dimension('x'), Dimension('y')]
-        assert dist.vdims == [Dimension('Density')]
+        dist = hv.Bivariate({'x': [0, 1, 2], 'y': [0, 1, 2]}, ['x', 'y'])
+        assert dist.kdims == [hv.Dimension('x'), hv.Dimension('y')]
+        assert dist.vdims == [hv.Dimension('Density')]
 
     def test_bivariate_array_constructor_custom_vdim(self):
-        dist = Bivariate(np.array([[0, 1, 2], [0, 1, 2]]), vdims=['Test'])
-        assert dist.kdims == [Dimension('x'), Dimension('y')]
-        assert dist.vdims == [Dimension('Test')]
+        dist = hv.Bivariate(np.array([[0, 1, 2], [0, 1, 2]]), vdims=['Test'])
+        assert dist.kdims == [hv.Dimension('x'), hv.Dimension('y')]
+        assert dist.vdims == [hv.Dimension('Test')]
 
     def test_distribution_array_range_kdims(self):
-        dist = Distribution(np.array([0, 1, 2]))
+        dist = hv.Distribution(np.array([0, 1, 2]))
         assert dist.range(0) == (0, 2)
 
     def test_bivariate_array_range_kdims(self):
-        dist = Bivariate(np.array([[0, 1], [1, 2], [2, 3]]))
+        dist = hv.Bivariate(np.array([[0, 1], [1, 2], [2, 3]]))
         assert dist.range(0) == (0, 2)
         assert dist.range(1) == (1, 3)
 
     def test_distribution_array_range_vdims(self):
-        dist = Distribution(np.array([0, 1, 2]))
+        dist = hv.Distribution(np.array([0, 1, 2]))
         dmin, dmax = dist.range(1)
         assert not np.isfinite(dmin)
         assert not np.isfinite(dmax)
 
     def test_bivariate_array_range_vdims(self):
-        dist = Bivariate(np.array([[0, 1, 2], [0, 1, 3]]))
+        dist = hv.Bivariate(np.array([[0, 1, 2], [0, 1, 3]]))
         dmin, dmax = dist.range(2)
         assert not np.isfinite(dmin)
         assert not np.isfinite(dmax)
 
     def test_distribution_array_kdim_type(self):
-        dist = Distribution(np.array([0, 1, 2]))
+        dist = hv.Distribution(np.array([0, 1, 2]))
         assert np.issubdtype(dist.get_dimension_type(0), np.int_)
 
     def test_bivariate_array_kdim_type(self):
-        dist = Bivariate(np.array([[0, 1], [1, 2], [2, 3]]))
+        dist = hv.Bivariate(np.array([[0, 1], [1, 2], [2, 3]]))
         assert np.issubdtype(dist.get_dimension_type(0), np.int_)
         assert np.issubdtype(dist.get_dimension_type(1), np.int_)
 
     def test_distribution_array_vdim_type(self):
-        dist = Distribution(np.array([0, 1, 2]))
+        dist = hv.Distribution(np.array([0, 1, 2]))
         assert dist.get_dimension_type(1) == np.float64
 
     def test_bivariate_array_vdim_type(self):
-        dist = Bivariate(np.array([[0, 1], [1, 2], [2, 3]]))
+        dist = hv.Bivariate(np.array([[0, 1], [1, 2], [2, 3]]))
         assert dist.get_dimension_type(2) == np.float64
 
     def test_distribution_from_image(self):
-        dist = Distribution(Image(np.arange(5)*np.arange(5)[:, np.newaxis]), 'z')
+        dist = hv.Distribution(hv.Image(np.arange(5)*np.arange(5)[:, np.newaxis]), 'z')
         assert dist.range(0) == (0, 16)
 
     def test_bivariate_from_points(self):
-        points = Points(np.array([[0, 1], [1, 2], [2, 3]]))
-        dist = Bivariate(points)
+        points = hv.Points(np.array([[0, 1], [1, 2], [2, 3]]))
+        dist = hv.Bivariate(points)
         assert dist.kdims == points.kdims
 
 
@@ -118,81 +108,81 @@ class TestStatisticalCompositor:
         pytest.importorskip('scipy')
 
     def test_distribution_composite(self):
-        dist = Distribution(np.array([0, 1, 2]))
+        dist = hv.Distribution(np.array([0, 1, 2]))
         area = Compositor.collapse_element(dist, backend='matplotlib')
-        assert isinstance(area, Area)
-        assert area.vdims == [Dimension(('Value_density', 'Density'))]
+        assert isinstance(area, hv.Area)
+        assert area.vdims == [hv.Dimension(('Value_density', 'Density'))]
 
     def test_distribution_composite_transfer_opts(self):
-        dist = Distribution(np.array([0, 1, 2])).opts(color='red')
+        dist = hv.Distribution(np.array([0, 1, 2])).opts(color='red')
         area = Compositor.collapse_element(dist, backend='matplotlib')
-        opts = Store.lookup_options('matplotlib', area, 'style').kwargs
+        opts = hv.Store.lookup_options('matplotlib', area, 'style').kwargs
         assert opts.get('color', None) == 'red'
 
     def test_distribution_composite_transfer_opts_with_group(self):
-        dist = Distribution(np.array([0, 1, 2]), group='Test').opts(color='red')
+        dist = hv.Distribution(np.array([0, 1, 2]), group='Test').opts(color='red')
         area = Compositor.collapse_element(dist, backend='matplotlib')
-        opts = Store.lookup_options('matplotlib', area, 'style').kwargs
+        opts = hv.Store.lookup_options('matplotlib', area, 'style').kwargs
         assert opts.get('color', None) == 'red'
 
     def test_distribution_composite_custom_vdim(self):
-        dist = Distribution(np.array([0, 1, 2]), vdims=['Test'])
+        dist = hv.Distribution(np.array([0, 1, 2]), vdims=['Test'])
         area = Compositor.collapse_element(dist, backend='matplotlib')
-        assert isinstance(area, Area)
-        assert area.vdims == [Dimension('Test')]
+        assert isinstance(area, hv.Area)
+        assert area.vdims == [hv.Dimension('Test')]
 
     def test_distribution_composite_not_filled(self):
-        dist = Distribution(np.array([0, 1, 2]), ).opts(filled=False)
+        dist = hv.Distribution(np.array([0, 1, 2]), ).opts(filled=False)
         curve = Compositor.collapse_element(dist, backend='matplotlib')
-        assert isinstance(curve, Curve)
-        assert curve.vdims == [Dimension(('Value_density', 'Density'))]
+        assert isinstance(curve, hv.Curve)
+        assert curve.vdims == [hv.Dimension(('Value_density', 'Density'))]
 
     def test_distribution_composite_empty_not_filled(self):
-        dist = Distribution([]).opts(filled=False)
+        dist = hv.Distribution([]).opts(filled=False)
         curve = Compositor.collapse_element(dist, backend='matplotlib')
-        assert isinstance(curve, Curve)
-        assert curve.vdims == [Dimension(('Value_density', 'Density'))]
+        assert isinstance(curve, hv.Curve)
+        assert curve.vdims == [hv.Dimension(('Value_density', 'Density'))]
 
     def test_bivariate_composite(self):
-        dist = Bivariate(np.random.rand(10, 2))
+        dist = hv.Bivariate(np.random.rand(10, 2))
         contours = Compositor.collapse_element(dist, backend='matplotlib')
-        assert isinstance(contours, Contours)
-        assert contours.vdims == [Dimension('Density')]
+        assert isinstance(contours, hv.Contours)
+        assert contours.vdims == [hv.Dimension('Density')]
 
     def test_bivariate_composite_transfer_opts(self):
-        dist = Bivariate(np.random.rand(10, 2)).opts(cmap='Blues')
+        dist = hv.Bivariate(np.random.rand(10, 2)).opts(cmap='Blues')
         contours = Compositor.collapse_element(dist, backend='matplotlib')
-        opts = Store.lookup_options('matplotlib', contours, 'style').kwargs
+        opts = hv.Store.lookup_options('matplotlib', contours, 'style').kwargs
         assert opts.get('cmap', None) == 'Blues'
 
     def test_bivariate_composite_transfer_opts_with_group(self):
-        dist = Bivariate(np.random.rand(10, 2), group='Test').opts(cmap='Blues')
+        dist = hv.Bivariate(np.random.rand(10, 2), group='Test').opts(cmap='Blues')
         contours = Compositor.collapse_element(dist, backend='matplotlib')
-        opts = Store.lookup_options('matplotlib', contours, 'style').kwargs
+        opts = hv.Store.lookup_options('matplotlib', contours, 'style').kwargs
         assert opts.get('cmap', None) == 'Blues'
 
     def test_bivariate_composite_custom_vdim(self):
-        dist = Bivariate(np.random.rand(10, 2), vdims=['Test'])
+        dist = hv.Bivariate(np.random.rand(10, 2), vdims=['Test'])
         contours = Compositor.collapse_element(dist, backend='matplotlib')
-        assert isinstance(contours, Contours)
-        assert contours.vdims == [Dimension('Test')]
+        assert isinstance(contours, hv.Contours)
+        assert contours.vdims == [hv.Dimension('Test')]
 
     def test_bivariate_composite_filled(self):
-        dist = Bivariate(np.random.rand(10, 2)).opts(filled=True)
+        dist = hv.Bivariate(np.random.rand(10, 2)).opts(filled=True)
         contours = Compositor.collapse_element(dist, backend='matplotlib')
-        assert isinstance(contours, Polygons)
+        assert isinstance(contours, hv.Polygons)
         assert contours.vdims[0].name == 'Density'
 
     def test_bivariate_composite_empty_filled(self):
-        dist = Bivariate([]).opts(filled=True)
+        dist = hv.Bivariate([]).opts(filled=True)
         contours = Compositor.collapse_element(dist, backend='matplotlib')
-        assert isinstance(contours, Polygons)
-        assert contours.vdims == [Dimension('Density')]
+        assert isinstance(contours, hv.Polygons)
+        assert contours.vdims == [hv.Dimension('Density')]
         assert len(contours) == 0
 
     def test_bivariate_composite_empty_not_filled(self):
-        dist = Bivariate([]).opts(filled=True)
+        dist = hv.Bivariate([]).opts(filled=True)
         contours = Compositor.collapse_element(dist, backend='matplotlib')
-        assert isinstance(contours, Contours)
-        assert contours.vdims == [Dimension('Density')]
+        assert isinstance(contours, hv.Contours)
+        assert contours.vdims == [hv.Dimension('Density')]
         assert len(contours) == 0

--- a/holoviews/tests/element/test_tiles.py
+++ b/holoviews/tests/element/test_tiles.py
@@ -1,30 +1,30 @@
 import numpy as np
 import pandas as pd
 
-from holoviews import Tiles
+import holoviews as hv
 
 
 class TestCoordinateConversion:
     def test_spot_check_lonlat_to_eastingnorthing(self):
         # Anchor implementation with a few hard-coded known values.
         # Generated ad-hoc from https://epsg.io/transform#s_srs=4326&t_srs=3857
-        easting, northing = Tiles.lon_lat_to_easting_northing(0, 0)
+        easting, northing = hv.Tiles.lon_lat_to_easting_northing(0, 0)
         np.testing.assert_array_almost_equal(easting, 0)
         np.testing.assert_array_almost_equal(northing, 0)
 
-        easting, northing = Tiles.lon_lat_to_easting_northing(20, 10)
+        easting, northing = hv.Tiles.lon_lat_to_easting_northing(20, 10)
         np.testing.assert_array_almost_equal(easting, 2226389.82, decimal=2)
         np.testing.assert_array_almost_equal(northing, 1118889.97, decimal=2)
 
-        easting, northing = Tiles.lon_lat_to_easting_northing(-33, -18)
+        easting, northing = hv.Tiles.lon_lat_to_easting_northing(-33, -18)
         np.testing.assert_array_almost_equal(easting, -3673543.20, decimal=2)
         np.testing.assert_array_almost_equal(northing, -2037548.54, decimal=2)
 
-        easting, northing = Tiles.lon_lat_to_easting_northing(85, -75)
+        easting, northing = hv.Tiles.lon_lat_to_easting_northing(85, -75)
         np.testing.assert_array_almost_equal(easting, 9462156.72, decimal=2)
         np.testing.assert_array_almost_equal(northing, -12932243.11, decimal=2)
 
-        easting, northing = Tiles.lon_lat_to_easting_northing(180, 85)
+        easting, northing = hv.Tiles.lon_lat_to_easting_northing(180, 85)
         np.testing.assert_array_almost_equal(easting, 20037508.34, decimal=2)
         np.testing.assert_array_almost_equal(northing, 19971868.88, decimal=2)
 
@@ -32,39 +32,39 @@ class TestCoordinateConversion:
         # Anchor implementation with a few hard-coded known values.
         # Generated ad-hoc from https://epsg.io/transform#s_srs=3857&t_srs=4326
 
-        lon, lat = Tiles.easting_northing_to_lon_lat(0, 0)
+        lon, lat = hv.Tiles.easting_northing_to_lon_lat(0, 0)
         np.testing.assert_array_almost_equal(lon, 0)
         np.testing.assert_array_almost_equal(lat, 0)
 
-        lon, lat = Tiles.easting_northing_to_lon_lat(1230020, -432501)
+        lon, lat = hv.Tiles.easting_northing_to_lon_lat(1230020, -432501)
         np.testing.assert_array_almost_equal(lon, 11.0494578, decimal=2)
         np.testing.assert_array_almost_equal(lat, -3.8822487, decimal=2)
 
-        lon, lat = Tiles.easting_northing_to_lon_lat(-2130123, 1829312)
+        lon, lat = hv.Tiles.easting_northing_to_lon_lat(-2130123, 1829312)
         np.testing.assert_array_almost_equal(lon, -19.1352205, decimal=2)
         np.testing.assert_array_almost_equal(lat, 16.2122187, decimal=2)
 
-        lon, lat = Tiles.easting_northing_to_lon_lat(-1000000, 5000000)
+        lon, lat = hv.Tiles.easting_northing_to_lon_lat(-1000000, 5000000)
         np.testing.assert_array_almost_equal(lon, -8.9831528, decimal=2)
         np.testing.assert_array_almost_equal(lat, 40.9162745, decimal=2)
 
-        lon, lat = Tiles.easting_northing_to_lon_lat(-20037508.34, 20037508.34)
+        lon, lat = hv.Tiles.easting_northing_to_lon_lat(-20037508.34, 20037508.34)
         np.testing.assert_array_almost_equal(lon, -180.0, decimal=2)
         np.testing.assert_array_almost_equal(lat, 85.0511288, decimal=2)
 
     def test_check_lonlat_to_eastingnorthing_identity(self):
         for lon in np.linspace(-180, 180, 100):
             for lat in np.linspace(-85, 85, 100):
-                easting, northing = Tiles.lon_lat_to_easting_northing(lon, lat)
-                new_lon, new_lat = Tiles.easting_northing_to_lon_lat(easting, northing)
+                easting, northing = hv.Tiles.lon_lat_to_easting_northing(lon, lat)
+                new_lon, new_lat = hv.Tiles.easting_northing_to_lon_lat(easting, northing)
                 np.testing.assert_array_almost_equal(lon, new_lon, decimal=2)
                 np.testing.assert_array_almost_equal(lat, new_lat, decimal=2)
 
     def test_check_eastingnorthing_to_lonlat_identity(self):
         for easting in np.linspace(-20037508.34, 20037508.34, 100):
             for northing in np.linspace(-20037508.34, 20037508.34, 100):
-                lon, lat = Tiles.easting_northing_to_lon_lat(easting, northing)
-                new_easting, new_northing = Tiles.lon_lat_to_easting_northing(lon, lat)
+                lon, lat = hv.Tiles.easting_northing_to_lon_lat(easting, northing)
+                new_easting, new_northing = hv.Tiles.lon_lat_to_easting_northing(lon, lat)
                 np.testing.assert_array_almost_equal(easting, new_easting, decimal=2)
                 np.testing.assert_array_almost_equal(northing, new_northing, decimal=2)
 
@@ -81,13 +81,13 @@ class TestCoordinateConversion:
         assert isinstance(array_lons, array_type)
         assert isinstance(array_lats, array_type)
 
-        eastings, northings = Tiles.lon_lat_to_easting_northing(
+        eastings, northings = hv.Tiles.lon_lat_to_easting_northing(
             array_lons, array_lats
         )
         assert isinstance(eastings, array_type)
         assert isinstance(northings, array_type)
 
-        new_lons, new_lats = Tiles.easting_northing_to_lon_lat(
+        new_lons, new_lats = hv.Tiles.easting_northing_to_lon_lat(
             eastings, northings
         )
         assert isinstance(new_lons, array_type)

--- a/holoviews/tests/ipython/test_displayhooks.py
+++ b/holoviews/tests/ipython/test_displayhooks.py
@@ -1,4 +1,5 @@
-from holoviews import Curve, Store
+
+import holoviews as hv
 
 from .utils import IPythonCase
 
@@ -10,13 +11,13 @@ class TestDisplayHooks(IPythonCase):
         from holoviews.ipython import notebook_extension
         if not notebook_extension._loaded:
             notebook_extension('matplotlib', ip=self.ip)
-        self.backup = Store.display_formats
-        Store.display_formats = self.format
+        self.backup = hv.Store.display_formats
+        hv.Store.display_formats = self.format
 
     def teardown_method(self):
         from holoviews.ipython import notebook_extension
         self.ip.run_line_magic("unload_ext", "holoviews.ipython")
-        Store.display_hooks = self.backup
+        hv.Store.display_hooks = self.backup
         notebook_extension._loaded = False
         super().teardown_method()
 
@@ -26,8 +27,8 @@ class TestHTMLDisplay(TestDisplayHooks):
     format = ['html']
 
     def test_store_render_html(self):
-        curve = Curve([1, 2, 3])
-        data, _metadata = Store.render(curve)
+        curve = hv.Curve([1, 2, 3])
+        data, _metadata = hv.Store.render(curve)
         mime_types = {'text/html'}
         assert set(data) == mime_types
 
@@ -37,8 +38,8 @@ class TestPNGDisplay(TestDisplayHooks):
     format = ['png']
 
     def test_store_render_png(self):
-        curve = Curve([1, 2, 3])
-        data, _metadata = Store.render(curve)
+        curve = hv.Curve([1, 2, 3])
+        data, _metadata = hv.Store.render(curve)
         mime_types = {'image/png'}
         assert set(data) == mime_types
 
@@ -48,8 +49,8 @@ class TestSVGDisplay(TestDisplayHooks):
     format = ['svg']
 
     def test_store_render_svg(self):
-        curve = Curve([1, 2, 3])
-        data, _metadata = Store.render(curve)
+        curve = hv.Curve([1, 2, 3])
+        data, _metadata = hv.Store.render(curve)
         mime_types = {'image/svg+xml'}
         assert set(data) == mime_types
 
@@ -59,7 +60,7 @@ class TestCombinedDisplay(TestDisplayHooks):
     format = ['html', 'svg', 'png']
 
     def test_store_render_combined(self):
-        curve = Curve([1, 2, 3])
-        data, _metadata = Store.render(curve)
+        curve = hv.Curve([1, 2, 3])
+        data, _metadata = hv.Store.render(curve)
         mime_types = {'text/html', 'image/svg+xml', 'image/png'}
         assert set(data) == mime_types

--- a/holoviews/tests/ipython/test_displayhooks.py
+++ b/holoviews/tests/ipython/test_displayhooks.py
@@ -1,4 +1,3 @@
-
 import holoviews as hv
 
 from .utils import IPythonCase

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -7,36 +7,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews import (
-    RGB,
-    Area,
-    Contours,
-    Curve,
-    Dataset,
-    Dimension,
-    DynamicMap,
-    Graph,
-    Image,
-    ImageStack,
-    NdOverlay,
-    Nodes,
-    Overlay,
-    Path,
-    Points,
-    Polygons,
-    QuadMesh,
-    Rectangles,
-    Segments,
-    Spikes,
-    Spread,
-    TriMesh,
-    renderer,
-)
+import holoviews as hv
 from holoviews.core.util.dependencies import PANDAS_GE_3_0_0
 from holoviews.operation import apply_when
 from holoviews.streams import Tap
 from holoviews.testing import assert_data_equal, assert_element_equal
-from holoviews.util import render
 
 from ..utils import optional_dependencies
 
@@ -100,7 +75,7 @@ def point_data():
 
 @pytest.fixture
 def point_plot(point_data):
-    return Points(point_data)
+    return hv.Points(point_data)
 
 
 class DatashaderAggregateTests:
@@ -109,38 +84,38 @@ class DatashaderAggregateTests:
     """
 
     def test_aggregate_points(self):
-        points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
+        points = hv.Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         assert_element_equal(img, expected)
 
     def test_aggregate_points_empty(self):
-        points = Points([])
+        points = hv.Points([])
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2, pixel_ratio=1)
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[0, 0], [0, 0]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[0, 0], [0, 0]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         assert_element_equal(img, expected)
 
     def test_aggregate_points_empty_with_pixel_ratio(self):
-        points = Points([])
+        points = hv.Points([])
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2, pixel_ratio=2)
-        expected = Image((
+        expected = hv.Image((
             [0.125, 0.375, 0.625, 0.875],
             [0.125, 0.375, 0.625, 0.875],
             [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
-        ), vdims=[Dimension('Count', nodata=0)])
+        ), vdims=[hv.Dimension('Count', nodata=0)])
         assert_element_equal(img, expected)
 
     def test_aggregate_points_count_column(self):
-        points = Points([(0.2, 0.3, np.nan), (0.4, 0.7, 22), (0, 0.99,np.nan)], vdims='z')
+        points = hv.Points([(0.2, 0.3, np.nan), (0.4, 0.7, 22), (0, 0.99,np.nan)], vdims='z')
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2, aggregator=ds.count('z'))
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[0, 0], [1, 0]]),
-                         vdims=[Dimension('z Count', nodata=0)])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[0, 0], [1, 0]]),
+                         vdims=[hv.Dimension('z Count', nodata=0)])
         assert_element_equal(img, expected)
 
     @pytest.mark.gpu
@@ -148,40 +123,40 @@ class DatashaderAggregateTests:
         import cudf
         import cupy
 
-        points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)], datatype=['cuDF'])
+        points = hv.Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)], datatype=['cuDF'])
         assert isinstance(points.data, cudf.DataFrame)
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         assert isinstance(img.data.Count.data, cupy.ndarray)
         assert_element_equal(img, expected)
 
     def test_aggregate_zero_range_points(self):
-        p = Points([(0, 0), (1, 1)])
+        p = hv.Points([(0, 0), (1, 1)])
         agg = rasterize(p, x_range=(0, 0), y_range=(0, 1), expand=False, dynamic=False,
                         width=2, height=2)
-        img = Image(([], [0.25, 0.75], np.zeros((2, 0))), bounds=(0, 0, 0, 1),
-                    xdensity=1, vdims=[Dimension('Count', nodata=0)])
+        img = hv.Image(([], [0.25, 0.75], np.zeros((2, 0))), bounds=(0, 0, 0, 1),
+                    xdensity=1, vdims=[hv.Dimension('Count', nodata=0)])
         assert_element_equal(agg, img)
 
     def test_aggregate_points_target(self):
-        points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        points = hv.Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         img = aggregate(points, dynamic=False,  target=expected)
         assert_element_equal(img, expected)
 
     def test_aggregate_points_sampling(self):
-        points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        points = hv.Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         x_sampling=0.5, y_sampling=0.5)
         assert_element_equal(img, expected)
 
     def test_aggregate_points_categorical(self):
-        points = Points([(0.2, 0.3, 'A'), (0.4, 0.7, 'B'), (0, 0.99, 'C')], vdims='z')
+        points = hv.Points([(0.2, 0.3, 'A'), (0.4, 0.7, 'B'), (0, 0.99, 'C')], vdims='z')
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2, aggregator=ds.count_cat('z'))
         x = np.array([0.25, 0.75])
@@ -193,43 +168,43 @@ class DatashaderAggregateTests:
             coords={"x": x, "y": y},
             data_vars={"a": (("x", "y"), a), "b": (("x", "y"), b), "c": (("x", "y"), c)},
         )
-        expected = ImageStack(xrds, kdims=["x", "y"], vdims=["a", "b", "c"])
+        expected = hv.ImageStack(xrds, kdims=["x", "y"], vdims=["a", "b", "c"])
         actual = img.data
         assert (expected.data.to_array("z").values == actual.T.values).all()
 
     def test_aggregate_points_categorical_zero_range(self):
-        points = Points([(0.2, 0.3, 'A'), (0.4, 0.7, 'B'), (0, 0.99, 'C')], vdims='z')
+        points = hv.Points([(0.2, 0.3, 'A'), (0.4, 0.7, 'B'), (0, 0.99, 'C')], vdims='z')
         img = aggregate(points, dynamic=False,  x_range=(0, 0), y_range=(0, 1),
                         aggregator=ds.count_cat('z'), height=2)
-        expected = ImageStack(
+        expected = hv.ImageStack(
             xr.Dataset(
                 {"z Count": (("y", "x"), [[], []])},
                 coords={"x": [], "y": [0.25, 0.75]},
             ),
-            vdims=Dimension('z Count', nodata=0),
+            vdims=hv.Dimension('z Count', nodata=0),
             bounds=(0, 0, 0, 1),
             xdensity=1
         )
         assert_element_equal(img, expected)
 
     def test_aggregate_curve(self):
-        curve = Curve([(0.2, 0.3), (0.4, 0.7), (0.8, 0.99)])
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [1, 1]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        curve = hv.Curve([(0.2, 0.3), (0.4, 0.7), (0.8, 0.99)])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [1, 1]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         img = aggregate(curve, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
         assert_element_equal(img, expected)
 
     def test_aggregate_curve_datetimes(self):
         dates = pd.date_range(start="2016-01-01", end="2016-01-03", freq='1D')
-        curve = Curve((dates, [1, 2, 3]))
+        curve = hv.Curve((dates, [1, 2, 3]))
         img = aggregate(curve, width=2, height=2, dynamic=False)
         bounds = (np.datetime64('2016-01-01T00:00:00.000000'), 1.0,
                   np.datetime64('2016-01-03T00:00:00.000000'), 3.0)
         dates = [np.datetime64('2016-01-01T12:00:00.000000000'),
                  np.datetime64('2016-01-02T12:00:00.000000000')]
-        expected = Image((dates, [1.5, 2.5], [[1, 0], [0, 2]]),
-                         datatype=['xarray'], bounds=bounds, vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((dates, [1.5, 2.5], [[1, 0], [0, 2]]),
+                         datatype=['xarray'], bounds=bounds, vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(img, expected)
 
     def test_aggregate_curve_datetimes_dask(self):
@@ -238,14 +213,14 @@ class DatashaderAggregateTests:
             index=pd.date_range('2019-01-01', freq='1min', periods=1000),
         )
         ddf = dd.from_pandas(df, npartitions=4)
-        curve = Curve(ddf, kdims=['index'], vdims=['a'])
+        curve = hv.Curve(ddf, kdims=['index'], vdims=['a'])
         img = aggregate(curve, width=2, height=3, dynamic=False)
         bounds = (np.datetime64('2019-01-01T00:00:00.000000'), 0.0,
                   np.datetime64('2019-01-01T16:39:00.000000'), 999.0)
         dates = [np.datetime64('2019-01-01T04:09:45.000000000'),
                  np.datetime64('2019-01-01T12:29:15.000000000')]
-        expected = Image((dates, [166.5, 499.5, 832.5], [[332, 0], [167, 166], [0, 334]]),
-                         kdims=['index', 'a'], vdims=Dimension('Count', nodata=0),
+        expected = hv.Image((dates, [166.5, 499.5, 832.5], [[332, 0], [167, 166], [0, 334]]),
+                         kdims=['index', 'a'], vdims=hv.Dimension('Count', nodata=0),
                          datatype=['xarray'], bounds=bounds)
         assert_element_equal(img, expected)
 
@@ -253,26 +228,26 @@ class DatashaderAggregateTests:
         dates = pd.date_range(start="2016-01-01", end="2016-01-03", freq='1D')
         xstart = np.datetime64('2015-12-31T23:59:59.723518000', 'us')
         xend = np.datetime64('2016-01-03T00:00:00.276482000', 'us')
-        curve = Curve((dates, [1, 2, 3]))
+        curve = hv.Curve((dates, [1, 2, 3]))
         img = aggregate(curve, width=2, height=2, x_range=(xstart, xend), dynamic=False)
         bounds = (np.datetime64('2015-12-31T23:59:59.723517952'), 1.0,
                   np.datetime64('2016-01-03T00:00:00.276482048'), 3.0)
         dates = [np.datetime64('2016-01-01T11:59:59.861758976',),
                  np.datetime64('2016-01-02T12:00:00.138241024')]
-        expected = Image((dates, [1.5, 2.5], [[1, 0], [0, 2]]),
-                         datatype=['xarray'], bounds=bounds, vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((dates, [1.5, 2.5], [[1, 0], [0, 2]]),
+                         datatype=['xarray'], bounds=bounds, vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(img, expected)
 
     def test_aggregate_ndoverlay_count_cat_datetimes_microsecond_timebase(self):
         dates = pd.date_range(start="2016-01-01", end="2016-01-03", freq='1D')
         xstart = np.datetime64('2015-12-31T23:59:59.723518000', 'us')
         xend = np.datetime64('2016-01-03T00:00:00.276482000', 'us')
-        curve = Curve((dates, [1, 2, 3]))
-        curve2 = Curve((dates, [3, 2, 1]))
-        ndoverlay = NdOverlay({0: curve, 1: curve2}, 'Cat')
+        curve = hv.Curve((dates, [1, 2, 3]))
+        curve2 = hv.Curve((dates, [3, 2, 1]))
+        ndoverlay = hv.NdOverlay({0: curve, 1: curve2}, 'Cat')
         img = aggregate(ndoverlay, aggregator=ds.count_cat('Cat'), width=2, height=2,
                          x_range=(xstart, xend), dynamic=False)
-        assert isinstance(img, ImageStack)
+        assert isinstance(img, hv.ImageStack)
         x = pd.date_range(xstart, xend, periods=4).to_numpy()
         y = np.array([1.25, 1.75, 2.25, 2.75])
         cat = np.array([0.0, 1.0])
@@ -287,97 +262,97 @@ class DatashaderAggregateTests:
             dims=('y', 'x', 'Cat'),
             coords={"y": y, "Cat": cat, "x": x}
         )
-        expected = ImageStack(xrds, kdims=["x", "y"], vdims=["0.0", "1.0"])
+        expected = hv.ImageStack(xrds, kdims=["x", "y"], vdims=["0.0", "1.0"])
         assert (expected.data == a).all()
 
     def test_aggregate_dt_xaxis_constant_yaxis(self):
         df = pd.DataFrame({'y': np.ones(100)}, index=pd.date_range('1980-01-01', periods=100, freq='1min'))
-        img = rasterize(Curve(df), dynamic=False, width=3)
+        img = rasterize(hv.Curve(df), dynamic=False, width=3)
         xs = np.array(['1980-01-01T00:16:30.000000', '1980-01-01T00:49:30.000000',
                        '1980-01-01T01:22:30.000000'], dtype='datetime64[us]')
         ys = np.array([])
         bounds = (np.datetime64('1980-01-01T00:00:00.000000'), 1.0,
                   np.datetime64('1980-01-01T01:39:00.000000'), 1.0)
-        expected = Image((xs, ys, np.empty((0, 3))), ['index', 'y'],
-                         vdims=Dimension('Count', nodata=0), xdensity=1,
+        expected = hv.Image((xs, ys, np.empty((0, 3))), ['index', 'y'],
+                         vdims=hv.Dimension('Count', nodata=0), xdensity=1,
                          ydensity=1, bounds=bounds)
         assert_element_equal(img, expected)
 
     def test_aggregate_ndoverlay(self):
-        ds = Dataset([(0.2, 0.3, 0), (0.4, 0.7, 1), (0, 0.99, 2)], kdims=['x', 'y', 'z'])
-        ndoverlay = ds.to(Points, ['x', 'y'], [], 'z').overlay()
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        ds = hv.Dataset([(0.2, 0.3, 0), (0.4, 0.7, 1), (0, 0.99, 2)], kdims=['x', 'y', 'z'])
+        ndoverlay = ds.to(hv.Points, ['x', 'y'], [], 'z').overlay()
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         img = aggregate(ndoverlay, dynamic=False, x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
         assert_element_equal(img, expected)
 
     def test_aggregate_path(self):
-        path = Path([[(0.2, 0.3), (0.4, 0.7)], [(0.4, 0.7), (0.8, 0.99)]])
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 1]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        path = hv.Path([[(0.2, 0.3), (0.4, 0.7)], [(0.4, 0.7), (0.8, 0.99)]])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 1]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         img = aggregate(path, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
         assert_element_equal(img, expected)
 
     def test_aggregate_contours_with_vdim(self):
-        contours = Contours([[(0.2, 0.3, 1), (0.4, 0.7, 1)], [(0.4, 0.7, 2), (0.8, 0.99, 2)]], vdims='z')
+        contours = hv.Contours([[(0.2, 0.3, 1), (0.4, 0.7, 1)], [(0.4, 0.7, 2), (0.8, 0.99, 2)]], vdims='z')
         img = rasterize(contours, dynamic=False)
         assert img.vdims == ['z']
 
     def test_aggregate_contours_without_vdim(self):
-        contours = Contours([[(0.2, 0.3), (0.4, 0.7)], [(0.4, 0.7), (0.8, 0.99)]])
+        contours = hv.Contours([[(0.2, 0.3), (0.4, 0.7)], [(0.4, 0.7), (0.8, 0.99)]])
         img = rasterize(contours, dynamic=False)
-        assert img.vdims == [Dimension('Any', nodata=0)]
+        assert img.vdims == [hv.Dimension('Any', nodata=0)]
 
     def test_aggregate_dframe_nan_path(self):
-        path = Path([Path([[(0.2, 0.3), (0.4, 0.7)], [(0.4, 0.7), (0.8, 0.99)]]).dframe()])
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 1]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        path = hv.Path([hv.Path([[(0.2, 0.3), (0.4, 0.7)], [(0.4, 0.7), (0.8, 0.99)]]).dframe()])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 1]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         img = aggregate(path, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
         assert_element_equal(img, expected)
 
     def test_spikes_aggregate_count(self):
-        spikes = Spikes([1, 2, 3])
+        spikes = hv.Spikes([1, 2, 3])
         agg = rasterize(spikes, width=5, dynamic=False, expand=False)
-        expected = Image(np.array([[1, 0, 1, 0, 1]]), vdims=Dimension('Count', nodata=0),
+        expected = hv.Image(np.array([[1, 0, 1, 0, 1]]), vdims=hv.Dimension('Count', nodata=0),
                          xdensity=2.5, ydensity=1, bounds=(1, 0, 3, 0.5))
         assert_element_equal(agg, expected)
 
     def test_spikes_aggregate_count_dask(self):
-        spikes = Spikes([1, 2, 3], datatype=['dask'])
+        spikes = hv.Spikes([1, 2, 3], datatype=['dask'])
         agg = rasterize(spikes, width=5, dynamic=False, expand=False)
-        expected = Image(np.array([[1, 0, 1, 0, 1]]), vdims=Dimension('Count', nodata=0),
+        expected = hv.Image(np.array([[1, 0, 1, 0, 1]]), vdims=hv.Dimension('Count', nodata=0),
                          xdensity=2.5, ydensity=1, bounds=(1, 0, 3, 0.5))
         assert_element_equal(agg, expected)
 
     def test_spikes_aggregate_dt_count(self):
-        spikes = Spikes([dt.datetime(2016, 1, 1),  dt.datetime(2016, 1, 2), dt.datetime(2016, 1, 3)])
+        spikes = hv.Spikes([dt.datetime(2016, 1, 1),  dt.datetime(2016, 1, 2), dt.datetime(2016, 1, 3)])
         agg = rasterize(spikes, width=5, dynamic=False, expand=False)
         bounds = (np.datetime64('2016-01-01T00:00:00.000000'), 0,
                   np.datetime64('2016-01-03T00:00:00.000000'), 0.5)
-        expected = Image(np.array([[1, 0, 1, 0, 1]]), vdims=Dimension('Count', nodata=0), bounds=bounds)
+        expected = hv.Image(np.array([[1, 0, 1, 0, 1]]), vdims=hv.Dimension('Count', nodata=0), bounds=bounds)
         assert_element_equal(agg, expected)
 
     def test_spikes_aggregate_dt_count_dask(self):
-        spikes = Spikes([dt.datetime(2016, 1, 1),  dt.datetime(2016, 1, 2), dt.datetime(2016, 1, 3)],
+        spikes = hv.Spikes([dt.datetime(2016, 1, 1),  dt.datetime(2016, 1, 2), dt.datetime(2016, 1, 3)],
                         datatype=['dask'])
         agg = rasterize(spikes, width=5, dynamic=False, expand=False)
         bounds = (np.datetime64('2016-01-01T00:00:00.000000'), 0,
                   np.datetime64('2016-01-03T00:00:00.000000'), 0.5)
-        expected = Image(np.array([[1, 0, 1, 0, 1]]), vdims=Dimension('Count', nodata=0), bounds=bounds)
+        expected = hv.Image(np.array([[1, 0, 1, 0, 1]]), vdims=hv.Dimension('Count', nodata=0), bounds=bounds)
         assert_element_equal(agg, expected)
 
     def test_spikes_aggregate_spike_length(self):
-        spikes = Spikes([1, 2, 3])
+        spikes = hv.Spikes([1, 2, 3])
         agg = rasterize(spikes, width=5, dynamic=False, expand=False, spike_length=7)
-        expected = Image(np.array([[1, 0, 1, 0, 1]]), vdims=Dimension('Count', nodata=0),
+        expected = hv.Image(np.array([[1, 0, 1, 0, 1]]), vdims=hv.Dimension('Count', nodata=0),
                          xdensity=2.5, ydensity=1, bounds=(1, 0, 3, 7.0))
         assert_element_equal(agg, expected)
 
     def test_spikes_aggregate_with_height_count(self):
-        spikes = Spikes([(1, 0.2), (2, 0.8), (3, 0.4)], vdims='y')
+        spikes = hv.Spikes([(1, 0.2), (2, 0.8), (3, 0.4)], vdims='y')
         agg = rasterize(spikes, width=5, height=5, y_range=(0, 1), dynamic=False)
         xs = [1.2, 1.6, 2.0, 2.4, 2.8]
         ys = [0.1, 0.3, 0.5, 0.7, 0.9]
@@ -388,11 +363,11 @@ class DatashaderAggregateTests:
             [0, 0, 1, 0, 0],
             [0, 0, 1, 0, 0]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_spikes_aggregate_with_height_count_override(self):
-        spikes = Spikes([(1, 0.2), (2, 0.8), (3, 0.4)], vdims='y')
+        spikes = hv.Spikes([(1, 0.2), (2, 0.8), (3, 0.4)], vdims='y')
         agg = rasterize(spikes, width=5, height=5, y_range=(0, 1),
                         spike_length=0.3, dynamic=False)
         xs = [1.2, 1.6, 2.0, 2.4, 2.8]
@@ -402,14 +377,14 @@ class DatashaderAggregateTests:
                         [0, 0, 0, 0, 0],
                         [0, 0, 0, 0, 0],
                         [0, 0, 0, 0, 0]])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_rasterize_regrid_and_spikes_overlay(self):
-        img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
-        spikes = Spikes([(0.5, 0.2), (1.5, 0.8), ], vdims='y')
+        img = hv.Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
+        spikes = hv.Spikes([(0.5, 0.2), (1.5, 0.8), ], vdims='y')
 
-        expected_regrid = Image(([0.25, 0.75, 1.25, 1.75],
+        expected_regrid = hv.Image(([0.25, 0.75, 1.25, 1.75],
                                  [0.25, 0.75, 1.25, 1.75],
                                  [[0, 0, 1, 1],
                                   [0, 0, 1, 1],
@@ -419,8 +394,8 @@ class DatashaderAggregateTests:
                                [0, 1, 0, 1],
                                [0, 0, 0, 0],
                                [0, 0, 0, 0]])
-        expected_spikes = Image(([0.25, 0.75, 1.25, 1.75],
-                                 [0.25, 0.75, 1.25, 1.75], spikes_arr), vdims=Dimension('Count', nodata=0))
+        expected_spikes = hv.Image(([0.25, 0.75, 1.25, 1.75],
+                                 [0.25, 0.75, 1.25, 1.75], spikes_arr), vdims=hv.Dimension('Count', nodata=0))
         overlay = img * spikes
         agg = rasterize(overlay, width=4, height=4, x_range=(0, 2), y_range=(0, 2),
                         spike_length=0.5, upsample=True, dynamic=False)
@@ -429,7 +404,7 @@ class DatashaderAggregateTests:
 
 
     def test_spikes_aggregate_with_height_count_dask(self):
-        spikes = Spikes([(1, 0.2), (2, 0.8), (3, 0.4)], vdims='y', datatype=['dask'])
+        spikes = hv.Spikes([(1, 0.2), (2, 0.8), (3, 0.4)], vdims='y', datatype=['dask'])
         agg = rasterize(spikes, width=5, height=5, y_range=(0, 1), dynamic=False)
         xs = [1.2, 1.6, 2.0, 2.4, 2.8]
         ys = [0.1, 0.3, 0.5, 0.7, 0.9]
@@ -440,11 +415,11 @@ class DatashaderAggregateTests:
             [0, 0, 1, 0, 0],
             [0, 0, 1, 0, 0]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_spikes_aggregate_with_negative_height_count(self):
-        spikes = Spikes([(1, -0.2), (2, -0.8), (3, -0.4)], vdims='y', datatype=['dask'])
+        spikes = hv.Spikes([(1, -0.2), (2, -0.8), (3, -0.4)], vdims='y', datatype=['dask'])
         agg = rasterize(spikes, width=5, height=5, y_range=(-1, 0), dynamic=False)
         xs = [1.2, 1.6, 2.0, 2.4, 2.8]
         ys = [-0.9, -0.7, -0.5, -0.3, -0.1]
@@ -455,11 +430,11 @@ class DatashaderAggregateTests:
             [0, 0, 1, 0, 1],
             [1, 0, 1, 0, 1]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_spikes_aggregate_with_positive_and_negative_height_count(self):
-        spikes = Spikes([(1, -0.2), (2, 0.8), (3, -0.4)], vdims='y', datatype=['dask'])
+        spikes = hv.Spikes([(1, -0.2), (2, 0.8), (3, -0.4)], vdims='y', datatype=['dask'])
         agg = rasterize(spikes, width=5, height=5, y_range=(-1, 1), dynamic=False)
         xs = [1.2, 1.6, 2.0, 2.4, 2.8]
         ys = [-0.8, -0.4, 0.0, 0.4, 0.8]
@@ -470,11 +445,11 @@ class DatashaderAggregateTests:
             [0, 0, 1, 0, 0],
             [0, 0, 1, 0, 0]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_rectangles_aggregate_count(self):
-        rects = Rectangles([(0, 0, 1, 2), (1, 1, 3, 2)])
+        rects = hv.Rectangles([(0, 0, 1, 2), (1, 1, 3, 2)])
         agg = rasterize(rects, width=4, height=4, dynamic=False)
         xs = [0.375, 1.125, 1.875, 2.625]
         ys = [0.25, 0.75, 1.25, 1.75]
@@ -484,11 +459,11 @@ class DatashaderAggregateTests:
             [1, 2, 1, 1],
             [0, 0, 0, 0]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_rectangles_aggregate_count_cat(self):
-        rects = Rectangles([(0, 0, 1, 2, 'A'), (1, 1, 3, 2, 'B')], vdims=['cat'])
+        rects = hv.Rectangles([(0, 0, 1, 2, 'A'), (1, 1, 3, 2, 'B')], vdims=['cat'])
         agg = rasterize(rects, width=4, height=4, aggregator=ds.count_cat('cat'),
                         dynamic=False)
         xs = [0.375, 1.125, 1.875, 2.625]
@@ -511,11 +486,11 @@ class DatashaderAggregateTests:
             coords={'x': xs, 'y': ys, 'cat': ['A', 'B']},
             dims=['x', 'y', 'cat']
         )
-        expected = ImageStack(xrda, kdims=['x', 'y'], vdims=['A', 'B'])
+        expected = hv.ImageStack(xrda, kdims=['x', 'y'], vdims=['A', 'B'])
         assert_element_equal(agg, expected)
 
     def test_rectangles_aggregate_sum(self):
-        rects = Rectangles([(0, 0, 1, 2, 0.5), (1, 1, 3, 2, 1.5)], vdims=['value'])
+        rects = hv.Rectangles([(0, 0, 1, 2, 0.5), (1, 1, 3, 2, 1.5)], vdims=['value'])
         agg = rasterize(rects, width=4, height=4, aggregator='sum', dynamic=False)
         xs = [0.375, 1.125, 1.875, 2.625]
         ys = [0.25, 0.75, 1.25, 1.75]
@@ -525,11 +500,11 @@ class DatashaderAggregateTests:
             [0.5, 2. , 1.5, 1.5],
             [np.nan, np.nan, np.nan, np.nan]
         ])
-        expected = Image((xs, ys, arr), vdims='value')
+        expected = hv.Image((xs, ys, arr), vdims='value')
         assert_element_equal(agg, expected)
 
     def test_rectangles_aggregate_dt_count(self):
-        rects = Rectangles([
+        rects = hv.Rectangles([
             (0, dt.datetime(2016, 1, 2), 4, dt.datetime(2016, 1, 3)),
             (1, dt.datetime(2016, 1, 1), 2, dt.datetime(2016, 1, 5))
         ])
@@ -547,11 +522,11 @@ class DatashaderAggregateTests:
         ])
         bounds = (0.0, np.datetime64('2016-01-01T00:00:00'),
                   4.0, np.datetime64('2016-01-05T00:00:00'))
-        expected = Image((xs, ys, arr), bounds=bounds, vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), bounds=bounds, vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_segments_aggregate_count(self):
-        segments = Segments([(0, 1, 4, 1), (1, 0, 1, 4)])
+        segments = hv.Segments([(0, 1, 4, 1), (1, 0, 1, 4)])
         agg = rasterize(segments, width=4, height=4, dynamic=False)
         xs = [0.5, 1.5, 2.5, 3.5]
         ys = [0.5, 1.5, 2.5, 3.5]
@@ -561,11 +536,11 @@ class DatashaderAggregateTests:
             [0, 1, 0, 0],
             [0, 1, 0, 0]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_segments_aggregate_sum(self, instance=False):
-        segments = Segments([(0, 1, 4, 1, 2), (1, 0, 1, 4, 4)], vdims=['value'])
+        segments = hv.Segments([(0, 1, 4, 1, 2), (1, 0, 1, 4, 4)], vdims=['value'])
         if instance:
             agg = rasterize.instance(
                 width=10, height=10, dynamic=False, aggregator='sum'
@@ -583,14 +558,14 @@ class DatashaderAggregateTests:
             [na, 4, na, na],
             [na, 4, na, na]
         ])
-        expected = Image((xs, ys, arr), vdims='value')
+        expected = hv.Image((xs, ys, arr), vdims='value')
         assert_element_equal(agg, expected)
 
     def test_segments_aggregate_sum_instance(self):
         self.test_segments_aggregate_sum(instance=True)
 
     def test_segments_aggregate_dt_count(self):
-        segments = Segments([
+        segments = hv.Segments([
             (0, dt.datetime(2016, 1, 2), 4, dt.datetime(2016, 1, 2)),
             (1, dt.datetime(2016, 1, 1), 1, dt.datetime(2016, 1, 5))
         ])
@@ -608,11 +583,11 @@ class DatashaderAggregateTests:
         ])
         bounds = (0.0, np.datetime64('2016-01-01T00:00:00'),
                   4.0, np.datetime64('2016-01-05T00:00:00'))
-        expected = Image((xs, ys, arr), bounds=bounds, vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), bounds=bounds, vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_area_aggregate_simple_count(self):
-        area = Area([1, 2, 1])
+        area = hv.Area([1, 2, 1])
         agg = rasterize(area, width=4, height=4, y_range=(0, 3), dynamic=False)
         xs = [0.25, 0.75, 1.25, 1.75]
         ys = [0.375, 1.125, 1.875, 2.625]
@@ -622,11 +597,11 @@ class DatashaderAggregateTests:
             [0, 1, 1, 0],
             [0, 0, 0, 0]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_area_aggregate_negative_count(self):
-        area = Area([-1, -2, -3])
+        area = hv.Area([-1, -2, -3])
         agg = rasterize(area, width=4, height=4, y_range=(-3, 0), dynamic=False)
         xs = [0.25, 0.75, 1.25, 1.75]
         ys = [-2.625, -1.875, -1.125, -0.375]
@@ -636,11 +611,11 @@ class DatashaderAggregateTests:
             [1, 1, 1, 1],
             [1, 1, 1, 1]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_area_aggregate_crossover_count(self):
-        area = Area([-1, 2, 3])
+        area = hv.Area([-1, 2, 3])
         agg = rasterize(area, width=4, height=4, y_range=(-3, 3), dynamic=False)
         xs = [0.25, 0.75, 1.25, 1.75]
         ys = [-2.25, -0.75, 0.75, 2.25]
@@ -650,11 +625,11 @@ class DatashaderAggregateTests:
             [1, 1, 1, 1],
             [0, 0, 1, 1]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_spread_aggregate_symmetric_count(self):
-        spread = Spread([(0, 1, 0.8), (1, 2, 0.3), (2, 3, 0.8)])
+        spread = hv.Spread([(0, 1, 0.8), (1, 2, 0.3), (2, 3, 0.8)])
         agg = rasterize(spread, width=4, height=4, dynamic=False)
         xs = [0.25, 0.75, 1.25, 1.75]
         ys = [0.65, 1.55, 2.45, 3.35]
@@ -664,11 +639,11 @@ class DatashaderAggregateTests:
             [0, 1, 1, 0],
             [0, 0, 0, 1]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_spread_aggregate_asymmetric_count(self):
-        spread = Spread([(0, 1, 0.4, 0.8), (1, 2, 0.8, 0.4), (2, 3, 0.5, 1)],
+        spread = hv.Spread([(0, 1, 0.4, 0.8), (1, 2, 0.8, 0.4), (2, 3, 0.5, 1)],
                         vdims=['y', 'pos', 'neg'])
         agg = rasterize(spread, width=4, height=4, dynamic=False)
         xs = [0.25, 0.75, 1.25, 1.75]
@@ -679,7 +654,7 @@ class DatashaderAggregateTests:
             [0, 1, 1, 0],
             [0, 0, 1, 1]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     def test_rgb_regrid_packed(self):
@@ -693,7 +668,7 @@ class DatashaderAggregateTests:
              [  0, 68]],
         ]).T
         da = xr.DataArray(data=arr, dims=('x', 'y', 'band'), coords=coords)
-        im = RGB(da, ['x', 'y'])
+        im = hv.RGB(da, ['x', 'y'])
         agg = rasterize(im, width=3, height=3, dynamic=False, upsample=True)
         xs = [0.8333333, 1.5, 2.166666]
         ys = [0.8333333, 1.5, 2.166666]
@@ -708,12 +683,12 @@ class DatashaderAggregateTests:
              [127, 127,  0],
              [  0,   0, 68]],
         ]).transpose((1, 2, 0))
-        expected = RGB((xs, ys, arr))
+        expected = hv.RGB((xs, ys, arr))
         assert_element_equal(agg, expected)
 
     @spd_skip
     def test_line_rasterize(self):
-        path = Path([[(0, 0), (1, 1), (2, 0)], [(0, 0), (0, 1)]], datatype=['spatialpandas'])
+        path = hv.Path([[(0, 0), (1, 1), (2, 0)], [(0, 0), (0, 1)]], datatype=['spatialpandas'])
         agg = rasterize(path, width=4, height=4, dynamic=False)
         xs = [0.25, 0.75, 1.25, 1.75]
         ys = [0.125, 0.375, 0.625, 0.875]
@@ -723,12 +698,12 @@ class DatashaderAggregateTests:
             [1, 1, 1, 0],
             [1, 0, 1, 0]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     @spd_skip
     def test_multi_line_rasterize(self):
-        path = Path([{'x': [0, 1, 2, np.nan, 0, 0], 'y': [0, 1, 0, np.nan, 0, 1]}],
+        path = hv.Path([{'x': [0, 1, 2, np.nan, 0, 0], 'y': [0, 1, 0, np.nan, 0, 1]}],
                     datatype=['spatialpandas'])
         agg = rasterize(path, width=4, height=4, dynamic=False)
         xs = [0.25, 0.75, 1.25, 1.75]
@@ -739,12 +714,12 @@ class DatashaderAggregateTests:
             [1, 1, 1, 0],
             [1, 0, 1, 0]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     @spd_skip
     def test_ring_rasterize(self):
-        path = Path([{'x': [0, 1, 2], 'y': [0, 1, 0], 'geom_type': 'Ring'}], datatype=['spatialpandas'])
+        path = hv.Path([{'x': [0, 1, 2], 'y': [0, 1, 0], 'geom_type': 'Ring'}], datatype=['spatialpandas'])
         agg = rasterize(path, width=4, height=4, dynamic=False)
         xs = [0.25, 0.75, 1.25, 1.75]
         ys = [0.125, 0.375, 0.625, 0.875]
@@ -754,12 +729,12 @@ class DatashaderAggregateTests:
             [0, 1, 1, 0],
             [0, 0, 1, 0]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     @spd_skip
     def test_polygon_rasterize(self):
-        poly = Polygons([
+        poly = hv.Polygons([
             {'x': [0, 1, 2], 'y': [0, 1, 0],
              'holes': [[[(1.6, 0.2), (1, 0.8), (0.4, 0.2)]]]}
         ])
@@ -774,12 +749,12 @@ class DatashaderAggregateTests:
             [0, 0, 1, 1, 0, 0],
             [0, 0, 0, 0, 0, 0]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
     @spd_skip
     def test_polygon_rasterize_mean_agg(self):
-        poly = Polygons([
+        poly = hv.Polygons([
             {'x': [0, 1, 2], 'y': [0, 1, 0], 'z': 2.4},
             {'x': [0, 0, 1], 'y': [0, 1, 1], 'z': 3.6}
         ], vdims='z')
@@ -791,12 +766,12 @@ class DatashaderAggregateTests:
             [ 3.6,  2.4,  2.4,    np.nan],
             [ 3.6,  2.4,  2.4,    np.nan],
             [ 3.6,  3.6,  np.nan, np.nan]])
-        expected = Image((xs, ys, arr), vdims='z')
+        expected = hv.Image((xs, ys, arr), vdims='z')
         assert_element_equal(agg, expected)
 
     @spd_skip
     def test_multi_poly_rasterize(self):
-        poly = Polygons([{'x': [0, 1, 2, np.nan, 0, 0, 1],
+        poly = hv.Polygons([{'x': [0, 1, 2, np.nan, 0, 0, 1],
                           'y': [0, 1, 0, np.nan, 0, 1, 1]}],
                         datatype=['spatialpandas'])
         agg = rasterize(poly, width=4, height=4, dynamic=False)
@@ -808,7 +783,7 @@ class DatashaderAggregateTests:
             [1, 1, 1, 0],
             [1, 1, 0, 0]
         ])
-        expected = Image((xs, ys, arr), vdims=Dimension('Count', nodata=0))
+        expected = hv.Image((xs, ys, arr), vdims=hv.Dimension('Count', nodata=0))
         assert_element_equal(agg, expected)
 
 
@@ -820,7 +795,7 @@ class DatashaderCatAggregateTests:
             pytest.skip('Regridding operations require datashader>=0.11.0')
 
     def test_aggregate_points_categorical(self):
-        points = Points([(0.2, 0.3, 'A'), (0.4, 0.7, 'B'), (0, 0.99, 'C')], vdims='z')
+        points = hv.Points([(0.2, 0.3, 'A'), (0.4, 0.7, 'B'), (0, 0.99, 'C')], vdims='z')
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2, aggregator=ds.by('z', ds.count()))
         x = np.array([0.25, 0.75])
@@ -832,12 +807,12 @@ class DatashaderCatAggregateTests:
             coords={"x": x, "y": y},
             data_vars={"a": (("x", "y"), a), "b": (("x", "y"), b), "c": (("x", "y"), c)},
         )
-        expected = ImageStack(xrds, kdims=["x", "y"], vdims=["a", "b", "c"])
+        expected = hv.ImageStack(xrds, kdims=["x", "y"], vdims=["a", "b", "c"])
         actual = img.data
         assert (expected.data.to_array("z").values == actual.T.values).all()
 
     def test_aggregate_points_categorical_one_category(self):
-        points = Points([(0.2, 0.3, 'A'), (0.4, 0.7, 'A'), (0, 0.99, 'A')], vdims='z')
+        points = hv.Points([(0.2, 0.3, 'A'), (0.4, 0.7, 'A'), (0, 0.99, 'A')], vdims='z')
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2, aggregator=ds.by('z', ds.count()))
         x = np.array([0.25, 0.75])
@@ -848,12 +823,12 @@ class DatashaderCatAggregateTests:
             dims=('x', 'y'),
             coords={"x": x, "y": y}
         )
-        expected = ImageStack(xrds, kdims=["x", "y"], vdims=["a"])
+        expected = hv.ImageStack(xrds, kdims=["x", "y"], vdims=["a"])
         actual = img.data
         assert (expected.data.to_array("z").values == actual.T.values).all()
 
     def test_aggregate_points_categorical_mean(self):
-        points = Points([(0.2, 0.3, 'A', 0.1), (0.4, 0.7, 'B', 0.2), (0, 0.99, 'C', 0.3)], vdims=['cat', 'z'])
+        points = hv.Points([(0.2, 0.3, 'A', 0.1), (0.4, 0.7, 'B', 0.2), (0, 0.99, 'C', 0.3)], vdims=['cat', 'z'])
         img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2, aggregator=ds.by('cat', ds.mean('z')))
         x = np.array([0.25, 0.75])
@@ -865,7 +840,7 @@ class DatashaderCatAggregateTests:
             coords={"x": x, "y": y},
             data_vars={"a": (("x", "y"), a), "b": (("x", "y"), b), "c": (("x", "y"), c)},
         )
-        expected = ImageStack(xrds, kdims=["x", "y"], vdims=["a", "b", "c"])
+        expected = hv.ImageStack(xrds, kdims=["x", "y"], vdims=["a", "b", "c"])
         actual = img.data
         np.testing.assert_equal(expected.data.to_array("z").values, actual.T.values)
 
@@ -874,49 +849,49 @@ class DatashaderShadeTests:
 
     def test_shade_categorical_images_xarray(self):
         xs, ys = [0.25, 0.75], [0.25, 0.75]
-        data = NdOverlay({'A': Image((xs, ys, np.array([[1, 0], [0, 0]], dtype='u4')),
-                                     datatype=['xarray'], vdims=Dimension('z Count', nodata=0)),
-                          'B': Image((xs, ys, np.array([[0, 0], [1, 0]], dtype='u4')),
-                                     datatype=['xarray'], vdims=Dimension('z Count', nodata=0)),
-                          'C': Image((xs, ys, np.array([[0, 0], [1, 0]], dtype='u4')),
-                                     datatype=['xarray'], vdims=Dimension('z Count', nodata=0))},
+        data = hv.NdOverlay({'A': hv.Image((xs, ys, np.array([[1, 0], [0, 0]], dtype='u4')),
+                                     datatype=['xarray'], vdims=hv.Dimension('z Count', nodata=0)),
+                          'B': hv.Image((xs, ys, np.array([[0, 0], [1, 0]], dtype='u4')),
+                                     datatype=['xarray'], vdims=hv.Dimension('z Count', nodata=0)),
+                          'C': hv.Image((xs, ys, np.array([[0, 0], [1, 0]], dtype='u4')),
+                                     datatype=['xarray'], vdims=hv.Dimension('z Count', nodata=0))},
                          kdims=['z'])
         shaded = shade(data, rescale_discrete_levels=False)
         r = [[228, 0], [66, 0]]
         g = [[26, 0], [150, 0]]
         b = [[28, 0], [129, 0]]
         a = [[40, 0], [255, 0]]
-        expected = RGB((xs, ys, r, g, b, a), datatype=['grid'],
-                       vdims=[*RGB.vdims, Dimension('A', range=(0, 1))])
+        expected = hv.RGB((xs, ys, r, g, b, a), datatype=['grid'],
+                       vdims=[*hv.RGB.vdims, hv.Dimension('A', range=(0, 1))])
         assert_element_equal(shaded, expected)
 
     def test_shade_categorical_images_grid(self):
         xs, ys = [0.25, 0.75], [0.25, 0.75]
-        data = NdOverlay({'A': Image((xs, ys, np.array([[1, 0], [0, 0]], dtype='u4')),
-                                     datatype=['grid'], vdims=Dimension('z Count', nodata=0)),
-                          'B': Image((xs, ys, np.array([[0, 0], [1, 0]], dtype='u4')),
-                                     datatype=['grid'], vdims=Dimension('z Count', nodata=0)),
-                          'C': Image((xs, ys, np.array([[0, 0], [1, 0]], dtype='u4')),
-                                     datatype=['grid'], vdims=Dimension('z Count', nodata=0))},
+        data = hv.NdOverlay({'A': hv.Image((xs, ys, np.array([[1, 0], [0, 0]], dtype='u4')),
+                                     datatype=['grid'], vdims=hv.Dimension('z Count', nodata=0)),
+                          'B': hv.Image((xs, ys, np.array([[0, 0], [1, 0]], dtype='u4')),
+                                     datatype=['grid'], vdims=hv.Dimension('z Count', nodata=0)),
+                          'C': hv.Image((xs, ys, np.array([[0, 0], [1, 0]], dtype='u4')),
+                                     datatype=['grid'], vdims=hv.Dimension('z Count', nodata=0))},
                          kdims=['z'])
         shaded = shade(data, rescale_discrete_levels=False)
         r = [[228, 0], [66, 0]]
         g = [[26, 0], [150, 0]]
         b = [[28, 0], [129, 0]]
         a = [[40, 0], [255, 0]]
-        expected = RGB((xs, ys, r, g, b, a), datatype=['grid'],
-                       vdims=[*RGB.vdims, Dimension('A', range=(0, 1))])
+        expected = hv.RGB((xs, ys, r, g, b, a), datatype=['grid'],
+                       vdims=[*hv.RGB.vdims, hv.Dimension('A', range=(0, 1))])
         assert_element_equal(shaded, expected)
 
     def test_shade_dt_xaxis_constant_yaxis(self):
         df = pd.DataFrame({'y': np.ones(100)}, index=pd.date_range('1980-01-01', periods=100, freq='1min'))
-        rgb = shade(rasterize(Curve(df), dynamic=False, width=3))
+        rgb = shade(rasterize(hv.Curve(df), dynamic=False, width=3))
         xs = np.array(['1980-01-01T00:16:30.000000', '1980-01-01T00:49:30.000000',
                        '1980-01-01T01:22:30.000000'], dtype='datetime64[us]')
         ys = np.array([])
         bounds = (np.datetime64('1980-01-01T00:00:00.000000'), 1.0,
                   np.datetime64('1980-01-01T01:39:00.000000'), 1.0)
-        expected = RGB((xs, ys, np.empty((0, 3, 4))), ['index', 'y'],
+        expected = hv.RGB((xs, ys, np.empty((0, 3, 4))), ['index', 'y'],
                        xdensity=1, ydensity=1, bounds=bounds)
         assert_element_equal(rgb, expected)
 
@@ -928,37 +903,37 @@ class DatashaderRegridTests:
     """
 
     def test_regrid_mean(self):
-        img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
+        img = hv.Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
         regridded = regrid(img, width=2, height=2, dynamic=False)
-        expected = Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
+        expected = hv.Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
         assert_element_equal(regridded, expected)
 
     def test_regrid_mean_xarray_transposed(self):
-        img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T),
+        img = hv.Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T),
                     datatype=['xarray'])
         img.data = img.data.transpose()
         regridded = regrid(img, width=2, height=2, dynamic=False)
-        expected = Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
+        expected = hv.Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
         assert_element_equal(regridded, expected)
 
     def test_regrid_rgb_mean(self):
         arr = (np.arange(10) * np.arange(5)[np.newaxis].T).astype('float64')
-        rgb = RGB((range(10), range(5), arr, arr*2, arr*2))
+        rgb = hv.RGB((range(10), range(5), arr, arr*2, arr*2))
         regridded = regrid(rgb, width=2, height=2, dynamic=False)
         new_arr = np.array([[1.6, 5.6], [6.4, 22.4]])
-        expected = RGB(([2., 7.], [0.75, 3.25], new_arr, new_arr*2, new_arr*2), datatype=['xarray'])
+        expected = hv.RGB(([2., 7.], [0.75, 3.25], new_arr, new_arr*2, new_arr*2), datatype=['xarray'])
         assert_element_equal(regridded, expected)
 
     def test_regrid_max(self):
-        img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
+        img = hv.Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
         regridded = regrid(img, aggregator='max', width=2, height=2, dynamic=False)
-        expected = Image(([2., 7.], [0.75, 3.25], [[8, 18], [16, 36]]))
+        expected = hv.Image(([2., 7.], [0.75, 3.25], [[8, 18], [16, 36]]))
         assert_element_equal(regridded, expected)
 
     def test_regrid_upsampling(self):
-        img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
+        img = hv.Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
         regridded = regrid(img, width=4, height=4, upsample=True, dynamic=False)
-        expected = Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
+        expected = hv.Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
                           [[0, 0, 1, 1],
                            [0, 0, 1, 1],
                            [2, 2, 3, 3],
@@ -966,9 +941,9 @@ class DatashaderRegridTests:
         assert_element_equal(regridded, expected)
 
     def test_regrid_upsampling_linear(self):
-        img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
+        img = hv.Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
         regridded = regrid(img, width=4, height=4, upsample=True, interpolation='linear', dynamic=False)
-        expected = Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
+        expected = hv.Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
                           [[0, 0, 0, 1],
                            [0, 1, 1, 1],
                            [1, 1, 2, 2],
@@ -976,12 +951,12 @@ class DatashaderRegridTests:
         assert_element_equal(regridded, expected)
 
     def test_regrid_disabled_upsampling(self):
-        img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
+        img = hv.Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
         regridded = regrid(img, width=3, height=3, dynamic=False, upsample=False)
         assert_element_equal(regridded, img)
 
     def test_regrid_disabled_expand(self):
-        img = Image(([0.5, 1.5], [0.5, 1.5], [[0., 1.], [2., 3.]]))
+        img = hv.Image(([0.5, 1.5], [0.5, 1.5], [[0., 1.], [2., 3.]]))
         regridded = regrid(img, width=2, height=2, x_range=(-2, 4), y_range=(-2, 4), expand=False,
                            dynamic=False)
         assert_element_equal(regridded, img)
@@ -989,18 +964,18 @@ class DatashaderRegridTests:
     def test_regrid_zero_range(self):
         ls = np.linspace(0, 10, 200)
         xx, yy = np.meshgrid(ls, ls)
-        img = Image(np.sin(xx)*np.cos(yy), bounds=(0, 0, 1, 1))
+        img = hv.Image(np.sin(xx)*np.cos(yy), bounds=(0, 0, 1, 1))
         regridded = regrid(img, x_range=(-1, -0.5), y_range=(-1, -0.5), dynamic=False)
-        expected = Image(np.zeros((0, 0)), bounds=(0, 0, 0, 0), xdensity=1, ydensity=1)
+        expected = hv.Image(np.zeros((0, 0)), bounds=(0, 0, 0, 0), xdensity=1, ydensity=1)
         assert_element_equal(regridded, expected)
 
 
 # None, False, and 'nearest' are expected to return the same Image values
 @pytest.mark.parametrize("interpolation", [None, False, "nearest"])
 def test_regrid_interpolation_nearest(interpolation):
-    img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
+    img = hv.Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
     regridded = regrid(img, width=4, height=4, upsample=True, interpolation=interpolation, dynamic=False)
-    expected = Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
+    expected = hv.Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
                       [[0, 0, 1, 1],
                        [0, 0, 1, 1],
                        [2, 2, 3, 3],
@@ -1011,9 +986,9 @@ def test_regrid_interpolation_nearest(interpolation):
 # 'bilinear' and 'linear' expected to return the same Image values
 @pytest.mark.parametrize("interpolation", ["linear", "bilinear"])
 def test_regrid_interpolation_linear(interpolation):
-    img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
+    img = hv.Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
     regridded = regrid(img, width=4, height=4, upsample=True, interpolation=interpolation, dynamic=False)
-    expected = Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
+    expected = hv.Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
                       [[0, 0, 0, 1],
                        [0, 1, 1, 1],
                        [1, 1, 2, 2],
@@ -1023,9 +998,9 @@ def test_regrid_interpolation_linear(interpolation):
 
 @pytest.mark.parametrize("interpolation", [False, None])
 def test_datashade_interpolation(interpolation):
-    img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
+    img = hv.Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
     shaded = datashade(img, interpolation=interpolation, dynamic=False, width=4, height=4)
-    assert isinstance(shaded, RGB)
+    assert isinstance(shaded, hv.RGB)
 
 
 class DatashaderRasterizeTests:
@@ -1043,46 +1018,46 @@ class DatashaderRasterizeTests:
         self.vertices_vdim = [(0., 0., 1), (0., 1., 2), (1., 0, 3), (1, 1, 4)]
 
     def test_rasterize_trimesh_no_vdims(self):
-        trimesh = TriMesh((self.simplexes, self.vertices))
+        trimesh = hv.TriMesh((self.simplexes, self.vertices))
         img = rasterize(trimesh, width=3, height=3, dynamic=False)
-        image = Image(np.array([[True, True, True], [True, True, True], [True, True, True]]),
-                      bounds=(0, 0, 1, 1), vdims=Dimension('Any', nodata=0))
+        image = hv.Image(np.array([[True, True, True], [True, True, True], [True, True, True]]),
+                      bounds=(0, 0, 1, 1), vdims=hv.Dimension('Any', nodata=0))
         assert_element_equal(img, image)
 
     def test_rasterize_trimesh_no_vdims_zero_range(self):
-        trimesh = TriMesh((self.simplexes, self.vertices))
+        trimesh = hv.TriMesh((self.simplexes, self.vertices))
         img = rasterize(trimesh, height=2, x_range=(0, 0), dynamic=False)
-        image = Image(([], [0.25, 0.75], np.zeros((2, 0))),
-                      bounds=(0, 0, 0, 1), xdensity=1, vdims=Dimension('Any', nodata=0))
+        image = hv.Image(([], [0.25, 0.75], np.zeros((2, 0))),
+                      bounds=(0, 0, 0, 1), xdensity=1, vdims=hv.Dimension('Any', nodata=0))
         assert_element_equal(img, image)
 
     def test_rasterize_trimesh_with_vdims_as_wireframe(self):
-        trimesh = TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
+        trimesh = hv.TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
         img = rasterize(trimesh, width=3, height=3, aggregator='any', interpolation=None, dynamic=False)
         array = np.array([
             [True, True, True],
             [True, True, True],
             [True, True, True]
         ])
-        image = Image(array, bounds=(0, 0, 1, 1), vdims=Dimension('Any', nodata=0))
+        image = hv.Image(array, bounds=(0, 0, 1, 1), vdims=hv.Dimension('Any', nodata=0))
         assert_element_equal(img, image)
 
     def test_rasterize_trimesh(self):
-        trimesh = TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
+        trimesh = hv.TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
         img = rasterize(trimesh, width=3, height=3, dynamic=False)
         array = np.array([
             [0.5, 1.5, 1.5],
             [0.5, 0.5, 1.5],
             [0.5, 0.5, 0.5]
         ])
-        image = Image(array, bounds=(0, 0, 1, 1))
+        image = hv.Image(array, bounds=(0, 0, 1, 1))
         assert_element_equal(img, image)
 
     def test_rasterize_pandas_trimesh_implicit_nodes(self):
         simplex_df = pd.DataFrame(self.simplexes, columns=['v0', 'v1', 'v2'])
         vertex_df = pd.DataFrame(self.vertices_vdim, columns=['x', 'y', 'z'])
 
-        trimesh = TriMesh((simplex_df, vertex_df))
+        trimesh = hv.TriMesh((simplex_df, vertex_df))
         img = rasterize(trimesh, width=3, height=3, dynamic=False)
 
         array = np.array([
@@ -1090,7 +1065,7 @@ class DatashaderRasterizeTests:
             [1.833333, 2.5,      3.166667],
             [1.5,      2.166667, 2.833333]
         ])
-        image = Image(array, bounds=(0, 0, 1, 1))
+        image = hv.Image(array, bounds=(0, 0, 1, 1))
         assert_element_equal(img, image)
 
     def test_rasterize_dask_trimesh_implicit_nodes(self):
@@ -1100,7 +1075,7 @@ class DatashaderRasterizeTests:
         simplex_ddf = dd.from_pandas(simplex_df, npartitions=2)
         vertex_ddf = dd.from_pandas(vertex_df, npartitions=2)
 
-        trimesh = TriMesh((simplex_ddf, vertex_ddf))
+        trimesh = hv.TriMesh((simplex_ddf, vertex_ddf))
 
         ri = rasterize.instance()
         img = ri(trimesh, width=3, height=3, dynamic=False, precompute=True)
@@ -1115,7 +1090,7 @@ class DatashaderRasterizeTests:
             [1.833333, 2.5,      3.166667],
             [1.5,      2.166667, 2.833333]
         ])
-        image = Image(array, bounds=(0, 0, 1, 1))
+        image = hv.Image(array, bounds=(0, 0, 1, 1))
         assert_element_equal(img, image)
 
     def test_rasterize_dask_trimesh(self):
@@ -1125,8 +1100,8 @@ class DatashaderRasterizeTests:
         simplex_ddf = dd.from_pandas(simplex_df, npartitions=2)
         vertex_ddf = dd.from_pandas(vertex_df, npartitions=2)
 
-        tri_nodes = Nodes(vertex_ddf, ['x', 'y', 'index'])
-        trimesh = TriMesh((simplex_ddf, tri_nodes), vdims=['z'])
+        tri_nodes = hv.Nodes(vertex_ddf, ['x', 'y', 'index'])
+        trimesh = hv.TriMesh((simplex_ddf, tri_nodes), vdims=['z'])
 
         ri = rasterize.instance()
         img = ri(trimesh, width=3, height=3, dynamic=False, precompute=True)
@@ -1141,7 +1116,7 @@ class DatashaderRasterizeTests:
             [0.5, 0.5, 1.5],
             [0.5, 0.5, 0.5]
         ])
-        image = Image(array, bounds=(0, 0, 1, 1))
+        image = hv.Image(array, bounds=(0, 0, 1, 1))
         assert_element_equal(img, image)
 
     def test_rasterize_dask_trimesh_with_node_vdims(self):
@@ -1151,8 +1126,8 @@ class DatashaderRasterizeTests:
         simplex_ddf = dd.from_pandas(simplex_df, npartitions=2)
         vertex_ddf = dd.from_pandas(vertex_df, npartitions=2)
 
-        tri_nodes = Nodes(vertex_ddf, ['x', 'y', 'index'], ['z'])
-        trimesh = TriMesh((simplex_ddf, tri_nodes))
+        tri_nodes = hv.Nodes(vertex_ddf, ['x', 'y', 'index'], ['z'])
+        trimesh = hv.TriMesh((simplex_ddf, tri_nodes))
 
         ri = rasterize.instance()
         img = ri(trimesh, width=3, height=3, dynamic=False, precompute=True)
@@ -1167,12 +1142,12 @@ class DatashaderRasterizeTests:
             [1.833333, 2.5,      3.166667],
             [1.5,      2.166667, 2.833333]
         ])
-        image = Image(array, bounds=(0, 0, 1, 1))
+        image = hv.Image(array, bounds=(0, 0, 1, 1))
         assert_element_equal(img, image)
 
     def test_rasterize_trimesh_node_vdim_precedence(self):
-        nodes = Points(self.vertices_vdim, vdims=['node_z'])
-        trimesh = TriMesh((self.simplexes_vdim, nodes), vdims=['z'])
+        nodes = hv.Points(self.vertices_vdim, vdims=['node_z'])
+        trimesh = hv.TriMesh((self.simplexes_vdim, nodes), vdims=['z'])
         img = rasterize(trimesh, width=3, height=3, dynamic=False)
 
         array = np.array([
@@ -1180,12 +1155,12 @@ class DatashaderRasterizeTests:
             [1.833333, 2.5,      3.166667],
             [1.5,      2.166667, 2.833333]
         ])
-        image = Image(array, bounds=(0, 0, 1, 1), vdims='node_z')
+        image = hv.Image(array, bounds=(0, 0, 1, 1), vdims='node_z')
         assert_element_equal(img, image)
 
     def test_rasterize_trimesh_node_explicit_vdim(self):
-        nodes = Points(self.vertices_vdim, vdims=['node_z'])
-        trimesh = TriMesh((self.simplexes_vdim, nodes), vdims=['z'])
+        nodes = hv.Points(self.vertices_vdim, vdims=['node_z'])
+        trimesh = hv.TriMesh((self.simplexes_vdim, nodes), vdims=['z'])
         img = rasterize(trimesh, width=3, height=3, dynamic=False, aggregator=ds.mean('z'))
 
         array = np.array([
@@ -1193,20 +1168,20 @@ class DatashaderRasterizeTests:
             [0.5, 0.5, 1.5],
             [0.5, 0.5, 0.5]
         ])
-        image = Image(array, bounds=(0, 0, 1, 1))
+        image = hv.Image(array, bounds=(0, 0, 1, 1))
         assert_element_equal(img, image)
 
     def test_rasterize_trimesh_zero_range(self):
-        trimesh = TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
+        trimesh = hv.TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
         img = rasterize(trimesh, x_range=(0, 0), height=2, dynamic=False)
-        image = Image(([], [0.25, 0.75], np.zeros((2, 0))),
+        image = hv.Image(([], [0.25, 0.75], np.zeros((2, 0))),
                       bounds=(0, 0, 0, 1), xdensity=1)
         assert_element_equal(img, image)
 
     def test_rasterize_trimesh_vertex_vdims(self):
         simplices = [(0, 1, 2), (3, 2, 1)]
         vertices = [(0., 0., 1), (0., 1., 2), (1., 0., 3), (1., 1., 4)]
-        trimesh = TriMesh((simplices, Points(vertices, vdims='z')))
+        trimesh = hv.TriMesh((simplices, hv.Points(vertices, vdims='z')))
         img = rasterize(trimesh, width=3, height=3, dynamic=False)
 
         array = np.array([
@@ -1214,88 +1189,88 @@ class DatashaderRasterizeTests:
             [1.833333, 2.5,      3.166667],
             [1.5,      2.166667, 2.833333]
         ])
-        image = Image(array, bounds=(0, 0, 1, 1), vdims='z')
+        image = hv.Image(array, bounds=(0, 0, 1, 1), vdims='z')
         assert_element_equal(img, image)
 
     def test_rasterize_trimesh_ds_aggregator(self):
-        trimesh = TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
+        trimesh = hv.TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
         img = rasterize(trimesh, width=3, height=3, dynamic=False, aggregator=ds.mean('z'))
         array = np.array([
             [0.5, 1.5, 1.5],
             [0.5, 0.5, 1.5],
             [0.5, 0.5, 0.5]
         ])
-        image = Image(array, bounds=(0, 0, 1, 1))
+        image = hv.Image(array, bounds=(0, 0, 1, 1))
         assert_element_equal(img, image)
 
     def test_rasterize_trimesh_string_aggregator(self):
-        trimesh = TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
+        trimesh = hv.TriMesh((self.simplexes_vdim, self.vertices), vdims=['z'])
         img = rasterize(trimesh, width=3, height=3, dynamic=False, aggregator='mean')
         array = np.array([
             [0.5, 1.5, 1.5],
             [0.5, 0.5, 1.5],
             [0.5, 0.5, 0.5]
         ])
-        image = Image(array, bounds=(0, 0, 1, 1))
+        image = hv.Image(array, bounds=(0, 0, 1, 1))
         assert_element_equal(img, image)
 
     def test_rasterize_quadmesh(self):
-        qmesh = QuadMesh(([0, 1], [0, 1], np.array([[0, 1], [2, 3]])))
+        qmesh = hv.QuadMesh(([0, 1], [0, 1], np.array([[0, 1], [2, 3]])))
         img = rasterize(qmesh, width=3, height=3, dynamic=False, aggregator=ds.mean('z'))
-        image = Image(np.array([[2, 3, 3], [2, 3, 3], [0, 1, 1]]),
+        image = hv.Image(np.array([[2, 3, 3], [2, 3, 3], [0, 1, 1]]),
                       bounds=(-.5, -.5, 1.5, 1.5))
         assert_element_equal(img, image)
 
     def test_rasterize_quadmesh_string_aggregator(self):
-        qmesh = QuadMesh(([0, 1], [0, 1], np.array([[0, 1], [2, 3]])))
+        qmesh = hv.QuadMesh(([0, 1], [0, 1], np.array([[0, 1], [2, 3]])))
         img = rasterize(qmesh, width=3, height=3, dynamic=False, aggregator='mean')
-        image = Image(np.array([[2, 3, 3], [2, 3, 3], [0, 1, 1]]),
+        image = hv.Image(np.array([[2, 3, 3], [2, 3, 3], [0, 1, 1]]),
                       bounds=(-.5, -.5, 1.5, 1.5))
         assert_element_equal(img, image)
 
     def test_rasterize_points(self):
-        points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
+        points = hv.Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
         img = rasterize(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         assert_element_equal(img, expected)
 
     def test_rasterize_curve(self):
-        curve = Curve([(0.2, 0.3), (0.4, 0.7), (0.8, 0.99)])
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [1, 1]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        curve = hv.Curve([(0.2, 0.3), (0.4, 0.7), (0.8, 0.99)])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [1, 1]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         img = rasterize(curve, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
         assert_element_equal(img, expected)
 
     def test_rasterize_ndoverlay(self):
-        ds = Dataset([(0.2, 0.3, 0), (0.4, 0.7, 1), (0, 0.99, 2)], kdims=['x', 'y', 'z'])
-        ndoverlay = ds.to(Points, ['x', 'y'], [], 'z').overlay()
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        ds = hv.Dataset([(0.2, 0.3, 0), (0.4, 0.7, 1), (0, 0.99, 2)], kdims=['x', 'y', 'z'])
+        ndoverlay = ds.to(hv.Points, ['x', 'y'], [], 'z').overlay()
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         img = rasterize(ndoverlay, dynamic=False, x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
         assert_element_equal(img, expected)
 
     def test_rasterize_path(self):
-        path = Path([[(0.2, 0.3), (0.4, 0.7)], [(0.4, 0.7), (0.8, 0.99)]])
-        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 1]]),
-                         vdims=[Dimension('Count', nodata=0)])
+        path = hv.Path([[(0.2, 0.3), (0.4, 0.7)], [(0.4, 0.7), (0.8, 0.99)]])
+        expected = hv.Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 1]]),
+                         vdims=[hv.Dimension('Count', nodata=0)])
         img = rasterize(path, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
         assert_element_equal(img, expected)
 
     def test_rasterize_image(self):
-        img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
+        img = hv.Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
         regridded = regrid(img, width=2, height=2, dynamic=False)
-        expected = Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
+        expected = hv.Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
         assert_element_equal(regridded, expected)
 
     def test_rasterize_image_string_aggregator(self):
-        img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
+        img = hv.Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
         regridded = regrid(img, width=2, height=2, dynamic=False, aggregator='mean')
-        expected = Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
+        expected = hv.Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
         assert_element_equal(regridded, expected)
 
     def test_rasterize_image_expand_default(self):
@@ -1306,14 +1281,14 @@ class DatashaderRasterizeTests:
         c = np.arange(10.0)
         da = xr.DataArray(data, coords=dict(x=c, y=c))
         rast_input = dict(x_range=(-1, 10), y_range=(-1, 10), precompute=True, dynamic=False)
-        img = rasterize(Image(da), **rast_input)
+        img = rasterize(hv.Image(da), **rast_input)
         output = img.data["z"].to_numpy()
 
         np.testing.assert_array_equal(output, data.T)
         assert not np.isnan(output).any()
 
         # Setting expand=True with the {x,y}_ranges will expand the data with nan's
-        img = rasterize(Image(da), expand=True, **rast_input)
+        img = rasterize(hv.Image(da), expand=True, **rast_input)
         output = img.data["z"].to_numpy()
         assert np.isnan(output).any()
 
@@ -1324,17 +1299,17 @@ class DatashaderRasterizeTests:
         )
         df.columns = ["a", "b"]
 
-        curve = Curve(df, kdims=["a"], vdims=["b"])
+        curve = hv.Curve(df, kdims=["a"], vdims=["b"])
         # line_width is not a parameter
         custom_rasterize = rasterize.instance(line_width=2)
         assert {'line_width': 2} == custom_rasterize._rasterize__instance_kwargs
         output = apply_when(
             curve, operation=custom_rasterize, predicate=lambda x: len(x) > 10
         )
-        render(output, "bokeh")
-        assert isinstance(output, DynamicMap)
+        hv.render(output, "bokeh")
+        assert isinstance(output, hv.DynamicMap)
         overlay = output.items()[0][1]
-        assert isinstance(overlay, Overlay)
+        assert isinstance(overlay, hv.Overlay)
         assert len(overlay) == 2
 
     def test_rasterize_path_empty_string_as_cat_sep(self):
@@ -1345,7 +1320,7 @@ class DatashaderRasterizeTests:
             # Empty strings on the sep rows.
             'cat': ['a', 'a', '', 'b', 'b', ''],
         })
-        path = Path(df, ['x', 'y'])
+        path = hv.Path(df, ['x', 'y'])
         rasterized = rasterize(
             path, aggregator=ds.count_cat('cat'), dynamic=False,
             width=4, height=4, pixel_ratio=1,
@@ -1364,9 +1339,9 @@ class DatashaderRasterizeTests:
         # Test for https://github.com/holoviz/holoviews/issues/5127
         t = pd.date_range(start='2020-01-01 10:00', end='2020-01-01 12:00', freq='h', tz='Asia/Shanghai')
         d = pd.DataFrame({'t': t, 'y': [1, 2, 3]})
-        curve = Curve(d, kdims=['t'], vdims=['y'])
+        curve = hv.Curve(d, kdims=['t'], vdims=['y'])
         img = rasterize(curve, dynamic=False)
-        assert isinstance(img, Image)
+        assert isinstance(img, hv.Image)
 
 
 @pytest.mark.parametrize(('agg_input_fn', 'index_col'),
@@ -1426,7 +1401,7 @@ def test_selector_rasterize(point_plot, sel_fn):
 
     # Count is from the aggregator
     assert list(img.data) == ["Count", "__index__", "s", "val", "cat"]
-    assert list(img.vdims) == [Dimension("Count")]  # Only the dimension send to the frontend
+    assert list(img.vdims) == [hv.Dimension("Count")]  # Only the dimension send to the frontend
 
     # The output for the selector should be equal to the output for the aggregator using
     # ds.where
@@ -1454,8 +1429,8 @@ def test_selector_rasterize_empty_selector(point_plot, sel_fn):
 @pytest.mark.usefixtures("bokeh_backend")
 def test_selector_hover_in_overlay(point_plot):
     inputs = dict(dynamic=False,  x_range=(-1, 1), y_range=(-1, 1), width=10, height=10)
-    overlay = rasterize(point_plot, selector=ds.first("val"), **inputs).opts(tools=["hover"]) * Points([])
-    renderer("bokeh").get_plot(overlay)
+    overlay = rasterize(point_plot, selector=ds.first("val"), **inputs).opts(tools=["hover"]) * hv.Points([])
+    hv.renderer("bokeh").get_plot(overlay)
 
 @pytest.mark.parametrize("sel_fn", [ds.first, ds.last, ds.min, ds.max])
 def test_selector_datashade(point_plot, sel_fn):
@@ -1464,7 +1439,7 @@ def test_selector_datashade(point_plot, sel_fn):
 
     # RGBA is from the aggregator
     assert list(img.data) == [*"RGBA", "__index__", "s", "val", "cat"]
-    assert list(img.vdims) == [*map(Dimension, "RGBA")]  # Only the RGBA send to the frontend
+    assert list(img.vdims) == [*map(hv.Dimension, "RGBA")]  # Only the RGBA send to the frontend
 
     # The output for the selector should be equal to the output for the aggregator using
     # ds.where
@@ -1509,7 +1484,7 @@ def test_selector_rasterize_with_datetime_column():
         "Timestamp": pd.date_range(start="2023-01-01", periods=n, freq="D", unit="ns"),
         "Value": np.random.rand(n) * 100,
     })
-    point_plot = Points(df)
+    point_plot = hv.Points(df)
     rast_input = dict(dynamic=False,  x_range=(-1, 1), y_range=(-1, 1), width=2, height=2)
     img_agg = rasterize(point_plot, selector=ds.first("Value"), **rast_input)
 
@@ -1520,7 +1495,7 @@ def test_selector_datashade_bad_column_name(point_data):
     point_data = point_data.rename({"cat": "R"}, axis=1)
     assert "R" in point_data.columns
 
-    point_plot = Points(point_data)
+    point_plot = hv.Points(point_data)
     inputs = dict(dynamic=False,  x_range=(-1, 1), y_range=(-1, 1), width=10, height=10)
 
     msg = "Cannot use 'R', 'G', 'B', or 'A' as columns, when using datashade with selector"
@@ -1531,15 +1506,15 @@ def test_selector_datashade_bad_column_name(point_data):
 @pytest.mark.usefixtures("bokeh_backend")
 def test_selector_single_categorical():
     # Test for https://github.com/holoviz/holoviews/issues/6595
-    plot = Points(([0, 1], [0, 1], ["A", "A"]), ["X", "Y"], "C")
+    plot = hv.Points(([0, 1], [0, 1], ["A", "A"]), ["X", "Y"], "C")
     plot = rasterize(plot, aggregator=ds.count_cat("C"), selector=ds.first("X"))
     plot = dynspread(plot)
     # Should not fail
-    renderer("bokeh").get_plot(plot)
+    hv.renderer("bokeh").get_plot(plot)
 
 
 def test_geom_aggregate_with_summary():
-    rects = Rectangles([
+    rects = hv.Rectangles([
         (0, 0, 1, 1, 128, 100, 200),
         (2, 3, 4, 6, 100, 50, 80),
         (0.5, 2, 1.5, 4, 20, 200, 120),
@@ -1557,7 +1532,7 @@ def test_geom_aggregate_with_summary():
         )
     )
 
-    assert isinstance(agg, Image)
+    assert isinstance(agg, hv.Image)
     assert isinstance(agg.data, xr.Dataset)
     assert "r" in agg.data
     assert "g" in agg.data
@@ -1565,7 +1540,7 @@ def test_geom_aggregate_with_summary():
 
 
 def test_geom_aggregate_with_selector():
-    rects = Rectangles([
+    rects = hv.Rectangles([
         (0, 0, 1, 1, 10, 0),
         (2, 3, 4, 6, 20, 1),
         (0.5, 2, 1.5, 4, 30, 2),
@@ -1579,7 +1554,7 @@ def test_geom_aggregate_with_selector():
         selector=ds.first("value")
     )
 
-    assert isinstance(agg, Image)
+    assert isinstance(agg, hv.Image)
     assert isinstance(agg.data, xr.Dataset)
     expected_columns = ['__index__', 'x0', 'y0', 'x1', 'y1', 'value', 'index_col']
     assert agg.data.attrs["selector_columns"] ==  expected_columns
@@ -1601,7 +1576,7 @@ def test_geom_aggregate_with_selector():
 
 @pytest.mark.parametrize("aggregator", [ds.count_cat("cat"), ds.by("cat", ds.count())], ids=["count_cat", "by"])
 def test_geom_aggregate_with_by_and_selector(aggregator):
-    rects = Rectangles([
+    rects = hv.Rectangles([
         (0, 0, 1, 2, 'A', 20, 0),
         (1, 1, 3, 2, 'B', 300, 1),
     ], vdims=['cat', "value", "index_col"])
@@ -1614,7 +1589,7 @@ def test_geom_aggregate_with_by_and_selector(aggregator):
         selector=ds.first("value")
     )
 
-    assert isinstance(agg, ImageStack)
+    assert isinstance(agg, hv.ImageStack)
     assert "A" in agg.vdims
     assert "B" in agg.vdims
 
@@ -1631,20 +1606,20 @@ class DatashaderSpreadTests:
         arr = np.array([[[0, 0, 0], [0, 1, 1], [0, 1, 1]],
                         [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
                         [[0, 0, 0], [0, 0, 0], [0, 0, 0]]], dtype=np.uint8).T*255
-        spreaded = spread(RGB(arr))
+        spreaded = spread(hv.RGB(arr))
         arr = np.array([[[0, 0, 1], [0, 0, 1], [0, 0, 1]],
                         [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
                         [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
                         [[1, 1, 1], [1, 1, 1], [1, 1, 1]]], dtype=np.uint8).T*255
-        assert_element_equal(spreaded, RGB(arr))
+        assert_element_equal(spreaded, hv.RGB(arr))
 
     def test_spread_img_1px(self):
         if DATASHADER_VERSION < (0, 12, 0):
             pytest.skip('Datashader does not support DataArray yet')
         arr = np.array([[0, 0, 0], [0, 0, 0], [1, 1, 1]]).T
-        spreaded = spread(Image(arr))
+        spreaded = spread(hv.Image(arr))
         arr = np.array([[0, 0, 0], [2, 3, 2], [2, 3, 2]]).T
-        assert_element_equal(spreaded, Image(arr))
+        assert_element_equal(spreaded, hv.Image(arr))
 
 
 class DatashaderStackTests:
@@ -1656,14 +1631,14 @@ class DatashaderStackTests:
         self.rgb2_arr = np.array([[[0, 0], [0, 0]],
                                   [[0, 0], [0, 0]],
                                   [[1, 0], [0, 1]]], dtype=np.uint8).T*255
-        self.rgb1 = RGB(self.rgb1_arr)
-        self.rgb2 = RGB(self.rgb2_arr)
+        self.rgb1 = hv.RGB(self.rgb1_arr)
+        self.rgb2 = hv.RGB(self.rgb2_arr)
 
 
     def test_stack_add_compositor(self):
         combined = stack(self.rgb1*self.rgb2, compositor='add')
         arr = np.array([[[0, 255, 255], [255,0, 0]], [[255, 0, 0], [0, 255, 255]]], dtype=np.uint8)
-        expected = RGB(arr)
+        expected = hv.RGB(arr)
         assert_element_equal(combined, expected)
 
     def test_stack_over_compositor(self):
@@ -1690,7 +1665,7 @@ class GraphBundlingTests:
             pytest.skip('Regridding operations require datashader>=0.7.0')
         self.source = np.arange(8)
         self.target = np.zeros(8)
-        self.graph = Graph(((self.source, self.target),))
+        self.graph = hv.Graph(((self.source, self.target),))
 
     def test_directly_connect_paths(self):
         direct = directly_connect_edges(self.graph)._split_edgepaths
@@ -1702,12 +1677,12 @@ class InspectorTests:
     Tests for inspector operations
     """
     def setup_method(self):
-        points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
+        points = hv.Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
         self.pntsimg = rasterize(
             points, dynamic=False, height=4, width=4,
             x_range=(0, 1), y_range=(0, 1)
         )
-        date_pts = Points([
+        date_pts = hv.Points([
             (np.datetime64('2024-09-25 11:00'), 0.3),
             (np.datetime64('2024-09-25 11:01'), 0.7),
             (np.datetime64('2024-09-25 11:04'), 0.99)])
@@ -1722,7 +1697,7 @@ class InspectorTests:
         holes = [ [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],]
         polydata = [{'x': xs1, 'y': ys1, 'holes': holes, 'z': 1},
                     {'x': xs2, 'y': ys2, 'holes': [[]], 'z': 2}]
-        self.polysrgb = datashade(Polygons(polydata, vdims=['z'],
+        self.polysrgb = datashade(hv.Polygons(polydata, vdims=['z'],
                                            datatype=['spatialpandas']),
                                   x_range=(0, 7), y_range=(0, 7), dynamic=False)
 
@@ -1733,7 +1708,7 @@ class InspectorTests:
     def test_inspect_points_or_polygons(self):
         polys = inspect(self.polysrgb,
                         max_indicators=3, dynamic=False, pixels=1, x=6, y=5)
-        assert_element_equal(polys, Polygons([{'x': [6, 3, 7], 'y': [7, 2, 5], 'z': 2}], vdims='z'))
+        assert_element_equal(polys, hv.Polygons([{'x': [6, 3, 7], 'y': [7, 2, 5], 'z': 2}], vdims='z'))
         points = inspect(self.pntsimg, max_indicators=3, dynamic=False, pixels=1, x=-0.1, y=-0.1)
         assert_data_equal(points.dimension_values('x'), np.array([]))
         assert_data_equal(points.dimension_values('y'), np.array([]))
@@ -1800,7 +1775,7 @@ class InspectorTests:
     def test_polys_inspection_1px_mask_hit(self):
         polys = inspect_polygons(self.polysrgb,
                                  max_indicators=3, dynamic=False, pixels=1, x=6, y=5)
-        assert_element_equal(polys, Polygons([{'x': [6, 3, 7], 'y': [7, 2, 5], 'z': 2}],
+        assert_element_equal(polys, hv.Polygons([{'x': [6, 3, 7], 'y': [7, 2, 5], 'z': 2}],
                                          vdims='z'))
 
     @spd_skip
@@ -1815,20 +1790,20 @@ class InspectorTests:
     def test_polys_inspection_1px_mask_miss(self):
         polys = inspect_polygons(self.polysrgb,
                                  max_indicators=3, dynamic=False, pixels=1, x=0, y=0)
-        assert_element_equal(polys, Polygons([], vdims='z'))
+        assert_element_equal(polys, hv.Polygons([], vdims='z'))
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.uint32])
 def test_uint_dtype(dtype):
     df = pd.DataFrame(np.arange(2, dtype=dtype), columns=["A"])
-    curve = Curve(df)
+    curve = hv.Curve(df)
     img = rasterize(curve, dynamic=False, height=10, width=10)
     assert (np.asarray(img.data["Count"]) == np.eye(10)).all()
 
 
 def test_uint64_dtype():
     df = pd.DataFrame(np.arange(2, dtype=np.uint64), columns=["A"])
-    curve = Curve(df)
+    curve = hv.Curve(df)
     with pytest.raises(TypeError, match=r"Dtype of uint64 for column A is not supported."):
         rasterize(curve, dynamic=False, height=10, width=10)
 
@@ -1836,7 +1811,7 @@ def test_uint64_dtype():
 def test_imagestack_datashader_color_key():
     d = np.arange(23)
     df = pd.DataFrame({"x": d, "y": d, "language": list(map(str, d))})
-    points = Points(df, ["x", "y"], ["language"])
+    points = hv.Points(df, ["x", "y"], ["language"])
 
     # This will run rasterize which outputs an ImageStack
     op = datashade(
@@ -1844,29 +1819,29 @@ def test_imagestack_datashader_color_key():
         aggregator=ds.by("language", ds.count()),
         color_key=cc.glasbey_light,
     )
-    render(op)  # should not error out
+    hv.render(op)  # should not error out
 
 
 def test_imagestack_datashade_count_cat():
     # Test for https://github.com/holoviz/holoviews/issues/6154
     df = pd.DataFrame({"x": range(3), "y": range(3), "c": range(3)})
-    op = datashade(Points(df), aggregator=ds.count_cat("c"))
-    render(op)  # should not error out
+    op = datashade(hv.Points(df), aggregator=ds.count_cat("c"))
+    hv.render(op)  # should not error out
 
 
 def test_imagestack_dynspread():
     df = pd.DataFrame({'x':[-16.8, 7.3], 'y': [-0.42, 13.6], 'language':['Marathi', 'Luganda']})
-    points = Points(df, ['x','y'], ['language'])
+    points = hv.Points(df, ['x','y'], ['language'])
     op = dynspread(rasterize(points, aggregator=ds.by('language', ds.count())))
-    render(op)  # should not error out
+    hv.render(op)  # should not error out
 
 def test_datashade_count_cat_no_change_inplace():
     # Test for https://github.com/holoviz/holoviews/issues/6324
     df = pd.DataFrame({"x": range(3), "y": range(3), "c": list(map(str, range(3)))})
     expected_dtype = pd.StringDtype(na_value=np.nan) if PANDAS_GE_3_0_0 else "object"
     assert df["c"].dtype == expected_dtype
-    op = datashade(Points(df), aggregator=ds.count_cat("c"))
-    render(op)
+    op = datashade(hv.Points(df), aggregator=ds.count_cat("c"))
+    hv.render(op)
     # Should not convert to category dtype
     assert df["c"].dtype == expected_dtype
 
@@ -1888,9 +1863,9 @@ def test_points_polars(lazy, op):
     )
 
     polars_df = pl.LazyFrame(data) if lazy else pl.DataFrame(data)
-    polars_img = op(Points(polars_df), **op_kwargs)
+    polars_img = op(hv.Points(polars_df), **op_kwargs)
 
     pandas_df = pd.DataFrame(data)
-    pandas_img = op(Points(pandas_df), **op_kwargs)
+    pandas_img = op(hv.Points(pandas_df), **op_kwargs)
 
     xr.testing.assert_equal(polars_img.data, pandas_img.data)

--- a/holoviews/tests/operation/test_downsample.py
+++ b/holoviews/tests/operation/test_downsample.py
@@ -2,8 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core.overlay import NdOverlay, Overlay
-from holoviews.element import Curve
+import holoviews as hv
 from holoviews.operation.downsample import _ALGORITHMS, downsample1d
 
 from ..utils import optional_dependencies
@@ -20,9 +19,9 @@ def test_downsample1d_multi(plottype):
     assert N > downsample1d.width
 
     if plottype == "overlay":
-        figure = Overlay([Curve(range(N)), Curve(range(N))])
+        figure = hv.Overlay([hv.Curve(range(N)), hv.Curve(range(N))])
     elif plottype == "ndoverlay":
-        figure = NdOverlay({"A": Curve(range(N)), "B": Curve(range(N))})
+        figure = hv.NdOverlay({"A": hv.Curve(range(N)), "B": hv.Curve(range(N))})
 
     figure_values = downsample1d(figure, dynamic=False).data.values()
     for n in figure_values:
@@ -36,7 +35,7 @@ def test_downsample1d_non_contiguous(algorithm):
     x = np.arange(20)
     y = np.arange(40).reshape(1, 40)[0, ::2]
 
-    downsampled = downsample1d(Curve((x, y), datatype=['array']), dynamic=False, width=10, algorithm=algorithm)
+    downsampled = downsample1d(hv.Curve((x, y), datatype=['array']), dynamic=False, width=10, algorithm=algorithm)
     assert len(downsampled)
 
 
@@ -52,7 +51,7 @@ def test_downsample1d_shared_data():
 
     N = 1000
     df = pd.DataFrame({c: range(N) for c in "xyz"})
-    figure = Overlay([Curve(df, kdims="x", vdims=c) for c in "yz"])
+    figure = hv.Overlay([hv.Curve(df, kdims="x", vdims=c) for c in "yz"])
 
     # We set x_range to trigger _compute_mask
     mocksample(figure, dynamic=False, x_range=(0, 500))
@@ -71,7 +70,7 @@ def test_downsample1d_shared_data_index():
 
     N = 1000
     df = pd.DataFrame({c: range(N) for c in "xyz"})
-    figure = Overlay([Curve(df, kdims="index", vdims=c) for c in "xyz"])
+    figure = hv.Overlay([hv.Curve(df, kdims="index", vdims=c) for c in "xyz"])
 
     # We set x_range to trigger _compute_mask
     mocksample(figure, dynamic=False, x_range=(0, 500))

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -6,27 +6,7 @@ import pandas as pd
 import param
 import pytest
 
-from holoviews import (
-    AdjointLayout,
-    Area,
-    Contours,
-    Curve,
-    Dataset,
-    Dendrogram,
-    Empty,
-    GridSpace,
-    HeatMap,
-    Histogram,
-    HoloMap,
-    Image,
-    Layout,
-    NdLayout,
-    NdOverlay,
-    Points,
-    Polygons,
-    QuadMesh,
-    renderer,
-)
+import holoviews as hv
 from holoviews.core.data.grid import GridInterface
 from holoviews.core.data.ibis import IBIS_VERSION
 from holoviews.core.operation import Operation
@@ -59,36 +39,36 @@ class OperationTests:
     """
 
     def test_operation_element(self):
-        img = Image(np.random.rand(10, 10))
+        img = hv.Image(np.random.rand(10, 10))
         op_img = operation(img, op=lambda x, k: x.clone(x.data*2))
         assert_element_equal(op_img, img.clone(img.data*2, group='Operation'))
 
     def test_operation_ndlayout(self):
-        ndlayout = NdLayout({i: Image(np.random.rand(10, 10)) for i in range(10)})
+        ndlayout = hv.NdLayout({i: hv.Image(np.random.rand(10, 10)) for i in range(10)})
         op_ndlayout = operation(ndlayout, op=lambda x, k: x.clone(x.data*2))
         doubled = ndlayout.clone({k: v.clone(v.data*2, group='Operation')
                                   for k, v in ndlayout.items()})
         assert_element_equal(op_ndlayout, doubled)
 
     def test_operation_grid(self):
-        grid = GridSpace({i: Image(np.random.rand(10, 10)) for i in range(10)}, kdims=['X'])
+        grid = hv.GridSpace({i: hv.Image(np.random.rand(10, 10)) for i in range(10)}, kdims=['X'])
         op_grid = operation(grid, op=lambda x, k: x.clone(x.data*2))
         doubled = grid.clone({k: v.clone(v.data*2, group='Operation')
                               for k, v in grid.items()})
         assert_element_equal(op_grid, doubled)
 
     def test_operation_holomap(self):
-        hmap = HoloMap({1: Image(np.random.rand(10, 10))})
+        hmap = hv.HoloMap({1: hv.Image(np.random.rand(10, 10))})
         op_hmap = operation(hmap, op=lambda x, k: x.clone(x.data*2))
         assert_element_equal(op_hmap.last, hmap.last.clone(hmap.last.data*2, group='Operation'))
 
     def test_image_transform(self):
-        img = Image(np.random.rand(10, 10))
+        img = hv.Image(np.random.rand(10, 10))
         op_img = transform(img, operator=lambda x: x*2)
         assert_element_equal(op_img, img.clone(img.data*2, group='Transform'))
 
     def test_operation_chain(self):
-        img = Image(np.random.rand(10, 10))
+        img = hv.Image(np.random.rand(10, 10))
         op_img = chain(
             img,
             operations=[
@@ -98,9 +78,9 @@ class OperationTests:
         assert_element_equal(op_img, img.clone(img.data*6, group='Transform'))
 
     def test_operation_chain_find(self):
-        class CustomOp1(Operation):
+        class CustomOp1(hv.Operation):
             link_inputs = param.Boolean(False)
-        class CustomOp2(Operation):
+        class CustomOp2(hv.Operation):
             link_inputs = param.Boolean(True)
 
         op1 = CustomOp1.instance()
@@ -112,16 +92,16 @@ class OperationTests:
         assert ch_op.find(CustomOp2, skip_nonlinked=True) is op2
 
     def test_operation_chain_find_apply(self):
-        img = Image(np.random.rand(10, 10))
+        img = hv.Image(np.random.rand(10, 10))
         tr_op = transform.instance(operator=lambda x: x*2)
         img_apply = img.apply(tr_op, dynamic=False)
         assert img_apply.pipeline.find(transform, skip_nonlinked=False) is tr_op
 
     def test_operation_chain_find_apply_chain(self):
-        class CustomOp1(Operation): pass
-        class CustomOp2(Operation): pass
+        class CustomOp1(hv.Operation): pass
+        class CustomOp2(hv.Operation): pass
 
-        img = Image(np.random.rand(10, 10))
+        img = hv.Image(np.random.rand(10, 10))
         op1 = CustomOp1.instance()
         op2 = CustomOp2.instance()
         ch_op = chain.instance(operations=[op1,op2])
@@ -129,35 +109,35 @@ class OperationTests:
         assert img_apply.pipeline.find(CustomOp1, skip_nonlinked=False) is op1
 
     def test_image_threshold(self):
-        img = Image(np.array([[0, 1, 0], [3, 4, 5.]]))
+        img = hv.Image(np.array([[0, 1, 0], [3, 4, 5.]]))
         op_img = threshold(img)
         assert_element_equal(op_img, img.clone(np.array([[0, 1, 0], [1, 1, 1]]), group='Threshold'))
 
     def test_image_gradient(self):
-        img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
+        img = hv.Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
         op_img = gradient(img)
         assert_element_equal(op_img, img.clone(np.array([[3.162278, 3.162278], [3.162278, 3.162278]]), group='Gradient'))
 
     def test_image_contours(self):
-        img = Image(np.array([[0, 1, 0], [0, 1, 0]]))
+        img = hv.Image(np.array([[0, 1, 0], [0, 1, 0]]))
         op_contours = contours(img, levels=[0.5])
         # Note multiple lines which are nan-separated.
-        contour = Contours([[(-0.166667, 0.25, 0.5), (-0.1666667, -0.25, 0.5),
+        contour = hv.Contours([[(-0.166667, 0.25, 0.5), (-0.1666667, -0.25, 0.5),
                              (np.nan, np.nan, 0.5), (0.1666667, -0.25, 0.5),
                              (0.1666667, 0.25, 0.5)]],
                             vdims=img.vdims)
         assert_element_equal(op_contours, contour)
 
     def test_image_contours_empty(self):
-        img = Image(np.array([[0, 1, 0], [0, 1, 0]]))
+        img = hv.Image(np.array([[0, 1, 0], [0, 1, 0]]))
         # Contour level outside of data limits
         op_contours = contours(img, levels=[23.0])
-        contour = Contours([], vdims=img.vdims)
+        contour = hv.Contours([], vdims=img.vdims)
         assert_element_equal(op_contours, contour)
 
     def test_image_contours_auto_levels(self):
         z = np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]])
-        img = Image(z)
+        img = hv.Image(z)
         for nlevels in range(3, 20):
             op_contours = contours(img, levels=nlevels)
             levels = [item['z'] for item in op_contours.data]
@@ -166,9 +146,9 @@ class OperationTests:
             assert np.max(levels) < z.max()
 
     def test_image_contours_no_range(self):
-        img = Image(np.zeros((2, 2)))
+        img = hv.Image(np.zeros((2, 2)))
         op_contours = contours(img, levels=2)
-        contour = Contours([], vdims=img.vdims)
+        contour = hv.Contours([], vdims=img.vdims)
         assert_element_equal(op_contours, contour)
 
     @mpl_skip
@@ -176,7 +156,7 @@ class OperationTests:
         x = np.array(['2023-09-01', '2023-09-03', '2023-09-05'], dtype='datetime64')
         y = [14, 15]
         z = np.array([[0, 1, 0], [0, 1, 0]])
-        img = Image((x, y, z))
+        img = hv.Image((x, y, z))
         op_contours = contours(img, levels=[0.5])
         # Note multiple lines which are nan-separated.
         tz = dt.timezone.utc
@@ -200,7 +180,7 @@ class OperationTests:
         x = [14, 15, 16]
         y = np.array(['2023-09-01', '2023-09-03'], dtype='datetime64')
         z = np.array([[0, 1, 0], [0, 1, 0]])
-        img = Image((x, y, z))
+        img = hv.Image((x, y, z))
         op_contours = contours(img, levels=[0.5])
         # Note multiple lines which are nan-separated.
         np.testing.assert_array_almost_equal(op_contours.dimension_values('x').astype(float),
@@ -225,7 +205,7 @@ class OperationTests:
         x = np.array(['2023-09-01', '2023-09-03', '2023-09-05'], dtype='datetime64')
         y = np.array(['2023-10-07', '2023-10-08'], dtype='datetime64')
         z = np.array([[0, 1, 0], [0, 1, 0]])
-        img = Image((x, y, z))
+        img = hv.Image((x, y, z))
         op_contours = contours(img, levels=[0.5])
         # Note multiple lines which are nan-separated.
 
@@ -254,7 +234,7 @@ class OperationTests:
     @mpl_skip
     def test_image_contours_z_datetime(self):
         z = np.array([['2023-09-10', '2023-09-10'], ['2023-09-10', '2023-09-12']], dtype='datetime64')
-        img = Image(z)
+        img = hv.Image(z)
         op_contours = contours(img, levels=[np.datetime64('2023-09-11')])
         np.testing.assert_array_almost_equal(op_contours.dimension_values('x'), [0.25, 0.0])
         np.testing.assert_array_almost_equal(op_contours.dimension_values('y'), [0.0, -0.25])
@@ -264,9 +244,9 @@ class OperationTests:
         np.testing.assert_array_equal(op_contours.dimension_values('z'), expected_z)
 
     def test_qmesh_contours(self):
-        qmesh = QuadMesh(([0, 1, 2], [1, 2, 3], np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]])))
+        qmesh = hv.QuadMesh(([0, 1, 2], [1, 2, 3], np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]])))
         op_contours = contours(qmesh, levels=[0.5])
-        contour = Contours([[(0,  1.166667, 0.5), (0.5, 1., 0.5),
+        contour = hv.Contours([[(0,  1.166667, 0.5), (0.5, 1., 0.5),
                              (np.nan, np.nan, 0.5), (1.5, 1., 0.5),
                              (2, 1.1, 0.5)]],
                             vdims=qmesh.vdims)
@@ -276,9 +256,9 @@ class OperationTests:
         x = y = np.arange(3)
         xs, ys = np.meshgrid(x, y)
         zs = np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]])
-        qmesh = QuadMesh((xs, ys+0.1, zs))
+        qmesh = hv.QuadMesh((xs, ys+0.1, zs))
         op_contours = contours(qmesh, levels=[0.5])
-        contour = Contours([[(0,  0.266667, 0.5), (0.5, 0.1, 0.5),
+        contour = hv.Contours([[(0,  0.266667, 0.5), (0.5, 0.1, 0.5),
                              (np.nan, np.nan, 0.5), (1.5, 0.1, 0.5),
                              (2, 0.2, 0.5)]],
                             vdims=qmesh.vdims)
@@ -292,45 +272,45 @@ class OperationTests:
         ys = GridInterface._infer_interval_breaks(ys)
         ys = GridInterface._infer_interval_breaks(ys, 1)
         zs = np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]])
-        qmesh = QuadMesh((xs, ys+0.1, zs))
+        qmesh = hv.QuadMesh((xs, ys+0.1, zs))
         op_contours = contours(qmesh, levels=[0.5])
-        contour = Contours([[(0,  0.266667, 0.5), (0.5, 0.1, 0.5),
+        contour = hv.Contours([[(0,  0.266667, 0.5), (0.5, 0.1, 0.5),
                              (np.nan, np.nan, 0.5), (1.5, 0.1, 0.5),
                              (2, 0.2, 0.5)]],
                             vdims=qmesh.vdims)
         assert_element_equal(op_contours, contour)
 
     def test_image_contours_filled(self):
-        img = Image(np.array([[0, 2, 0], [0, 2, 0]]))
+        img = hv.Image(np.array([[0, 2, 0], [0, 2, 0]]))
         # Two polygons (nan-separated) without holes
         op_contours = contours(img, filled=True, levels=[0.5, 1.5])
         data = [[(-0.25, -0.25, 1), (-0.08333333, -0.25, 1), (-0.08333333, 0.25, 1),
                  (-0.25, 0.25, 1), (-0.25, -0.25, 1), (np.nan, np.nan, 1), (0.08333333, -0.25, 1),
                  (0.25, -0.25, 1), (0.25, 0.25, 1), (0.08333333, 0.25, 1), (0.08333333, -0.25, 1)]]
-        polys = Polygons(data, vdims=img.vdims[0].clone(range=(0.5, 1.5)))
+        polys = hv.Polygons(data, vdims=img.vdims[0].clone(range=(0.5, 1.5)))
         assert_element_equal(op_contours, polys)
 
     def test_image_contours_filled_with_hole(self):
-        img = Image(np.array([[0, 0, 0], [0, 1, 0.], [0, 0, 0]]))
+        img = hv.Image(np.array([[0, 0, 0], [0, 1, 0.], [0, 0, 0]]))
         # Single polygon with hole
         op_contours = contours(img, filled=True, levels=[0.25, 0.75])
         data = [[(-0.25, 0.0, 0.5), (0.0, -0.25, 0.5), (0.25, 0.0, 0.5), (0.0, 0.25, 0.5),
                   (-0.25, 0.0, 0.5)]]
-        polys = Polygons(data, vdims=img.vdims[0].clone(range=(0.25, 0.75)))
+        polys = hv.Polygons(data, vdims=img.vdims[0].clone(range=(0.25, 0.75)))
         assert_element_equal(op_contours, polys)
         expected_holes = [[[np.array([[0.0, -0.08333333], [-0.08333333, 0.0], [0.0,  0.08333333],
                                       [0.08333333, 0.0], [0.0, -0.08333333]])]]]
         np.testing.assert_array_almost_equal(op_contours.holes(), expected_holes)
 
     def test_image_contours_filled_multi_holes(self):
-        img = Image(np.array([[0, 0, 0, 0, 0], [0, 1, 0, 1, 0], [0, 0, 0, 0, 0]]))
+        img = hv.Image(np.array([[0, 0, 0, 0, 0], [0, 1, 0, 1, 0], [0, 0, 0, 0, 0]]))
         # Single polygon with two holes
         op_contours = contours(img, filled=True, levels=[-0.5, 0.5])
         data = [[(-0.4, -0.3333333, 0), (-0.2, -0.3333333, 0), (0, -0.3333333, 0),
                  (0.2, -0.3333333, 0), (0.4, -0.3333333, 0), (0.4, 0, 0), (0.4, 0.3333333, 0),
                  (0.2, 0.3333333, 0), (0, 0.3333333, 0), (-0.2, 0.3333333, 0), (-0.4, 0.3333333, 0),
                  (-0.4, 0, 0), (-0.4, -0.3333333, 0)]]
-        polys = Polygons(data, vdims=img.vdims[0].clone(range=(-0.5, 0.5)))
+        polys = hv.Polygons(data, vdims=img.vdims[0].clone(range=(-0.5, 0.5)))
         assert_element_equal(op_contours, polys)
         expected_holes = [[[np.array([[-0.2, -0.16666667], [-0.3, 0], [-0.2, 0.16666667], [-0.1, 0],
                                       [-0.2, -0.16666667]]),
@@ -339,15 +319,15 @@ class OperationTests:
         np.testing.assert_array_almost_equal(op_contours.holes(), expected_holes)
 
     def test_image_contours_filled_empty(self):
-        img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
+        img = hv.Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
         # Contour level outside of data limits
         op_contours = contours(img, filled=True, levels=[20.0, 23.0])
-        polys = Polygons([], vdims=img.vdims[0].clone(range=(20.0, 23.0)))
+        polys = hv.Polygons([], vdims=img.vdims[0].clone(range=(20.0, 23.0)))
         assert_element_equal(op_contours, polys)
 
     def test_image_contours_filled_auto_levels(self):
         z = np.array([[0, 1, 0], [3, 4, 5], [6, 7, 8]])
-        img = Image(z)
+        img = hv.Image(z)
         for nlevels in range(3, 20):
             op_contours = contours(img, filled=True, levels=nlevels)
             levels = [item['z'] for item in op_contours.data]
@@ -360,24 +340,24 @@ class OperationTests:
         x = np.array(['2023-09-01', '2023-09-05', '2023-09-09'], dtype='datetime64')
         y = np.array([6, 7])
         z = np.array([[0, 2, 0], [0, 2, 0]])
-        img = Image((x, y, z))
+        img = hv.Image((x, y, z))
         msg = r'Datetime spatial coordinates are not supported for filled contour calculations.'
         with pytest.raises(RuntimeError, match=msg):
             _ = contours(img, filled=True, levels=[0.5, 1.5])
 
     def test_points_histogram(self):
-        points = Points([float(i) for i in range(10)])
+        points = hv.Points([float(i) for i in range(10)])
         op_hist = histogram(points, num_bins=3, normed=True)
 
-        hist = Histogram(([0, 3, 6, 9], [0.1, 0.1, 0.133333]),
+        hist = hv.Histogram(([0, 3, 6, 9], [0.1, 0.1, 0.133333]),
                          vdims=('x_frequency', 'Frequency'))
         assert_element_equal(op_hist, hist)
 
     def test_dataset_histogram_empty_explicit_bins(self):
-        ds = Dataset([np.nan, np.nan], ['x'])
+        ds = hv.Dataset([np.nan, np.nan], ['x'])
         op_hist = histogram(ds, bins=[0, 1, 2])
 
-        hist = Histogram(([0, 1, 2], [0, 0]), vdims=('x_count', 'Count'))
+        hist = hv.Histogram(([0, 1, 2], [0, 0]), vdims=('x_count', 'Count'))
         assert_element_equal(op_hist, hist)
 
     def test_dataset_histogram_groupby_range_shared(self):
@@ -386,7 +366,7 @@ class OperationTests:
         xy = np.concatenate([x, y])
         label = ["x"] * 10 + ["y"] * 10
 
-        ds = Dataset(pd.DataFrame([xy, label], index=["xy", "label"]).T, vdims=["xy", "label"])
+        ds = hv.Dataset(pd.DataFrame([xy, label], index=["xy", "label"]).T, vdims=["xy", "label"])
         hist = histogram(ds, groupby="label", groupby_range="shared")
         exp = np.linspace(0, 19, 21)
         for k, v in hist.items():
@@ -402,7 +382,7 @@ class OperationTests:
         xy = np.concatenate([x, y])
         label = ["x"] * 10 + ["y"] * 10
 
-        ds = Dataset(pd.DataFrame([xy, label], index=["xy", "label"]).T, vdims=["xy", "label"])
+        ds = hv.Dataset(pd.DataFrame([xy, label], index=["xy", "label"]).T, vdims=["xy", "label"])
         hist = histogram(ds, groupby="label", groupby_range="separated")
 
         for idx, v in enumerate(hist):
@@ -415,7 +395,7 @@ class OperationTests:
         y = pd.date_range("2020-01-01", periods=100)
         xy = np.concatenate([x, y])
         label = ["x"] * 100 + ["y"] * 100
-        ds = Dataset(pd.DataFrame([xy, label], index=["xy", "label"]).T, vdims=["xy", "label"])
+        ds = hv.Dataset(pd.DataFrame([xy, label], index=["xy", "label"]).T, vdims=["xy", "label"])
         hist = histogram(ds, groupby="label")
 
         exp = pd.date_range("2020-01-01", '2020-04-09', periods=21)
@@ -426,11 +406,11 @@ class OperationTests:
     @dask_skip
     def test_dataset_histogram_dask(self):
         import dask.array as da
-        ds = Dataset((da.from_array(np.array(range(10), dtype='f'), chunks=(3)),),
+        ds = hv.Dataset((da.from_array(np.array(range(10), dtype='f'), chunks=(3)),),
                      ['x'], datatype=['dask'])
         op_hist = histogram(ds, num_bins=3, normed=True)
 
-        hist = Histogram(([0, 3, 6, 9], [0.1, 0.1, 0.133333]),
+        hist = hv.Histogram(([0, 3, 6, 9], [0.1, 0.1, 0.133333]),
                          vdims=('x_frequency', 'Frequency'))
         assert isinstance(op_hist.data['x_frequency'], da.Array)
         assert_element_equal(op_hist, hist)
@@ -438,11 +418,11 @@ class OperationTests:
     @dask_skip
     def test_dataset_cumulative_histogram_dask(self):
         import dask.array as da
-        ds = Dataset((da.from_array(np.array(range(10), dtype='f'), chunks=(3)),),
+        ds = hv.Dataset((da.from_array(np.array(range(10), dtype='f'), chunks=(3)),),
                      ['x'], datatype=['dask'])
         op_hist = histogram(ds, num_bins=3, cumulative=True, normed=True)
 
-        hist = Histogram(([0, 3, 6, 9], [0.3, 0.6, 1]),
+        hist = hv.Histogram(([0, 3, 6, 9], [0.3, 0.6, 1]),
                          vdims=('x_frequency', 'Frequency'))
         assert isinstance(op_hist.data['x_frequency'], da.Array)
         assert_element_equal(op_hist, hist)
@@ -450,12 +430,12 @@ class OperationTests:
     @dask_skip
     def test_dataset_weighted_histogram_dask(self):
         import dask.array as da
-        ds = Dataset((da.from_array(np.array(range(10), dtype='f'), chunks=3),
+        ds = hv.Dataset((da.from_array(np.array(range(10), dtype='f'), chunks=3),
                       da.from_array([i/10. for i in range(10)], chunks=3)),
                      ['x', 'y'], datatype=['dask'])
         op_hist = histogram(ds, weight_dimension='y', num_bins=3, normed=True)
 
-        hist = Histogram(([0, 3, 6, 9], [0.022222, 0.088889, 0.222222]),
+        hist = hv.Histogram(([0, 3, 6, 9], [0.022222, 0.088889, 0.222222]),
                          vdims='y')
         assert isinstance(op_hist.data['y'], da.Array)
         assert_element_equal(op_hist, hist)
@@ -465,10 +445,10 @@ class OperationTests:
     def test_dataset_histogram_ibis(self):
         df = pd.DataFrame(dict(x=np.arange(10)))
         t = ibis.memtable(df, **({} if IBIS_VERSION >= (11, 0, 0) else {"name": "t"}))
-        ds = Dataset(t, vdims='x')
+        ds = hv.Dataset(t, vdims='x')
         op_hist = histogram(ds, dimension='x', num_bins=3, normed=True)
 
-        hist = Histogram(([0, 3, 6, 9], [0.1, 0.1, 0.133333]),
+        hist = hv.Histogram(([0, 3, 6, 9], [0.1, 0.1, 0.133333]),
                          vdims=('x_frequency', 'Frequency'))
         assert_element_equal(op_hist, hist)
 
@@ -477,10 +457,10 @@ class OperationTests:
     def test_dataset_cumulative_histogram_ibis(self):
         df = pd.DataFrame(dict(x=np.arange(10)))
         t = ibis.memtable(df, **({} if IBIS_VERSION >= (11, 0, 0) else {"name": "t"}))
-        ds = Dataset(t, vdims='x')
+        ds = hv.Dataset(t, vdims='x')
         op_hist = histogram(ds, num_bins=3, cumulative=True, normed=True)
 
-        hist = Histogram(([0, 3, 6, 9], [0.3, 0.6, 1]),
+        hist = hv.Histogram(([0, 3, 6, 9], [0.3, 0.6, 1]),
                          vdims=('x_frequency', 'Frequency'))
         assert_element_equal(op_hist, hist)
 
@@ -489,10 +469,10 @@ class OperationTests:
     def test_dataset_histogram_explicit_bins_ibis(self):
         df = pd.DataFrame(dict(x=np.arange(10)))
         t = ibis.memtable(df, **({} if IBIS_VERSION >= (11, 0, 0) else {"name": "t"}))
-        ds = Dataset(t, vdims='x')
+        ds = hv.Dataset(t, vdims='x')
         op_hist = histogram(ds, bins=[0, 1, 3], normed=False)
 
-        hist = Histogram(([0, 1, 3], [1, 3]),
+        hist = hv.Histogram(([0, 1, 3], [1, 3]),
                          vdims=('x_count', 'Count'))
         assert_element_equal(op_hist, hist)
 
@@ -501,10 +481,10 @@ class OperationTests:
         import cudf
         df = pd.DataFrame(dict(x=np.arange(10)))
         t = cudf.from_pandas(df)
-        ds = Dataset(t, vdims='x')
+        ds = hv.Dataset(t, vdims='x')
         op_hist = histogram(ds, dimension='x', num_bins=3, normed=True)
 
-        hist = Histogram(([0, 3, 6, 9], [0.1, 0.1, 0.133333]),
+        hist = hv.Histogram(([0, 3, 6, 9], [0.1, 0.1, 0.133333]),
                          vdims=('x_frequency', 'Frequency'))
         assert_element_equal(op_hist, hist)
 
@@ -513,10 +493,10 @@ class OperationTests:
         import cudf
         df = pd.DataFrame(dict(x=np.arange(10)))
         t = cudf.from_pandas(df)
-        ds = Dataset(t, vdims='x')
+        ds = hv.Dataset(t, vdims='x')
         op_hist = histogram(ds, num_bins=3, cumulative=True, normed=True)
 
-        hist = Histogram(([0, 3, 6, 9], [0.3, 0.6, 1]),
+        hist = hv.Histogram(([0, 3, 6, 9], [0.3, 0.6, 1]),
                          vdims=('x_frequency', 'Frequency'))
         assert_element_equal(op_hist, hist)
 
@@ -525,49 +505,49 @@ class OperationTests:
         import cudf
         df = pd.DataFrame(dict(x=np.arange(10)))
         t = cudf.from_pandas(df)
-        ds = Dataset(t, vdims='x')
+        ds = hv.Dataset(t, vdims='x')
         op_hist = histogram(ds, bins=[0, 1, 3], normed=False)
 
-        hist = Histogram(([0, 1, 3], [1, 3]),
+        hist = hv.Histogram(([0, 1, 3], [1, 3]),
                          vdims=('x_count', 'Count'))
         assert_element_equal(op_hist, hist)
 
     def test_points_histogram_bin_range(self):
-        points = Points([float(i) for i in range(10)])
+        points = hv.Points([float(i) for i in range(10)])
         op_hist = histogram(points, num_bins=3, bin_range=(0, 3), normed=True)
 
-        hist = Histogram(([0.25, 0.25, 0.5], [0., 1., 2., 3.]),
+        hist = hv.Histogram(([0.25, 0.25, 0.5], [0., 1., 2., 3.]),
                          vdims=('x_frequency', 'Frequency'))
         assert_element_equal(op_hist, hist)
 
     def test_points_histogram_explicit_bins(self):
-        points = Points([float(i) for i in range(10)])
+        points = hv.Points([float(i) for i in range(10)])
         op_hist = histogram(points, bins=[0, 1, 3], normed=False)
 
-        hist = Histogram(([0, 1, 3], [1, 3]),
+        hist = hv.Histogram(([0, 1, 3], [1, 3]),
                          vdims=('x_count', 'Count'))
         assert_element_equal(op_hist, hist)
 
     def test_points_histogram_cumulative(self):
         arr = np.arange(4)
-        points = Points(arr)
+        points = hv.Points(arr)
         op_hist = histogram(points, cumulative=True, num_bins=3, normed=False)
 
-        hist = Histogram(([0, 1, 2, 3], [1, 2, 4]),
+        hist = hv.Histogram(([0, 1, 2, 3], [1, 2, 4]),
                          vdims=('x_count', 'Count'))
         assert_element_equal(op_hist, hist)
 
     def test_points_histogram_not_normed(self):
-        points = Points([float(i) for i in range(10)])
+        points = hv.Points([float(i) for i in range(10)])
         op_hist = histogram(points, num_bins=3, normed=False)
 
-        hist = Histogram(([0, 3, 6, 9], [3, 3, 4]),
+        hist = hv.Histogram(([0, 3, 6, 9], [3, 3, 4]),
                          vdims=('x_count', 'Count'))
         assert_element_equal(op_hist, hist)
 
     def test_histogram_operation_datetime(self):
         dates = np.array([dt.datetime(2017, 1, i) for i in range(1, 5)])
-        op_hist = histogram(Dataset(dates, 'Date'), num_bins=4, normed=True)
+        op_hist = histogram(hv.Dataset(dates, 'Date'), num_bins=4, normed=True)
         hist_data = {
             'Date': np.array([
                 '2017-01-01T00:00:00.000000', '2017-01-01T18:00:00.000000',
@@ -577,12 +557,12 @@ class OperationTests:
                 3.85802469e-18, 3.85802469e-18, 3.85802469e-18,
                 3.85802469e-18])
         }
-        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Frequency'))
+        hist = hv.Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Frequency'))
         assert_element_equal(op_hist, hist)
 
     def test_histogram_operation_datetime64(self):
         dates = np.array([dt.datetime(2017, 1, i) for i in range(1, 5)]).astype('M')
-        op_hist = histogram(Dataset(dates, 'Date'), num_bins=4, normed=True)
+        op_hist = histogram(hv.Dataset(dates, 'Date'), num_bins=4, normed=True)
         hist_data = {
             'Date': np.array([
                 '2017-01-01T00:00:00.000000', '2017-01-01T18:00:00.000000',
@@ -592,12 +572,12 @@ class OperationTests:
                 3.85802469e-18, 3.85802469e-18, 3.85802469e-18,
                 3.85802469e-18])
         }
-        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Frequency'))
+        hist = hv.Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Frequency'))
         assert_element_equal(op_hist, hist)
 
     def test_histogram_operation_pd_period(self):
         dates = pd.date_range('2017-01-01', '2017-01-04', freq='D').to_period('D')
-        op_hist = histogram(Dataset(dates, 'Date'), num_bins=4, normed=True)
+        op_hist = histogram(hv.Dataset(dates, 'Date'), num_bins=4, normed=True)
         hist_data = {
             'Date': np.array([
                 '2017-01-01T00:00:00.000000', '2017-01-01T18:00:00.000000',
@@ -607,66 +587,66 @@ class OperationTests:
                 3.85802469e-18, 3.85802469e-18, 3.85802469e-18,
                 3.85802469e-18])
         }
-        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Frequency'))
+        hist = hv.Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Frequency'))
         assert_element_equal(op_hist, hist)
 
     def test_histogram_categorical(self):
-        series = Dataset(pd.Series(['A', 'B', 'C']))
+        series = hv.Dataset(pd.Series(['A', 'B', 'C']))
         kwargs = {'bin_range': ('A', 'C'), 'normed': False, 'cumulative': False, 'num_bins': 3}
         with pytest.raises(ValueError):  # noqa: PT011
             histogram(series, **kwargs)
 
     def test_points_histogram_weighted(self):
-        points = Points([float(i) for i in range(10)])
+        points = hv.Points([float(i) for i in range(10)])
         op_hist = histogram(points, num_bins=3, weight_dimension='y', normed=True)
-        hist = Histogram(([0.022222, 0.088889, 0.222222], [0, 3, 6, 9]), vdims=['y'])
+        hist = hv.Histogram(([0.022222, 0.088889, 0.222222], [0, 3, 6, 9]), vdims=['y'])
         assert_element_equal(op_hist, hist)
 
     def test_points_histogram_mean_weighted(self):
-        points = Points([float(i) for i in range(10)])
+        points = hv.Points([float(i) for i in range(10)])
         op_hist = histogram(points, num_bins=3, weight_dimension='y',
                             mean_weighted=True, normed=True)
-        hist = Histogram(([1.,  4., 7.5], [0, 3, 6, 9]), vdims=['y'])
+        hist = hv.Histogram(([1.,  4., 7.5], [0, 3, 6, 9]), vdims=['y'])
         assert_element_equal(op_hist, hist)
 
     def test_histogram_narwhals_pandas(self):
         df = pd.DataFrame({'x': range(10)})
-        ds = Dataset(df, vdims='x', datatype=["narwhals"])
+        ds = hv.Dataset(df, vdims='x', datatype=["narwhals"])
         op_hist = histogram(ds, num_bins=3, normed=False)
 
-        hist = Histogram(([0, 3, 6, 9], [3, 3, 4]),
+        hist = hv.Histogram(([0, 3, 6, 9], [3, 3, 4]),
                          vdims=('x_count', 'Count'))
         assert_element_equal(op_hist, hist)
 
     def test_histogram_narwhals_polars(self):
         pl = pytest.importorskip("polars")
         df = pl.DataFrame({'x': range(10)})
-        ds = Dataset(df, vdims='x')
+        ds = hv.Dataset(df, vdims='x')
         op_hist = histogram(ds, num_bins=3, normed=False)
 
-        hist = Histogram(([0, 3, 6, 9], [3, 3, 4]),
+        hist = hv.Histogram(([0, 3, 6, 9], [3, 3, 4]),
                          vdims=('x_count', 'Count'))
         assert_element_equal(op_hist, hist)
 
     def test_histogram_narwhals_polars_lazy(self):
         pl = pytest.importorskip("polars")
         df = pl.LazyFrame({'x': range(10)})
-        ds = Dataset(df, vdims='x')
+        ds = hv.Dataset(df, vdims='x')
         op_hist = histogram(ds, num_bins=3, normed=False)
 
-        hist = Histogram(([0, 3, 6, 9], [3, 3, 4]),
+        hist = hv.Histogram(([0, 3, 6, 9], [3, 3, 4]),
                          vdims=('x_count', 'Count'))
         assert_element_equal(op_hist, hist)
 
     def test_histogram_narwhals_polars_lazy_groupby(self):
         pl = pytest.importorskip("polars")
         df = pl.LazyFrame({"x": [1, 2], "y": [1, 2]})
-        ds = Dataset(df)
+        ds = hv.Dataset(df)
         op_hist = histogram(ds, num_bins=2, groupby="x")
 
-        hist1 = Histogram(([1, 1.5, 2], [1, 0]), kdims="y", vdims=[('y_count', 'Count')])
-        hist2 = Histogram(([1, 1.5, 2], [0, 1]), kdims="y", vdims=[('y_count', 'Count')])
-        expected = NdOverlay({(1,): hist1, (2,): hist2}, kdims=['x'])
+        hist1 = hv.Histogram(([1, 1.5, 2], [1, 0]), kdims="y", vdims=[('y_count', 'Count')])
+        hist2 = hv.Histogram(([1, 1.5, 2], [0, 1]), kdims="y", vdims=[('y_count', 'Count')])
+        expected = hv.NdOverlay({(1,): hist1, (2,): hist2}, kdims=['x'])
 
         assert_element_equal(op_hist, expected)
 
@@ -682,46 +662,46 @@ class OperationTests:
         flights = dd.from_pandas(pd.DataFrame(data), npartitions=2)
 
         by = "carrier"
-        ds = Dataset(flights, by)
+        ds = hv.Dataset(flights, by)
         ds_grouped = ds.groupby(by)
         hists = histogram(ds_grouped, dimension="depdelay")
 
         # Should not error
-        renderer("matplotlib").get_plot(hists)
+        hv.renderer("matplotlib").get_plot(hists)
 
     def test_interpolate_curve_pre(self):
-        interpolated = interpolate_curve(Curve([0, 0.5, 1]), interpolation='steps-pre')
-        curve = Curve([(0, 0), (0, 0.5), (1, 0.5), (1, 1), (2, 1)])
+        interpolated = interpolate_curve(hv.Curve([0, 0.5, 1]), interpolation='steps-pre')
+        curve = hv.Curve([(0, 0), (0, 0.5), (1, 0.5), (1, 1), (2, 1)])
         assert_element_equal(interpolated, curve)
 
     def test_interpolate_curve_pre_with_values(self):
-        interpolated = interpolate_curve(Curve([(0, 0, 'A'), (1, 0.5, 'B'), (2, 1, 'C')], vdims=['y', 'z']),
+        interpolated = interpolate_curve(hv.Curve([(0, 0, 'A'), (1, 0.5, 'B'), (2, 1, 'C')], vdims=['y', 'z']),
                                          interpolation='steps-pre')
-        curve = Curve([(0, 0, 'A'), (0, 0.5, 'B'), (1, 0.5, 'B'), (1, 1, 'C'), (2, 1, 'C')], vdims=['y', 'z'])
+        curve = hv.Curve([(0, 0, 'A'), (0, 0.5, 'B'), (1, 0.5, 'B'), (1, 1, 'C'), (2, 1, 'C')], vdims=['y', 'z'])
         assert_element_equal(interpolated, curve)
 
     def test_interpolate_datetime_curve_pre(self):
         dates = np.array([dt.datetime(2017, 1, i) for i in range(1, 5)]).astype('M')
         values = [0, 1, 2, 3]
-        interpolated = interpolate_curve(Curve((dates, values)), interpolation='steps-pre')
+        interpolated = interpolate_curve(hv.Curve((dates, values)), interpolation='steps-pre')
         dates_interp = np.array([
             '2017-01-01T00:00:00', '2017-01-01T00:00:00',
             '2017-01-02T00:00:00', '2017-01-02T00:00:00',
             '2017-01-03T00:00:00', '2017-01-03T00:00:00',
             '2017-01-04T00:00:00'
         ], dtype='datetime64[ns]')
-        curve = Curve((dates_interp, [0, 1, 1, 2, 2, 3, 3]))
+        curve = hv.Curve((dates_interp, [0, 1, 1, 2, 2, 3, 3]))
         assert_element_equal(interpolated, curve)
 
     def test_interpolate_curve_mid(self):
-        interpolated = interpolate_curve(Curve([0, 0.5, 1]), interpolation='steps-mid')
-        curve = Curve([(0, 0), (0.5, 0), (0.5, 0.5), (1.5, 0.5), (1.5, 1), (2, 1)])
+        interpolated = interpolate_curve(hv.Curve([0, 0.5, 1]), interpolation='steps-mid')
+        curve = hv.Curve([(0, 0), (0.5, 0), (0.5, 0.5), (1.5, 0.5), (1.5, 1), (2, 1)])
         assert_element_equal(interpolated, curve)
 
     def test_interpolate_curve_mid_with_values(self):
-        interpolated = interpolate_curve(Curve([(0, 0, 'A'), (1, 0.5, 'B'), (2, 1, 'C')], vdims=['y', 'z']),
+        interpolated = interpolate_curve(hv.Curve([(0, 0, 'A'), (1, 0.5, 'B'), (2, 1, 'C')], vdims=['y', 'z']),
                                          interpolation='steps-mid')
-        curve = Curve([(0, 0, 'A'), (0.5, 0, 'A'), (0.5, 0.5, 'B'),
+        curve = hv.Curve([(0, 0, 'A'), (0.5, 0, 'A'), (0.5, 0.5, 'B'),
                        (1.5, 0.5, 'B'), (1.5, 1, 'C'), (2, 1, 'C')],
                       vdims=['y', 'z'])
         assert_element_equal(interpolated, curve)
@@ -729,25 +709,25 @@ class OperationTests:
     def test_interpolate_datetime_curve_mid(self):
         dates = np.array([dt.datetime(2017, 1, i) for i in range(1, 5)]).astype('M')
         values = [0, 1, 2, 3]
-        interpolated = interpolate_curve(Curve((dates, values)), interpolation='steps-mid')
+        interpolated = interpolate_curve(hv.Curve((dates, values)), interpolation='steps-mid')
         dates_interp = np.array([
             '2017-01-01T00:00:00', '2017-01-01T12:00:00',
             '2017-01-01T12:00:00', '2017-01-02T12:00:00',
             '2017-01-02T12:00:00', '2017-01-03T12:00:00',
             '2017-01-03T12:00:00', '2017-01-04T00:00:00'
         ], dtype='datetime64[ns]')
-        curve = Curve((dates_interp, [0, 0, 1, 1, 2, 2, 3, 3]))
+        curve = hv.Curve((dates_interp, [0, 0, 1, 1, 2, 2, 3, 3]))
         assert_element_equal(interpolated, curve)
 
     def test_interpolate_curve_post(self):
-        interpolated = interpolate_curve(Curve([0, 0.5, 1]), interpolation='steps-post')
-        curve = Curve([(0, 0), (1, 0), (1, 0.5), (2, 0.5), (2, 1)])
+        interpolated = interpolate_curve(hv.Curve([0, 0.5, 1]), interpolation='steps-post')
+        curve = hv.Curve([(0, 0), (1, 0), (1, 0.5), (2, 0.5), (2, 1)])
         assert_element_equal(interpolated, curve)
 
     def test_interpolate_curve_post_with_values(self):
-        interpolated = interpolate_curve(Curve([(0, 0, 'A'), (1, 0.5, 'B'), (2, 1, 'C')], vdims=['y', 'z']),
+        interpolated = interpolate_curve(hv.Curve([(0, 0, 'A'), (1, 0.5, 'B'), (2, 1, 'C')], vdims=['y', 'z']),
                                          interpolation='steps-post')
-        curve = Curve([(0, 0, 'A'), (1, 0, 'A'), (1, 0.5, 'B'),
+        curve = hv.Curve([(0, 0, 'A'), (1, 0, 'A'), (1, 0.5, 'B'),
                        (2, 0.5, 'B'), (2, 1, 'C')],
                       vdims=['y', 'z'])
         assert_element_equal(interpolated, curve)
@@ -755,44 +735,44 @@ class OperationTests:
     def test_interpolate_datetime_curve_post(self):
         dates = np.array([dt.datetime(2017, 1, i) for i in range(1, 5)]).astype('M')
         values = [0, 1, 2, 3]
-        interpolated = interpolate_curve(Curve((dates, values)), interpolation='steps-post')
+        interpolated = interpolate_curve(hv.Curve((dates, values)), interpolation='steps-post')
         dates_interp = np.array([
             '2017-01-01T00:00:00', '2017-01-02T00:00:00',
             '2017-01-02T00:00:00', '2017-01-03T00:00:00',
             '2017-01-03T00:00:00', '2017-01-04T00:00:00',
             '2017-01-04T00:00:00'
         ], dtype='datetime64[ns]')
-        curve = Curve((dates_interp, [0, 0, 1, 1, 2, 2, 3]))
+        curve = hv.Curve((dates_interp, [0, 0, 1, 1, 2, 2, 3]))
         assert_element_equal(interpolated, curve)
 
     @pytest.mark.parametrize("dtype", [pd.Int64Dtype(), np.int64])
     def test_interpolate_pandas_dtype_curve_post(self, dtype):
         df = pd.DataFrame(dict(a=[1, 2, 3], b=[3, 4, 5]), dtype=dtype)
-        interpolated = interpolate_curve(Curve(df), interpolation='steps-post')
+        interpolated = interpolate_curve(hv.Curve(df), interpolation='steps-post')
         df = pd.DataFrame(dict(a=[1, 2, 2, 3, 3], b=[3, 3, 4, 4, 5]))
-        expected = Curve(df)
+        expected = hv.Curve(df)
         assert_element_equal(interpolated, expected)
 
     def test_stack_area_overlay(self):
-        areas = Area([1, 2, 3]) * Area([1, 2, 3])
-        stacked = Area.stack(areas)
-        area1 = Area(([0, 1, 2], [1, 2, 3], [0, 0, 0]), vdims=['y', 'Baseline'])
-        area2 = Area(([0, 1, 2], [2, 4, 6], [1, 2, 3]), vdims=['y', 'Baseline'])
+        areas = hv.Area([1, 2, 3]) * hv.Area([1, 2, 3])
+        stacked = hv.Area.stack(areas)
+        area1 = hv.Area(([0, 1, 2], [1, 2, 3], [0, 0, 0]), vdims=['y', 'Baseline'])
+        area2 = hv.Area(([0, 1, 2], [2, 4, 6], [1, 2, 3]), vdims=['y', 'Baseline'])
         assert_element_equal(stacked, area1 * area2)
 
     def test_stack_area_ndoverlay(self):
-        areas = NdOverlay([(0, Area([1, 2, 3])), (1, Area([1, 2, 3]))])
-        stacked = Area.stack(areas)
-        area1 = Area(([0, 1, 2], [1, 2, 3], [0, 0, 0]), vdims=['y', 'Baseline'])
-        area2 = Area(([0, 1, 2], [2, 4, 6], [1, 2, 3]), vdims=['y', 'Baseline'])
-        assert_element_equal(stacked, NdOverlay([(0, area1), (1, area2)]))
+        areas = hv.NdOverlay([(0, hv.Area([1, 2, 3])), (1, hv.Area([1, 2, 3]))])
+        stacked = hv.Area.stack(areas)
+        area1 = hv.Area(([0, 1, 2], [1, 2, 3], [0, 0, 0]), vdims=['y', 'Baseline'])
+        area2 = hv.Area(([0, 1, 2], [2, 4, 6], [1, 2, 3]), vdims=['y', 'Baseline'])
+        assert_element_equal(stacked, hv.NdOverlay([(0, area1), (1, area2)]))
 
     def test_pre_and_postprocess_hooks(self):
         pre_backup = operation._preprocess_hooks
         post_backup = operation._postprocess_hooks
         operation._preprocess_hooks = [lambda op, x: {'label': str(x.id)}]
         operation._postprocess_hooks = [lambda op, x, **kwargs: x.clone(**kwargs)]
-        curve = Curve([1, 2, 3])
+        curve = hv.Curve([1, 2, 3])
         assert operation(curve).label == str(curve.id)
         operation._preprocess_hooks = pre_backup
         operation._postprocess_hooks = post_backup
@@ -801,9 +781,9 @@ class OperationTests:
     def test_decimate_ordering(self):
         x = np.linspace(0, 10, 100)
         y = np.sin(x)
-        curve = Curve((x, y))
+        curve = hv.Curve((x, y))
         decimated = decimate(curve, max_samples=20)
-        renderer("bokeh").get_plot(decimated)
+        hv.renderer("bokeh").get_plot(decimated)
 
         index = decimated.data[()].data.index
         assert np.all(index == np.sort(index))
@@ -811,10 +791,10 @@ class OperationTests:
     @pytest.mark.usefixtures("bokeh_backend")
     def test_decimate_same_y(self):
         data = pd.DataFrame({'x': np.arange(10), 'y': np.ones(10)})
-        points = Points(data, kdims=['x', 'y']).opts(xlim=(0, 10))
+        points = hv.Points(data, kdims=['x', 'y']).opts(xlim=(0, 10))
         decimated = decimate(points)
 
-        renderer("bokeh").get_plot(decimated)
+        hv.renderer("bokeh").get_plot(decimated)
         output = decimated.data[()].data
         pd.testing.assert_series_equal(data["x"], output["x"])
         pd.testing.assert_series_equal(data["y"], output["y"])
@@ -862,9 +842,9 @@ class TestDendrogramOperation:
             "data": data,
             "counts": [x for x in counts for _ in range(10)],
          })
-        self.ds = Dataset(df, kdims=["obs", "var"], vdims=["data", "counts"])
+        self.ds = hv.Dataset(df, kdims=["obs", "var"], vdims=["data", "counts"])
 
-        self.bokeh_renderer = renderer("bokeh")
+        self.bokeh_renderer = hv.renderer("bokeh")
 
     def get_childrens(self, adjoint):
         bk_childrens = self.bokeh_renderer.get_plot(adjoint).handles["plot"].children
@@ -881,43 +861,43 @@ class TestDendrogramOperation:
         return (atop, amain, aright), (top, main, right)
 
     def test_right_only(self):
-        dataset = Dataset(self.df)
+        dataset = hv.Dataset(self.df)
         dendro = dendrogram(dataset, adjoint_dims=["x"], main_dim="y")
-        assert isinstance(dendro, AdjointLayout)
-        assert isinstance(dendro["main"], HeatMap)
-        assert isinstance(dendro["right"], Dendrogram)
-        assert isinstance(dendro["top"], Empty)
+        assert isinstance(dendro, hv.AdjointLayout)
+        assert isinstance(dendro["main"], hv.HeatMap)
+        assert isinstance(dendro["right"], hv.Dendrogram)
+        assert isinstance(dendro["top"], hv.Empty)
         assert dendro["right"].kdims == ["__dendrogram_x_x", "__dendrogram_y_x"]
 
     def test_top_only(self):
-        dataset = Dataset(self.df)
+        dataset = hv.Dataset(self.df)
         dendro = dendrogram(dataset, adjoint_dims=["z"], main_dim="y")
-        assert isinstance(dendro, AdjointLayout)
-        assert isinstance(dendro["main"], HeatMap)
-        assert isinstance(dendro["right"], Empty)
-        assert isinstance(dendro["top"], Dendrogram)
+        assert isinstance(dendro, hv.AdjointLayout)
+        assert isinstance(dendro["main"], hv.HeatMap)
+        assert isinstance(dendro["right"], hv.Empty)
+        assert isinstance(dendro["top"], hv.Dendrogram)
         assert dendro["top"].kdims == ["__dendrogram_x_z", "__dendrogram_y_z"]
 
     @pytest.mark.parametrize("adjoint_dims", [["x", "z"], ["z", "x"]], ids=["xz", "zx"])
     def test_both_xz(self, adjoint_dims):
-        dataset = Dataset(self.df)
+        dataset = hv.Dataset(self.df)
         dendro = dendrogram(dataset, adjoint_dims=adjoint_dims, main_dim="y")
-        assert isinstance(dendro, AdjointLayout)
-        assert isinstance(dendro["main"], HeatMap)
-        assert isinstance(dendro["right"], Dendrogram)
-        assert isinstance(dendro["top"], Dendrogram)
+        assert isinstance(dendro, hv.AdjointLayout)
+        assert isinstance(dendro["main"], hv.HeatMap)
+        assert isinstance(dendro["right"], hv.Dendrogram)
+        assert isinstance(dendro["top"], hv.Dendrogram)
         assert dendro["right"].kdims == ["__dendrogram_x_x", "__dendrogram_y_x"]
         assert dendro["top"].kdims == ["__dendrogram_x_z", "__dendrogram_y_z"]
 
     def test_point_plot(self):
-        dataset = Points(self.df)
+        dataset = hv.Points(self.df)
         dendro = dendrogram(dataset, adjoint_dims=["x", "z"], main_dim="y")
-        assert isinstance(dendro, AdjointLayout)
-        assert isinstance(dendro["main"], Points)
+        assert isinstance(dendro, hv.AdjointLayout)
+        assert isinstance(dendro["main"], hv.Points)
 
     def test_depth_matches_non_adjoint(self):
         # depth dimensions is the orthogonal axis to the main plot
-        dataset = Dataset(self.df)
+        dataset = hv.Dataset(self.df)
         dendro = dendrogram(dataset, adjoint_dims=["x", "z"], main_dim="y")
         (atop, amain, aright), (top, _main, right) = self.get_childrens(dendro)
 
@@ -938,19 +918,19 @@ class TestDendrogramOperation:
         assert aright.y_range.factors == amain.y_range.factors
 
     def test_adjoned_False_1dim(self):
-        dataset = Dataset(self.df)
+        dataset = hv.Dataset(self.df)
         dendro = dendrogram(dataset, adjoint_dims=["x"], main_dim="y", adjoined=False)
 
-        assert isinstance(dendro, Dendrogram)
+        assert isinstance(dendro, hv.Dendrogram)
 
     def test_adjoned_False_2dim(self):
-        dataset = Dataset(self.df)
+        dataset = hv.Dataset(self.df)
         dendro = dendrogram(dataset, adjoint_dims=["x", "z"], main_dim="y", adjoined=False)
 
-        assert isinstance(dendro, Layout)
+        assert isinstance(dendro, hv.Layout)
         assert len(dendro) == 2
-        assert isinstance(dendro[0], Dendrogram)
-        assert isinstance(dendro[1], Dendrogram)
+        assert isinstance(dendro[0], hv.Dendrogram)
+        assert isinstance(dendro[1], hv.Dendrogram)
 
     @pytest.mark.parametrize(
         "adjoint_dims",
@@ -958,7 +938,7 @@ class TestDendrogramOperation:
         ids=["right", "top", "both"],
     )
     def test_invert_dendrogram(self, adjoint_dims):
-        plot = Points(self.df2, kdims=["gene", "cluster"])
+        plot = hv.Points(self.df2, kdims=["gene", "cluster"])
         dendro1 = dendrogram(plot, adjoint_dims=adjoint_dims, main_dim="value")
         dendro2 = dendrogram(plot, adjoint_dims=adjoint_dims, main_dim="value", invert=True)
 
@@ -979,7 +959,7 @@ class TestDendrogramOperation:
     @pytest.mark.parametrize("adjoint_dims", [["cluster"], ["gene"],], ids=["right", "top"])
     def test_assure_non_adjoined_axis_is_unchanged_points(self, adjoint_dims):
         # See: https://github.com/holoviz/holoviews/pull/6625#issuecomment-2981268665
-        plot = Points(self.df2, kdims=["gene", "cluster"])
+        plot = hv.Points(self.df2, kdims=["gene", "cluster"])
         main1 = self.bokeh_renderer.get_plot(plot).handles["plot"]
 
         dendro = dendrogram(plot, adjoint_dims=adjoint_dims, main_dim="value")
@@ -994,7 +974,7 @@ class TestDendrogramOperation:
     def test_assure_non_adjoined_axis_is_unchanged_heatmap(self):
         # Follow up to previous test, see
         # https://github.com/holoviz/holoviews/pull/6669#issuecomment-3237153317
-        plot = HeatMap(self.ds)
+        plot = hv.HeatMap(self.ds)
         main1 = self.bokeh_renderer.get_plot(plot).handles["plot"]
 
         dendro = dendrogram(plot, adjoint_dims=["obs"], main_dim="data")
@@ -1021,8 +1001,8 @@ class TestDendrogramOperation:
             },
         )
 
-        dendro = dendrogram(Dataset(da), adjoint_dims=adjoint_dims, main_dim="main")
-        assert isinstance(dendro, AdjointLayout)
+        dendro = dendrogram(hv.Dataset(da), adjoint_dims=adjoint_dims, main_dim="main")
+        assert isinstance(dendro, hv.AdjointLayout)
 
     def test_failed_linkage(self):
         msg = "Could not calculate linkage for dendrogram"
@@ -1034,7 +1014,7 @@ class TestDendrogramOperation:
 
     def test_not_primary_main_dim(self):
         # Adding hover to have access to the other dimension values
-        plot = HeatMap(self.ds).opts(tools=["hover"])
+        plot = hv.HeatMap(self.ds).opts(tools=["hover"])
         assert plot.vdims[0] == "data"
         dendro = dendrogram(
             plot,
@@ -1059,4 +1039,4 @@ def test_compositor_operations_size():
 
     # To verify we don't add a string instead of class
     for op in Compositor.operations:
-        assert not isinstance(op, str)
+        ssert not isinstance(op, str)

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -9,7 +9,6 @@ import pytest
 import holoviews as hv
 from holoviews.core.data.grid import GridInterface
 from holoviews.core.data.ibis import IBIS_VERSION
-from holoviews.core.operation import Operation
 from holoviews.core.options import Compositor, SkipRendering
 from holoviews.operation.element import (
     chain,
@@ -1039,4 +1038,4 @@ def test_compositor_operations_size():
 
     # To verify we don't add a string instead of class
     for op in Compositor.operations:
-        ssert not isinstance(op, str)
+        assert not isinstance(op, str)

--- a/holoviews/tests/operation/test_statsoperations.py
+++ b/holoviews/tests/operation/test_statsoperations.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews import Area, Bivariate, Contours, Distribution, Image, Polygons
+import holoviews as hv
 from holoviews.operation.stats import bivariate_kde, univariate_kde
 from holoviews.testing import assert_element_equal
 
@@ -18,59 +18,59 @@ class KDEOperationTests:
 
     def setup_method(self):
         self.values = np.arange(4)
-        self.dist = Distribution(self.values)
+        self.dist = hv.Distribution(self.values)
         self.nans = np.full(5, np.nan)
         self.values2d = [(i, j) for i in np.linspace(0, 4, 10)
                          for j in np.linspace(0, 4, 10)]
-        self.bivariate = Bivariate(self.values2d)
-        self.dist_nans = Distribution(self.nans)
-        self.bivariate_nans = Bivariate(np.column_stack([self.nans, self.nans]))
+        self.bivariate = hv.Bivariate(self.values2d)
+        self.dist_nans = hv.Distribution(self.nans)
+        self.bivariate_nans = hv.Bivariate(np.column_stack([self.nans, self.nans]))
 
     def test_univariate_kde(self):
         kde = univariate_kde(self.dist, n_samples=5, bin_range=(0, 4))
         xs = np.arange(5)
         ys = [0.17594505, 0.23548218, 0.23548218, 0.17594505, 0.0740306]
-        area = Area((xs, ys), 'Value', ('Value_density', 'Density'))
+        area = hv.Area((xs, ys), 'Value', ('Value_density', 'Density'))
         assert_element_equal(kde, area)
 
     def test_univariate_kde_flat_distribution(self):
-        dist = Distribution([1, 1, 1])
+        dist = hv.Distribution([1, 1, 1])
         kde = univariate_kde(dist, n_samples=5, bin_range=(0, 4))
-        area = Area([], 'Value', ('Value_density', 'Density'))
+        area = hv.Area([], 'Value', ('Value_density', 'Density'))
         assert_element_equal(kde, area)
 
     def test_univariate_kde_nans(self):
         kde = univariate_kde(self.dist_nans, n_samples=5, bin_range=(0, 4))
         xs = np.arange(5)
         ys = [0, 0, 0, 0, 0]
-        area = Area((xs, ys), 'Value', ('Value_density', 'Density'))
+        area = hv.Area((xs, ys), 'Value', ('Value_density', 'Density'))
         assert_element_equal(kde, area)
 
     def test_bivariate_kde(self):
         kde = bivariate_kde(self.bivariate, n_samples=2, x_range=(0, 4),
                             y_range=(0, 4), contours=False)
-        img = Image(np.array([[0.021315, 0.021315], [0.021315, 0.021315]]),
+        img = hv.Image(np.array([[0.021315, 0.021315], [0.021315, 0.021315]]),
                     bounds=(-2, -2, 6, 6), vdims=['Density'])
         assert_element_equal(kde, img)
 
     def test_bivariate_kde_contours(self):
         np.random.seed(1)
-        bivariate = Bivariate(np.random.rand(100, 2))
+        bivariate = hv.Bivariate(np.random.rand(100, 2))
         kde = bivariate_kde(bivariate, n_samples=100, x_range=(0, 1),
                             y_range=(0, 1), contours=True, levels=10)
-        assert isinstance(kde, Contours)
+        assert isinstance(kde, hv.Contours)
         assert len(kde.data) == 9
 
     def test_bivariate_kde_contours_filled(self):
         np.random.seed(1)
-        bivariate = Bivariate(np.random.rand(100, 2))
+        bivariate = hv.Bivariate(np.random.rand(100, 2))
         kde = bivariate_kde(bivariate, n_samples=100, x_range=(0, 1),
                             y_range=(0, 1), contours=True, filled=True, levels=10)
-        assert isinstance(kde, Polygons)
+        assert isinstance(kde, hv.Polygons)
         assert len(kde.data) == 10
 
     def test_bivariate_kde_nans(self):
         kde = bivariate_kde(self.bivariate_nans, n_samples=2, x_range=(0, 4),
                             y_range=(0, 4), contours=False)
-        img = Image(np.zeros((2, 2)), bounds=(-2, -2, 6, 6), vdims=['Density'])
+        img = hv.Image(np.zeros((2, 2)), bounds=(-2, -2, 6, 6), vdims=['Density'])
         assert_element_equal(kde, img)

--- a/holoviews/tests/operation/test_timeseriesoperations.py
+++ b/holoviews/tests/operation/test_timeseriesoperations.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews import Curve, Scatter
+import holoviews as hv
 from holoviews.operation.timeseries import resample, rolling, rolling_outlier_std
 from holoviews.testing import assert_element_equal
 
@@ -20,58 +20,58 @@ class TimeseriesOperationTests:
         self.dates = pd.date_range("2016-01-01", "2016-01-07", freq='D')
         self.values = [1, 2, 3, 4, 5, 6, 7]
         self.outliers = [1, 2, 1, 2, 10., 2, 1]
-        self.date_curve = Curve((self.dates, self.values))
-        self.int_curve = Curve(self.values)
-        self.date_outliers = Curve((self.dates, self.outliers))
-        self.int_outliers = Curve(self.outliers)
+        self.date_curve = hv.Curve((self.dates, self.values))
+        self.int_curve = hv.Curve(self.values)
+        self.date_outliers = hv.Curve((self.dates, self.outliers))
+        self.int_outliers = hv.Curve(self.outliers)
 
     def test_roll_dates(self):
         rolled = rolling(self.date_curve, rolling_window=2)
         rolled_vals = [np.nan, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5]
-        assert_element_equal(rolled, Curve((self.dates, rolled_vals)))
+        assert_element_equal(rolled, hv.Curve((self.dates, rolled_vals)))
 
     def test_roll_ints(self):
         rolled = rolling(self.int_curve, rolling_window=2)
         rolled_vals = [np.nan, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5]
-        assert_element_equal(rolled, Curve(rolled_vals))
+        assert_element_equal(rolled, hv.Curve(rolled_vals))
 
     @scipy_skip
     def test_roll_date_with_window_type(self):
         rolled = rolling(self.date_curve, rolling_window=3, window_type='triang')
         rolled_vals = [np.nan, 2, 3, 4, 5, 6, np.nan]
-        assert_element_equal(rolled, Curve((self.dates, rolled_vals)))
+        assert_element_equal(rolled, hv.Curve((self.dates, rolled_vals)))
 
     @scipy_skip
     def test_roll_ints_with_window_type(self):
         rolled = rolling(self.int_curve, rolling_window=3, window_type='triang')
         rolled_vals = [np.nan, 2, 3, 4, 5, 6, np.nan]
-        assert_element_equal(rolled, Curve(rolled_vals))
+        assert_element_equal(rolled, hv.Curve(rolled_vals))
 
     def test_resample_weekly(self):
         resampled = resample(self.date_curve, rule='W')
         dates = list(map(pd.Timestamp, ["2016-01-03", "2016-01-10"]))
         vals = [2, 5.5]
-        assert_element_equal(resampled, Curve((dates, vals)))
+        assert_element_equal(resampled, hv.Curve((dates, vals)))
 
     def test_resample_weekly_closed_left(self):
         resampled = resample(self.date_curve, rule='W', closed='left')
         dates = list(map(pd.Timestamp, ["2016-01-03", "2016-01-10"]))
         vals = [1.5, 5]
-        assert_element_equal(resampled, Curve((dates, vals)))
+        assert_element_equal(resampled, hv.Curve((dates, vals)))
 
     def test_resample_weekly_label_left(self):
         resampled = resample(self.date_curve, rule='W', label='left')
         dates = list(map(pd.Timestamp, ["2015-12-27", "2016-01-03"]))
         vals = [2, 5.5]
-        assert_element_equal(resampled, Curve((dates, vals)))
+        assert_element_equal(resampled, hv.Curve((dates, vals)))
 
     def test_rolling_outliers_std_ints(self):
         outliers = rolling_outlier_std(self.int_outliers, rolling_window=2, sigma=1)
-        assert_element_equal(outliers, Scatter([(4, 10)]))
+        assert_element_equal(outliers, hv.Scatter([(4, 10)]))
 
     def test_rolling_outliers_std_dates(self):
         outliers = rolling_outlier_std(self.date_outliers, rolling_window=2, sigma=1)
-        assert_element_equal(outliers, Scatter([(pd.Timestamp("2016-01-05"), 10)]))
+        assert_element_equal(outliers, hv.Scatter([(pd.Timestamp("2016-01-05"), 10)]))
 
     def test_rolling_outliers_std_dataset(self):
         xr = pytest.importorskip("xarray")
@@ -80,7 +80,7 @@ class TimeseriesOperationTests:
             data_vars={"y": ("x", self.outliers)},
             coords={"x": self.dates}
         )
-        curve = Curve(ds, ["x"], ["y"])
+        curve = hv.Curve(ds, ["x"], ["y"])
         outliers = rolling_outlier_std(curve, rolling_window=2, sigma=1)
-        expected = Scatter([(pd.Timestamp("2016-01-05"), 10)])
+        expected = hv.Scatter([(pd.Timestamp("2016-01-05"), 10)])
         assert_element_equal(outliers, expected)

--- a/holoviews/tests/plotting/__init__.py
+++ b/holoviews/tests/plotting/__init__.py
@@ -1,16 +1,16 @@
 from itertools import combinations
 
-from holoviews.core.options import Options, Store
+import holoviews as hv
 
 
 def option_intersections(backend):
     intersections = []
-    options = Store.options(backend)
+    options = hv.Store.options(backend)
     for k, opts in sorted(options.items()):
         if len(k) > 1: continue
         valid_options = {k: set(o.allowed_keywords)
                          for k, o in opts.groups.items()}
-        for g1, g2 in combinations(Options._option_groups, 2):
+        for g1, g2 in combinations(hv.Options._option_groups, 2):
             intersection = valid_options[g1] & valid_options[g2]
             if intersection:
                 intersections.append((k, intersection))

--- a/holoviews/tests/plotting/bokeh/test_annotationplot.py
+++ b/holoviews/tests/plotting/bokeh/test_annotationplot.py
@@ -2,20 +2,6 @@ import numpy as np
 import pytest
 
 import holoviews as hv
-from holoviews.element import (
-    Arrow,
-    HLine,
-    HLines,
-    HSpan,
-    HSpans,
-    Labels,
-    Slope,
-    Text,
-    VLine,
-    VLines,
-    VSpan,
-    VSpans,
-)
 from holoviews.plotting.bokeh.util import BOKEH_GE_3_2_0, BOKEH_GE_3_3_0, BOKEH_GE_3_4_0
 
 from .test_plot import TestBokehPlot, bokeh_renderer
@@ -37,28 +23,28 @@ elif BOKEH_GE_3_3_0:
 class TestHVLinePlot(TestBokehPlot):
 
     def test_hline_invert_axes(self):
-        hline = HLine(1.1).opts(invert_axes=True)
+        hline = hv.HLine(1.1).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(hline)
         span = plot.handles['glyph']
         assert span.dimension == 'height'
         assert span.location == 1.1
 
     def test_hline_plot(self):
-        hline = HLine(1.1)
+        hline = hv.HLine(1.1)
         plot = bokeh_renderer.get_plot(hline)
         span = plot.handles['glyph']
         assert span.dimension == 'width'
         assert span.location == 1.1
 
     def test_vline_invert_axes(self):
-        vline = VLine(1.1).opts(invert_axes=True)
+        vline = hv.VLine(1.1).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(vline)
         span = plot.handles['glyph']
         assert span.dimension == 'width'
         assert span.location == 1.1
 
     def test_vline_plot(self):
-        vline = VLine(1.1)
+        vline = hv.VLine(1.1)
         plot = bokeh_renderer.get_plot(vline)
         span = plot.handles['glyph']
         assert span.dimension == 'height'
@@ -68,7 +54,7 @@ class TestHVLinePlot(TestBokehPlot):
 class TestHVSpanPlot(TestBokehPlot):
 
     def test_hspan_invert_axes(self):
-        hspan = HSpan(1.1, 1.5).opts(invert_axes=True)
+        hspan = hv.HSpan(1.1, 1.5).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(hspan)
         span = plot.handles['glyph']
 
@@ -83,7 +69,7 @@ class TestHVSpanPlot(TestBokehPlot):
         assert span.visible
 
     def test_hspan_plot(self):
-        hspan = HSpan(1.1, 1.5)
+        hspan = hv.HSpan(1.1, 1.5)
         plot = bokeh_renderer.get_plot(hspan)
         span = plot.handles['glyph']
         if BOKEH_GE_3_3_0:
@@ -97,13 +83,13 @@ class TestHVSpanPlot(TestBokehPlot):
         assert span.visible
 
     def test_hspan_empty(self):
-        vline = HSpan(None)
+        vline = hv.HSpan(None)
         plot = bokeh_renderer.get_plot(vline)
         span = plot.handles['glyph']
         assert span.visible is False
 
     def test_vspan_invert_axes(self):
-        vspan = VSpan(1.1, 1.5).opts(invert_axes=True)
+        vspan = hv.VSpan(1.1, 1.5).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(vspan)
         span = plot.handles['glyph']
         if BOKEH_GE_3_3_0:
@@ -117,7 +103,7 @@ class TestHVSpanPlot(TestBokehPlot):
         assert span.visible
 
     def test_vspan_plot(self):
-        vspan = VSpan(1.1, 1.5)
+        vspan = hv.VSpan(1.1, 1.5)
         plot = bokeh_renderer.get_plot(vspan)
         span = plot.handles['glyph']
         assert span.left == 1.1
@@ -131,7 +117,7 @@ class TestHVSpanPlot(TestBokehPlot):
         assert span.visible
 
     def test_vspan_empty(self):
-        vline = VSpan(None)
+        vline = hv.VSpan(None)
         plot = bokeh_renderer.get_plot(vline)
         span = plot.handles['glyph']
         assert span.visible is False
@@ -140,14 +126,14 @@ class TestHVSpanPlot(TestBokehPlot):
 class TestSlopePlot(TestBokehPlot):
 
     def test_slope(self):
-        hspan = Slope(2, 10)
+        hspan = hv.Slope(2, 10)
         plot = bokeh_renderer.get_plot(hspan)
         slope = plot.handles['glyph']
         assert slope.gradient == 2
         assert slope.y_intercept == 10
 
     def test_slope_invert_axes(self):
-        hspan = Slope(2, 10).opts(invert_axes=True)
+        hspan = hv.Slope(2, 10).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(hspan)
         slope = plot.handles['glyph']
         assert slope.gradient == 0.5
@@ -158,25 +144,25 @@ class TestSlopePlot(TestBokehPlot):
 class TestTextPlot(TestBokehPlot):
 
     def test_text_plot(self):
-        text = Text(0, 0, 'Test')
+        text = hv.Text(0, 0, 'Test')
         plot = bokeh_renderer.get_plot(text)
         source = plot.handles['source']
         assert source.data == {'x': [0], 'y': [0], 'text': ['Test']}
 
     def test_text_plot_fontsize(self):
-        text = Text(0, 0, 'Test', fontsize=18)
+        text = hv.Text(0, 0, 'Test', fontsize=18)
         plot = bokeh_renderer.get_plot(text)
         glyph = plot.handles['glyph']
         assert glyph.text_font_size == '18Pt'
 
     def test_text_plot_rotation(self):
-        text = Text(0, 0, 'Test', rotation=90)
+        text = hv.Text(0, 0, 'Test', rotation=90)
         plot = bokeh_renderer.get_plot(text)
         glyph = plot.handles['glyph']
         assert glyph.angle == np.pi/2.
 
     def test_text_plot_rotation_style(self):
-        text = Text(0, 0, 'Test').opts(angle=90)
+        text = hv.Text(0, 0, 'Test').opts(angle=90)
         plot = bokeh_renderer.get_plot(text)
         glyph = plot.handles['glyph']
         assert glyph.angle == np.pi/2.
@@ -204,22 +190,22 @@ class TestArrowPlot(TestBokehPlot):
                                           'y_start': [y0], 'y_end': [y1]}
 
     def test_arrow_plot_left(self):
-        arrow = Arrow(0, 0, 'Test')
+        arrow = hv.Arrow(0, 0, 'Test')
         plot = bokeh_renderer.get_plot(arrow)
         self._compare_arrow_plot(plot, (1/6., 0), (0, 0))
 
     def test_arrow_plot_up(self):
-        arrow = Arrow(0, 0, 'Test', '^')
+        arrow = hv.Arrow(0, 0, 'Test', '^')
         plot = bokeh_renderer.get_plot(arrow)
         self._compare_arrow_plot(plot, (0, -1/6.), (0, 0))
 
     def test_arrow_plot_right(self):
-        arrow = Arrow(0, 0, 'Test', '>')
+        arrow = hv.Arrow(0, 0, 'Test', '>')
         plot = bokeh_renderer.get_plot(arrow)
         self._compare_arrow_plot(plot, (-1/6., 0), (0, 0))
 
     def test_arrow_plot_down(self):
-        arrow = Arrow(0, 0, 'Test', 'v')
+        arrow = hv.Arrow(0, 0, 'Test', 'v')
         plot = bokeh_renderer.get_plot(arrow)
         self._compare_arrow_plot(plot, (0, 1/6.), (0, 0))
 
@@ -227,7 +213,7 @@ class TestArrowPlot(TestBokehPlot):
 class TestLabelsPlot(TestBokehPlot):
 
     def test_labels_plot(self):
-        text = Labels([(0, 0, 'Test')])
+        text = hv.Labels([(0, 0, 'Test')])
         plot = bokeh_renderer.get_plot(text)
         source = plot.handles['source']
         data = {'x': np.array([0]), 'y': np.array([0]), 'Label': ['Test']}
@@ -235,7 +221,7 @@ class TestLabelsPlot(TestBokehPlot):
             assert col == data[c]
 
     def test_labels_plot_rotation_style(self):
-        text = Labels([(0, 0, 'Test')]).opts(angle=90)
+        text = hv.Labels([(0, 0, 'Test')]).opts(angle=90)
         plot = bokeh_renderer.get_plot(text)
         glyph = plot.handles['glyph']
         assert glyph.angle == np.pi/2.
@@ -248,7 +234,7 @@ class TestHVLinesPlot(TestBokehPlot):
             pytest.skip("Bokeh 3.2 added H/VLines")
 
     def test_hlines_plot(self):
-        hlines = HLines(
+        hlines = hv.HLines(
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(hlines)
@@ -267,7 +253,7 @@ class TestHVLinesPlot(TestBokehPlot):
 
     def test_hlines_plot_multi_y(self):
         hlines = (
-            HLines({"y1": [1, 2, 3]}, 'y1') * HLines({'y2': [3, 4, 5]}, 'y2')
+            hv.HLines({"y1": [1, 2, 3]}, 'y1') * hv.HLines({'y2': [3, 4, 5]}, 'y2')
         ).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(hlines)
         sp1, sp2 = plot.subplots.values()
@@ -281,7 +267,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert y2_range.end == 5
 
     def test_hlines_xlabel_ylabel(self):
-        hlines = HLines(
+        hlines = hv.HLines(
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         ).opts(xlabel="xlabel", ylabel="xlabel")
         plot = bokeh_renderer.get_plot(hlines)
@@ -290,7 +276,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert plot.handles["yaxis"].axis_label == "xlabel"
 
     def test_hlines_array(self):
-        hlines = HLines(np.array([0, 1, 2, 5.5]))
+        hlines = hv.HLines(np.array([0, 1, 2, 5.5]))
         plot = bokeh_renderer.get_plot(hlines)
         assert isinstance(plot.handles["glyph"], BkHSpan)
         assert plot.handles["xaxis"].axis_label == "x"
@@ -306,7 +292,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert (source.data["y"] == [0, 1, 2, 5.5]).all()
 
     def test_hlines_plot_invert_axes(self):
-        hlines = HLines(
+        hlines = hv.HLines(
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         ).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(hlines)
@@ -324,7 +310,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert (source.data["y"] == [0, 1, 2, 5.5]).all()
 
     def test_hlines_nondefault_kdim(self):
-        hlines = HLines(
+        hlines = hv.HLines(
             {"extra": [0, 1, 2, 5.5]}, kdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(hlines)
@@ -342,7 +328,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert (source.data["extra"] == [0, 1, 2, 5.5]).all()
 
     def test_vlines_plot(self):
-        vlines = VLines(
+        vlines = hv.VLines(
             {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(vlines)
@@ -360,7 +346,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert (source.data["x"] == [0, 1, 2, 5.5]).all()
 
     def test_vlines_plot_invert_axes(self):
-        vlines = VLines(
+        vlines = hv.VLines(
             {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         ).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(vlines)
@@ -378,7 +364,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert (source.data["x"] == [0, 1, 2, 5.5]).all()
 
     def test_vlines_nondefault_kdim(self):
-        vlines = VLines(
+        vlines = hv.VLines(
             {"extra": [0, 1, 2, 5.5]}, kdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(vlines)
@@ -396,10 +382,10 @@ class TestHVLinesPlot(TestBokehPlot):
         assert (source.data["extra"] == [0, 1, 2, 5.5]).all()
 
     def test_vlines_hlines_overlay(self):
-        hlines = HLines(
+        hlines = hv.HLines(
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
-        vlines = VLines(
+        vlines = hv.VLines(
             {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(hlines * vlines)
@@ -413,10 +399,10 @@ class TestHVLinesPlot(TestBokehPlot):
 
     def test_vlines_hlines_overlay_non_annotation(self):
         non_annotation = hv.Curve([], kdims=["time"])
-        hlines = HLines(
+        hlines = hv.HLines(
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
-        vlines = VLines(
+        vlines = hv.VLines(
             {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(non_annotation * hlines * vlines)
@@ -424,7 +410,7 @@ class TestHVLinesPlot(TestBokehPlot):
         assert plot.handles["yaxis"].axis_label == "y"
 
     def test_coloring_hline(self):
-        hlines = HLines({"y": [1, 2, 3]})
+        hlines = hv.HLines({"y": [1, 2, 3]})
         hlines = hlines.opts(
             alpha=hv.dim("y").norm(),
             line_color="red",
@@ -446,7 +432,7 @@ class TestHVSpansPlot(TestBokehPlot):
             pytest.skip("Bokeh 3.2 added H/VSpans")
 
     def test_hspans_plot(self):
-        hspans = HSpans(
+        hspans = hv.HSpans(
             {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(hspans)
@@ -465,7 +451,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert (source.data["y1"] == [1, 4, 6.5]).all()
 
     def test_hspans_plot_xlabel_ylabel(self):
-        hspans = HSpans(
+        hspans = hv.HSpans(
             {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
         ).opts(xlabel="xlabel", ylabel="xlabel")
         plot = bokeh_renderer.get_plot(hspans)
@@ -474,7 +460,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert plot.handles["yaxis"].axis_label == "xlabel"
 
     def test_hspans_plot_invert_axes(self):
-        hspans = HSpans(
+        hspans = hv.HSpans(
             {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
         ).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(hspans)
@@ -493,7 +479,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert (source.data["y1"] == [1, 4, 6.5]).all()
 
     def test_hspans_nondefault_kdims(self):
-        hspans = HSpans(
+        hspans = hv.HSpans(
             {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
         )
         plot = bokeh_renderer.get_plot(hspans)
@@ -512,7 +498,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert (source.data["other1"] == [1, 4, 6.5]).all()
 
     def test_vspans_plot(self):
-        vspans = VSpans(
+        vspans = hv.VSpans(
             {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(vspans)
@@ -531,7 +517,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert (source.data["x1"] == [1, 4, 6.5]).all()
 
     def test_vspans_plot_invert_axes(self):
-        vspans = VSpans(
+        vspans = hv.VSpans(
             {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
         ).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(vspans)
@@ -550,7 +536,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert (source.data["x1"] == [1, 4, 6.5]).all()
 
     def test_vspans_nondefault_kdims(self):
-        vspans = VSpans(
+        vspans = hv.VSpans(
             {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
         )
         plot = bokeh_renderer.get_plot(vspans)
@@ -581,10 +567,10 @@ class TestHVSpansPlot(TestBokehPlot):
         assert plot_el.handles["y_range"].end == plot_dmap.handles["y_range"].end
 
     def test_vspans_hspans_overlay(self):
-        hspans = HSpans(
+        hspans = hv.HSpans(
             {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
         )
-        vspans = VSpans(
+        vspans = hv.VSpans(
             {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(hspans * vspans)
@@ -598,10 +584,10 @@ class TestHVSpansPlot(TestBokehPlot):
 
     def test_vlines_hlines_overlay_non_annotation(self):
         non_annotation = hv.Curve([], kdims=["time"])
-        hspans = HSpans(
+        hspans = hv.HSpans(
             {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
         )
-        vspans = VSpans(
+        vspans = hv.VSpans(
             {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]}, vdims=["extra"]
         )
         plot = bokeh_renderer.get_plot(non_annotation * hspans * vspans)
@@ -609,7 +595,7 @@ class TestHVSpansPlot(TestBokehPlot):
         assert plot.handles["yaxis"].axis_label == "y"
 
     def test_coloring_hline(self):
-        hspans = HSpans({"y0": [1, 3, 5], "y1": [2, 4, 6]}).opts(
+        hspans = hv.HSpans({"y0": [1, 3, 5], "y1": [2, 4, 6]}).opts(
             alpha=hv.dim("y0").norm(),
             line_color="red",
             line_dash=hv.dim("y1").bin([0, 3, 6], ["dashed", "solid"]),

--- a/holoviews/tests/plotting/bokeh/test_areaplot.py
+++ b/holoviews/tests/plotting/bokeh/test_areaplot.py
@@ -3,8 +3,7 @@ import datetime as dt
 import numpy as np
 import pandas as pd
 
-from holoviews.core import Overlay
-from holoviews.element import Area
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from ...utils import LoggingComparison
@@ -14,7 +13,7 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestAreaPlot(LoggingComparison, TestBokehPlot):
 
     def test_area_with_nans(self):
-        area = Area([1, 2, 3, np.nan, 5, 6, 7])
+        area = hv.Area([1, 2, 3, np.nan, 5, 6, 7])
         plot = bokeh_renderer.get_plot(area)
         cds = plot.handles['cds']
         assert_data_equal(cds.data['x'], np.array([0., 1., 2., 2., 1., 0., np.nan,
@@ -23,7 +22,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
                                                   0., 0., 0., 7., 6., 5.]))
 
     def test_area_empty(self):
-        area = Area([])
+        area = hv.Area([])
         plot = bokeh_renderer.get_plot(area)
         cds = plot.handles['cds']
         assert cds.data['x'] == []
@@ -33,7 +32,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         values = [(np.datetime64(dt.datetime(2017, 1, i)), i) for i in range(1, 4)]
         values.append((np.datetime64('nat'), np.nan))
         values += [(np.datetime64(dt.datetime(2017, 1, i)), i) for i in range(4, 6)]
-        area = Area(values)
+        area = hv.Area(values)
         plot = bokeh_renderer.get_plot(area)
         cds = plot.handles['cds']
         xs = np.array([
@@ -52,7 +51,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         assert_data_equal(cds.data['y'], ys)
 
     def test_area_padding_square(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1)
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -61,7 +60,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_area_padding_square_per_axis(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=((0, 0.1), (0.1, 0.2)))
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 1.0
@@ -70,7 +69,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.4
 
     def test_area_with_lower_vdim(self):
-        area = Area([(1, 0.5, 1), (2, 1.5, 2), (3, 2.5, 3)], vdims=['y', 'y2']).opts(padding=0.1)
+        area = hv.Area([(1, 0.5, 1), (2, 1.5, 2), (3, 2.5, 3)], vdims=['y', 'y2']).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -79,7 +78,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.25
 
     def test_area_padding_negative(self):
-        area = Area([(1, -1), (2, -2), (3, -3)]).opts(padding=0.1)
+        area = hv.Area([(1, -1), (2, -2), (3, -3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -88,7 +87,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 0
 
     def test_area_padding_mixed(self):
-        area = Area([(1, 1), (2, -2), (3, 3)]).opts(padding=0.1)
+        area = hv.Area([(1, 1), (2, -2), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -97,7 +96,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.5
 
     def test_area_padding_hard_range(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).redim.range(y=(0, 4)).opts(padding=0.1)
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).redim.range(y=(0, 4)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -106,7 +105,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 4
 
     def test_area_padding_soft_range(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -115,7 +114,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.5
 
     def test_area_padding_nonsquare(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, width=600)
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.9
@@ -124,7 +123,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_area_padding_logx(self):
-        area = Area([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
+        area = hv.Area([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.89595845984076228
@@ -133,7 +132,7 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_area_padding_logy(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, logy=True)
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(area)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -148,18 +147,18 @@ class TestAreaPlot(LoggingComparison, TestBokehPlot):
         jython = np.array([22, 43, 10, 25, 26, 101, 114, 203, 194, 215, 201, 227, 139, 160])
 
         dims = dict(kdims="time", vdims="memory")
-        python = Area(python, label="python", **dims)
-        pypy = Area(pypy, label="pypy", **dims)
-        jython = Area(jython, label="jython", **dims)
+        python = hv.Area(python, label="python", **dims)
+        pypy = hv.Area(pypy, label="pypy", **dims)
+        jython = hv.Area(jython, label="jython", **dims)
 
-        overlay = Area.stack(python * pypy * jython)
+        overlay = hv.Area.stack(python * pypy * jython)
         labels = [n[1] for n in overlay.data]
         assert labels == ['Python', 'Pypy', 'Jython']
 
     def test_area_stack_vdims(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y_1': [1, 2, 3], 'y_2': [6, 4, 2], 'y_3': [8, 1, 2]})
-        overlay = Overlay([Area(df, kdims='x', vdims=col, label=col) for col in ['y_1', 'y_2', 'y_3']])
-        plot = Area.stack(overlay)
+        overlay = hv.Overlay([hv.Area(df, kdims='x', vdims=col, label=col) for col in ['y_1', 'y_2', 'y_3']])
+        plot = hv.Area.stack(overlay)
         baselines = [np.array([0, 0, 0]), np.array([1., 2., 3.]), np.array([7., 6., 5.])]
         for n, baseline in zip(plot.data, baselines, strict=True):
             np.testing.assert_array_equal(plot.data[n].data.Baseline.to_numpy(), baseline)

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -8,8 +8,7 @@ from bokeh.models import (
     LinearColorMapper,
 )
 
-from holoviews.core.overlay import NdOverlay, Overlay
-from holoviews.element import Bars
+import holoviews as hv
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal
 
@@ -20,24 +19,24 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestBarPlot(TestBokehPlot):
 
     def test_bars_hover_ensure_kdims_sanitized(self):
-        obj = Bars(np.random.rand(10,2), kdims=['Dim with spaces'])
+        obj = hv.Bars(np.random.rand(10,2), kdims=['Dim with spaces'])
         obj = obj.opts(tools=['hover'])
         self._test_hover_info(obj, [('Dim with spaces', '@{Dim_with_spaces}'), ('y', '@{y}')])
 
     def test_bars_hover_ensure_vdims_sanitized(self):
-        obj = Bars(np.random.rand(10,2), vdims=['Dim with spaces'])
+        obj = hv.Bars(np.random.rand(10,2), vdims=['Dim with spaces'])
         obj = obj.opts(tools=['hover'])
         self._test_hover_info(obj, [('x', '@{x}'), ('Dim with spaces', '@{Dim_with_spaces}')])
 
     def test_bars_suppress_legend(self):
-        bars = Bars([('A', 1), ('B', 2)]).opts(show_legend=False)
+        bars = hv.Bars([('A', 1), ('B', 2)]).opts(show_legend=False)
         plot = bokeh_renderer.get_plot(bars)
         plot.initialize_plot()
         fig = plot.state
         assert len(fig.legend) == 0
 
     def test_empty_bars(self):
-        bars = Bars([], kdims=['x', 'y'], vdims=['z'])
+        bars = hv.Bars([], kdims=['x', 'y'], vdims=['z'])
         plot = bokeh_renderer.get_plot(bars)
         plot.initialize_plot()
         source = plot.handles['source']
@@ -46,14 +45,14 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_single_value(self):
         df = pd.DataFrame({"time": [1], "value": [-1]})
-        bars = Bars(df)
+        bars = hv.Bars(df)
         plot = bokeh_renderer.get_plot(bars)
         source = plot.handles['source']
         assert source.data['time'] == np.array([1])
         assert source.data['value'] == np.array([-1])
 
     def test_bars_grouped_categories(self):
-        bars = Bars([('A', 0, 1), ('A', 1, -1), ('B', 0, 2)],
+        bars = hv.Bars([('A', 0, 1), ('A', 1, -1), ('B', 0, 2)],
                     kdims=['Index', 'Category'], vdims=['Value'])
         plot = bokeh_renderer.get_plot(bars)
         source = plot.handles['source']
@@ -64,7 +63,7 @@ class TestBarPlot(TestBokehPlot):
         assert x_range.factors == [('A', '0'), ('A', '1'), ('B', '0'), ('B', '1')]
 
     def test_bars_multi_level_sorted(self):
-        box= Bars((['A', 'B']*15, [3, 10, 1]*10, np.random.randn(30)),
+        box= hv.Bars((['A', 'B']*15, [3, 10, 1]*10, np.random.randn(30)),
                   ['Group', 'Category'], 'Value').aggregate(function=np.mean)
         plot = bokeh_renderer.get_plot(box)
         x_range = plot.handles['x_range']
@@ -72,7 +71,7 @@ class TestBarPlot(TestBokehPlot):
             ('A', '1'), ('A', '3'), ('A', '10'), ('B', '1'), ('B', '3'), ('B', '10')]
 
     def test_box_whisker_multi_level_sorted_alphanumerically(self):
-        box= Bars(([3, 10, 1]*10, ['A', 'B']*15, np.random.randn(30)),
+        box= hv.Bars(([3, 10, 1]*10, ['A', 'B']*15, np.random.randn(30)),
                   ['Group', 'Category'], 'Value').aggregate(function=np.mean)
         plot = bokeh_renderer.get_plot(box)
         x_range = plot.handles['x_range']
@@ -81,15 +80,15 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_multi_level_two_factors_in_overlay(self):
         # See: https://github.com/holoviz/holoviews/pull/5850
-        box= Bars((["1", "2", "3"]*10, ['A', 'B']*15, np.random.randn(30)),
+        box= hv.Bars((["1", "2", "3"]*10, ['A', 'B']*15, np.random.randn(30)),
                   ['Group', 'Category'], 'Value').aggregate(function=np.mean)
-        overlay = Overlay([box])
+        overlay = hv.Overlay([box])
         plot = bokeh_renderer.get_plot(overlay)
         left_axis = plot.handles["plot"].left[0]
         assert isinstance(left_axis, LinearAxis)
 
     def test_bars_positive_negative_mixed(self):
-        bars = Bars([('A', 0, 1), ('A', 1, -1), ('B', 0, 2)],
+        bars = hv.Bars([('A', 0, 1), ('A', 1, -1), ('B', 0, 2)],
                     kdims=['Index', 'Category'], vdims=['Value'])
         plot = bokeh_renderer.get_plot(bars.opts(stacked=True))
         source = plot.handles['source']
@@ -99,7 +98,7 @@ class TestBarPlot(TestBokehPlot):
         assert_data_equal(source.data['bottom'], np.array([-1, 0, 0]))
 
     def test_bars_logy(self):
-        bars = Bars([('A', 1), ('B', 2), ('C', 3)],
+        bars = hv.Bars([('A', 1), ('B', 2), ('C', 3)],
                     kdims=['Index'], vdims=['Value'])
         plot = bokeh_renderer.get_plot(bars.opts(logy=True))
         source = plot.handles['source']
@@ -112,7 +111,7 @@ class TestBarPlot(TestBokehPlot):
         assert y_range.end == 3.348369522101713
 
     def test_bars_logy_explicit_range(self):
-        bars = Bars([('A', 1), ('B', 2), ('C', 3)],
+        bars = hv.Bars([('A', 1), ('B', 2), ('C', 3)],
                     kdims=['Index'], vdims=['Value']).redim.range(Value=(0.001, 3))
         plot = bokeh_renderer.get_plot(bars.opts(logy=True))
         source = plot.handles['source']
@@ -125,49 +124,49 @@ class TestBarPlot(TestBokehPlot):
         assert y_range.end == 3
 
     def test_bars_ylim(self):
-        bars = Bars([1, 2, 3]).opts(ylim=(0, 200))
+        bars = hv.Bars([1, 2, 3]).opts(ylim=(0, 200))
         plot = bokeh_renderer.get_plot(bars)
         y_range = plot.handles['y_range']
         assert y_range.start == 0
         assert y_range.end == 200
 
     def test_bars_padding_square(self):
-        points = Bars([(1, 2), (2, -1), (3, 3)]).opts(padding=0.1)
+        points = hv.Bars([(1, 2), (2, -1), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         y_range = plot.handles['y_range']
         assert y_range.start == -1.4
         assert y_range.end == 3.4
 
     def test_bars_padding_square_positive(self):
-        points = Bars([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1)
+        points = hv.Bars([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         y_range = plot.handles['y_range']
         assert y_range.start == 0
         assert y_range.end == 3.2
 
     def test_bars_padding_square_negative(self):
-        points = Bars([(1, -2), (2, -1), (3, -3)]).opts(padding=0.1)
+        points = hv.Bars([(1, -2), (2, -1), (3, -3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         y_range = plot.handles['y_range']
         assert y_range.start == -3.2
         assert y_range.end == 0
 
     def test_bars_padding_nonsquare(self):
-        bars = Bars([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, width=600)
+        bars = hv.Bars([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(bars)
         y_range = plot.handles['y_range']
         assert y_range.start == 0
         assert y_range.end == 3.2
 
     def test_bars_padding_logx(self):
-        bars = Bars([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
+        bars = hv.Bars([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(bars)
         y_range = plot.handles['y_range']
         assert y_range.start == 0
         assert y_range.end == 3.2
 
     def test_bars_padding_logy(self):
-        bars = Bars([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, logy=True)
+        bars = hv.Bars([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(bars)
         y_range = plot.handles['y_range']
         assert y_range.start == 0.01
@@ -175,7 +174,7 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_boolean_kdims(self):
         data = pd.DataFrame({"x1": [1, 1, 2, 2], "x2": [False, True, False, True], "y": [3, 1, 2, 2]})
-        bars = Bars(data, kdims=["x1", "x2"])
+        bars = hv.Bars(data, kdims=["x1", "x2"])
         plot = bokeh_renderer.get_plot(bars)
         x_range = plot.handles['x_range']
         assert x_range.factors == [('1', 'False'), ('1', 'True'), ('2', 'False'), ('2', 'True')]
@@ -185,7 +184,7 @@ class TestBarPlot(TestBokehPlot):
     ###########################
 
     def test_bars_color_op(self):
-        bars = Bars([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        bars = hv.Bars([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                               vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
@@ -195,7 +194,7 @@ class TestBarPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == 'black'
 
     def test_bars_linear_color_op(self):
-        bars = Bars([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        bars = hv.Bars([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                               vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
@@ -209,7 +208,7 @@ class TestBarPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == 'black'
 
     def test_bars_categorical_color_op(self):
-        bars = Bars([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
+        bars = hv.Bars([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
                               vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
@@ -222,7 +221,7 @@ class TestBarPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == 'black'
 
     def test_bars_line_color_op(self):
-        bars = Bars([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        bars = hv.Bars([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                               vdims=['y', 'color']).opts(line_color='color')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
@@ -232,7 +231,7 @@ class TestBarPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'line_color'}
 
     def test_bars_fill_color_op(self):
-        bars = Bars([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        bars = hv.Bars([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                               vdims=['y', 'color']).opts(fill_color='color')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
@@ -242,7 +241,7 @@ class TestBarPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) != {'field': 'fill_color'}
 
     def test_bars_alpha_op(self):
-        bars = Bars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        bars = hv.Bars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
@@ -251,7 +250,7 @@ class TestBarPlot(TestBokehPlot):
         assert property_to_dict(glyph.fill_alpha) == {'field': 'alpha'}
 
     def test_bars_line_alpha_op(self):
-        bars = Bars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        bars = hv.Bars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(line_alpha='alpha')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
@@ -261,7 +260,7 @@ class TestBarPlot(TestBokehPlot):
         assert property_to_dict(glyph.fill_alpha) != {'field': 'line_alpha'}
 
     def test_bars_fill_alpha_op(self):
-        bars = Bars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        bars = hv.Bars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(fill_alpha='alpha')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
@@ -271,7 +270,7 @@ class TestBarPlot(TestBokehPlot):
         assert property_to_dict(glyph.fill_alpha) == {'field': 'fill_alpha'}
 
     def test_bars_line_width_op(self):
-        bars = Bars([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
+        bars = hv.Bars([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
                               vdims=['y', 'line_width']).opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(bars)
         cds = plot.handles['cds']
@@ -281,13 +280,13 @@ class TestBarPlot(TestBokehPlot):
 
     def test_op_ndoverlay_value(self):
         colors = ['blue', 'red']
-        overlay = NdOverlay({color: Bars(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Bars', fill_color='Color')
+        overlay = hv.NdOverlay({color: hv.Bars(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Bars', fill_color='Color')
         plot = bokeh_renderer.get_plot(overlay)
         for subplot, color in zip(plot.subplots.values(),  colors, strict=True):
             assert subplot.handles['glyph'].fill_color == color
 
     def test_bars_color_index_color_clash(self):
-        bars = Bars([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        bars = hv.Bars([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                     vdims=['y', 'color']).opts(color='color', color_index='color')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(bars)
@@ -300,29 +299,29 @@ class TestBarPlot(TestBokehPlot):
         assert log_msg == warning
 
     def test_bars_continuous_data_list_same_interval(self):
-        bars = Bars(([0, 1, 2], [10, 20, 30]))
+        bars = hv.Bars(([0, 1, 2], [10, 20, 30]))
         plot = bokeh_renderer.get_plot(bars)
         np.testing.assert_almost_equal(plot.handles["glyph"].width, 0.8)
 
     def test_bars_continuous_data_list_same_interval_custom_width(self):
-        bars = Bars(([0, 1, 2], [10, 20, 30])).opts(bar_width=0.5)
+        bars = hv.Bars(([0, 1, 2], [10, 20, 30])).opts(bar_width=0.5)
         plot = bokeh_renderer.get_plot(bars)
         assert plot.handles["glyph"].width == 0.5
 
     def test_bars_continuous_data_list_diff_interval(self):
-        bars = Bars(([0, 3, 10], [10, 20, 30]))
+        bars = hv.Bars(([0, 3, 10], [10, 20, 30]))
         plot = bokeh_renderer.get_plot(bars)
         np.testing.assert_almost_equal(plot.handles["glyph"].width, 0.11428571)
 
     def test_bars_continuous_datetime(self):
-        bars = Bars((pd.date_range("1/1/2000", periods=10), np.random.rand(10)))
+        bars = hv.Bars((pd.date_range("1/1/2000", periods=10), np.random.rand(10)))
         plot = bokeh_renderer.get_plot(bars)
         np.testing.assert_almost_equal(plot.handles["glyph"].width, 69120000.0)
 
     def test_bars_continuous_datetime_timezone_in_overlay(self):
         # See: https://github.com/holoviz/holoviews/issues/6364
-        bars = Bars((pd.date_range("1/1/2000", periods=10, tz="UTC"), np.random.rand(10)))
-        overlay = Overlay([bars])
+        bars = hv.Bars((pd.date_range("1/1/2000", periods=10, tz="UTC"), np.random.rand(10)))
+        overlay = hv.Overlay([bars])
         plot = bokeh_renderer.get_plot(overlay)
         assert isinstance(plot.handles["xaxis"], DatetimeAxis)
 
@@ -338,17 +337,17 @@ class TestBarPlot(TestBokehPlot):
             "cat": ["A", "B", "A", "B"],
             "y": [1, 2, 3, 4],
         })
-        bars = Bars(data, ["x", "cat"], ["y"]).opts(stacked=True)
+        bars = hv.Bars(data, ["x", "cat"], ["y"]).opts(stacked=True)
         plot = bokeh_renderer.get_plot(bars)
         assert isinstance(plot.handles["xaxis"], DatetimeAxis)
 
     def test_bars_not_continuous_data_list(self):
-        bars = Bars([("A", 1), ("B", 2), ("C", 3)])
+        bars = hv.Bars([("A", 1), ("B", 2), ("C", 3)])
         plot = bokeh_renderer.get_plot(bars)
         assert plot.handles["glyph"].width == 0.8
 
     def test_bars_not_continuous_data_list_custom_width(self):
-        bars = Bars([("A", 1), ("B", 2), ("C", 3)]).opts(bar_width=1)
+        bars = hv.Bars([("A", 1), ("B", 2), ("C", 3)]).opts(bar_width=1)
         plot = bokeh_renderer.get_plot(bars)
         assert plot.handles["glyph"].width == 1
 
@@ -363,7 +362,7 @@ class TestBarPlot(TestBokehPlot):
             function=pd.array(["read", "read", "read"]),
         ))
 
-        bars = Bars(df, ["function", "cells"], ["time"])
+        bars = hv.Bars(df, ["function", "cells"], ["time"])
         plot = bokeh_renderer.get_plot(bars)
         x_factors = plot.handles["x_range"].factors
 
@@ -383,7 +382,7 @@ class TestBarPlot(TestBokehPlot):
         pets_sample = np.random.choice(pets, samples)
         gender_sample = np.random.choice(genders, samples)
 
-        bars = Bars(
+        bars = hv.Bars(
             (pets_sample, gender_sample, np.ones(samples)), ["Pets", "Gender"]
         ).aggregate(function=np.sum)
         plot = bokeh_renderer.get_plot(bars)
@@ -400,7 +399,7 @@ class TestBarPlot(TestBokehPlot):
         gender_sample = np.random.choice(genders, samples)
 
         bars = (
-            Bars((pets_sample, gender_sample, np.ones(samples)), ["Pets", "Gender"])
+            hv.Bars((pets_sample, gender_sample, np.ones(samples)), ["Pets", "Gender"])
             .aggregate(function=np.sum)
             .opts(stacked=True)
         )
@@ -410,14 +409,14 @@ class TestBarPlot(TestBokehPlot):
     def test_bar_stacked_stack_variable_sorted(self):
         # Check that if the stack dim is ordered
         df = pd.DataFrame({"a": [*range(50), *range(50)], "b": sorted("ab" * 50), "c": range(100)})
-        bars = Bars(df, kdims=["a", "b"], vdims=["c"]).opts(stacked=True)
+        bars = hv.Bars(df, kdims=["a", "b"], vdims=["c"]).opts(stacked=True)
         plot = bokeh_renderer.get_plot(bars)
         assert plot.handles["glyph"].width == 0.8
 
     def test_bar_narrow_non_monotonous_xvals(self):
         # Tests regression: https://github.com/holoviz/hvplot/issues/1450
         dic = {"ratio": [0.82, 1.11, 3, 6], "count": [1, 2, 1, 3]}
-        bars = Bars(dic, kdims=["ratio"], vdims=["count"])
+        bars = hv.Bars(dic, kdims=["ratio"], vdims=["count"])
         plot = bokeh_renderer.get_plot(bars)
         assert np.isclose(plot.handles["glyph"].width, 0.232)
 
@@ -432,7 +431,7 @@ def test_grouped_bars_color(stacked):
     }
 
     df = pd.DataFrame(data)
-    bar = Bars(df, kdims=["A", "B"], vdims=["count"]).opts(
+    bar = hv.Bars(df, kdims=["A", "B"], vdims=["count"]).opts(
         stacked=stacked,
         cmap="Category10",
         color="B",

--- a/holoviews/tests/plotting/bokeh/test_boxwhiskerplot.py
+++ b/holoviews/tests/plotting/bokeh/test_boxwhiskerplot.py
@@ -3,7 +3,7 @@ import datetime as dt
 import numpy as np
 from bokeh.models import CategoricalColorMapper, ColumnDataSource, LinearColorMapper
 
-from holoviews.element import BoxWhisker
+import holoviews as hv
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal
 
@@ -15,14 +15,14 @@ class TestBoxWhiskerPlot(TestBokehPlot):
     def test_box_whisker_datetime(self):
         times = np.arange(dt.datetime(2017,1,1), dt.datetime(2017,2,1),
                           dt.timedelta(days=1))
-        box = BoxWhisker((times, np.random.rand(len(times))), kdims=['Date'])
+        box = hv.BoxWhisker((times, np.random.rand(len(times))), kdims=['Date'])
         plot = bokeh_renderer.get_plot(box)
         formatted = [box.kdims[0].pprint_value(t) for t in times]
         assert all(cds.data['index'][0] in formatted for cds in plot.state.select(ColumnDataSource) if len(cds.data.get('index', [])))
 
     def test_box_whisker_hover(self):
         xs, ys = np.random.randint(0, 5, 100), np.random.randn(100)
-        box = BoxWhisker((xs, ys), 'A').sort().opts(tools=['hover'])
+        box = hv.BoxWhisker((xs, ys), 'A').sort().opts(tools=['hover'])
         plot = bokeh_renderer.get_plot(box)
         src = plot.handles['vbar_1_source']
         ys = box.aggregate(function=np.median).dimension_values('y')
@@ -33,7 +33,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
         assert plot.handles['circle_1_glyph_renderer'] in hover_tool.renderers
 
     def test_box_whisker_multi_level(self):
-        box= BoxWhisker((['A', 'B']*15, [3, 10, 1]*10, np.random.randn(30)),
+        box= hv.BoxWhisker((['A', 'B']*15, [3, 10, 1]*10, np.random.randn(30)),
                         ['Group', 'Category'], 'Value')
         plot = bokeh_renderer.get_plot(box)
         x_range = plot.handles['x_range']
@@ -41,7 +41,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
             ('A', '1'), ('A', '3'), ('A', '10'), ('B', '1'), ('B', '3'), ('B', '10')]
 
     def test_box_whisker_padding_square(self):
-        curve = BoxWhisker([1, 2, 3]).opts(padding=0.1)
+        curve = hv.BoxWhisker([1, 2, 3]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(curve)
         y_range = plot.handles['y_range']
         assert y_range.start == 0.8
@@ -54,7 +54,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
     def test_box_whisker_linear_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
+        box = hv.BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
         plot = bokeh_renderer.get_plot(box)
         source = plot.handles['vbar_1_source']
         cmapper = plot.handles['box_color_color_mapper']
@@ -68,7 +68,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
     def test_box_whisker_categorical_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(['A', 'B', 'C', 'D', 'E'], 5)
-        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
+        box = hv.BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
         plot = bokeh_renderer.get_plot(box)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']
@@ -81,7 +81,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
     def test_box_whisker_alpha_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5)/10., 5)
-        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_alpha='b')
+        box = hv.BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_alpha='b')
         plot = bokeh_renderer.get_plot(box)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']
@@ -91,7 +91,7 @@ class TestBoxWhiskerPlot(TestBokehPlot):
     def test_box_whisker_line_width_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        box = BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_line_width='b')
+        box = hv.BoxWhisker((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_line_width='b')
         plot = bokeh_renderer.get_plot(box)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']

--- a/holoviews/tests/plotting/bokeh/test_callbacks.py
+++ b/holoviews/tests/plotting/bokeh/test_callbacks.py
@@ -9,9 +9,7 @@ from bokeh.events import Tap
 from bokeh.io.doc import set_curdoc
 from bokeh.models import ColumnDataSource, Plot, PolyEditTool, Range1d, Selection
 
-from holoviews.core import DynamicMap
-from holoviews.core.options import Store
-from holoviews.element import Box, Curve, Points, Polygons, Rectangles, Table
+import holoviews as hv
 from holoviews.plotting.bokeh.callbacks import (
     BoxEditCallback,
     Callback,
@@ -46,13 +44,13 @@ bokeh_renderer = BokehRenderer.instance()
 class CallbackTestCase:
 
     def setup_method(self):
-        self.previous_backend = Store.current_backend
-        Store.current_backend = 'bokeh'
+        self.previous_backend = hv.Store.current_backend
+        hv.Store.current_backend = 'bokeh'
         self.comm_manager = bokeh_renderer.comm_manager
         bokeh_renderer.comm_manager = comms.CommManager
 
     def teardown_method(self):
-        Store.current_backend = self.previous_backend
+        hv.Store.current_backend = self.previous_backend
         bokeh_server_renderer.last_plot = None
         bokeh_renderer.last_plot = None
         Callback._callbacks = {}
@@ -62,7 +60,7 @@ class CallbackTestCase:
 class TestCallbacks(CallbackTestCase):
 
     async def test_stream_callback(self):
-        dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PointerXY()])
+        dmap = hv.DynamicMap(lambda x, y: hv.Points([(x, y)]), kdims=[], streams=[PointerXY()])
         plot = bokeh_server_renderer.get_plot(dmap)
         bokeh_server_renderer(plot)
         set_curdoc(plot.document)
@@ -72,7 +70,7 @@ class TestCallbacks(CallbackTestCase):
         assert_data_equal(data['y'], np.array([0.2]))
 
     async def test_point_stream_callback_clip(self):
-        dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PointerXY()])
+        dmap = hv.DynamicMap(lambda x, y: hv.Points([(x, y)]), kdims=[], streams=[PointerXY()])
         plot = bokeh_server_renderer.get_plot(dmap)
         bokeh_server_renderer(plot)
         set_curdoc(plot.document)
@@ -82,7 +80,7 @@ class TestCallbacks(CallbackTestCase):
         assert_data_equal(data['y'], np.array([1]))
 
     async def test_stream_callback_on_clone(self):
-        points = Points([])
+        points = hv.Points([])
         stream = PointerXY(source=points)
         plot = bokeh_server_renderer.get_plot(points.clone())
         bokeh_server_renderer(plot)
@@ -92,14 +90,14 @@ class TestCallbacks(CallbackTestCase):
         assert stream.y == 0.3
 
     def test_stream_callback_on_unlinked_clone(self):
-        points = Points([])
+        points = hv.Points([])
         PointerXY(source=points)
         plot = bokeh_server_renderer.get_plot(points.clone(link=False))
         bokeh_server_renderer(plot)
         assert len(plot.callbacks) == 0
 
     async def test_stream_callback_with_ids(self):
-        dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PointerXY()])
+        dmap = hv.DynamicMap(lambda x, y: hv.Points([(x, y)]), kdims=[], streams=[PointerXY()])
         plot = bokeh_server_renderer.get_plot(dmap)
         bokeh_server_renderer(plot)
         set_curdoc(plot.document)
@@ -114,9 +112,9 @@ class TestCallbacks(CallbackTestCase):
         history = deque(maxlen=10)
         def history_callback(x):
             history.append(x)
-            return Curve(list(history))
+            return hv.Curve(list(history))
         stream = PointerX(x=0)
-        dmap = DynamicMap(history_callback, kdims=[], streams=[stream])
+        dmap = hv.DynamicMap(history_callback, kdims=[], streams=[stream])
         plot = bokeh_server_renderer.get_plot(dmap)
         bokeh_server_renderer(plot)
         set_curdoc(plot.document)
@@ -129,7 +127,7 @@ class TestCallbacks(CallbackTestCase):
     @pytest.mark.flaky(reruns=3)
     def test_callback_cleanup(self):
         stream = PointerX(x=0)
-        dmap = DynamicMap(lambda x: Curve([x]), streams=[stream])
+        dmap = hv.DynamicMap(lambda x: hv.Curve([x]), streams=[stream])
         plot = bokeh_server_renderer.get_plot(dmap)
         assert bool(stream._subscribers)
         assert bool(Callback._callbacks)
@@ -138,7 +136,7 @@ class TestCallbacks(CallbackTestCase):
         assert not bool(Callback._callbacks)
 
     def test_selection1d_syncs_to_selected(self):
-        points = Points([(0, 0), (1, 1), (2, 2)]).opts(selected=[0, 2])
+        points = hv.Points([(0, 0), (1, 1), (2, 2)]).opts(selected=[0, 2])
         stream = Selection1D(source=points)
         bokeh_renderer.get_plot(points)
         assert stream.index == [0, 2]
@@ -150,7 +148,7 @@ class TestResetCallback(CallbackTestCase):
         resets = []
         def record(resetting):
             resets.append(resetting)
-        curve = Curve([])
+        curve = hv.Curve([])
         stream = PlotReset(source=curve)
         stream.add_subscriber(record)
         plot = bokeh_server_renderer.get_plot(curve)
@@ -163,7 +161,7 @@ class TestResetCallback(CallbackTestCase):
 class TestPointerCallbacks(CallbackTestCase):
 
     def test_pointer_x_datetime_out_of_bounds(self):
-        points = Points([(dt.datetime(2017, 1, 1), 1), (dt.datetime(2017, 1, 3), 3)]).opts(padding=0)
+        points = hv.Points([(dt.datetime(2017, 1, 1), 1), (dt.datetime(2017, 1, 3), 3)]).opts(padding=0)
         PointerX(source=points)
         plot = bokeh_server_renderer.get_plot(points)
         set_curdoc(plot.document)
@@ -175,7 +173,7 @@ class TestPointerCallbacks(CallbackTestCase):
         assert msg['x'] == np.datetime64(dt.datetime(2017, 1, 3))
 
     def test_tap_datetime_out_of_bounds(self):
-        points = Points([(dt.datetime(2017, 1, 1), 1), (dt.datetime(2017, 1, 3), 3)])
+        points = hv.Points([(dt.datetime(2017, 1, 1), 1), (dt.datetime(2017, 1, 3), 3)])
         SingleTap(source=points)
         plot = bokeh_server_renderer.get_plot(points)
         set_curdoc(plot.document)
@@ -191,29 +189,29 @@ class TestPointerCallbacks(CallbackTestCase):
 class TestEditToolCallbacks(CallbackTestCase):
 
     async def test_point_draw_callback(self):
-        points = Points([(0, 1)])
+        points = hv.Points([(0, 1)])
         point_draw = PointDraw(source=points)
         plot = bokeh_server_renderer.get_plot(points)
         assert isinstance(plot.callbacks[0], PointDrawCallback)
         callback = plot.callbacks[0]
         data = {'x': [1, 2, 3], 'y': [1, 2, 3]}
         await callback.on_msg({'data': data})
-        assert_element_equal(point_draw.element, Points(data))
+        assert_element_equal(point_draw.element, hv.Points(data))
 
     def test_point_draw_callback_initialized_server(self):
-        points = Points([(0, 1)])
+        points = hv.Points([(0, 1)])
         PointDraw(source=points)
         plot = bokeh_server_renderer.get_plot(points)
         assert 'data' in plot.handles['source']._callbacks
 
     def test_point_draw_callback_with_vdims_initialization(self):
-        points = Points([(0, 1, 'A')], vdims=['A'])
+        points = hv.Points([(0, 1, 'A')], vdims=['A'])
         stream = PointDraw(source=points)
         bokeh_server_renderer.get_plot(points)
         assert_data_equal(stream.element.dimension_values('A'), np.array(['A']))
 
     async def test_point_draw_callback_with_vdims(self):
-        points = Points([(0, 1, 'A')], vdims=['A'])
+        points = hv.Points([(0, 1, 'A')], vdims=['A'])
         point_draw = PointDraw(source=points)
         plot = bokeh_server_renderer.get_plot(points)
         assert isinstance(plot.callbacks[0], PointDrawCallback)
@@ -221,51 +219,51 @@ class TestEditToolCallbacks(CallbackTestCase):
         data = {'x': [1, 2, 3], 'y': [1, 2, 3], 'A': [None, None, 1]}
         await callback.on_msg({'data': data})
         processed = dict(data, A=[np.nan, np.nan, 1])
-        assert_element_equal(point_draw.element, Points(processed, vdims=['A']))
+        assert_element_equal(point_draw.element, hv.Points(processed, vdims=['A']))
 
     async def test_poly_draw_callback(self):
-        polys = Polygons([[(0, 0), (2, 2), (4, 0)]])
+        polys = hv.Polygons([[(0, 0), (2, 2), (4, 0)]])
         poly_draw = PolyDraw(source=polys)
         plot = bokeh_server_renderer.get_plot(polys)
         assert isinstance(plot.callbacks[0], PolyDrawCallback)
         callback = plot.callbacks[0]
         data = {'x': [[1, 2, 3], [3, 4, 5]], 'y': [[1, 2, 3], [3, 4, 5]]}
         await callback.on_msg({'data': data})
-        element = Polygons([[(1, 1), (2, 2), (3, 3)], [(3, 3), (4, 4), (5, 5)]])
+        element = hv.Polygons([[(1, 1), (2, 2), (3, 3)], [(3, 3), (4, 4), (5, 5)]])
         assert_element_equal(poly_draw.element, element)
 
     def test_poly_draw_callback_initialized_server(self):
-        polys = Polygons([[(0, 0), (2, 2), (4, 0)]])
+        polys = hv.Polygons([[(0, 0), (2, 2), (4, 0)]])
         PolyDraw(source=polys)
         plot = bokeh_server_renderer.get_plot(polys)
         assert 'data' in plot.handles['source']._callbacks
 
     async def test_poly_draw_callback_with_vdims(self):
-        polys = Polygons([{'x': [0, 2, 4], 'y': [0, 2, 0], 'A': 1}], vdims=['A'])
+        polys = hv.Polygons([{'x': [0, 2, 4], 'y': [0, 2, 0], 'A': 1}], vdims=['A'])
         poly_draw = PolyDraw(source=polys)
         plot = bokeh_server_renderer.get_plot(polys)
         assert isinstance(plot.callbacks[0], PolyDrawCallback)
         callback = plot.callbacks[0]
         data = {'x': [[1, 2, 3], [3, 4, 5]], 'y': [[1, 2, 3], [3, 4, 5]], 'A': [1, 2]}
         await callback.on_msg({'data': data})
-        element = Polygons([{'x': [1, 2, 3], 'y': [1, 2, 3], 'A': 1},
+        element = hv.Polygons([{'x': [1, 2, 3], 'y': [1, 2, 3], 'A': 1},
                             {'x': [3, 4, 5], 'y': [3, 4, 5], 'A': 2}], vdims=['A'])
         assert_element_equal(poly_draw.element, element)
 
     async def test_poly_draw_callback_with_vdims_no_color_index(self):
-        polys = Polygons([{'x': [0, 2, 4], 'y': [0, 2, 0], 'A': 1}], vdims=['A']).options(color_index=None)
+        polys = hv.Polygons([{'x': [0, 2, 4], 'y': [0, 2, 0], 'A': 1}], vdims=['A']).options(color_index=None)
         poly_draw = PolyDraw(source=polys)
         plot = bokeh_server_renderer.get_plot(polys)
         assert isinstance(plot.callbacks[0], PolyDrawCallback)
         callback = plot.callbacks[0]
         data = {'x': [[1, 2, 3], [3, 4, 5]], 'y': [[1, 2, 3], [3, 4, 5]], 'A': [1, 2]}
         await callback.on_msg({'data': data})
-        element = Polygons([{'x': [1, 2, 3], 'y': [1, 2, 3], 'A': 1},
+        element = hv.Polygons([{'x': [1, 2, 3], 'y': [1, 2, 3], 'A': 1},
                             {'x': [3, 4, 5], 'y': [3, 4, 5], 'A': 2}], vdims=['A'])
         assert_element_equal(poly_draw.element, element)
 
     async def test_box_edit_callback(self):
-        boxes = Rectangles([(-0.5, -0.5, 0.5, 0.5)])
+        boxes = hv.Rectangles([(-0.5, -0.5, 0.5, 0.5)])
         box_edit = BoxEdit(source=boxes)
         plot = bokeh_server_renderer.get_plot(boxes)
         assert isinstance(plot.callbacks[0], BoxEditCallback)
@@ -277,11 +275,11 @@ class TestEditToolCallbacks(CallbackTestCase):
         assert source.data['top'] == [0.5]
         data = {'left': [-0.25, 0], 'bottom': [-1, 0.75], 'right': [0.25, 2], 'top': [1, 1.25]}
         await callback.on_msg({'data': data})
-        element = Rectangles([(-0.25, -1, 0.25, 1), (0, 0.75, 2, 1.25)])
+        element = hv.Rectangles([(-0.25, -1, 0.25, 1), (0, 0.75, 2, 1.25)])
         assert_element_equal(box_edit.element, element)
 
     def test_box_edit_stream_data_initialized(self):
-        boxes = Rectangles([(-0.5, -0.5, 0.5, 0.5), (0, 0, 1, 1)])
+        boxes = hv.Rectangles([(-0.5, -0.5, 0.5, 0.5), (0, 0, 1, 1)])
         box_edit = BoxEdit(source=boxes)
         bokeh_server_renderer.get_plot(boxes)
 
@@ -291,7 +289,7 @@ class TestEditToolCallbacks(CallbackTestCase):
         assert list(box_edit.data['y1']) == [0.5, 1]
 
     async def test_box_edit_callback_legacy(self):
-        boxes = Polygons([Box(0, 0, 1)])
+        boxes = hv.Polygons([hv.Box(0, 0, 1)])
         box_edit = BoxEdit(source=boxes)
         plot = bokeh_server_renderer.get_plot(boxes)
         assert isinstance(plot.callbacks[0], BoxEditCallback)
@@ -303,36 +301,36 @@ class TestEditToolCallbacks(CallbackTestCase):
         assert source.data['top'] == [0.5]
         data = {'left': [-0.25, 0], 'bottom': [-1, 0.75], 'right': [0.25, 2], 'top': [1, 1.25]}
         await callback.on_msg({'data': data})
-        element = Polygons([Box(0, 0, (0.5, 2)), Box(1, 1, (2, 0.5))])
+        element = hv.Polygons([hv.Box(0, 0, (0.5, 2)), hv.Box(1, 1, (2, 0.5))])
         assert_element_equal(box_edit.element, element)
 
     def test_box_edit_callback_initialized_server(self):
-        boxes = Polygons([Box(0, 0, 1)])
+        boxes = hv.Polygons([hv.Box(0, 0, 1)])
         BoxEdit(source=boxes)
         plot = bokeh_server_renderer.get_plot(boxes)
         assert 'data' in plot.handles['cds']._callbacks
 
     @pytest.mark.flaky(reruns=3)
     async def test_poly_edit_callback(self):
-        polys = Polygons([[(0, 0), (2, 2), (4, 0)]])
+        polys = hv.Polygons([[(0, 0), (2, 2), (4, 0)]])
         poly_edit = PolyEdit(source=polys)
         plot = bokeh_server_renderer.get_plot(polys)
         assert isinstance(plot.callbacks[0], PolyEditCallback)
         callback = plot.callbacks[0]
         data = {'x': [[1, 2, 3], [3, 4, 5]], 'y': [[1, 2, 3], [3, 4, 5]]}
         await callback.on_msg({'data': data})
-        element = Polygons([[(1, 1), (2, 2), (3, 3)], [(3, 3), (4, 4), (5, 5)]])
+        element = hv.Polygons([[(1, 1), (2, 2), (3, 3)], [(3, 3), (4, 4), (5, 5)]])
         assert_element_equal(poly_edit.element, element)
 
     def test_poly_edit_callback_initialized_server(self):
-        polys = Polygons([[(0, 0), (2, 2), (4, 0)]])
+        polys = hv.Polygons([[(0, 0), (2, 2), (4, 0)]])
         PolyEdit(source=polys)
         plot = bokeh_server_renderer.get_plot(polys)
         assert 'data' in plot.handles['source']._callbacks
 
     async def test_poly_edit_shared_callback(self):
-        polys = Polygons([[(0, 0), (2, 2), (4, 0)]])
-        polys2 = Polygons([[(0, 0), (2, 2), (4, 0)]])
+        polys = hv.Polygons([[(0, 0), (2, 2), (4, 0)]])
+        polys2 = hv.Polygons([[(0, 0), (2, 2), (4, 0)]])
         poly_edit = PolyEdit(source=polys, shared=True)
         poly_edit2 = PolyEdit(source=polys2, shared=True)
         plot = bokeh_server_renderer.get_plot(polys*polys2)
@@ -347,13 +345,13 @@ class TestEditToolCallbacks(CallbackTestCase):
         callback = plot2.callbacks[0]
         data = {'x': [[1, 2, 3], [3, 4, 5]], 'y': [[1, 2, 3], [3, 4, 5]]}
         await callback.on_msg({'data': data})
-        element = Polygons([[(1, 1), (2, 2), (3, 3)], [(3, 3), (4, 4), (5, 5)]])
+        element = hv.Polygons([[(1, 1), (2, 2), (3, 3)], [(3, 3), (4, 4), (5, 5)]])
         assert_element_equal(poly_edit.element, element)
         assert_element_equal(poly_edit2.element, element)
 
     def test_point_draw_shared_datasource_callback(self):
-        points = Points([1, 2, 3])
-        table = Table(points.data, ['x', 'y'])
+        points = hv.Points([1, 2, 3])
+        table = hv.Table(points.data, ['x', 'y'])
         layout = (points + table).opts(shared_datasource=True, clone=False)
         PointDraw(source=points)
         assert points.data is table.data
@@ -388,7 +386,7 @@ class TestServerCallbacks(CallbackTestCase):
         assert msg == {'id': plot.ref['id'], 'value': 42}
 
     def test_selection1d_resolves(self):
-        points = Points([1, 2, 3])
+        points = hv.Points([1, 2, 3])
         Selection1D(source=points)
         plot = bokeh_server_renderer.get_plot(points)
         selected = Selection(indices=[0, 2])
@@ -398,7 +396,7 @@ class TestServerCallbacks(CallbackTestCase):
         assert resolved == {'id': selected.ref['id'], 'value': [0, 2]}
 
     def test_selection1d_resolves_table(self):
-        table = Table([1, 2, 3], 'x')
+        table = hv.Table([1, 2, 3], 'x')
         Selection1D(source=table)
         plot = bokeh_server_renderer.get_plot(table)
         selected = Selection(indices=[0, 2])
@@ -408,7 +406,7 @@ class TestServerCallbacks(CallbackTestCase):
         assert resolved == {'id': selected.ref['id'], 'value': [0, 2]}
 
     def test_plotsize_resolves(self):
-        points = Points([1, 2, 3])
+        points = hv.Points([1, 2, 3])
         PlotSize(source=points)
         plot = bokeh_server_renderer.get_plot(points)
         callback = plot.callbacks[0]
@@ -421,7 +419,7 @@ class TestServerCallbacks(CallbackTestCase):
         assert resolved == {'id': 'Test', 'value': 300}
 
     def test_cds_resolves(self):
-        points = Points([1, 2, 3])
+        points = hv.Points([1, 2, 3])
         CDSStream(source=points)
         plot = bokeh_server_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -437,7 +435,7 @@ class TestServerCallbacks(CallbackTestCase):
             columns=list('ABCD'),
             index=pd.date_range('2018-01-01', freq='D', periods=30),
         )
-        curve = Curve(df, 'index', 'C')
+        curve = hv.Curve(df, 'index', 'C')
         stream = RangeXY(source=curve)
         plot = bokeh_server_renderer.get_plot(curve)
         callback = plot.callbacks[0]
@@ -450,7 +448,7 @@ class TestServerCallbacks(CallbackTestCase):
     def test_rangexy_framewise_reset(self):
         pytest.skip('The fix for this was reverted, see #4396')
         stream = RangeXY(x_range=(0, 2), y_range=(0, 1))
-        curve = DynamicMap(lambda z, x_range, y_range: Curve([1, 2, z]),
+        curve = hv.DynamicMap(lambda z, x_range, y_range: hv.Curve([1, 2, z]),
                            kdims=['z'], streams=[stream]).redim.range(z=(0, 3))
         plot = bokeh_server_renderer.get_plot(curve.opts(framewise=True))
         plot.update((1,))
@@ -458,7 +456,7 @@ class TestServerCallbacks(CallbackTestCase):
 
     def test_rangexy_framewise_not_reset_if_triggering(self):
         stream = RangeXY(x_range=(0, 2), y_range=(0, 1))
-        curve = DynamicMap(lambda z, x_range, y_range: Curve([1, 2, z]),
+        curve = hv.DynamicMap(lambda z, x_range, y_range: hv.Curve([1, 2, z]),
                            kdims=['z'], streams=[stream]).redim.range(z=(0, 3))
         bokeh_server_renderer.get_plot(curve.opts(framewise=True
         ))
@@ -504,8 +502,8 @@ def test_msg_with_polyedit_polyline():
 
 @pytest.mark.usefixtures('bokeh_backend')
 def test_rangexy_multi_yaxes():
-    c1 = Curve(np.arange(100).cumsum(), vdims='y')
-    c2 = Curve(-np.arange(100).cumsum(), vdims='y2')
+    c1 = hv.Curve(np.arange(100).cumsum(), vdims='y')
+    c2 = hv.Curve(-np.arange(100).cumsum(), vdims='y2')
     RangeXY(source=c1)
     RangeXY(source=c2)
 
@@ -525,8 +523,8 @@ def test_rangexy_multi_yaxes():
 
 @pytest.mark.usefixtures('bokeh_backend')
 def test_rangexy_subcoordinate_y():
-    c1 = Curve(np.arange(100).cumsum(), vdims='y', label='A').opts(subcoordinate_y=True)
-    c2 = Curve(-np.arange(100).cumsum(), vdims='y2', label='B').opts(subcoordinate_y=True)
+    c1 = hv.Curve(np.arange(100).cumsum(), vdims='y', label='A').opts(subcoordinate_y=True)
+    c2 = hv.Curve(-np.arange(100).cumsum(), vdims='y2', label='B').opts(subcoordinate_y=True)
 
     overlay = (c1 * c2)
     RangeXY(source=overlay)
@@ -547,12 +545,12 @@ def test_rangexy_subcoordinate_y_dynamic():
 
     def cb(x_range, y_range):
         return (
-            Curve(np.arange(100).cumsum(), vdims='y', label='A').opts(subcoordinate_y=True) *
-            Curve(-np.arange(100).cumsum(), vdims='y2', label='B').opts(subcoordinate_y=True)
+            hv.Curve(np.arange(100).cumsum(), vdims='y', label='A').opts(subcoordinate_y=True) *
+            hv.Curve(-np.arange(100).cumsum(), vdims='y2', label='B').opts(subcoordinate_y=True)
         )
 
     stream = RangeXY()
-    dmap = DynamicMap(cb, streams=[stream])
+    dmap = hv.DynamicMap(cb, streams=[stream])
     plot = bokeh_server_renderer.get_plot(dmap)
 
     p1, p2 = plot.subplots.values()

--- a/holoviews/tests/plotting/bokeh/test_curveplot.py
+++ b/holoviews/tests/plotting/bokeh/test_curveplot.py
@@ -5,13 +5,11 @@ import pandas as pd
 import pytest
 from bokeh.models import FactorRange, FixedTicker
 
-from holoviews.core import Dimension, DynamicMap, HoloMap, NdOverlay
-from holoviews.core.options import AbbreviatedException, Cycle, Palette
-from holoviews.element import Curve
+import holoviews as hv
+from holoviews.core.options import AbbreviatedException
 from holoviews.plotting.bokeh.callbacks import Callback, PointerXCallback
 from holoviews.plotting.util import rgb2hex
 from holoviews.streams import PointerX
-from holoviews.util.transform import dim
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
@@ -21,8 +19,8 @@ class TestCurvePlot(TestBokehPlot):
     def test_batched_curve_subscribers_correctly_attached(self):
         posx = PointerX()
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Curve': dict(line_color=Cycle(values=['red', 'blue']))}
-        overlay = DynamicMap(lambda x: NdOverlay({i: Curve([(i, j) for j in range(2)])
+                'Curve': dict(line_color=hv.Cycle(values=['red', 'blue']))}
+        overlay = hv.DynamicMap(lambda x: hv.NdOverlay({i: hv.Curve([(i, j) for j in range(2)])
                                                   for i in range(2)}).opts(opts), kdims=[],
                              streams=[posx])
         plot = bokeh_renderer.get_plot(overlay)
@@ -35,8 +33,8 @@ class TestCurvePlot(TestBokehPlot):
         Callback._callbacks.clear()  # Reset to not be sensitive to other test
         posx = PointerX()
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Curve': dict(line_color=Cycle(values=['red', 'blue']))}
-        overlay = DynamicMap(lambda x: NdOverlay({i: Curve([(i, j) for j in range(2)])
+                'Curve': dict(line_color=hv.Cycle(values=['red', 'blue']))}
+        overlay = hv.DynamicMap(lambda x: hv.NdOverlay({i: hv.Curve([(i, j) for j in range(2)])
                                                   for i in range(2)}).opts(opts), kdims=[],
                              streams=[posx])
         plot = bokeh_renderer.get_plot(overlay)
@@ -45,8 +43,8 @@ class TestCurvePlot(TestBokehPlot):
         assert key == (id(plot.handles['plot']), id(PointerXCallback))
 
     def test_cyclic_palette_curves(self):
-        palette = Palette('Set1')
-        hmap = HoloMap({i: NdOverlay({j: Curve(np.random.rand(3)).opts(color=palette)
+        palette = hv.Palette('Set1')
+        hmap = hv.HoloMap({i: hv.NdOverlay({j: hv.Curve(np.random.rand(3)).opts(color=palette)
                                       for j in range(3)})
                         for i in range(3)})
         colors = palette[3].values
@@ -57,8 +55,8 @@ class TestCurvePlot(TestBokehPlot):
 
     def test_batched_curve_line_color_and_color(self):
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Curve': dict(line_color=Cycle(values=['red', 'blue']))}
-        overlay = NdOverlay({i: Curve([(i, j) for j in range(2)])
+                'Curve': dict(line_color=hv.Cycle(values=['red', 'blue']))}
+        overlay = hv.NdOverlay({i: hv.Curve([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         line_color = ['red', 'blue']
@@ -66,8 +64,8 @@ class TestCurvePlot(TestBokehPlot):
 
     def test_batched_curve_alpha_and_color(self):
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Curve': dict(alpha=Cycle(values=[0.5, 1]))}
-        overlay = NdOverlay({i: Curve([(i, j) for j in range(2)])
+                'Curve': dict(alpha=hv.Cycle(values=[0.5, 1]))}
+        overlay = hv.NdOverlay({i: hv.Curve([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         alpha = [0.5, 1.]
@@ -77,8 +75,8 @@ class TestCurvePlot(TestBokehPlot):
 
     def test_batched_curve_line_width_and_color(self):
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Curve': dict(line_width=Cycle(values=[0.5, 1]))}
-        overlay = NdOverlay({i: Curve([(i, j) for j in range(2)])
+                'Curve': dict(line_width=hv.Cycle(values=[0.5, 1]))}
+        overlay = hv.NdOverlay({i: hv.Curve([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         line_width = [0.5, 1.]
@@ -87,7 +85,7 @@ class TestCurvePlot(TestBokehPlot):
         assert plot.handles['source'].data['color'] == color
 
     def test_curve_overlay_datetime_hover(self):
-        obj = NdOverlay({i: Curve([(dt.datetime(2016, 1, j+1), j) for j in range(31)]) for i in range(5)},
+        obj = hv.NdOverlay({i: hv.Curve([(dt.datetime(2016, 1, j+1), j) for j in range(31)]) for i in range(5)},
                         kdims=['Test'])
         opts = {'Curve': {'tools': ['hover']}}
         obj = obj.opts(opts)
@@ -95,7 +93,7 @@ class TestCurvePlot(TestBokehPlot):
                               formatters={'@{x}': "datetime"})
 
     def test_curve_overlay_hover_batched(self):
-        obj = NdOverlay({i: Curve(np.random.rand(10,2)) for i in range(5)},
+        obj = hv.NdOverlay({i: hv.Curve(np.random.rand(10,2)) for i in range(5)},
                         kdims=['Test'])
         opts = {'Curve': {'tools': ['hover']},
                 'NdOverlay': {'legend_limit': 0}}
@@ -103,33 +101,33 @@ class TestCurvePlot(TestBokehPlot):
         self._test_hover_info(obj, [('Test', '@{Test}')], 'prev')
 
     def test_curve_overlay_hover(self):
-        obj = NdOverlay({i: Curve(np.random.rand(10,2)) for i in range(5)},
+        obj = hv.NdOverlay({i: hv.Curve(np.random.rand(10,2)) for i in range(5)},
                         kdims=['Test'])
         opts = {'Curve': {'tools': ['hover']}}
         obj = obj.opts(opts)
         self._test_hover_info(obj, [('Test', '@{Test}'), ('x', '@{x}'), ('y', '@{y}')], 'nearest')
 
     def test_curve_hover_dimension(self):
-        obj = Curve(
-            range(10), Dimension('name', label='label')
+        obj = hv.Curve(
+            range(10), hv.Dimension('name', label='label')
         ).opts(hover_tooltips=['label'])
         self._test_hover_info(obj, [('label', '@{name}')], 'nearest')
 
     def test_curve_hover_dimension_unit(self):
-        obj = Curve(
-            range(10), Dimension('name', label='label', unit='unit')
+        obj = hv.Curve(
+            range(10), hv.Dimension('name', label='label', unit='unit')
         ).opts(hover_tooltips=['label'])
         self._test_hover_info(obj, [('label (unit)', '@{name}')], 'nearest')
 
     def test_curve_categorical_xaxis(self):
-        curve = Curve((['A', 'B', 'C'], [1,2,3]))
+        curve = hv.Curve((['A', 'B', 'C'], [1,2,3]))
         plot = bokeh_renderer.get_plot(curve)
         x_range = plot.handles['x_range']
         assert isinstance(x_range, FactorRange)
         assert x_range.factors == ['A', 'B', 'C']
 
     def test_curve_categorical_xaxis_invert_axes(self):
-        curve = Curve((['A', 'B', 'C'], (1,2,3))).opts(invert_axes=True)
+        curve = hv.Curve((['A', 'B', 'C'], (1,2,3))).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(curve)
         y_range = plot.handles['y_range']
         assert isinstance(y_range, FactorRange)
@@ -137,21 +135,21 @@ class TestCurvePlot(TestBokehPlot):
 
     def test_curve_datetime64(self):
         dates = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]
-        curve = Curve((dates, np.random.rand(10)))
+        curve = hv.Curve((dates, np.random.rand(10)))
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['x_range'].start == np.datetime64(dt.datetime(2016, 1, 1))
         assert plot.handles['x_range'].end == np.datetime64(dt.datetime(2016, 1, 10))
 
     def test_curve_pandas_timestamps(self):
         dates = pd.date_range('2016-01-01', '2016-01-10', freq='D')
-        curve = Curve((dates, np.random.rand(10)))
+        curve = hv.Curve((dates, np.random.rand(10)))
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['x_range'].start == np.datetime64(dt.datetime(2016, 1, 1))
         assert plot.handles['x_range'].end == np.datetime64(dt.datetime(2016, 1, 10))
 
     def test_curve_dt_datetime(self):
         dates = [dt.datetime(2016,1,i) for i in range(1, 11)]
-        curve = Curve((dates, np.random.rand(10)))
+        curve = hv.Curve((dates, np.random.rand(10)))
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['x_range'].start == np.datetime64(dt.datetime(2016, 1, 1))
         assert plot.handles['x_range'].end == np.datetime64(dt.datetime(2016, 1, 10))
@@ -159,8 +157,8 @@ class TestCurvePlot(TestBokehPlot):
     def test_curve_heterogeneous_datetime_types_overlay(self):
         dates64 = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]
         dates = [dt.datetime(2016,1,i) for i in range(2, 12)]
-        curve_dt64 = Curve((dates64, np.random.rand(10)))
-        curve_dt = Curve((dates, np.random.rand(10)))
+        curve_dt64 = hv.Curve((dates64, np.random.rand(10)))
+        curve_dt = hv.Curve((dates, np.random.rand(10)))
         plot = bokeh_renderer.get_plot(curve_dt*curve_dt64)
         assert plot.handles['x_range'].start == np.datetime64(dt.datetime(2016, 1, 1))
         assert plot.handles['x_range'].end == np.datetime64(dt.datetime(2016, 1, 11))
@@ -169,79 +167,79 @@ class TestCurvePlot(TestBokehPlot):
         dates_pd = pd.date_range('2016-01-04', '2016-01-13', freq='D')
         dates64 = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]
         dates = [dt.datetime(2016,1,i) for i in range(2, 12)]
-        curve_dt64 = Curve((dates64, np.random.rand(10)))
-        curve_dt = Curve((dates, np.random.rand(10)))
-        curve_pd = Curve((dates_pd, np.random.rand(10)))
+        curve_dt64 = hv.Curve((dates64, np.random.rand(10)))
+        curve_dt = hv.Curve((dates, np.random.rand(10)))
+        curve_pd = hv.Curve((dates_pd, np.random.rand(10)))
         plot = bokeh_renderer.get_plot(curve_dt*curve_dt64*curve_pd)
         assert plot.handles['x_range'].start == np.datetime64(dt.datetime(2016, 1, 1))
         assert plot.handles['x_range'].end == np.datetime64(dt.datetime(2016, 1, 13))
 
     def test_curve_fontsize_xlabel(self):
-        curve = Curve(range(10)).opts(fontsize={'xlabel': '14pt'})
+        curve = hv.Curve(range(10)).opts(fontsize={'xlabel': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['xaxis'].axis_label_text_font_size == '14pt'
 
     def test_curve_fontsize_ylabel(self):
-        curve = Curve(range(10)).opts(fontsize={'ylabel': '14pt'})
+        curve = hv.Curve(range(10)).opts(fontsize={'ylabel': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['yaxis'].axis_label_text_font_size == '14pt'
 
     def test_curve_fontsize_both_labels(self):
-        curve = Curve(range(10)).opts(fontsize={'labels': '14pt'})
+        curve = hv.Curve(range(10)).opts(fontsize={'labels': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['xaxis'].axis_label_text_font_size == '14pt'
         assert plot.handles['yaxis'].axis_label_text_font_size == '14pt'
 
     def test_curve_fontsize_xticks(self):
-        curve = Curve(range(10)).opts(fontsize={'xticks': '14pt'})
+        curve = hv.Curve(range(10)).opts(fontsize={'xticks': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['xaxis'].major_label_text_font_size == '14pt'
 
     def test_curve_fontsize_yticks(self):
-        curve = Curve(range(10)).opts(fontsize={'yticks': '14pt'})
+        curve = hv.Curve(range(10)).opts(fontsize={'yticks': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['yaxis'].major_label_text_font_size == '14pt'
 
     def test_curve_fontsize_both_ticks(self):
-        curve = Curve(range(10)).opts(fontsize={'ticks': '14pt'})
+        curve = hv.Curve(range(10)).opts(fontsize={'ticks': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['xaxis'].major_label_text_font_size == '14pt'
         assert plot.handles['yaxis'].major_label_text_font_size == '14pt'
 
     def test_curve_fontsize_xticks_and_both_ticks(self):
-        curve = Curve(range(10)).opts(fontsize={'xticks': '18pt', 'ticks': '14pt'})
+        curve = hv.Curve(range(10)).opts(fontsize={'xticks': '18pt', 'ticks': '14pt'})
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['xaxis'].major_label_text_font_size == '18pt'
         assert plot.handles['yaxis'].major_label_text_font_size == '14pt'
 
     def test_curve_xticks_list(self):
-        curve = Curve(range(10)).opts(xticks=[0, 5, 10])
+        curve = hv.Curve(range(10)).opts(xticks=[0, 5, 10])
         plot = bokeh_renderer.get_plot(curve).state
         assert isinstance(plot.xaxis[0].ticker, FixedTicker)
         assert plot.xaxis[0].ticker.ticks == [0, 5, 10]
 
     def test_curve_xticks_list_of_tuples_xaxis(self):
         ticks = [(0, 'zero'), (5, 'five'), (10, 'ten')]
-        curve = Curve(range(10)).opts(xticks=ticks)
+        curve = hv.Curve(range(10)).opts(xticks=ticks)
         plot = bokeh_renderer.get_plot(curve).state
         assert isinstance(plot.xaxis[0].ticker, FixedTicker)
         assert plot.xaxis[0].major_label_overrides == dict(ticks)
 
     def test_curve_yticks_list(self):
-        curve = Curve(range(10)).opts(yticks=[0, 5, 10])
+        curve = hv.Curve(range(10)).opts(yticks=[0, 5, 10])
         plot = bokeh_renderer.get_plot(curve).state
         assert isinstance(plot.yaxis[0].ticker, FixedTicker)
         assert plot.yaxis[0].ticker.ticks == [0, 5, 10]
 
     def test_curve_xticks_list_of_tuples_yaxis(self):
         ticks = [(0, 'zero'), (5, 'five'), (10, 'ten')]
-        curve = Curve(range(10)).opts(yticks=ticks)
+        curve = hv.Curve(range(10)).opts(yticks=ticks)
         plot = bokeh_renderer.get_plot(curve).state
         assert isinstance(plot.yaxis[0].ticker, FixedTicker)
         assert plot.yaxis[0].major_label_overrides == dict(ticks)
 
     def test_curve_padding_square(self):
-        curve = Curve([1, 2, 3]).opts(padding=0.1)
+        curve = hv.Curve([1, 2, 3]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == -0.2
@@ -250,7 +248,7 @@ class TestCurvePlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_curve_padding_square_per_axis(self):
-        curve = Curve([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
+        curve = hv.Curve([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0
@@ -259,7 +257,7 @@ class TestCurvePlot(TestBokehPlot):
         assert y_range.end == 3.4
 
     def test_curve_padding_hard_xrange(self):
-        curve = Curve([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
+        curve = hv.Curve([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0
@@ -268,7 +266,7 @@ class TestCurvePlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_curve_padding_soft_xrange(self):
-        curve = Curve([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
+        curve = hv.Curve([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0
@@ -277,7 +275,7 @@ class TestCurvePlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_curve_padding_unequal(self):
-        curve = Curve([1, 2, 3]).opts(padding=(0.05, 0.1))
+        curve = hv.Curve([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == -0.1
@@ -286,7 +284,7 @@ class TestCurvePlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_curve_padding_nonsquare(self):
-        curve = Curve([1, 2, 3]).opts(padding=0.1, width=600)
+        curve = hv.Curve([1, 2, 3]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == -0.1
@@ -295,7 +293,7 @@ class TestCurvePlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_curve_padding_logx(self):
-        curve = Curve([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
+        curve = hv.Curve([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.89595845984076228
@@ -304,7 +302,7 @@ class TestCurvePlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_curve_padding_logy(self):
-        curve = Curve([1, 2, 3]).opts(padding=0.1, logy=True)
+        curve = hv.Curve([1, 2, 3]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == -0.2
@@ -313,7 +311,7 @@ class TestCurvePlot(TestBokehPlot):
         assert y_range.end == 3.3483695221017129
 
     def test_curve_padding_datetime_square(self):
-        curve = Curve([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
+        curve = hv.Curve([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = bokeh_renderer.get_plot(curve)
@@ -324,7 +322,7 @@ class TestCurvePlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_curve_padding_datetime_nonsquare(self):
-        curve = Curve([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
+        curve = hv.Curve([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
             padding=0.1, width=600
         )
         plot = bokeh_renderer.get_plot(curve)
@@ -339,7 +337,7 @@ class TestCurvePlot(TestBokehPlot):
     ###########################
 
     def test_curve_scalar_color_op(self):
-        curve = Curve([(0, 0, 'red'), (0, 1, 'red'), (0, 2, 'red')],
+        curve = hv.Curve([(0, 0, 'red'), (0, 1, 'red'), (0, 2, 'red')],
                        vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(curve)
         glyph = plot.handles['glyph']
@@ -347,7 +345,7 @@ class TestCurvePlot(TestBokehPlot):
 
     def test_op_ndoverlay_color_value(self):
         colors = ['blue', 'red']
-        overlay = NdOverlay({color: Curve(np.arange(i))
+        overlay = hv.NdOverlay({color: hv.Curve(np.arange(i))
                              for i, color in enumerate(colors)},
                             'color').opts('Curve', color='color')
         plot = bokeh_renderer.get_plot(overlay)
@@ -357,35 +355,35 @@ class TestCurvePlot(TestBokehPlot):
             assert style['color'] == color
 
     def test_curve_color_op(self):
-        curve = Curve([(0, 0, 'red'), (0, 1, 'blue'), (0, 2, 'red')],
+        curve = hv.Curve([(0, 0, 'red'), (0, 1, 'blue'), (0, 2, 'red')],
                        vdims=['y', 'color']).opts(color='color')
         msg = 'ValueError: Mapping a dimension to the "color" style'
         with pytest.raises(AbbreviatedException, match=msg):
             bokeh_renderer.get_plot(curve)
 
     def test_curve_alpha_op(self):
-        curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
+        curve = hv.Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
                        vdims=['y', 'alpha']).opts(alpha='alpha')
         msg = 'ValueError: Mapping a dimension to the "alpha" style'
         with pytest.raises(AbbreviatedException, match=msg):
             bokeh_renderer.get_plot(curve)
 
     def test_curve_line_width_op(self):
-        curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
+        curve = hv.Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
                        vdims=['y', 'linewidth']).opts(line_width='linewidth')
         msg = 'ValueError: Mapping a dimension to the "line_width" style'
         with pytest.raises(AbbreviatedException, match=msg):
             bokeh_renderer.get_plot(curve)
 
     def test_curve_style_mapping_ndoverlay_dimensions(self):
-        ndoverlay = NdOverlay({
-            (0, 'A'): Curve([1, 2, 0]), (0, 'B'): Curve([1, 2, 1]),
-            (1, 'A'): Curve([1, 2, 2]), (1, 'B'): Curve([1, 2, 3])},
+        ndoverlay = hv.NdOverlay({
+            (0, 'A'): hv.Curve([1, 2, 0]), (0, 'B'): hv.Curve([1, 2, 1]),
+            (1, 'A'): hv.Curve([1, 2, 2]), (1, 'B'): hv.Curve([1, 2, 3])},
                               ['num', 'cat']
         ).opts({
             'Curve': dict(
-                color=dim('num').categorize({0: 'red', 1: 'blue'}),
-                line_dash=dim('cat').categorize({'A': 'solid', 'B': 'dashed'})
+                color=hv.dim('num').categorize({0: 'red', 1: 'blue'}),
+                line_dash=hv.dim('cat').categorize({'A': 'solid', 'B': 'dashed'})
             )
         })
         plot = bokeh_renderer.get_plot(ndoverlay)
@@ -404,15 +402,15 @@ class TestCurvePlot(TestBokehPlot):
 
     def test_curve_style_mapping_constant_value_dimensions(self):
         vdims = ['y', 'num', 'cat']
-        ndoverlay = NdOverlay({
-            0: Curve([(0, 1, 0, 'A'), (1, 0, 0, 'A')], vdims=vdims),
-            1: Curve([(0, 1, 0, 'B'), (1, 1, 0, 'B')], vdims=vdims),
-            2: Curve([(0, 1, 1, 'A'), (1, 2, 1, 'A')], vdims=vdims),
-            3: Curve([(0, 1, 1, 'B'), (1, 3, 1, 'B')], vdims=vdims)}
+        ndoverlay = hv.NdOverlay({
+            0: hv.Curve([(0, 1, 0, 'A'), (1, 0, 0, 'A')], vdims=vdims),
+            1: hv.Curve([(0, 1, 0, 'B'), (1, 1, 0, 'B')], vdims=vdims),
+            2: hv.Curve([(0, 1, 1, 'A'), (1, 2, 1, 'A')], vdims=vdims),
+            3: hv.Curve([(0, 1, 1, 'B'), (1, 3, 1, 'B')], vdims=vdims)}
         ).opts({
             'Curve': dict(
-                color=dim('num').categorize({0: 'red', 1: 'blue'}),
-                line_dash=dim('cat').categorize({'A': 'solid', 'B': 'dashed'})
+                color=hv.dim('num').categorize({0: 'red', 1: 'blue'}),
+                line_dash=hv.dim('cat').categorize({'A': 'solid', 'B': 'dashed'})
             )
         })
         plot = bokeh_renderer.get_plot(ndoverlay)

--- a/holoviews/tests/plotting/bokeh/test_divplot.py
+++ b/holoviews/tests/plotting/bokeh/test_divplot.py
@@ -1,4 +1,3 @@
-
 import holoviews as hv
 
 from .test_plot import TestBokehPlot, bokeh_renderer

--- a/holoviews/tests/plotting/bokeh/test_divplot.py
+++ b/holoviews/tests/plotting/bokeh/test_divplot.py
@@ -1,4 +1,5 @@
-from holoviews.element import Div
+
+import holoviews as hv
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
@@ -7,14 +8,14 @@ class TestDivPlot(TestBokehPlot):
 
     def test_div_plot(self):
         html = '<h1>Test</h1>'
-        div = Div(html)
+        div = hv.Div(html)
         plot = bokeh_renderer.get_plot(div)
         bkdiv = plot.handles['plot']
         assert bkdiv.text == '&lt;h1&gt;Test&lt;/h1&gt;'
 
     def test_div_plot_width(self):
         html = '<h1>Test</h1>'
-        div = Div(html).opts(width=342, height=432, backend='bokeh')
+        div = hv.Div(html).opts(width=342, height=432, backend='bokeh')
         plot = bokeh_renderer.get_plot(div)
         bkdiv = plot.handles['plot']
         assert bkdiv.width == 342

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -16,16 +16,13 @@ from bokeh.models import (
     tools,
 )
 
-from holoviews import opts
-from holoviews.core import Dimension, DynamicMap, HoloMap, NdOverlay, Overlay
+import holoviews as hv
 from holoviews.core.options import AbbreviatedException
 from holoviews.core.util import dt_to_int
-from holoviews.element import Curve, HeatMap, Image, Labels, Rectangles, Scatter
 from holoviews.plotting.bokeh.util import BOKEH_GE_3_4_0, BOKEH_GE_3_6_0, BOKEH_GE_3_8_0
 from holoviews.plotting.util import process_cmap
 from holoviews.streams import Pipe, PointDraw, Stream
 from holoviews.testing import assert_data_equal
-from holoviews.util import render
 
 from ...utils import LoggingComparison
 from .test_plot import TestBokehPlot, bokeh_renderer
@@ -34,12 +31,12 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestElementPlot(LoggingComparison, TestBokehPlot):
 
     def test_element_show_frame_disabled(self):
-        curve = Curve(range(10)).opts(show_frame=False)
+        curve = hv.Curve(range(10)).opts(show_frame=False)
         plot = bokeh_renderer.get_plot(curve).state
         assert plot.outline_line_alpha == 0
 
     def test_element_font_scaling(self):
-        curve = Curve(range(10)).opts(fontscale=2, title='A title')
+        curve = hv.Curve(range(10)).opts(fontscale=2, title='A title')
         plot = bokeh_renderer.get_plot(curve)
         fig = plot.state
         xaxis = plot.handles['xaxis']
@@ -51,7 +48,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert yaxis.major_label_text_font_size == '22px'
 
     def test_element_font_scaling_fontsize_override_common(self):
-        curve = Curve(range(10)).opts(fontscale=2, fontsize='14pt', title='A title')
+        curve = hv.Curve(range(10)).opts(fontscale=2, fontsize='14pt', title='A title')
         plot = bokeh_renderer.get_plot(curve)
         fig = plot.state
         xaxis = plot.handles['xaxis']
@@ -63,7 +60,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert yaxis.major_label_text_font_size == '22px'
 
     def test_element_font_scaling_fontsize_override_specific(self):
-        curve = Curve(range(10)).opts(
+        curve = hv.Curve(range(10)).opts(
             fontscale=2, fontsize={'title': '100%', 'xlabel': '12pt', 'xticks': '1.2em'},
             title='A title')
         plot = bokeh_renderer.get_plot(curve)
@@ -77,13 +74,13 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert yaxis.major_label_text_font_size == '22px'
 
     def test_element_xaxis_top(self):
-        curve = Curve(range(10)).opts(xaxis='top')
+        curve = hv.Curve(range(10)).opts(xaxis='top')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         assert xaxis in plot.state.above
 
     def test_element_xaxis_bare(self):
-        curve = Curve(range(10)).opts(xaxis='bare')
+        curve = hv.Curve(range(10)).opts(xaxis='bare')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         assert xaxis.axis_label_text_font_size == '0pt'
@@ -93,7 +90,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert xaxis in plot.state.below
 
     def test_element_xaxis_bottom_bare(self):
-        curve = Curve(range(10)).opts(xaxis='bottom-bare')
+        curve = hv.Curve(range(10)).opts(xaxis='bottom-bare')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         assert xaxis.axis_label_text_font_size == '0pt'
@@ -103,7 +100,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert xaxis in plot.state.below
 
     def test_element_xaxis_top_bare(self):
-        curve = Curve(range(10)).opts(xaxis='top-bare')
+        curve = hv.Curve(range(10)).opts(xaxis='top-bare')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         assert xaxis.axis_label_text_font_size == '0pt'
@@ -113,33 +110,33 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert xaxis in plot.state.above
 
     def test_element_yaxis_true(self):
-        curve = Curve(range(10)).opts(yaxis=True)
+        curve = hv.Curve(range(10)).opts(yaxis=True)
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         assert yaxis in plot.state.left
 
     def test_element_yaxis_false(self):
-        curve = Curve(range(10)).opts(yaxis=False)
+        curve = hv.Curve(range(10)).opts(yaxis=False)
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         assert yaxis in plot.state.left
         assert not yaxis.visible
 
     def test_element_yaxis_none(self):
-        curve = Curve(range(10)).opts(yaxis=None)
+        curve = hv.Curve(range(10)).opts(yaxis=None)
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         assert yaxis in plot.state.left
         assert not yaxis.visible
 
     def test_element_yaxis_right(self):
-        curve = Curve(range(10)).opts(yaxis='right')
+        curve = hv.Curve(range(10)).opts(yaxis='right')
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         assert yaxis in plot.state.right
 
     def test_element_yaxis_bare(self):
-        curve = Curve(range(10)).opts(yaxis='bare')
+        curve = hv.Curve(range(10)).opts(yaxis='bare')
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         assert yaxis.axis_label_text_font_size == '0pt'
@@ -149,7 +146,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert yaxis in plot.state.left
 
     def test_element_yaxis_left_bare(self):
-        curve = Curve(range(10)).opts(yaxis='left-bare')
+        curve = hv.Curve(range(10)).opts(yaxis='left-bare')
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         assert yaxis.axis_label_text_font_size == '0pt'
@@ -159,7 +156,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert yaxis in plot.state.left
 
     def test_element_yaxis_right_bare(self):
-        curve = Curve(range(10)).opts(yaxis='right-bare')
+        curve = hv.Curve(range(10)).opts(yaxis='right-bare')
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         assert yaxis.axis_label_text_font_size == '0pt'
@@ -171,24 +168,24 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
     def test_element_title_format(self):
         title_str = ('Label: {label}, group: {group}, '
                      'dims: {dimensions}, type: {type}')
-        e = Scatter(
+        e = hv.Scatter(
             [],
             label='the_label',
             group='the_group',
         ).opts(title=title_str)
         title = 'Label: the_label, group: the_group, dims: , type: Scatter'
-        assert render(e).title.text == title
+        assert hv.render(e).title.text == title
 
     def test_element_hooks(self):
         def hook(plot, element):
             plot.handles['plot'].title.text = 'Called'
-        curve = Curve(range(10), label='Not Called').opts(hooks=[hook])
+        curve = hv.Curve(range(10), label='Not Called').opts(hooks=[hook])
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.title.text == 'Called'
 
     def test_element_update_visible(self):
         checkbox = pn.widgets.Checkbox(value=True)
-        scatter = Scatter([]).apply.opts(visible=checkbox)
+        scatter = hv.Scatter([]).apply.opts(visible=checkbox)
         plot = bokeh_renderer.get_plot(scatter)
         assert plot.handles['glyph_renderer'].visible
         checkbox.value = False
@@ -197,14 +194,14 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.handles['glyph_renderer'].visible
 
     def test_element_xformatter_string(self):
-        curve = Curve(range(10)).opts(xformatter='%d')
+        curve = hv.Curve(range(10)).opts(xformatter='%d')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         assert isinstance(xaxis.formatter, PrintfTickFormatter)
         assert xaxis.formatter.format == '%d'
 
     def test_element_yformatter_string(self):
-        curve = Curve(range(10)).opts(yformatter='%d')
+        curve = hv.Curve(range(10)).opts(yformatter='%d')
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         assert isinstance(yaxis.formatter, PrintfTickFormatter)
@@ -212,74 +209,74 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
 
     def test_element_xformatter_instance(self):
         formatter = NumeralTickFormatter()
-        curve = Curve(range(10)).opts(xformatter=formatter)
+        curve = hv.Curve(range(10)).opts(xformatter=formatter)
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         assert xaxis.formatter is formatter
 
     def test_element_yformatter_instance(self):
         formatter = NumeralTickFormatter()
-        curve = Curve(range(10)).opts(yformatter=formatter)
+        curve = hv.Curve(range(10)).opts(yformatter=formatter)
         plot = bokeh_renderer.get_plot(curve)
         yaxis = plot.handles['yaxis']
         assert yaxis.formatter is formatter
 
     def test_empty_element_visibility(self):
-        curve = Curve([])
+        curve = hv.Curve([])
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['glyph_renderer'].visible
 
     def test_element_no_xaxis(self):
-        curve = Curve(range(10)).opts(xaxis=None)
+        curve = hv.Curve(range(10)).opts(xaxis=None)
         plot = bokeh_renderer.get_plot(curve).state
         assert not plot.xaxis[0].visible
 
     def test_element_no_yaxis(self):
-        curve = Curve(range(10)).opts(yaxis=None)
+        curve = hv.Curve(range(10)).opts(yaxis=None)
         plot = bokeh_renderer.get_plot(curve).state
         assert not plot.yaxis[0].visible
 
     def test_element_xrotation(self):
-        curve = Curve(range(10)).opts(xrotation=90)
+        curve = hv.Curve(range(10)).opts(xrotation=90)
         plot = bokeh_renderer.get_plot(curve).state
         assert plot.xaxis[0].major_label_orientation == np.pi/2
 
     def test_element_yrotation(self):
-        curve = Curve(range(10)).opts(yrotation=90)
+        curve = hv.Curve(range(10)).opts(yrotation=90)
         plot = bokeh_renderer.get_plot(curve).state
         assert plot.yaxis[0].major_label_orientation == np.pi/2
 
     def test_element_xlabel_override(self):
-        curve = Curve(range(10)).opts(xlabel='custom x-label')
+        curve = hv.Curve(range(10)).opts(xlabel='custom x-label')
         plot = bokeh_renderer.get_plot(curve).state
         assert plot.xaxis[0].axis_label == 'custom x-label'
 
     def test_element_ylabel_override(self):
-        curve = Curve(range(10)).opts(ylabel='custom y-label')
+        curve = hv.Curve(range(10)).opts(ylabel='custom y-label')
         plot = bokeh_renderer.get_plot(curve).state
         assert plot.yaxis[0].axis_label == 'custom y-label'
 
     def test_element_labelled_x_disabled(self):
-        curve = Curve(range(10)).opts(labelled=['y'])
+        curve = hv.Curve(range(10)).opts(labelled=['y'])
         plot = bokeh_renderer.get_plot(curve).state
         assert plot.xaxis[0].axis_label == ''
         assert plot.yaxis[0].axis_label == 'y'
 
     def test_element_labelled_y_disabled(self):
-        curve = Curve(range(10)).opts(labelled=['x'])
+        curve = hv.Curve(range(10)).opts(labelled=['x'])
         plot = bokeh_renderer.get_plot(curve).state
         assert plot.xaxis[0].axis_label == 'x'
         assert plot.yaxis[0].axis_label == ''
 
     def test_element_labelled_both_disabled(self):
-        curve = Curve(range(10)).opts(labelled=[])
+        curve = hv.Curve(range(10)).opts(labelled=[])
         plot = bokeh_renderer.get_plot(curve).state
         assert plot.xaxis[0].axis_label == ''
         assert plot.yaxis[0].axis_label == ''
 
     def test_static_source_optimization(self):
         data = np.ones((5, 5))
-        img = Image(data)
+        img = hv.Image(data)
 
         def get_img(test):
             get_img.data *= test
@@ -288,7 +285,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         get_img.data = data
 
         stream = Stream.define('Test', test=1)()
-        dmap = DynamicMap(get_img, streams=[stream])
+        dmap = hv.DynamicMap(get_img, streams=[stream])
         plot = bokeh_renderer.get_plot(dmap, doc=Document())
         source = plot.handles['source']
         assert source.data['image'][0].mean() == 1
@@ -299,7 +296,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
 
     def test_stream_cleanup(self):
         stream = Stream.define('Test', test=1)()
-        dmap = DynamicMap(lambda test: Curve([]), streams=[stream])
+        dmap = hv.DynamicMap(lambda test: hv.Curve([]), streams=[stream])
         plot = bokeh_renderer.get_plot(dmap)
         assert bool(stream._subscribers)
         plot.cleanup()
@@ -308,32 +305,32 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
     def test_element_xticks_datetime(self):
         dates = [(dt.datetime(2016, 1, i), i) for i in range(1, 4)]
         tick = dt.datetime(2016, 1, 1, 12)
-        curve = Curve(dates).opts(xticks=[tick])
+        curve = hv.Curve(dates).opts(xticks=[tick])
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.xaxis.ticker.ticks == [dt_to_int(tick, 'ms')]
 
     def test_element_xticks_datetime_label_override(self):
         dates = [(dt.datetime(2016, 1, i), i) for i in range(1, 4)]
         tick = dt.datetime(2016, 1, 1, 12)
-        curve = Curve(dates).opts(xticks=[(tick, 'A')])
+        curve = hv.Curve(dates).opts(xticks=[(tick, 'A')])
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.xaxis.ticker.ticks == [dt_to_int(tick, 'ms')]
         assert plot.state.xaxis.major_label_overrides == {dt_to_int(tick, 'ms'): 'A'}
 
     def test_element_grid_custom_xticker(self):
-        curve = Curve([1, 2, 3]).opts(xticks=[0.5, 1.5], show_grid=True)
+        curve = hv.Curve([1, 2, 3]).opts(xticks=[0.5, 1.5], show_grid=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.xgrid[0].ticker is plot.state.xaxis[0].ticker
 
     def test_element_grid_custom_yticker(self):
-        curve = Curve([1, 2, 3]).opts(yticks=[0.5, 2.5], show_grid=True)
+        curve = hv.Curve([1, 2, 3]).opts(yticks=[0.5, 2.5], show_grid=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.ygrid[0].ticker is plot.state.yaxis[0].ticker
 
     def test_element_grid_options(self):
         grid_style = {'grid_line_color': 'blue', 'grid_line_width': 1.5, 'ygrid_bounds': (0.3, 0.7),
                       'minor_xgrid_line_color': 'lightgray', 'xgrid_line_dash': [4, 4]}
-        curve = Curve(range(10)).opts(show_grid=True, gridstyle=grid_style)
+        curve = hv.Curve(range(10)).opts(show_grid=True, gridstyle=grid_style)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.xgrid[0].grid_line_color == 'blue'
         assert plot.state.xgrid[0].grid_line_width == 1.5
@@ -345,7 +342,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
 
     def test_change_cds_columns(self):
         lengths = {'a': 1, 'b': 2, 'c': 3}
-        curve = DynamicMap(lambda a: Curve(range(lengths[a]), a), kdims=['a']).redim.values(a=['a', 'b', 'c'])
+        curve = hv.DynamicMap(lambda a: hv.Curve(range(lengths[a]), a), kdims=['a']).redim.values(a=['a', 'b', 'c'])
         plot = bokeh_renderer.get_plot(curve)
         assert sorted(plot.handles['source'].data.keys()) == ['a', 'y']
         assert plot.state.xaxis[0].axis_label == 'a'
@@ -354,7 +351,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.xaxis[0].axis_label == 'b'
 
     def test_update_cds_columns(self):
-        curve = DynamicMap(lambda a: Curve(range(10), a), kdims=['a']).redim.values(a=['a', 'b', 'c'])
+        curve = hv.DynamicMap(lambda a: hv.Curve(range(10), a), kdims=['a']).redim.values(a=['a', 'b', 'c'])
         plot = bokeh_renderer.get_plot(curve)
         assert sorted(plot.handles['source'].data.keys()) == ['a', 'y']
         assert plot.state.xaxis[0].axis_label == 'a'
@@ -363,14 +360,14 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.xaxis[0].axis_label == 'b'
 
     def test_categorical_axis_fontsize(self):
-        curve = Curve([('A', 1), ('B', 2)]).opts(fontsize={'minor_xticks': '6pt', 'xticks': 18})
+        curve = hv.Curve([('A', 1), ('B', 2)]).opts(fontsize={'minor_xticks': '6pt', 'xticks': 18})
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         assert xaxis.major_label_text_font_size == '6pt'
         assert xaxis.group_text_font_size == '18pt'
 
     def test_categorical_axis_fontsize_both(self):
-        curve = Curve([('A', 1), ('B', 2)]).opts(fontsize={'xticks': 18})
+        curve = hv.Curve([('A', 1), ('B', 2)]).opts(fontsize={'xticks': 18})
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         assert xaxis.major_label_text_font_size == '18pt'
@@ -381,7 +378,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         gregorian_dates = [cftime.DatetimeGregorian(2000, 2, 28),
                            cftime.DatetimeGregorian(2000, 3, 1),
                            cftime.DatetimeGregorian(2000, 3, 2)]
-        curve = Curve((gregorian_dates, [1, 2, 3]))
+        curve = hv.Curve((gregorian_dates, [1, 2, 3]))
         plot = bokeh_renderer.get_plot(curve)
         xs = plot.handles['cds'].data['x']
         assert_data_equal(xs.astype('int64'),
@@ -392,7 +389,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         gregorian_dates = [cftime.DatetimeNoLeap(2000, 2, 28),
                            cftime.DatetimeNoLeap(2000, 3, 1),
                            cftime.DatetimeNoLeap(2000, 3, 2)]
-        curve = Curve((gregorian_dates, [1, 2, 3]))
+        curve = hv.Curve((gregorian_dates, [1, 2, 3]))
         plot = bokeh_renderer.get_plot(curve)
         xs = plot.handles['cds'].data['x']
         assert_data_equal(xs.astype('int64'),
@@ -405,25 +402,25 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_endswith('WARNING', substr)
 
     def test_active_tools_drag(self):
-        curve = Curve([1, 2, 3]).opts(active_tools=['box_zoom'])
+        curve = hv.Curve([1, 2, 3]).opts(active_tools=['box_zoom'])
         plot = bokeh_renderer.get_plot(curve)
         toolbar = plot.state.toolbar
         assert isinstance(toolbar.active_drag, tools.BoxZoomTool)
 
     def test_active_tools_scroll(self):
-        curve = Curve([1, 2, 3]).opts(active_tools=['wheel_zoom'])
+        curve = hv.Curve([1, 2, 3]).opts(active_tools=['wheel_zoom'])
         plot = bokeh_renderer.get_plot(curve)
         toolbar = plot.state.toolbar
         assert isinstance(toolbar.active_scroll, tools.WheelZoomTool)
 
     def test_active_tools_tap(self):
-        curve = Curve([1, 2, 3]).opts(active_tools=['tap'], tools=['tap'])
+        curve = hv.Curve([1, 2, 3]).opts(active_tools=['tap'], tools=['tap'])
         plot = bokeh_renderer.get_plot(curve)
         toolbar = plot.state.toolbar
         assert isinstance(toolbar.active_tap, tools.TapTool)
 
     def test_active_tools_draw_stream(self):
-        scatter = Scatter([1, 2, 3]).opts(active_tools=['point_draw'])
+        scatter = hv.Scatter([1, 2, 3]).opts(active_tools=['point_draw'])
         PointDraw(source=scatter)
         plot = bokeh_renderer.get_plot(scatter)
         toolbar = plot.state.toolbar
@@ -431,7 +428,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert isinstance(toolbar.active_drag, tools.PointDrawTool)
 
     def test_hover_tooltip_update(self):
-        hmap = HoloMap({'a': Curve([1, 2, 3], vdims='a'), 'b': Curve([1, 2, 3], vdims='b')}).opts(
+        hmap = hv.HoloMap({'a': hv.Curve([1, 2, 3], vdims='a'), 'b': hv.Curve([1, 2, 3], vdims='b')}).opts(
             tools=['hover'])
         plot = bokeh_renderer.get_plot(hmap)
         assert plot.handles['hover'].tooltips == [('x', '@{x}'), ('a', '@{a}')]
@@ -439,21 +436,21 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.handles['hover'].tooltips == [('x', '@{x}'), ('b', '@{b}')]
 
     def test_categorical_dimension_values(self):
-        curve = Curve([('C', 1), ('B', 3)]).redim.values(x=['A', 'B', 'C'])
+        curve = hv.Curve([('C', 1), ('B', 3)]).redim.values(x=['A', 'B', 'C'])
         plot = bokeh_renderer.get_plot(curve)
         x_range = plot.handles['x_range']
         assert x_range.factors == ['A', 'B', 'C']
 
     def test_categorical_dimension_type(self):
-        curve = Curve([]).redim.type(x=str)
+        curve = hv.Curve([]).redim.type(x=str)
         plot = bokeh_renderer.get_plot(curve)
         x_range = plot.handles['x_range']
         assert x_range.factors == []
 
     def test_style_map_dimension_object(self):
-        x = Dimension('x')
-        y = Dimension('y')
-        scatter = Scatter([1, 2, 3], kdims=[x], vdims=[y]).opts(color=x)
+        x = hv.Dimension('x')
+        y = hv.Dimension('y')
+        scatter = hv.Scatter([1, 2, 3], kdims=[x], vdims=[y]).opts(color=x)
         self._test_colormapping(scatter, 'x', prefix='color_')
 
     #################################################################
@@ -461,7 +458,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
     #################################################################
 
     def test_element_aspect(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -470,7 +467,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.aspect_ratio is None
 
     def test_element_aspect_width(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2, width=400)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2, width=400)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -480,7 +477,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "uses those values as frame_width/frame_height instead")
 
     def test_element_aspect_height(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2, height=400)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2, height=400)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -490,7 +487,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "uses those values as frame_width/frame_height instead")
 
     def test_element_aspect_width_height(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2, height=400, width=400)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2, height=400, width=400)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height == 400
         assert plot.state.width == 400
@@ -500,7 +497,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "aspect value was ignored")
 
     def test_element_aspect_frame_width(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2, frame_width=400)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2, frame_width=400)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -509,7 +506,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.aspect_ratio is None
 
     def test_element_aspect_frame_height(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2, frame_height=400)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2, frame_height=400)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -518,7 +515,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.aspect_ratio is None
 
     def test_element_aspect_frame_width_frame_height(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2, frame_height=400, frame_width=400)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2, frame_height=400, frame_width=400)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -528,7 +525,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "aspect value was ignored")
 
     def test_element_data_aspect(self):
-        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=1.5)
+        curve = hv.Curve([0, 0.5, 1, 1.5]).opts(data_aspect=1.5)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -537,7 +534,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.aspect_scale == 1.5
 
     def test_element_data_aspect_width(self):
-        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, width=400)
+        curve = hv.Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, width=400)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -547,7 +544,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "uses those values as frame_width/frame_height instead")
 
     def test_element_data_aspect_height(self):
-        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, height=400)
+        curve = hv.Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, height=400)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -557,7 +554,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "uses those values as frame_width/frame_height instead")
 
     def test_element_data_aspect_width_height(self):
-        curve = Curve([0, 2, 3]).opts(data_aspect=2, height=400, width=400)
+        curve = hv.Curve([0, 2, 3]).opts(data_aspect=2, height=400, width=400)
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert plot.state.height == 400
@@ -569,7 +566,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3
 
     def test_element_data_aspect_frame_width(self):
-        curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_width=400)
+        curve = hv.Curve([1, 2, 3]).opts(data_aspect=2, frame_width=400)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -578,7 +575,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.aspect_scale == 2
 
     def test_element_data_aspect_frame_height(self):
-        curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400)
+        curve = hv.Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -587,7 +584,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.aspect_scale == 2
 
     def test_element_data_aspect_frame_width_frame_height(self):
-        curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400, frame_width=400)
+        curve = hv.Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400, frame_width=400)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -600,7 +597,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
     #################################################################
 
     def test_element_responsive(self):
-        curve = Curve([1, 2, 3]).opts(responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -609,7 +606,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.sizing_mode == 'stretch_both'
 
     def test_element_width_responsive(self):
-        curve = Curve([1, 2, 3]).opts(width=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(width=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width == 400
@@ -618,7 +615,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.sizing_mode == 'stretch_height'
 
     def test_element_height_responsive(self):
-        curve = Curve([1, 2, 3]).opts(height=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(height=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height == 400
         assert plot.state.width is None
@@ -627,7 +624,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.sizing_mode == 'stretch_width'
 
     def test_element_frame_width_responsive(self):
-        curve = Curve([1, 2, 3]).opts(frame_width=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(frame_width=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -636,7 +633,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.sizing_mode == 'stretch_height'
 
     def test_element_frame_height_responsive(self):
-        curve = Curve([1, 2, 3]).opts(frame_height=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(frame_height=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -645,7 +642,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.sizing_mode == 'stretch_width'
 
     def test_element_aspect_responsive(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height is None
         assert plot.state.width is None
@@ -654,7 +651,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.sizing_mode == 'scale_both'
 
     def test_element_aspect_width_responsive(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2, width=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2, width=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         self.log_handler.assert_contains('WARNING', "responsive mode could not be enabled")
         assert plot.state.height is None
@@ -665,7 +662,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "uses those values as frame_width/frame_height instead")
 
     def test_element_aspect_height_responsive(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2, height=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2, height=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.frame_height == 400
         assert plot.state.frame_width == 800
@@ -676,7 +673,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "uses those values as frame_width/frame_height instead")
 
     def test_element_width_height_responsive(self):
-        curve = Curve([1, 2, 3]).opts(height=400, width=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(height=400, width=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.height == 400
         assert plot.state.width == 400
@@ -686,7 +683,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.sizing_mode == 'fixed'
 
     def test_element_aspect_frame_width_responsive(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2, frame_width=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2, frame_width=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         self.log_handler.assert_contains('WARNING', "responsive mode could not be enabled")
         assert plot.state.height is None
@@ -696,7 +693,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.sizing_mode == 'fixed'
 
     def test_element_aspect_frame_height_responsive(self):
-        curve = Curve([1, 2, 3]).opts(aspect=2, frame_height=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(aspect=2, frame_height=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.frame_height == 400
         assert plot.state.frame_width == 800
@@ -704,7 +701,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "responsive mode could not be enabled")
 
     def test_element_frame_width_frame_height_responsive(self):
-        curve = Curve([1, 2, 3]).opts(frame_height=400, frame_width=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(frame_height=400, frame_width=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.frame_height == 400
         assert plot.state.frame_width == 400
@@ -712,14 +709,14 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "responsive mode could not be enabled")
 
     def test_element_data_aspect_responsive(self):
-        curve = Curve([0, 2]).opts(data_aspect=1, responsive=True)
+        curve = hv.Curve([0, 2]).opts(data_aspect=1, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.aspect_ratio == 0.5
         assert plot.state.aspect_scale == 1
         assert plot.state.sizing_mode == 'scale_both'
 
     def test_element_data_aspect_and_aspect_responsive(self):
-        curve = Curve([0, 2]).opts(data_aspect=1, aspect=2, responsive=True)
+        curve = hv.Curve([0, 2]).opts(data_aspect=1, aspect=2, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.aspect_ratio == 0.5
         assert plot.state.aspect_scale == 1
@@ -732,7 +729,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 2
 
     def test_element_data_aspect_width_responsive(self):
-        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, width=400, responsive=True)
+        curve = hv.Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, width=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.frame_height == 400
         assert plot.state.frame_width == 400
@@ -741,7 +738,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "uses those values as frame_width/frame_height instead")
 
     def test_element_data_aspect_height_responsive(self):
-        curve = Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, height=400, responsive=True)
+        curve = hv.Curve([0, 0.5, 1, 1.5]).opts(data_aspect=2, height=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.frame_height == 400
         assert plot.state.frame_width == 400
@@ -750,7 +747,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "uses those values as frame_width/frame_height instead")
 
     def test_element_data_aspect_frame_width_responsive(self):
-        curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_width=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(data_aspect=2, frame_width=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.frame_height == 800
         assert plot.state.frame_width == 400
@@ -758,7 +755,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         self.log_handler.assert_contains('WARNING', "responsive mode could not be enabled")
 
     def test_element_data_aspect_frame_height_responsive(self):
-        curve = Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400, responsive=True)
+        curve = hv.Curve([1, 2, 3]).opts(data_aspect=2, frame_height=400, responsive=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.state.frame_height == 400
         assert plot.state.frame_width == 200
@@ -770,7 +767,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
     #################################################################
 
     def test_element_backend_opts(self):
-        heat_map = HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
+        heat_map = hv.HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
             colorbar=True,
             backend_opts={
                 "colorbar.title": "Testing",
@@ -785,7 +782,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert colorbar.major_label_overrides == {3.5: "A", 5: "B"}
 
     def test_element_backend_opts_alias(self):
-        heat_map = HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
+        heat_map = hv.HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
             colorbar=True,
             backend_opts={
                 "cbar.title": "Testing",
@@ -800,7 +797,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert colorbar.major_label_overrides == {3.5: "A", 5: "B"}
 
     def test_element_backend_opts_two_accessors(self):
-        heat_map = HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
+        heat_map = hv.HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
             colorbar=True, backend_opts={"colorbar": "Testing"},
         )
         bokeh_renderer.get_plot(heat_map)
@@ -809,7 +806,7 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         )
 
     def test_element_backend_opts_model_not_resolved(self):
-        heat_map = HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
+        heat_map = hv.HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
             colorbar=True, backend_opts={"cb.title": "Testing"},
         )
         bokeh_renderer.get_plot(heat_map)
@@ -831,15 +828,15 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         def func(data, plot_labels):
             if not data:
                 return (
-                        Curve([], label=plot_labels[0]) *
-                        Curve([], label=plot_labels[1])
+                        hv.Curve([], label=plot_labels[0]) *
+                        hv.Curve([], label=plot_labels[1])
                 )
-            plot1 = Curve([0, 1], label=plot_labels[2]).opts(subcoordinate_y=True)
-            plot2 = Curve([2, 1], label=plot_labels[3]).opts(subcoordinate_y=True)
+            plot1 = hv.Curve([0, 1], label=plot_labels[2]).opts(subcoordinate_y=True)
+            plot2 = hv.Curve([2, 1], label=plot_labels[3]).opts(subcoordinate_y=True)
             return plot1 * plot2
 
         pipe = Pipe(data=False)
-        dmap = DynamicMap(lambda data, labels=labels: func(data, labels), streams=[pipe])
+        dmap = hv.DynamicMap(lambda data, labels=labels: func(data, labels), streams=[pipe])
         bokeh_renderer.get_plot(dmap)
 
         msg = 'Failed retrieving "subcoordinate_y". Labels mismatched for initial and updated DynamicMap plots.'
@@ -854,15 +851,15 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         def func(data, plot_labels):
             if not data:
                 return (
-                        Curve([], label=plot_labels[0]) *
-                        Curve([], label=plot_labels[1])
+                        hv.Curve([], label=plot_labels[0]) *
+                        hv.Curve([], label=plot_labels[1])
                 )
-            plot1 = Curve([0, 1], label=plot_labels[2]).opts(subcoordinate_y=True)
-            plot2 = Curve([2, 1], label=plot_labels[3]).opts(subcoordinate_y=True)
+            plot1 = hv.Curve([0, 1], label=plot_labels[2]).opts(subcoordinate_y=True)
+            plot2 = hv.Curve([2, 1], label=plot_labels[3]).opts(subcoordinate_y=True)
             return plot1 * plot2
 
         pipe = Pipe(data=False)
-        dmap = DynamicMap(lambda data, labels=labels: func(data, labels), streams=[pipe])
+        dmap = hv.DynamicMap(lambda data, labels=labels: func(data, labels), streams=[pipe])
         bokeh_renderer.get_plot(dmap)
         # works with no issue
         pipe.send(True)
@@ -877,8 +874,8 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
                 "data": [1, 2, 3],
             }
         ).with_columns(pl.col("duration").cast(pl.Duration("ns")))
-        el = Curve(df)
-        assert isinstance(render(el).below[0], TimedeltaAxis)
+        el = hv.Curve(df)
+        assert isinstance(hv.render(el).below[0], TimedeltaAxis)
 
     @pytest.mark.skipif(not BOKEH_GE_3_8_0, reason="requires Bokeh >= 3.8")
     def test_timedelta_axis_pandas(self):
@@ -890,8 +887,8 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
                 "data": [1, 2, 3],
             }
         )
-        el = Curve(df)
-        assert isinstance(render(el).below[0], TimedeltaAxis)
+        el = hv.Curve(df)
+        assert isinstance(hv.render(el).below[0], TimedeltaAxis)
 
 
 @pytest.mark.usefixtures("bokeh_backend")
@@ -903,7 +900,7 @@ class TestScalebarPlot:
         return plot.handles.get('scalebar')
 
     def test_scalebar(self):
-        curve = Curve([1, 2, 3]).opts(scalebar=True)
+        curve = hv.Curve([1, 2, 3]).opts(scalebar=True)
         scalebar = self.get_scalebar(curve)
         assert scalebar.visible
         assert scalebar.location == 'bottom_right'
@@ -911,52 +908,52 @@ class TestScalebarPlot:
         assert scalebar.unit == "m"
 
     def test_no_scalebar(self):
-        curve = Curve([1, 2, 3])
+        curve = hv.Curve([1, 2, 3])
         scalebar = self.get_scalebar(curve)
         assert scalebar is None
 
     def test_scalebar_unit(self):
-        curve = Curve([1, 2, 3]).opts(scalebar=True, scalebar_unit='cm')
+        curve = hv.Curve([1, 2, 3]).opts(scalebar=True, scalebar_unit='cm')
         scalebar = self.get_scalebar(curve)
         assert scalebar.visible
         assert scalebar.unit == "cm"
 
     def test_dim_unit(self):
-        dim = Dimension("dim", unit="cm")
-        curve = Curve([1, 2, 3], kdims=dim).opts(scalebar=True)
+        dim = hv.Dimension("dim", unit="cm")
+        curve = hv.Curve([1, 2, 3], kdims=dim).opts(scalebar=True)
         scalebar = self.get_scalebar(curve)
         assert scalebar.visible
         assert scalebar.unit == "cm"
 
     def test_scalebar_custom_opts(self):
-        curve = Curve([1, 2, 3]).opts(scalebar=True, scalebar_opts={'background_fill_alpha': 1})
+        curve = hv.Curve([1, 2, 3]).opts(scalebar=True, scalebar_opts={'background_fill_alpha': 1})
         scalebar = self.get_scalebar(curve)
         assert scalebar.visible
         assert scalebar.background_fill_alpha == 1
 
     def test_scalebar_label(self):
-        curve = Curve([1, 2, 3]).opts(scalebar=True, scalebar_label='Test')
+        curve = hv.Curve([1, 2, 3]).opts(scalebar=True, scalebar_label='Test')
         scalebar = self.get_scalebar(curve)
         assert scalebar.visible
         assert scalebar.label == 'Test'
 
     def test_scalebar_icon(self):
-        curve = Curve([1, 2, 3]).opts(scalebar=True)
+        curve = hv.Curve([1, 2, 3]).opts(scalebar=True)
         plot = bokeh_renderer.get_plot(curve)
         toolbar = plot.handles['plot'].toolbar
         scalebar_icon = [tool for tool in toolbar.tools if tool.description == "Toggle ScaleBar"]
         assert len(scalebar_icon) == 1
 
     def test_scalebar_no_icon(self):
-        curve = Curve([1, 2, 3]).opts(scalebar=False)
+        curve = hv.Curve([1, 2, 3]).opts(scalebar=False)
         plot = bokeh_renderer.get_plot(curve)
         toolbar = plot.handles['plot'].toolbar
         scalebar_icon = [tool for tool in toolbar.tools if tool.description == "Toggle ScaleBar"]
         assert len(scalebar_icon) == 0
 
     def test_scalebar_icon_multiple_overlay(self):
-        curve1 = Curve([1, 2, 3]).opts(scalebar=True)
-        curve2 = Curve([1, 2, 3]).opts(scalebar=True)
+        curve1 = hv.Curve([1, 2, 3]).opts(scalebar=True)
+        curve2 = hv.Curve([1, 2, 3]).opts(scalebar=True)
         plot = bokeh_renderer.get_plot(curve1 * curve2)
         toolbar = plot.handles['plot'].toolbar
         scalebar_icon = [tool for tool in toolbar.tools if tool.description == "Toggle ScaleBar"]
@@ -970,9 +967,9 @@ class TestScalebarPlot:
         from bokeh.models import ScaleBar
 
         enabled = [enabled1, enabled2, enabled3]
-        curve1 = Curve([1, 2, 3], label='c1').opts(scalebar=enabled1, subcoordinate_y=True)
-        curve2 = Curve([1, 2, 3], label='c2').opts(scalebar=enabled2, subcoordinate_y=True)
-        curve3 = Curve([1, 2, 3], label='c3').opts(scalebar=enabled3, subcoordinate_y=True)
+        curve1 = hv.Curve([1, 2, 3], label='c1').opts(scalebar=enabled1, subcoordinate_y=True)
+        curve2 = hv.Curve([1, 2, 3], label='c2').opts(scalebar=enabled2, subcoordinate_y=True)
+        curve3 = hv.Curve([1, 2, 3], label='c3').opts(scalebar=enabled3, subcoordinate_y=True)
         curves = curve1 * curve2 * curve3
 
         plot = bokeh_renderer.get_plot(curves).handles["plot"]
@@ -991,21 +988,21 @@ class TestScalebarPlot:
 class TestColorbarPlot(LoggingComparison, TestBokehPlot):
 
     def test_colormapper_symmetric(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(symmetric=True)
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(symmetric=True)
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         assert cmapper.low == -3
         assert cmapper.high == 3
 
     def test_colormapper_logz_int_zero_bound(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(logz=True)
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(logz=True)
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         assert cmapper.low == 1
         assert cmapper.high == 3
 
     def test_colormapper_logz_float_zero_bound(self):
-        img = Image(np.array([[0, 1], [2, 3.]])).opts(logz=True)
+        img = hv.Image(np.array([[0, 1], [2, 3.]])).opts(logz=True)
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         assert cmapper.low == 0
@@ -1014,39 +1011,39 @@ class TestColorbarPlot(LoggingComparison, TestBokehPlot):
 
     def test_colormapper_color_levels(self):
         cmap = process_cmap('viridis', provider='bokeh')
-        img = Image(np.array([[0, 1], [2, 3]])).opts(color_levels=5, cmap=cmap)
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(color_levels=5, cmap=cmap)
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         assert len(cmapper.palette) == 5
         assert cmapper.palette == ['#440154', '#440255', '#440357', '#450558', '#45065A']
 
     def test_colormapper_transparent_nan(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'NaN': 'transparent'})
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'NaN': 'transparent'})
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         assert cmapper.nan_color == 'rgba(0, 0, 0, 0)'
 
     def test_colormapper_cnorm_linear(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(cnorm='linear')
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(cnorm='linear')
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         assert isinstance(cmapper, LinearColorMapper)
 
     def test_colormapper_cnorm_log(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(cnorm='log')
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(cnorm='log')
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         assert isinstance(cmapper, LogColorMapper)
 
     def test_colormapper_cnorm_eqhist(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(cnorm='eq_hist')
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(cnorm='eq_hist')
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         assert isinstance(cmapper, EqHistColorMapper)
 
 
     def test_colormapper_min_max_colors(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'min': 'red', 'max': 'blue'})
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'min': 'red', 'max': 'blue'})
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         assert cmapper.low_color == 'red'
@@ -1054,13 +1051,13 @@ class TestColorbarPlot(LoggingComparison, TestBokehPlot):
 
     def test_custom_colorbar_ticker(self):
         ticker = LogTicker()
-        img = Image(np.array([[0, 1], [2, 3]])).opts(colorbar=True, colorbar_opts=dict(ticker=ticker))
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(colorbar=True, colorbar_opts=dict(ticker=ticker))
         plot = bokeh_renderer.get_plot(img)
         colorbar = plot.handles['colorbar']
         assert colorbar.ticker is ticker
 
     def test_colorbar_fontsize_scaling(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(colorbar=True, fontscale=2)
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(colorbar=True, fontscale=2)
         plot = bokeh_renderer.get_plot(img)
         colorbar = plot.handles['colorbar']
         assert colorbar.title_text_font_size == '26px'
@@ -1068,7 +1065,7 @@ class TestColorbarPlot(LoggingComparison, TestBokehPlot):
 
     def test_explicit_categorical_cmap_on_integer_data(self):
         explicit_mapping = dict([(0, 'blue'), (1, 'red'), (2, 'green'), (3, 'purple')])
-        points = Scatter(([0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]), vdims=['y', 'Category']).opts(
+        points = hv.Scatter(([0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]), vdims=['y', 'Category']).opts(
             color_index='Category', cmap=explicit_mapping
         )
         plot = bokeh_renderer.get_plot(points)
@@ -1079,35 +1076,35 @@ class TestColorbarPlot(LoggingComparison, TestBokehPlot):
         assert cmapper.palette == ['blue', 'red', 'green', 'purple']
 
     def test_cticks_int(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(cticks=3, colorbar=True)
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(cticks=3, colorbar=True)
         plot = bokeh_renderer.get_plot(img)
         colorbar = plot.handles["colorbar"]
         ticker = colorbar.ticker
         assert ticker.desired_num_ticks == 3
 
     def test_cticks_list(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(cticks=[1, 2], colorbar=True)
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(cticks=[1, 2], colorbar=True)
         plot = bokeh_renderer.get_plot(img)
         colorbar = plot.handles["colorbar"]
         ticker = colorbar.ticker
         assert ticker.ticks == [1, 2]
 
     def test_cticks_tuple(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(cticks=(1, 2), colorbar=True)
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(cticks=(1, 2), colorbar=True)
         plot = bokeh_renderer.get_plot(img)
         colorbar = plot.handles["colorbar"]
         ticker = colorbar.ticker
         assert ticker.ticks == (1, 2)
 
     def test_cticks_np_array(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(cticks=np.array([1, 2]), colorbar=True)
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(cticks=np.array([1, 2]), colorbar=True)
         plot = bokeh_renderer.get_plot(img)
         colorbar = plot.handles["colorbar"]
         ticker = colorbar.ticker
         assert ticker.ticks == [1, 2]
 
     def test_cticks_labels(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(cticks=[(1, "A"), (2, "B")], colorbar=True)
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(cticks=[(1, "A"), (2, "B")], colorbar=True)
         plot = bokeh_renderer.get_plot(img)
         colorbar = plot.handles["colorbar"]
         assert colorbar.major_label_overrides == {1: "A", 2: "B"}
@@ -1115,7 +1112,7 @@ class TestColorbarPlot(LoggingComparison, TestBokehPlot):
         assert ticker.ticks == [1, 2]
 
     def test_cticks_ticker(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(
             cticks=FixedTicker(ticks=[0, 1]), colorbar=True
         )
         plot = bokeh_renderer.get_plot(img)
@@ -1127,48 +1124,48 @@ class TestColorbarPlot(LoggingComparison, TestBokehPlot):
 class TestOverlayPlot(TestBokehPlot):
 
     def test_overlay_projection_clashing(self):
-        overlay = Curve([]).opts(projection='polar') * Curve([]).opts(projection='custom')
+        overlay = hv.Curve([]).opts(projection='polar') * hv.Curve([]).opts(projection='custom')
         msg = "An axis may only be assigned one projection type"
         with pytest.raises(ValueError, match=msg):
             bokeh_renderer.get_plot(overlay)
 
     def test_overlay_projection_propagates(self):
-        overlay = Curve([]) * Curve([]).opts(projection='custom')
+        overlay = hv.Curve([]) * hv.Curve([]).opts(projection='custom')
         plot = bokeh_renderer.get_plot(overlay)
         assert [p.projection for p in plot.subplots.values()] == ['custom', 'custom']
 
     def test_overlay_propagates_batched(self):
-        overlay = NdOverlay({
-            i: Curve([1, 2, 3]).opts(yformatter='%.1f') for i in range(10)
+        overlay = hv.NdOverlay({
+            i: hv.Curve([1, 2, 3]).opts(yformatter='%.1f') for i in range(10)
         }).opts(yformatter='%.3f', legend_limit=1)
         plot = bokeh_renderer.get_plot(overlay)
         assert plot.state.yaxis.formatter.format == '%.3f'
 
     def test_overlay_gridstyle_applies(self):
         grid_style = {'grid_line_color': 'blue', 'grid_line_width': 2}
-        overlay = (Scatter([(10,10)]).opts(gridstyle=grid_style, show_grid=True, size=20)
-                   * Labels([(10, 10, 'A')]))
+        overlay = (hv.Scatter([(10,10)]).opts(gridstyle=grid_style, show_grid=True, size=20)
+                   * hv.Labels([(10, 10, 'A')]))
         plot = bokeh_renderer.get_plot(overlay)
         assert plot.state.xgrid[0].grid_line_color == 'blue'
         assert plot.state.xgrid[0].grid_line_width == 2
 
     def test_ndoverlay_legend_muted(self):
-        overlay = NdOverlay({i: Curve(np.random.randn(10).cumsum()) for i in range(5)}).opts(legend_muted=True)
+        overlay = hv.NdOverlay({i: hv.Curve(np.random.randn(10).cumsum()) for i in range(5)}).opts(legend_muted=True)
         plot = bokeh_renderer.get_plot(overlay)
         for sp in plot.subplots.values():
             assert sp.handles['glyph_renderer'].muted
 
     def test_overlay_legend_muted(self):
-        overlay = (Curve(np.random.randn(10).cumsum(), label='A') *
-                   Curve(np.random.randn(10).cumsum(), label='B')).opts(legend_muted=True)
+        overlay = (hv.Curve(np.random.randn(10).cumsum(), label='A') *
+                   hv.Curve(np.random.randn(10).cumsum(), label='B')).opts(legend_muted=True)
         plot = bokeh_renderer.get_plot(overlay)
         for sp in plot.subplots.values():
             assert sp.handles['glyph_renderer'].muted
 
     def test_overlay_legend_opts(self):
         overlay = (
-            Curve(np.random.randn(10).cumsum(), label='A') *
-            Curve(np.random.randn(10).cumsum(), label='B')
+            hv.Curve(np.random.randn(10).cumsum(), label='A') *
+            hv.Curve(np.random.randn(10).cumsum(), label='B')
         ).opts(legend_opts={'background_fill_alpha': 0.5, 'background_fill_color': 'red'})
         plot = bokeh_renderer.get_plot(overlay)
         legend = plot.state.legend
@@ -1176,32 +1173,32 @@ class TestOverlayPlot(TestBokehPlot):
         assert legend.background_fill_color == 'red'
 
     def test_active_tools_drag(self):
-        curve = Curve([1, 2, 3])
-        scatter = Scatter([1, 2, 3])
+        curve = hv.Curve([1, 2, 3])
+        scatter = hv.Scatter([1, 2, 3])
         overlay = (scatter * curve).opts(active_tools=['box_zoom'])
         plot = bokeh_renderer.get_plot(overlay)
         toolbar = plot.state.toolbar
         assert isinstance(toolbar.active_drag, tools.BoxZoomTool)
 
     def test_active_tools_scroll(self):
-        curve = Curve([1, 2, 3])
-        scatter = Scatter([1, 2, 3])
+        curve = hv.Curve([1, 2, 3])
+        scatter = hv.Scatter([1, 2, 3])
         overlay = (scatter * curve).opts(active_tools=['wheel_zoom'])
         plot = bokeh_renderer.get_plot(overlay)
         toolbar = plot.state.toolbar
         assert isinstance(toolbar.active_scroll, tools.WheelZoomTool)
 
     def test_active_tools_tap(self):
-        curve = Curve([1, 2, 3])
-        scatter = Scatter([1, 2, 3]).opts(tools=['tap'])
+        curve = hv.Curve([1, 2, 3])
+        scatter = hv.Scatter([1, 2, 3]).opts(tools=['tap'])
         overlay = (scatter * curve).opts(active_tools=['tap'])
         plot = bokeh_renderer.get_plot(overlay)
         toolbar = plot.state.toolbar
         assert isinstance(toolbar.active_tap, tools.TapTool)
 
     def test_active_tools_draw_stream(self):
-        curve = Curve([1, 2, 3])
-        scatter = Scatter([1, 2, 3]).opts(active_tools=['point_draw'])
+        curve = hv.Curve([1, 2, 3])
+        scatter = hv.Scatter([1, 2, 3]).opts(active_tools=['point_draw'])
         PointDraw(source=scatter)
         overlay = (scatter * curve)
         plot = bokeh_renderer.get_plot(overlay)
@@ -1210,15 +1207,15 @@ class TestOverlayPlot(TestBokehPlot):
         assert isinstance(toolbar.active_drag, tools.PointDrawTool)
 
     def test_categorical_overlay_dimension_values(self):
-        curve = Curve([('C', 1), ('B', 3)]).redim.values(x=['A', 'B', 'C'])
-        scatter = Scatter([('A', 2)])
+        curve = hv.Curve([('C', 1), ('B', 3)]).redim.values(x=['A', 'B', 'C'])
+        scatter = hv.Scatter([('A', 2)])
         plot = bokeh_renderer.get_plot(curve*scatter)
         x_range = plot.handles['x_range']
         assert x_range.factors == ['A', 'B', 'C']
 
     def test_categorical_overlay_dimension_values_skip_factor(self):
-        curve = Curve([('C', 1), ('B', 3)])
-        scatter = Scatter([('A', 2)])
+        curve = hv.Curve([('C', 1), ('B', 3)])
+        scatter = hv.Scatter([('A', 2)])
         plot = bokeh_renderer.get_plot((curve*scatter).redim.values(x=['A', 'C']))
         x_range = plot.handles['x_range']
         assert x_range.factors == ['A', 'C']
@@ -1227,7 +1224,7 @@ class TestOverlayPlot(TestBokehPlot):
         arr = np.random.rand(10,10)
         arr[0, 0] = -100
         arr[-1, -1] = 100
-        im = Image(arr).opts(clim_percentile=True)
+        im = hv.Image(arr).opts(clim_percentile=True)
 
         plot = bokeh_renderer.get_plot(im)
         low, high = plot.ranges[('Image',)]['z']['robust']
@@ -1235,7 +1232,7 @@ class TestOverlayPlot(TestBokehPlot):
         assert high < 1
 
     def test_propagate_tools(self):
-        scatter = lambda: Scatter([]).opts(default_tools=[])
+        scatter = lambda: hv.Scatter([]).opts(default_tools=[])
         overlay = scatter() * scatter()
         plot = bokeh_renderer.get_plot(overlay)
         assert plot.default_tools == []
@@ -1245,7 +1242,7 @@ class TestApplyHardBounds(TestBokehPlot):
         """Test `apply_hard_bounds` with a single element."""
         x_values = np.linspace(10, 50, 5)
         y_values = np.array([10, 20, 30, 40, 50])
-        curve = Curve((x_values, y_values)).opts(apply_hard_bounds=True)
+        curve = hv.Curve((x_values, y_values)).opts(apply_hard_bounds=True)
         plot = bokeh_renderer.get_plot(curve)
         assert plot.handles['x_range'].bounds == (10, 50)
 
@@ -1254,9 +1251,9 @@ class TestApplyHardBounds(TestBokehPlot):
         x1_values = np.linspace(10, 50, 5)
         x2_values = np.linspace(10, 90, 5)
         y_values = np.array([10, 20, 30, 40, 50])
-        curve1 = Curve((x1_values, y_values))
-        curve2 = Curve((x2_values, y_values))
-        overlay = Overlay([curve1, curve2]).opts(opts.Curve(apply_hard_bounds=True))
+        curve1 = hv.Curve((x1_values, y_values))
+        curve2 = hv.Curve((x2_values, y_values))
+        overlay = hv.Overlay([curve1, curve2]).opts(hv.opts.Curve(apply_hard_bounds=True))
         plot = bokeh_renderer.get_plot(overlay)
         # Check if the large of the data range can be navigated to
         assert plot.handles['x_range'].bounds == (10, 90)
@@ -1265,7 +1262,7 @@ class TestApplyHardBounds(TestBokehPlot):
         """Test `apply_hard_bounds` with `xlim` set. Initial view should be within xlim but allow panning to data range."""
         x_values = np.linspace(10, 50, 5)
         y_values = np.array([10, 20, 30, 40, 50])
-        curve = Curve((x_values, y_values)).opts(apply_hard_bounds=True, xlim=(15, 35))
+        curve = hv.Curve((x_values, y_values)).opts(apply_hard_bounds=True, xlim=(15, 35))
         plot = bokeh_renderer.get_plot(curve)
         initial_view_range = (plot.handles['x_range'].start, plot.handles['x_range'].end)
         assert initial_view_range == (15, 35)
@@ -1276,7 +1273,7 @@ class TestApplyHardBounds(TestBokehPlot):
         """Test `apply_hard_bounds` with `.redim.range(x=...)`. Hard bounds should strictly apply."""
         x_values = np.linspace(10, 50, 5)
         y_values = np.array([10, 20, 30, 40, 50])
-        curve = Curve((x_values, y_values)).redim.range(x=(25, None)).opts(apply_hard_bounds=True)
+        curve = hv.Curve((x_values, y_values)).redim.range(x=(25, None)).opts(apply_hard_bounds=True)
         plot = bokeh_renderer.get_plot(curve)
         # Expected to strictly adhere to any redim.range bounds, otherwise the data range
         assert (plot.handles['x_range'].start, plot.handles['x_range'].end)  == (25, 50)
@@ -1288,7 +1285,7 @@ class TestApplyHardBounds(TestBokehPlot):
         target_xlim_h = dt.datetime(2020, 1, 7)
         dates = [dt.datetime(2020, 1, i) for i in range(1, 11)]
         values = np.linspace(0, 100, 10)
-        curve = Curve((dates, values)).opts(
+        curve = hv.Curve((dates, values)).opts(
             apply_hard_bounds=True,
             xlim=(target_xlim_l, target_xlim_h)
         )
@@ -1308,15 +1305,15 @@ class TestApplyHardBounds(TestBokehPlot):
                 'set2': (np.linspace(0, 20, 100), np.random.rand(100)),
             }
             x, y = datasets[choice]
-            return Curve((x, y))
+            return hv.Curve((x, y))
 
         ChoiceStream = Stream.define(
             'Choice',
             choice=param.Selector(default='set1', objects=['set1', 'set2'])
         )
         choice_stream = ChoiceStream()
-        dmap = DynamicMap(curve_data, kdims=[], streams=[choice_stream])
-        dmap = dmap.opts(opts.Curve(apply_hard_bounds=True, xlim=(2,3), framewise=True))
+        dmap = hv.DynamicMap(curve_data, kdims=[], streams=[choice_stream])
+        dmap = dmap.opts(hv.opts.Curve(apply_hard_bounds=True, xlim=(2,3), framewise=True))
         dmap = dmap.redim.values(choice=['set1', 'set2'])
         plot = bokeh_renderer.get_plot(dmap)
 
@@ -1344,7 +1341,7 @@ def test_rectangles_colormapping_with_polars():
         'd': [10, 20],
         'e': [1, 2],
     })
-    rectangles = Rectangles(df, kdims=['a', 'b', 'c', 'd']).opts(color='e')
+    rectangles = hv.Rectangles(df, kdims=['a', 'b', 'c', 'd']).opts(color='e')
     plot = bokeh_renderer.get_plot(rectangles)
     glyph_renderer = plot.handles['glyph_renderer']
     fill_color = glyph_renderer.glyph.fill_color

--- a/holoviews/tests/plotting/bokeh/test_errorbarplot.py
+++ b/holoviews/tests/plotting/bokeh/test_errorbarplot.py
@@ -1,7 +1,7 @@
 import numpy as np
 from bokeh.models import CategoricalColorMapper, LinearColorMapper
 
-from holoviews.element import ErrorBars
+import holoviews as hv
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal
 
@@ -11,7 +11,7 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestErrorBarsPlot(TestBokehPlot):
 
     def test_errorbars_padding_square(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1)
+        errorbars = hv.ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -20,7 +20,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         assert y_range.end == 3.8
 
     def test_errorbars_padding_hard_range(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.range(y=(0, 4)).opts(padding=0.1)
+        errorbars = hv.ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.range(y=(0, 4)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -29,7 +29,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         assert y_range.end == 4
 
     def test_errorbars_padding_soft_range(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
+        errorbars = hv.ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -38,7 +38,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         assert y_range.end == 3.5
 
     def test_errorbars_padding_nonsquare(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, width=600)
+        errorbars = hv.ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.9
@@ -47,7 +47,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         assert y_range.end == 3.8
 
     def test_errorbars_padding_logx(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3,3, 0.5)]).opts(padding=0.1, logx=True)
+        errorbars = hv.ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3,3, 0.5)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.89595845984076228
@@ -56,7 +56,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         assert y_range.end == 3.8
 
     def test_errorbars_padding_logy(self):
-        errorbars = ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, logy=True)
+        errorbars = hv.ErrorBars([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(errorbars)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -69,7 +69,7 @@ class TestErrorBarsPlot(TestBokehPlot):
     ###########################
 
     def test_errorbars_color_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, '#000'), (0, 1, 0.2, 0.4, '#F00'), (0, 2, 0.6, 1.2, '#0F0')],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, '#000'), (0, 1, 0.2, 0.4, '#F00'), (0, 2, 0.6, 1.2, '#0F0')],
                               vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
@@ -78,7 +78,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color'}
 
     def test_errorbars_linear_color_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 1), (0, 2, 0.6, 1.2, 2)],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 1), (0, 2, 0.6, 1.2, 2)],
                               vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
@@ -91,7 +91,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color', 'transform': cmapper}
 
     def test_errorbars_categorical_color_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, 'A'), (0, 1, 0.2, 0.4, 'B'), (0, 2, 0.6, 1.2, 'C')],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, 'A'), (0, 1, 0.2, 0.4, 'B'), (0, 2, 0.6, 1.2, 'C')],
                               vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
@@ -103,7 +103,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color', 'transform': cmapper}
 
     def test_errorbars_line_color_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, '#000'), (0, 1, 0.2, 0.4, '#F00'), (0, 2, 0.6, 1.2, '#0F0')],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, '#000'), (0, 1, 0.2, 0.4, '#F00'), (0, 2, 0.6, 1.2, '#0F0')],
                               vdims=['y', 'perr', 'nerr', 'color']).opts(line_color='color')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
@@ -112,7 +112,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'line_color'}
 
     def test_errorbars_alpha_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 0.2), (0, 2, 0.6, 1.2, 0.7)],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 0.2), (0, 2, 0.6, 1.2, 0.7)],
                               vdims=['y', 'perr', 'nerr', 'alpha']).opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
@@ -121,7 +121,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_alpha) == {'field': 'alpha'}
 
     def test_errorbars_line_alpha_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 0.2), (0, 2, 0.6, 1.2, 0.7)],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 0.2), (0, 2, 0.6, 1.2, 0.7)],
                               vdims=['y', 'perr', 'nerr', 'alpha']).opts(line_alpha='alpha')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']
@@ -130,7 +130,7 @@ class TestErrorBarsPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_alpha) == {'field': 'line_alpha'}
 
     def test_errorbars_line_width_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, 1), (0, 1, 0.2, 0.4, 4), (0, 2, 0.6, 1.2, 8)],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, 1), (0, 1, 0.2, 0.4, 4), (0, 2, 0.6, 1.2, 8)],
                               vdims=['y', 'perr', 'nerr', 'line_width']).opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(errorbars)
         cds = plot.handles['cds']

--- a/holoviews/tests/plotting/bokeh/test_geomplot.py
+++ b/holoviews/tests/plotting/bokeh/test_geomplot.py
@@ -1,8 +1,7 @@
 import pandas as pd
 from bokeh.models import FactorRange
 
-from holoviews.core import NdOverlay
-from holoviews.element import Segments
+import holoviews as hv
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
@@ -11,7 +10,7 @@ class TestSegmentPlot(TestBokehPlot):
 
     def test_segments_color_selection_nonselection(self):
         opts = dict(color='green', selection_color='red', nonselection_color='blue')
-        segments = Segments([(i, i*2, i*3, i*4, i*5, chr(65+i)) for i in range(10)],
+        segments = hv.Segments([(i, i*2, i*3, i*4, i*5, chr(65+i)) for i in range(10)],
                             vdims=['a', 'b']).opts(**opts)
         plot = bokeh_renderer.get_plot(segments)
         glyph_renderer = plot.handles['glyph_renderer']
@@ -21,7 +20,7 @@ class TestSegmentPlot(TestBokehPlot):
 
     def test_segments_alpha_selection_nonselection(self):
         opts = dict(alpha=0.8, selection_alpha=1.0, nonselection_alpha=0.2)
-        segments = Segments([(i, i*2, i*3, i*4, i*5, chr(65+i)) for i in range(10)],
+        segments = hv.Segments([(i, i*2, i*3, i*4, i*5, chr(65+i)) for i in range(10)],
                             vdims=['a', 'b']).opts(**opts)
         plot = bokeh_renderer.get_plot(segments)
         glyph_renderer = plot.handles['glyph_renderer']
@@ -30,8 +29,8 @@ class TestSegmentPlot(TestBokehPlot):
         assert glyph_renderer.nonselection_glyph.line_alpha == 0.2
 
     def test_segments_overlay_hover(self):
-        obj = NdOverlay({
-            i: Segments((range(31), range(31),range(1, 32), range(31)))
+        obj = hv.NdOverlay({
+            i: hv.Segments((range(31), range(31),range(1, 32), range(31)))
             for i in range(5)
         }, kdims=['Test']).opts({'Segments': {'tools': ['hover']}})
         tooltips = [
@@ -44,8 +43,8 @@ class TestSegmentPlot(TestBokehPlot):
         self._test_hover_info(obj, tooltips)
 
     def test_segments_overlay_datetime_hover(self):
-        obj = NdOverlay({
-            i: Segments((
+        obj = hv.NdOverlay({
+            i: hv.Segments((
                 list(pd.date_range('2016-01-01', '2016-01-31')),
                 range(31),
                 pd.date_range('2016-01-02', '2016-02-01'),
@@ -64,45 +63,45 @@ class TestSegmentPlot(TestBokehPlot):
         self._test_hover_info(obj, tooltips, formatters=formatters)
 
     def test_segments_categorical_xaxis(self):
-        segments = Segments((['A', 'B', 'C'], [1, 2, 3], ['A', 'B', 'C'], [4, 5, 6]))
+        segments = hv.Segments((['A', 'B', 'C'], [1, 2, 3], ['A', 'B', 'C'], [4, 5, 6]))
         plot = bokeh_renderer.get_plot(segments)
         x_range = plot.handles['x_range']
         assert isinstance(x_range, FactorRange)
         assert x_range.factors == ['A', 'B', 'C']
 
     def test_segments_categorical_yaxis(self):
-        segments = Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C']))
+        segments = hv.Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C']))
         plot = bokeh_renderer.get_plot(segments)
         y_range = plot.handles['y_range']
         assert isinstance(y_range, FactorRange)
         assert y_range.factors == ['A', 'B', 'C']
 
     def test_segments_categorical_yaxis_invert_axes(self):
-        segments = Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C']))
+        segments = hv.Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C']))
         plot = bokeh_renderer.get_plot(segments)
         y_range = plot.handles['y_range']
         assert isinstance(y_range, FactorRange)
         assert y_range.factors == ['A', 'B', 'C']
 
     def test_segments_overlay_categorical_yaxis(self):
-        segments = Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C']))
-        segments2 = Segments(([1, 2, 3], ['B', 'C', 'D'], [4, 5, 6], ['B', 'C', 'D']))
+        segments = hv.Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C']))
+        segments2 = hv.Segments(([1, 2, 3], ['B', 'C', 'D'], [4, 5, 6], ['B', 'C', 'D']))
         plot = bokeh_renderer.get_plot(segments*segments2)
         y_range = plot.handles['y_range']
         assert isinstance(y_range, FactorRange)
         assert y_range.factors == ['A', 'B', 'C', 'D']
 
     def test_segments_overlay_categorical_yaxis_invert_yaxis(self):
-        segments = Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C'])).opts(invert_yaxis=True)
-        segments2 = Segments(([1, 2, 3], ['B', 'C', 'D'], [4, 5, 6], ['B', 'C', 'D']))
+        segments = hv.Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C'])).opts(invert_yaxis=True)
+        segments2 = hv.Segments(([1, 2, 3], ['B', 'C', 'D'], [4, 5, 6], ['B', 'C', 'D']))
         plot = bokeh_renderer.get_plot(segments*segments2)
         y_range = plot.handles['y_range']
         assert isinstance(y_range, FactorRange)
         assert y_range.factors == ['A', 'B', 'C', 'D'][::-1]
 
     def test_segments_overlay_categorical_xaxis_invert_axes(self):
-        segments = Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C'])).opts(invert_axes=True)
-        segments2 = Segments(([1, 2, 3], ['B', 'C', 'D'], [4, 5, 6], ['B', 'C', 'D']))
+        segments = hv.Segments(([1, 2, 3], ['A', 'B', 'C'], [4, 5, 6], ['A', 'B', 'C'])).opts(invert_axes=True)
+        segments2 = hv.Segments(([1, 2, 3], ['B', 'C', 'D'], [4, 5, 6], ['B', 'C', 'D']))
         plot = bokeh_renderer.get_plot(segments*segments2)
         x_range = plot.handles['x_range']
         assert isinstance(x_range, FactorRange)

--- a/holoviews/tests/plotting/bokeh/test_graphplot.py
+++ b/holoviews/tests/plotting/bokeh/test_graphplot.py
@@ -2,19 +2,10 @@ import numpy as np
 from bokeh.models import EdgesAndLinkedNodes, NodesAndLinkedEdges, NodesOnly, Patches
 from bokeh.models.mappers import CategoricalColorMapper, LinearColorMapper
 
-from holoviews.core.data import Dataset
-from holoviews.element import (
-    Chord,
-    Graph,
-    Nodes,
-    Sankey,
-    TriMesh,
-    VLine,
-    circular_layout,
-)
+import holoviews as hv
+from holoviews.element import circular_layout
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal
-from holoviews.util.transform import dim
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
@@ -29,12 +20,12 @@ class TestBokehGraphPlot(TestBokehPlot):
         self.source = np.arange(N, dtype=np.int32)
         self.target = np.zeros(N, dtype=np.int32)
         self.weights = np.random.rand(N)
-        self.graph = Graph(((self.source, self.target),))
-        self.node_info = Dataset(['Output']+['Input']*(N-1), vdims=['Label'])
-        self.node_info2 = Dataset(self.weights, vdims='Weight')
-        self.graph2 = Graph(((self.source, self.target), self.node_info))
-        self.graph3 = Graph(((self.source, self.target), self.node_info2))
-        self.graph4 = Graph(((self.source, self.target, self.weights),), vdims='Weight')
+        self.graph = hv.Graph(((self.source, self.target),))
+        self.node_info = hv.Dataset(['Output']+['Input']*(N-1), vdims=['Label'])
+        self.node_info2 = hv.Dataset(self.weights, vdims='Weight')
+        self.graph2 = hv.Graph(((self.source, self.target), self.node_info))
+        self.graph3 = hv.Graph(((self.source, self.target), self.node_info2))
+        self.graph4 = hv.Graph(((self.source, self.target, self.weights),), vdims='Weight')
 
     def test_plot_simple_graph(self):
         plot = bokeh_renderer.get_plot(self.graph)
@@ -49,7 +40,7 @@ class TestBokehGraphPlot(TestBokehPlot):
         assert layout_source.graph_layout == layout
 
     def test_plot_graph_annotation_overlay(self):
-        plot = bokeh_renderer.get_plot(VLine(0) * self.graph)
+        plot = bokeh_renderer.get_plot(hv.VLine(0) * self.graph)
         x_range = plot.handles['x_range']
         y_range = plot.handles['x_range']
         assert x_range.start == -1
@@ -174,9 +165,9 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_node_color(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 'red'), (0, 1, 1, 'green'), (1, 1, 2, 'blue')],
+        nodes = hv.Nodes([(0, 0, 0, 'red'), (0, 1, 1, 'green'), (1, 1, 2, 'blue')],
                       vdims='color')
-        graph = Graph((edges, nodes)).opts(node_color='color')
+        graph = hv.Graph((edges, nodes)).opts(node_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -186,9 +177,9 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_node_color_linear(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 0.5), (0, 1, 1, 1.5), (1, 1, 2, 2.5)],
+        nodes = hv.Nodes([(0, 0, 0, 0.5), (0, 1, 1, 1.5), (1, 1, 2, 2.5)],
                       vdims='color')
-        graph = Graph((edges, nodes)).opts(node_color='color')
+        graph = hv.Graph((edges, nodes)).opts(node_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -199,18 +190,18 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_node_color_colorbar(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 0.5), (0, 1, 1, 1.5), (1, 1, 2, 2.5)],
+        nodes = hv.Nodes([(0, 0, 0, 0.5), (0, 1, 1, 1.5), (1, 1, 2, 2.5)],
                       vdims='color')
-        graph = Graph((edges, nodes)).opts(node_color='color', colorbar=True)
+        graph = hv.Graph((edges, nodes)).opts(node_color='color', colorbar=True)
         plot = bokeh_renderer.get_plot(graph)
         assert 'node_color_colorbar' in plot.handles
         assert plot.handles['node_color_colorbar'].color_mapper is plot.handles['node_color_color_mapper']
 
     def test_graph_op_node_color_categorical(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 'A'), (0, 1, 1, 'B'), (1, 1, 2, 'C')],
+        nodes = hv.Nodes([(0, 0, 0, 'A'), (0, 1, 1, 'B'), (1, 1, 2, 'C')],
                       vdims='color')
-        graph = Graph((edges, nodes)).opts(node_color='color')
+        graph = hv.Graph((edges, nodes)).opts(node_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -221,9 +212,9 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_node_size(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 6)],
+        nodes = hv.Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 6)],
                       vdims='size')
-        graph = Graph((edges, nodes)).opts(node_size='size')
+        graph = hv.Graph((edges, nodes)).opts(node_size='size')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -232,8 +223,8 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_node_alpha(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 0.2), (0, 1, 1, 0.6), (1, 1, 2, 1)], vdims='alpha')
-        graph = Graph((edges, nodes)).opts(node_alpha='alpha')
+        nodes = hv.Nodes([(0, 0, 0, 0.2), (0, 1, 1, 0.6), (1, 1, 2, 1)], vdims='alpha')
+        graph = hv.Graph((edges, nodes)).opts(node_alpha='alpha')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -243,8 +234,8 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_node_line_width(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 6)], vdims='line_width')
-        graph = Graph((edges, nodes)).opts(node_line_width='line_width')
+        nodes = hv.Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 6)], vdims='line_width')
+        graph = hv.Graph((edges, nodes)).opts(node_line_width='line_width')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -253,7 +244,7 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_edge_color(self):
         edges = [(0, 1, 'red'), (0, 2, 'green'), (1, 3, 'blue')]
-        graph = Graph(edges, vdims='color').opts(edge_color='color')
+        graph = hv.Graph(edges, vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -262,7 +253,7 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_edge_color_linear(self):
         edges = [(0, 1, 2), (0, 2, 0.5), (1, 3, 3)]
-        graph = Graph(edges, vdims='color').opts(edge_color='color')
+        graph = hv.Graph(edges, vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -272,14 +263,14 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_edge_color_colorbar(self):
         edges = [(0, 1, 2), (0, 2, 0.5), (1, 3, 3)]
-        graph = Graph(edges, vdims='color').opts(edge_color='color', colorbar=True)
+        graph = hv.Graph(edges, vdims='color').opts(edge_color='color', colorbar=True)
         plot = bokeh_renderer.get_plot(graph)
         assert 'edge_color_colorbar' in plot.handles
         assert plot.handles['edge_color_colorbar'].color_mapper is plot.handles['edge_color_color_mapper']
 
     def test_graph_op_edge_color_categorical(self):
         edges = [(0, 1, 'C'), (0, 2, 'B'), (1, 3, 'A')]
-        graph = Graph(edges, vdims='color').opts(edge_color='color')
+        graph = hv.Graph(edges, vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -289,7 +280,7 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_edge_alpha(self):
         edges = [(0, 1, 0.1), (0, 2, 0.5), (1, 3, 0.3)]
-        graph = Graph(edges, vdims='alpha').opts(edge_alpha='alpha')
+        graph = hv.Graph(edges, vdims='alpha').opts(edge_alpha='alpha')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -298,7 +289,7 @@ class TestBokehGraphPlot(TestBokehPlot):
 
     def test_graph_op_edge_line_width(self):
         edges = [(0, 1, 2), (0, 2, 10), (1, 3, 6)]
-        graph = Graph(edges, vdims='line_width').opts(edge_line_width='line_width')
+        graph = hv.Graph(edges, vdims='line_width').opts(edge_line_width='line_width')
         plot = bokeh_renderer.get_plot(graph)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -313,8 +304,8 @@ class TestBokehTriMeshPlot(TestBokehPlot):
 
         self.nodes = [(0, 0, 0), (0.5, 1, 1), (1., 0, 2), (1.5, 1, 3)]
         self.simplices = [(0, 1, 2, 0), (1, 2, 3, 1)]
-        self.trimesh = TriMesh((self.simplices, self.nodes))
-        self.trimesh_weighted = TriMesh((self.simplices, self.nodes), vdims='weight')
+        self.trimesh = hv.TriMesh((self.simplices, self.nodes))
+        self.trimesh_weighted = hv.TriMesh((self.simplices, self.nodes), vdims='weight')
 
     def test_plot_simple_trimesh(self):
         plot = bokeh_renderer.get_plot(self.trimesh)
@@ -374,7 +365,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_color(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 'red'), (0, 0, 1, 'green'), (0, 1, 2, 'blue'), (1, 0, 3, 'black')]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -385,7 +376,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_color_linear(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 2), (0, 0, 1, 1), (0, 1, 2, 3), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -399,7 +390,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_color_categorical(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 'B'), (0, 0, 1, 'C'), (0, 1, 2, 'A'), (1, 0, 3, 'B')]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -411,7 +402,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_size(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 3), (0, 0, 1, 2), (0, 1, 2, 8), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='size'))).opts(node_size='size')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='size'))).opts(node_size='size')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -421,7 +412,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_alpha(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 0.2), (0, 0, 1, 0.6), (0, 1, 2, 1), (1, 0, 3, 0.3)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='alpha'))).opts(node_alpha='alpha')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='alpha'))).opts(node_alpha='alpha')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -432,7 +423,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_node_line_width(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 0.2), (0, 0, 1, 0.6), (0, 1, 2, 1), (1, 0, 3, 0.3)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='line_width'))).opts(node_line_width='line_width')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='line_width'))).opts(node_line_width='line_width')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['scatter_1_source']
         glyph = plot.handles['scatter_1_glyph']
@@ -442,7 +433,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_color_linear_mean_node(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 2), (0, 0, 1, 1), (0, 1, 2, 3), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(edge_color='color')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='color'))).opts(edge_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -455,7 +446,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_color(self):
         edges = [(0, 1, 2, 'red'), (1, 2, 3, 'blue')]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
+        trimesh = hv.TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -465,7 +456,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_color_linear(self):
         edges = [(0, 1, 2, 2.4), (1, 2, 3, 3.6)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
+        trimesh = hv.TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -478,7 +469,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_color_linear_filled(self):
         edges = [(0, 1, 2, 2.4), (1, 2, 3, 3.6)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color', filled=True)
+        trimesh = hv.TriMesh((edges, nodes), vdims='color').opts(edge_color='color', filled=True)
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['patches_1_source']
         glyph = plot.handles['patches_1_glyph']
@@ -492,7 +483,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_color_categorical(self):
         edges = [(0, 1, 2, 'A'), (1, 2, 3, 'B')]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
+        trimesh = hv.TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -504,7 +495,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_alpha(self):
         edges = [(0, 1, 2, 0.7), (1, 2, 3, 0.3)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='alpha').opts(edge_alpha='alpha')
+        trimesh = hv.TriMesh((edges, nodes), vdims='alpha').opts(edge_alpha='alpha')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -514,7 +505,7 @@ class TestBokehTriMeshPlot(TestBokehPlot):
     def test_trimesh_op_edge_line_width(self):
         edges = [(0, 1, 2, 7), (1, 2, 3, 3)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='line_width').opts(edge_line_width='line_width')
+        trimesh = hv.TriMesh((edges, nodes), vdims='line_width').opts(edge_line_width='line_width')
         plot = bokeh_renderer.get_plot(trimesh)
         cds = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -527,8 +518,8 @@ class TestBokehChordPlot(TestBokehPlot):
     def setup_method(self):
         super().setup_method()
         self.edges = [(0, 1, 1), (0, 2, 2), (1, 2, 3)]
-        self.nodes = Dataset([(0, 'A'), (1, 'B'), (2, 'C')], 'index', 'Label')
-        self.chord = Chord((self.edges, self.nodes))
+        self.nodes = hv.Dataset([(0, 'A'), (1, 'B'), (2, 'C')], 'index', 'Label')
+        self.chord = hv.Chord((self.edges, self.nodes))
 
     def test_chord_draw_order(self):
         plot = bokeh_renderer.get_plot(self.chord)
@@ -607,7 +598,7 @@ class TestBokehChordPlot(TestBokehPlot):
 
     def test_chord_edge_color_style_mapping(self):
         g = self.chord.opts(
-            edge_color=dim('start').astype(str), edge_cmap=['#FFFFFF', '#000000']
+            edge_color=hv.dim('start').astype(str), edge_cmap=['#FFFFFF', '#000000']
         )
         plot = bokeh_renderer.get_plot(g)
         cmapper = plot.handles['edge_color_color_mapper']
@@ -634,11 +625,11 @@ class TestBokehSankeyPlot(TestBokehPlot):
             'C': '#2ca02c',  # green
         }
         # Provide nodes with explicit index->label mapping
-        self.nodes = Dataset(
+        self.nodes = hv.Dataset(
             {'index': [0, 1, 2], 'Label': ['A', 'B', 'C']},
             kdims=['index'], vdims=['Label']
         )
-        self.sk = Sankey(((self.src, self.tgt, self.val), self.nodes), vdims=['Value'])
+        self.sk = hv.Sankey(((self.src, self.tgt, self.val), self.nodes), vdims=['Value'])
         self.sk = self.sk.opts(
             # Color nodes by their label using the provided palette
             node_color='Label',

--- a/holoviews/tests/plotting/bokeh/test_gridplot.py
+++ b/holoviews/tests/plotting/bokeh/test_gridplot.py
@@ -2,15 +2,7 @@ import numpy as np
 from bokeh.layouts import Column
 from bokeh.models import Div, Toolbar
 
-from holoviews.core import (
-    Dataset,
-    DynamicMap,
-    GridMatrix,
-    GridSpace,
-    HoloMap,
-    NdOverlay,
-)
-from holoviews.element import Curve, Image, Points
+import holoviews as hv
 from holoviews.operation import gridmatrix
 from holoviews.streams import Stream
 from holoviews.testing import assert_data_equal
@@ -21,7 +13,7 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestGridPlot(TestBokehPlot):
 
     def test_grid_title(self):
-        grid = GridSpace({(i, j): HoloMap({a: Image(np.random.rand(10,10))
+        grid = hv.GridSpace({(i, j): hv.HoloMap({a: hv.Image(np.random.rand(10,10))
                                            for a in range(3)}, kdims=['X'])
                           for i in range(2) for j in range(3)})
         plot = bokeh_renderer.get_plot(grid)
@@ -32,7 +24,7 @@ class TestGridPlot(TestBokehPlot):
         assert title.text == text
 
     def test_grid_title_update(self):
-        grid = GridSpace({(i, j): HoloMap({a: Image(np.random.rand(10,10))
+        grid = hv.GridSpace({(i, j): hv.HoloMap({a: hv.Image(np.random.rand(10,10))
                                            for a in range(3)}, kdims=['X'])
                           for i in range(2) for j in range(3)})
         plot = bokeh_renderer.get_plot(grid)
@@ -44,9 +36,9 @@ class TestGridPlot(TestBokehPlot):
         assert title.text == text
 
     def test_gridmatrix_overlaid_batched(self):
-        ds = Dataset((['A']*5+['B']*5, np.random.rand(10), np.random.rand(10)),
+        ds = hv.Dataset((['A']*5+['B']*5, np.random.rand(10), np.random.rand(10)),
                      kdims=['a', 'b', 'c'])
-        gmatrix = gridmatrix(ds.groupby('a', container_type=NdOverlay))
+        gmatrix = gridmatrix(ds.groupby('a', container_type=hv.NdOverlay))
         plot = bokeh_renderer.get_plot(gmatrix)
 
         sp1 = plot.subplots[('b', 'c')]
@@ -63,24 +55,24 @@ class TestGridPlot(TestBokehPlot):
         assert sp4.state.yaxis[0].visible is False
 
     def test_gridspace_sparse(self):
-        grid = GridSpace({(i, j): Curve(range(i+j)) for i in range(1, 3)
+        grid = hv.GridSpace({(i, j): hv.Curve(range(i+j)) for i in range(1, 3)
                             for j in range(2,4) if not (i==1 and j == 2)})
         plot = bokeh_renderer.get_plot(grid)
         size = bokeh_renderer.get_size(plot.state)
         assert size == (320, 311)
 
     def test_grid_shared_source_synced_update(self):
-        hmap = HoloMap({i: Dataset({chr(65+j): np.random.rand(i+2)
+        hmap = hv.HoloMap({i: hv.Dataset({chr(65+j): np.random.rand(i+2)
                                     for j in range(4)}, kdims=['A', 'B', 'C', 'D'])
                         for i in range(3)})
 
         # Create two holomaps of points sharing the same data source
-        hmap1=  hmap.map(lambda x: Points(x.clone(kdims=['A', 'B'])), Dataset)
-        hmap2 = hmap.map(lambda x: Points(x.clone(kdims=['D', 'C'])), Dataset)
+        hmap1=  hmap.map(lambda x: hv.Points(x.clone(kdims=['A', 'B'])), hv.Dataset)
+        hmap2 = hmap.map(lambda x: hv.Points(x.clone(kdims=['D', 'C'])), hv.Dataset)
 
         # Pop key (1,) for one of the HoloMaps and make GridSpace
         hmap2.pop(1)
-        grid = GridSpace({0: hmap1, 2: hmap2}, kdims=['X']).opts(shared_datasource=True)
+        grid = hv.GridSpace({0: hmap1, 2: hmap2}, kdims=['X']).opts(shared_datasource=True)
 
         # Get plot
         plot = bokeh_renderer.get_plot(grid)
@@ -107,22 +99,22 @@ class TestGridPlot(TestBokehPlot):
         assert_data_equal(data['D'], np.full_like(hmap1[1].dimension_values(0), np.nan))
 
     def test_grid_set_toolbar_location(self):
-        grid = GridSpace({0: Curve([]), 1: Points([])}, 'X').opts(toolbar='left')
+        grid = hv.GridSpace({0: hv.Curve([]), 1: hv.Points([])}, 'X').opts(toolbar='left')
         plot = bokeh_renderer.get_plot(grid)
         assert isinstance(plot.state, Column)
         assert isinstance(plot.state.children[0].toolbar, Toolbar)
 
 
     def test_grid_disable_toolbar(self):
-        grid = GridSpace({0: Curve([]), 1: Points([])}, 'X').opts(toolbar=None)
+        grid = hv.GridSpace({0: hv.Curve([]), 1: hv.Points([])}, 'X').opts(toolbar=None)
         plot = bokeh_renderer.get_plot(grid)
         assert isinstance(plot.state, Column)
         assert [p for p in plot.state.children if isinstance(p, Toolbar)] == []
 
     def test_grid_dimensioned_stream_title_update(self):
         stream = Stream.define('Test', test=0)()
-        dmap = DynamicMap(lambda test: Curve([]), kdims=['test'], streams=[stream])
-        grid = GridMatrix({0: dmap, 1: Curve([])}, 'X')
+        dmap = hv.DynamicMap(lambda test: hv.Curve([]), kdims=['test'], streams=[stream])
+        grid = hv.GridMatrix({0: dmap, 1: hv.Curve([])}, 'X')
         plot = bokeh_renderer.get_plot(grid)
         assert 'test: 0' in plot.handles['title'].text
         stream.event(test=1)

--- a/holoviews/tests/plotting/bokeh/test_heatmapplot.py
+++ b/holoviews/tests/plotting/bokeh/test_heatmapplot.py
@@ -9,7 +9,7 @@ from bokeh.models import (
     Rect as bkRect,
 )
 
-from holoviews.element import HeatMap, Image, Points
+import holoviews as hv
 from holoviews.plotting.bokeh.heatmap import HeatMapPlot
 from holoviews.testing import assert_data_equal
 
@@ -19,7 +19,7 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestHeatMapPlot(TestBokehPlot):
 
     def test_heatmap_hover_ensure_kdims_sanitized(self):
-        hm = HeatMap([(1,1,1), (2,2,0)], kdims=['x with space', 'y with $pecial symbol'])
+        hm = hv.HeatMap([(1,1,1), (2,2,0)], kdims=['x with space', 'y with $pecial symbol'])
         hm = hm.opts(tools=['hover'])
         self._test_hover_info(hm, [('x with space', '@{x_with_space}'),
                                    ('y with $pecial symbol', '@{y_with_pecial_symbol}'),
@@ -28,7 +28,7 @@ class TestHeatMapPlot(TestBokehPlot):
     def test_heatmap_custom_string_tooltip_hover(self):
         tooltips = "<div><h1>Test</h1></div>"
         custom_hover = HoverTool(tooltips=tooltips)
-        hm = HeatMap([(1,1,1), (2,2,0)], kdims=['x with space', 'y with $pecial symbol'])
+        hm = hv.HeatMap([(1,1,1), (2,2,0)], kdims=['x with space', 'y with $pecial symbol'])
         hm = hm.opts(tools=[custom_hover])
         plot = bokeh_renderer.get_plot(hm)
         hover = plot.handles['hover']
@@ -36,16 +36,16 @@ class TestHeatMapPlot(TestBokehPlot):
         assert hover.renderers == [plot.handles['glyph_renderer']]
 
     def test_heatmap_hover_ensure_vdims_sanitized(self):
-        hm = HeatMap([(1,1,1), (2,2,0)], vdims=['z with $pace']).opts(tools=['hover'])
+        hm = hv.HeatMap([(1,1,1), (2,2,0)], vdims=['z with $pace']).opts(tools=['hover'])
         self._test_hover_info(hm, [('x', '@{x}'), ('y', '@{y}'),
                                    ('z with $pace', '@{z_with_pace}')])
 
     def test_heatmap_colormapping(self):
-        hm = HeatMap([(1,1,1), (2,2,0)])
+        hm = hv.HeatMap([(1,1,1), (2,2,0)])
         self._test_colormapping(hm, 2)
 
     def test_heatmap_categorical_axes_string_int(self):
-        hmap = HeatMap([('A', 1, 1), ('B', 2, 2)])
+        hmap = hv.HeatMap([('A', 1, 1), ('B', 2, 2)])
         plot = bokeh_renderer.get_plot(hmap)
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
@@ -57,7 +57,7 @@ class TestHeatMapPlot(TestBokehPlot):
 
     def test_heatmap_categorical_axes_string_int_invert_xyaxis(self):
         opts = dict(invert_xaxis=True, invert_yaxis=True)
-        hmap = HeatMap([('A', 1, 1), ('B', 2, 2)]).opts(**opts)
+        hmap = hv.HeatMap([('A', 1, 1), ('B', 2, 2)]).opts(**opts)
         plot = bokeh_renderer.get_plot(hmap)
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
@@ -68,7 +68,7 @@ class TestHeatMapPlot(TestBokehPlot):
         assert y_range.end == 0.5
 
     def test_heatmap_categorical_axes_string_int_inverted(self):
-        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).opts(invert_axes=True)
+        hmap = hv.HeatMap([('A',1, 1), ('B', 2, 2)]).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(hmap)
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
@@ -79,8 +79,8 @@ class TestHeatMapPlot(TestBokehPlot):
         assert y_range.factors == ['A', 'B']
 
     def test_heatmap_points_categorical_axes_string_int(self):
-        hmap = HeatMap([('A', 1, 1), ('B', 2, 2)])
-        points = Points([('A', 2), ('B', 1),  ('C', 3)])
+        hmap = hv.HeatMap([('A', 1, 1), ('B', 2, 2)])
+        points = hv.Points([('A', 2), ('B', 1),  ('C', 3)])
         plot = bokeh_renderer.get_plot(hmap*points)
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
@@ -91,8 +91,8 @@ class TestHeatMapPlot(TestBokehPlot):
         assert y_range.end == 3
 
     def test_heatmap_points_categorical_axes_string_int_inverted(self):
-        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).opts(invert_axes=True)
-        points = Points([('A', 2), ('B', 1),  ('C', 3)])
+        hmap = hv.HeatMap([('A',1, 1), ('B', 2, 2)]).opts(invert_axes=True)
+        points = hv.Points([('A', 2), ('B', 1),  ('C', 3)])
         plot = bokeh_renderer.get_plot(hmap*points)
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
@@ -104,7 +104,7 @@ class TestHeatMapPlot(TestBokehPlot):
 
     def test_heatmap_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4,  5]])
-        hm = HeatMap(Image(arr)).opts(invert_axes=True)
+        hm = hv.HeatMap(hv.Image(arr)).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(hm)
         assert plot._is_contiguous_gridded is True
         assert isinstance(plot.handles["glyph"], bkImage)
@@ -117,13 +117,13 @@ class TestHeatMapPlot(TestBokehPlot):
         assert data["dh"] == [1]
 
     def test_heatmap_dilate(self):
-        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).opts(dilate=True)
+        hmap = hv.HeatMap([('A',1, 1), ('B', 2, 2)]).opts(dilate=True)
         plot = bokeh_renderer.get_plot(hmap)
         glyph = plot.handles['glyph']
         assert glyph.dilate
 
     def test_heatmap_single_x_value(self):
-        hmap = HeatMap(([1], ['A', 'B'], np.array([[1], [2]])))
+        hmap = hv.HeatMap(([1], ['A', 'B'], np.array([[1], [2]])))
         plot = bokeh_renderer.get_plot(hmap)
         assert plot._is_contiguous_gridded is True
         assert isinstance(plot.handles["glyph"], bkImage)
@@ -135,7 +135,7 @@ class TestHeatMapPlot(TestBokehPlot):
         assert data["dh"] == [2]
 
     def test_heatmap_single_y_value(self):
-        hmap = HeatMap((['A', 'B'], [1], np.array([[1, 2]])))
+        hmap = hv.HeatMap((['A', 'B'], [1], np.array([[1, 2]])))
         plot = bokeh_renderer.get_plot(hmap)
         assert plot._is_contiguous_gridded is True
         assert isinstance(plot.handles["glyph"], bkImage)
@@ -153,7 +153,7 @@ class TestHeatMapPlot(TestBokehPlot):
             "alpha": [0, 0, 0, 1],
             "val": [.5, .6, .2, .1]
         }
-        hm = HeatMap(data, kdims=["col", "row"], vdims=["val", "alpha"]).opts(alpha="alpha")
+        hm = hv.HeatMap(data, kdims=["col", "row"], vdims=["val", "alpha"]).opts(alpha="alpha")
         plot = bokeh_renderer.get_plot(hm)
         cds = plot.handles['cds']
         assert_data_equal(cds.data['row'], np.array([1, 2, 1, 2]))
@@ -169,7 +169,7 @@ class TestHeatMapPlot(TestBokehPlot):
             'Z': [1, 2, 3, 4, 5, 6, 7, 8, 9],
         })
 
-        hm = HeatMap(df, ['X', 'Y'], 'Z').aggregate(function=np.mean)
+        hm = hv.HeatMap(df, ['X', 'Y'], 'Z').aggregate(function=np.mean)
         plot = bokeh_renderer.get_plot(hm)
         data = plot.handles["cds"].data
         np.testing.assert_array_equal(data["X"], df["X"])
@@ -181,7 +181,7 @@ class TestHeatMapPlot(TestBokehPlot):
             data={'C': [5, 2, -1, 5]},
             index=pd.MultiIndex.from_product([(0, 1), (0, 1)], names=['A', 'B']),
         )
-        hm = HeatMap(df, ['A', 'B'], 'C')
+        hm = hv.HeatMap(df, ['A', 'B'], 'C')
         plot = bokeh_renderer.get_plot(hm)
         data = plot.handles["cds"].data
         np.testing.assert_array_equal(data['A'], df.index.get_level_values('A'))
@@ -193,7 +193,7 @@ class TestHeatMapPlot(TestBokehPlot):
         x[4:] += 5
         y = [chr(65 + i) for i in range(10)]
         arr = np.ones((10, 12)) * np.arange(12) * np.atleast_2d(np.arange(10)).T
-        hm = HeatMap((x, y, arr))
+        hm = hv.HeatMap((x, y, arr))
 
         plot = bokeh_renderer.get_plot(hm)
         assert isinstance(plot.handles["glyph"], bkRect)
@@ -228,7 +228,7 @@ def test_heatmap_style_opts(optimized_gridded, style_name):
     else:
         style_value = 1
 
-    fig = HeatMap(([1,2,3,4], [1,2], [[1,2,3,4], [1,2,3,4]]))
+    fig = hv.HeatMap(([1,2,3,4], [1,2], [[1,2,3,4], [1,2,3,4]]))
     styled = fig.opts(optimize_gridded=optimized_gridded, **{style_name: style_value})
 
     plot = bokeh_renderer.get_plot(styled)

--- a/holoviews/tests/plotting/bokeh/test_hextilesplot.py
+++ b/holoviews/tests/plotting/bokeh/test_hextilesplot.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from holoviews.core import Dimension
-from holoviews.element import HexTiles
+import holoviews as hv
 from holoviews.plotting.bokeh.hex_tiles import hex_binning
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal, assert_element_equal
@@ -12,21 +11,21 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestHexTilesOperation(TestBokehPlot):
 
     def test_hex_tiles_count_aggregation(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)])
+        tiles = hv.HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)])
         binned = hex_binning(tiles, gridsize=3)
-        expected = HexTiles([(0, 0, 1), (2, -1, 1), (-2, 1, 2)],
-                            kdims=[Dimension('x', range=(-0.5, 0.5)),
-                                   Dimension('y', range=(-0.5, 0.5))],
+        expected = hv.HexTiles([(0, 0, 1), (2, -1, 1), (-2, 1, 2)],
+                            kdims=[hv.Dimension('x', range=(-0.5, 0.5)),
+                                   hv.Dimension('y', range=(-0.5, 0.5))],
                             vdims='Count')
         assert_element_equal(binned, expected)
 
 
     def test_hex_tiles_sum_value_aggregation(self):
-        tiles = HexTiles([(0, 0, 1), (0.5, 0.5, 2), (-0.5, -0.5, 3), (-0.4, -0.4, 4)], vdims='z')
+        tiles = hv.HexTiles([(0, 0, 1), (0.5, 0.5, 2), (-0.5, -0.5, 3), (-0.4, -0.4, 4)], vdims='z')
         binned = hex_binning(tiles, gridsize=3, aggregator=np.sum)
-        expected = HexTiles([(0, 0, 1), (2, -1, 2), (-2, 1, 7)],
-                            kdims=[Dimension('x', range=(-0.5, 0.5)),
-                                   Dimension('y', range=(-0.5, 0.5))],
+        expected = hv.HexTiles([(0, 0, 1), (2, -1, 2), (-2, 1, 7)],
+                            kdims=[hv.Dimension('x', range=(-0.5, 0.5)),
+                                   hv.Dimension('y', range=(-0.5, 0.5))],
                             vdims='z')
         assert_element_equal(binned, expected)
 
@@ -35,60 +34,60 @@ class TestHexTilesOperation(TestBokehPlot):
 class TestHexTilesPlot(TestBokehPlot):
 
     def test_hex_tiles_empty(self):
-        tiles = HexTiles([])
+        tiles = hv.HexTiles([])
         plot = bokeh_renderer.get_plot(tiles)
         assert plot.handles['source'].data == {'q': [], 'r': []}
 
     def test_hex_tiles_only_nans(self):
-        tiles = HexTiles([(np.nan, 0), (1, np.nan)])
+        tiles = hv.HexTiles([(np.nan, 0), (1, np.nan)])
         plot = bokeh_renderer.get_plot(tiles)
         assert plot.handles['source'].data == {'q': [], 'r': []}
 
     def test_hex_tiles_zero_min_count(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(min_count=0)
+        tiles = hv.HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(min_count=0)
         plot = bokeh_renderer.get_plot(tiles)
         cmapper = plot.handles['color_mapper']
         assert cmapper.low == 0
         assert plot.state.background_fill_color == cmapper.palette[0]
 
     def test_hex_tiles_gridsize_tuple(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(gridsize=(5, 10))
+        tiles = hv.HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(gridsize=(5, 10))
         plot = bokeh_renderer.get_plot(tiles)
         glyph = plot.handles['glyph']
         assert glyph.size == 0.066666666666666666
         assert glyph.aspect_scale == 0.5
 
     def test_hex_tiles_gridsize_tuple_flat_orientation(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(gridsize=(5, 10), orientation='flat')
+        tiles = hv.HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(gridsize=(5, 10), orientation='flat')
         plot = bokeh_renderer.get_plot(tiles)
         glyph = plot.handles['glyph']
         assert glyph.size == 0.13333333333333333
         assert glyph.aspect_scale == 0.5
 
     def test_hex_tiles_scale(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(size_index=2, gridsize=3)
+        tiles = hv.HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(size_index=2, gridsize=3)
         plot = bokeh_renderer.get_plot(tiles)
         source = plot.handles['source']
         assert_data_equal(source.data['scale'], np.array([0.45, 0.45, 0.9]))
 
     def test_hex_tiles_scale_all_equal(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(size_index=2)
+        tiles = hv.HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(size_index=2)
         plot = bokeh_renderer.get_plot(tiles)
         source = plot.handles['source']
         assert_data_equal(source.data['scale'], np.array([0.9, 0.9, 0.9, 0.9]))
 
     def test_hex_tiles_hover_count(self):
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(tools=['hover'])
+        tiles = hv.HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)]).opts(tools=['hover'])
         plot = bokeh_renderer.get_plot(tiles)
         dims, opts = plot._hover_opts(tiles)
-        assert dims == [Dimension('Count')]
+        assert dims == [hv.Dimension('Count')]
         assert opts == {}
 
     def test_hex_tiles_hover_weighted(self):
-        tiles = HexTiles([(0, 0, 0.1), (0.5, 0.5, 0.2), (-0.5, -0.5, 0.3)], vdims='z').opts(aggregator=np.mean)
+        tiles = hv.HexTiles([(0, 0, 0.1), (0.5, 0.5, 0.2), (-0.5, -0.5, 0.3)], vdims='z').opts(aggregator=np.mean)
         plot = bokeh_renderer.get_plot(tiles)
         dims, opts = plot._hover_opts(tiles)
-        assert dims == [Dimension('z')]
+        assert dims == [hv.Dimension('z')]
         assert opts == {}
 
     ###########################
@@ -96,19 +95,19 @@ class TestHexTilesPlot(TestBokehPlot):
     ###########################
 
     def test_hex_tile_line_width_op(self):
-        hextiles = HexTiles(np.random.randn(1000, 2)).opts(line_width='Count')
+        hextiles = hv.HexTiles(np.random.randn(1000, 2)).opts(line_width='Count')
         plot = bokeh_renderer.get_plot(hextiles)
         glyph = plot.handles['glyph']
         assert property_to_dict(glyph.line_width) == {'field': 'line_width'}
 
     def test_hex_tile_alpha_op(self):
-        hextiles = HexTiles(np.random.randn(1000, 2)).opts(alpha='Count')
+        hextiles = hv.HexTiles(np.random.randn(1000, 2)).opts(alpha='Count')
         plot = bokeh_renderer.get_plot(hextiles)
         glyph = plot.handles['glyph']
         assert property_to_dict(glyph.fill_alpha) == {'field': 'alpha'}
 
     def test_hex_tile_scale_op(self):
-        hextiles = HexTiles(np.random.randn(1000, 2)).opts(scale='Count')
+        hextiles = hv.HexTiles(np.random.randn(1000, 2)).opts(scale='Count')
         plot = bokeh_renderer.get_plot(hextiles)
         glyph = plot.handles['glyph']
         assert property_to_dict(glyph.scale) == {'field': 'scale'}

--- a/holoviews/tests/plotting/bokeh/test_histogramplot.py
+++ b/holoviews/tests/plotting/bokeh/test_histogramplot.py
@@ -3,8 +3,7 @@ import datetime as dt
 import numpy as np
 from bokeh.models import CategoricalColorMapper, DatetimeAxis, LinearColorMapper
 
-from holoviews.core.overlay import NdOverlay
-from holoviews.element import Dataset, Histogram, Image, Points
+import holoviews as hv
 from holoviews.operation import histogram
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal, assert_element_equal
@@ -16,7 +15,7 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
 
     def test_side_histogram_no_cmapper(self):
-        points = Points(np.random.rand(100, 2))
+        points = hv.Points(np.random.rand(100, 2))
         plot = bokeh_renderer.get_plot(points.hist())
         plot.initialize_plot()
         adjoint_plot = next(iter(plot.subplots.values()))
@@ -28,7 +27,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
     def test_side_histogram_cmapper(self):
         """Assert histogram shares colormapper"""
         x,y = np.mgrid[-50:51, -50:51] * 0.1
-        img = Image(np.sin(x**2+y**2), bounds=(-1,-1,1,1))
+        img = hv.Image(np.sin(x**2+y**2), bounds=(-1,-1,1,1))
         plot = bokeh_renderer.get_plot(img.hist())
         plot.initialize_plot()
         adjoint_plot = next(iter(plot.subplots.values()))
@@ -40,7 +39,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
     def test_side_histogram_cmapper_weighted(self):
         """Assert weighted histograms share colormapper"""
         x,y = np.mgrid[-50:51, -50:51] * 0.1
-        img = Image(np.sin(x**2+y**2), bounds=(-1,-1,1,1))
+        img = hv.Image(np.sin(x**2+y**2), bounds=(-1,-1,1,1))
         adjoint = img.hist(dimension=['x', 'y'], weight_dimension='z',
                            mean_weighted=True)
         plot = bokeh_renderer.get_plot(adjoint)
@@ -55,7 +54,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
 
     def test_histogram_datetime64_plot(self):
         dates = np.array([dt.datetime(2017, 1, i) for i in range(1, 5)])
-        hist = histogram(Dataset(dates, 'Date'), num_bins=4)
+        hist = histogram(hv.Dataset(dates, 'Date'), num_bins=4)
         plot = bokeh_renderer.get_plot(hist)
         source = plot.handles['source']
         data = {
@@ -78,7 +77,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert range_x.end == np.datetime64('2017-01-04T00:00:00.000000', 'us')
 
     def test_histogram_padding_square(self):
-        points = Histogram([(1, 2), (2, -1), (3, 3)]).opts(padding=0.1)
+        points = hv.Histogram([(1, 2), (2, -1), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.19999999999999996
@@ -87,7 +86,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.4
 
     def test_histogram_padding_square_positive(self):
-        points = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1)
+        points = hv.Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.19999999999999996
@@ -96,7 +95,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_histogram_padding_square_negative(self):
-        points = Histogram([(1, -2), (2, -1), (3, -3)]).opts(padding=0.1)
+        points = hv.Histogram([(1, -2), (2, -1), (3, -3)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.19999999999999996
@@ -105,7 +104,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 0
 
     def test_histogram_padding_nonsquare(self):
-        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, width=600)
+        histogram = hv.Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.35
@@ -114,7 +113,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_histogram_padding_logx(self):
-        histogram = Histogram([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
+        histogram = hv.Histogram([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.41158562699652224
@@ -123,7 +122,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_histogram_padding_logy(self):
-        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, logy=True)
+        histogram = hv.Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.19999999999999996
@@ -135,7 +134,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert last_line == []
 
     def test_histogram_padding_datetime_square(self):
-        histogram = Histogram([(np.datetime64(f'2016-04-0{i}', 'ns'), i) for i in range(1, 4)]).opts(
+        histogram = hv.Histogram([(np.datetime64(f'2016-04-0{i}', 'ns'), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = bokeh_renderer.get_plot(histogram)
@@ -146,7 +145,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_histogram_padding_datetime_nonsquare(self):
-        histogram = Histogram([(np.datetime64(f'2016-04-0{i}', 'ns'), i) for i in range(1, 4)]).opts(
+        histogram = hv.Histogram([(np.datetime64(f'2016-04-0{i}', 'ns'), i) for i in range(1, 4)]).opts(
             padding=0.1, width=600
         )
         plot = bokeh_renderer.get_plot(histogram)
@@ -161,7 +160,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
     ###########################
 
     def test_histogram_color_op(self):
-        histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        histogram = hv.Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                               vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
@@ -171,7 +170,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert glyph.line_color == 'black'
 
     def test_histogram_linear_color_op(self):
-        histogram = Histogram([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        histogram = hv.Histogram([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                               vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
@@ -185,7 +184,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert glyph.line_color == 'black'
 
     def test_histogram_categorical_color_op(self):
-        histogram = Histogram([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
+        histogram = hv.Histogram([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
                               vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
@@ -198,7 +197,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert glyph.line_color == 'black'
 
     def test_histogram_line_color_op(self):
-        histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        histogram = hv.Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                               vdims=['y', 'color']).opts(line_color='color')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
@@ -208,7 +207,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'line_color'}
 
     def test_histogram_fill_color_op(self):
-        histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        histogram = hv.Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                               vdims=['y', 'color']).opts(fill_color='color')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
@@ -218,7 +217,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert property_to_dict(glyph.line_color) != {'field': 'fill_color'}
 
     def test_histogram_alpha_op(self):
-        histogram = Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        histogram = hv.Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
@@ -227,7 +226,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert property_to_dict(glyph.fill_alpha) == {'field': 'alpha'}
 
     def test_histogram_line_alpha_op(self):
-        histogram = Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        histogram = hv.Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(line_alpha='alpha')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
@@ -237,7 +236,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert property_to_dict(glyph.fill_alpha) != {'field': 'line_alpha'}
 
     def test_histogram_fill_alpha_op(self):
-        histogram = Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        histogram = hv.Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(fill_alpha='alpha')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
@@ -247,7 +246,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
         assert property_to_dict(glyph.fill_alpha) == {'field': 'fill_alpha'}
 
     def test_histogram_line_width_op(self):
-        histogram = Histogram([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
+        histogram = hv.Histogram([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
                               vdims=['y', 'line_width']).opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(histogram)
         cds = plot.handles['cds']
@@ -257,7 +256,7 @@ class TestSideHistogramPlot(LoggingComparison, TestBokehPlot):
 
     def test_op_ndoverlay_value(self):
         colors = ['blue', 'red']
-        overlay = NdOverlay({color: Histogram(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Histogram', fill_color='Color')
+        overlay = hv.NdOverlay({color: hv.Histogram(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Histogram', fill_color='Color')
         plot = bokeh_renderer.get_plot(overlay)
         for subplot, color in zip(plot.subplots.values(),  colors, strict=True):
             assert subplot.handles['glyph'].fill_color == color

--- a/holoviews/tests/plotting/bokeh/test_labels.py
+++ b/holoviews/tests/plotting/bokeh/test_labels.py
@@ -1,10 +1,7 @@
 import numpy as np
 from bokeh.models import CategoricalColorMapper, LinearColorMapper
 
-from holoviews.core.dimension import Dimension
-from holoviews.core.options import Cycle
-from holoviews.core.spaces import HoloMap
-from holoviews.element import Labels
+import holoviews as hv
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal, assert_dict_equal
 
@@ -15,7 +12,7 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestLabelsPlot(TestBokehPlot):
 
     def test_labels_simple(self):
-        labels = Labels([(0, 1, 'A'), (1, 0, 'B')])
+        labels = hv.Labels([(0, 1, 'A'), (1, 0, 'B')])
         plot = bokeh_renderer.get_plot(labels)
         source = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -28,7 +25,7 @@ class TestLabelsPlot(TestBokehPlot):
         assert glyph.text == 'Label'
 
     def test_labels_empty(self):
-        labels = Labels([])
+        labels = hv.Labels([])
         plot = bokeh_renderer.get_plot(labels)
         source = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -40,8 +37,8 @@ class TestLabelsPlot(TestBokehPlot):
         assert glyph.text == 'Label'
 
     def test_labels_formatter(self):
-        vdim = Dimension('text', value_format=lambda x: f'{x:.1f}')
-        labels = Labels([(0, 1, 0.33333), (1, 0, 0.66666)], vdims=vdim)
+        vdim = hv.Dimension('text', value_format=lambda x: f'{x:.1f}')
+        labels = hv.Labels([(0, 1, 0.33333), (1, 0, 0.66666)], vdims=vdim)
         plot = bokeh_renderer.get_plot(labels)
         source = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -54,7 +51,7 @@ class TestLabelsPlot(TestBokehPlot):
         assert glyph.text == 'text'
 
     def test_labels_inverted(self):
-        labels = Labels([(0, 1, 'A'), (1, 0, 'B')]).opts(invert_axes=True)
+        labels = hv.Labels([(0, 1, 'A'), (1, 0, 'B')]).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(labels)
         source = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -66,7 +63,7 @@ class TestLabelsPlot(TestBokehPlot):
         assert glyph.text == 'Label'
 
     def test_labels_color_mapped_text_vals(self):
-        labels = Labels([(0, 1, 0.33333), (1, 0, 0.66666)]).opts(color_index=2)
+        labels = hv.Labels([(0, 1, 0.33333), (1, 0, 0.66666)]).opts(color_index=2)
         plot = bokeh_renderer.get_plot(labels)
         source = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -84,7 +81,7 @@ class TestLabelsPlot(TestBokehPlot):
         assert cmapper.high == 0.66666
 
     def test_labels_color_mapped(self):
-        labels = Labels([(0, 1, 0.33333, 2), (1, 0, 0.66666, 1)], vdims=['text', 'color']).opts(color_index=3)
+        labels = hv.Labels([(0, 1, 0.33333, 2), (1, 0, 0.66666, 1)], vdims=['text', 'color']).opts(color_index=3)
         plot = bokeh_renderer.get_plot(labels)
         source = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -106,7 +103,7 @@ class TestLabelsPlot(TestBokehPlot):
     ###########################
 
     def test_label_color_op(self):
-        labels = Labels([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        labels = hv.Labels([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                         vdims='color').opts(text_color='color')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
@@ -115,7 +112,7 @@ class TestLabelsPlot(TestBokehPlot):
         assert property_to_dict(glyph.text_color) == {'field': 'text_color'}
 
     def test_label_linear_color_op(self):
-        labels = Labels([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        labels = hv.Labels([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(text_color='color')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
@@ -128,7 +125,7 @@ class TestLabelsPlot(TestBokehPlot):
         assert property_to_dict(glyph.text_color) == {'field': 'text_color', 'transform': cmapper}
 
     def test_label_categorical_color_op(self):
-        labels = Labels([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
+        labels = hv.Labels([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
                         vdims='color').opts(text_color='color')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
@@ -140,7 +137,7 @@ class TestLabelsPlot(TestBokehPlot):
         assert property_to_dict(glyph.text_color) == {'field': 'text_color', 'transform': cmapper}
 
     def test_label_angle_op(self):
-        labels = Labels([(0, 0, 0), (0, 1, 45), (0, 2, 90)],
+        labels = hv.Labels([(0, 0, 0), (0, 1, 45), (0, 2, 90)],
                         vdims='angle').opts(angle='angle')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
@@ -149,7 +146,7 @@ class TestLabelsPlot(TestBokehPlot):
         assert property_to_dict(glyph.angle) == {'field': 'angle'}
 
     def test_label_alpha_op(self):
-        labels = Labels([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        labels = hv.Labels([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                         vdims='alpha').opts(text_alpha='alpha')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
@@ -158,7 +155,7 @@ class TestLabelsPlot(TestBokehPlot):
         assert property_to_dict(glyph.text_alpha) == {'field': 'text_alpha'}
 
     def test_label_font_size_op_strings(self):
-        labels = Labels([(0, 0, '10pt'), (0, 1, '4pt'), (0, 2, '8pt')],
+        labels = hv.Labels([(0, 0, '10pt'), (0, 1, '4pt'), (0, 2, '8pt')],
                         vdims='size').opts(text_font_size='size')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
@@ -167,7 +164,7 @@ class TestLabelsPlot(TestBokehPlot):
         assert property_to_dict(glyph.text_font_size) == {'field': 'text_font_size'}
 
     def test_label_font_size_op_ints(self):
-        labels = Labels([(0, 0, 10), (0, 1, 4), (0, 2, 8)],
+        labels = hv.Labels([(0, 0, 10), (0, 1, 4), (0, 2, 8)],
                         vdims='size').opts(text_font_size='size')
         plot = bokeh_renderer.get_plot(labels)
         cds = plot.handles['cds']
@@ -176,7 +173,7 @@ class TestLabelsPlot(TestBokehPlot):
         assert property_to_dict(glyph.text_font_size) == {'field': 'text_font_size'}
 
     def test_labels_color_index_color_clash(self):
-        labels = Labels([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        labels = hv.Labels([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(text_color='color', color_index='color')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(labels)
@@ -190,16 +187,16 @@ class TestLabelsPlot(TestBokehPlot):
         assert log_msg == warning
 
     def test_labels_text_color_cycle(self):
-        hm = HoloMap(
-            {i: Labels([
+        hm = hv.HoloMap(
+            {i: hv.Labels([
                 (0, 0 + i, "Label 1"),
                 (1, 1 + i, "Label 2")
             ]) for i in range(3)}
         ).overlay()
-        assert isinstance(hm[0].opts["text_color"], Cycle)
+        assert isinstance(hm[0].opts["text_color"], hv.Cycle)
 
     def test_labels_hover_with_vdims(self):
-        labels = Labels(
+        labels = hv.Labels(
             [(0, 1, 'A', 10.5, 100), (1, 0, 'B', 20.3, 200)],
             vdims=['text', 'value', 'count']
         ).opts(hover_tooltips=[('Text', '@text'), ('Value', '@value'), ('Count', '@count')])

--- a/holoviews/tests/plotting/bokeh/test_layoutplot.py
+++ b/holoviews/tests/plotting/bokeh/test_layoutplot.py
@@ -6,22 +6,9 @@ from bokeh.models import Div, GlyphRenderer, GridPlot, Spacer, Tabs, Title, Tool
 from bokeh.models.layouts import TabPanel
 from bokeh.plotting import figure
 
-from holoviews.core import (
-    Dataset,
-    Dimension,
-    DynamicMap,
-    Empty,
-    GridSpace,
-    HoloMap,
-    Layout,
-    NdLayout,
-    NdOverlay,
-)
-from holoviews.element import Curve, Histogram, Image, Points, Scatter
+import holoviews as hv
 from holoviews.streams import Stream
 from holoviews.testing import assert_data_equal
-from holoviews.util import opts, render
-from holoviews.util.transform import dim
 
 from ...utils import LoggingComparison
 from .test_plot import TestBokehPlot, bokeh_renderer
@@ -30,8 +17,8 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestLayoutPlot(LoggingComparison, TestBokehPlot):
 
     def test_layout_update_visible(self):
-        hmap = HoloMap({i: Curve(np.arange(i), label='A') for i in range(1, 3)})
-        hmap2 = HoloMap({i: Curve(np.arange(i), label='B') for i in range(3, 5)})
+        hmap = hv.HoloMap({i: hv.Curve(np.arange(i), label='A') for i in range(1, 3)})
+        hmap2 = hv.HoloMap({i: hv.Curve(np.arange(i), label='B') for i in range(3, 5)})
         plot = bokeh_renderer.get_plot(hmap+hmap2)
         subplot1, subplot2 = (p for k, p in sorted(plot.subplots.items()))
         subplot1 = subplot1.subplots['main']
@@ -43,8 +30,8 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert subplot2.handles['glyph_renderer'].visible
 
     def test_layout_framewise_norm(self):
-        img1 = Image(np.mgrid[0:5, 0:5][0]).opts(framewise=True)
-        img2 = Image(np.mgrid[0:5, 0:5][0]*10).opts(framewise=True)
+        img1 = hv.Image(np.mgrid[0:5, 0:5][0]).opts(framewise=True)
+        img2 = hv.Image(np.mgrid[0:5, 0:5][0]*10).opts(framewise=True)
         plot = bokeh_renderer.get_plot(img1+img2)
         img1_plot, img2_plot = (sp.subplots['main'] for sp in plot.subplots.values())
         img1_cmapper = img1_plot.handles['color_mapper']
@@ -55,10 +42,10 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert img2_cmapper.high == 40
 
     def test_layout_framewise_matching_norm_update(self):
-        img1 = Image(np.mgrid[0:5, 0:5][0], vdims='z').opts(framewise=True, axiswise=True)
+        img1 = hv.Image(np.mgrid[0:5, 0:5][0], vdims='z').opts(framewise=True, axiswise=True)
         stream = Stream.define('zscale', value=1)()
-        transform = dim('z')*stream.param.value
-        img2 = Image(np.mgrid[0:5, 0:5][0], vdims='z').apply.transform(
+        transform = hv.dim('z')*stream.param.value
+        img2 = hv.Image(np.mgrid[0:5, 0:5][0], vdims='z').apply.transform(
             z=transform).opts(framewise=True, axiswise=True)
         plot = bokeh_renderer.get_plot(img1+img2)
         img1_plot = plot.subplots[(0, 0)].subplots['main']
@@ -77,10 +64,10 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert img2_cmapper.high == 8
 
     def test_layout_framewise_nonmatching_norm_update(self):
-        img1 = Image(np.mgrid[0:5, 0:5][0], vdims='z').opts(framewise=True)
+        img1 = hv.Image(np.mgrid[0:5, 0:5][0], vdims='z').opts(framewise=True)
         stream = Stream.define('zscale', value=1)()
-        transform = dim('z2')*stream.param.value
-        img2 = Image(np.mgrid[0:5, 0:5][0], vdims='z2').apply.transform(
+        transform = hv.dim('z2')*stream.param.value
+        img2 = hv.Image(np.mgrid[0:5, 0:5][0], vdims='z2').apply.transform(
             z2=transform).opts(framewise=True)
         plot = bokeh_renderer.get_plot(img1+img2)
         img1_plot = plot.subplots[(0, 0)].subplots['main']
@@ -99,8 +86,8 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert img2_cmapper.high == 8
 
     def test_layout_title(self):
-        hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
-        hmap2 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
+        hmap1 = hv.HoloMap({a: hv.Image(np.random.rand(10,10)) for a in range(3)})
+        hmap2 = hv.HoloMap({a: hv.Image(np.random.rand(10,10)) for a in range(3)})
         plot = bokeh_renderer.get_plot(hmap1+hmap2)
         title = plot.handles['title']
         assert isinstance(title, Div)
@@ -111,12 +98,12 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
     def test_layout_title_format(self):
         title_str = ('Label: {label}, group: {group}, '
                      'dims: {dimensions}, type: {type}')
-        layout = NdLayout(
-            {'Element 1': Scatter(
+        layout = hv.NdLayout(
+            {'Element 1': hv.Scatter(
                 [],
                 label='ONE',
                 group='first',
-            ), 'Element 2': Scatter(
+            ), 'Element 2': hv.Scatter(
                 [],
                 label='TWO',
                 group='second',
@@ -124,14 +111,14 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
             kdims='MYDIM',
             label='the_label',
             group='the_group',
-        ).opts(opts.NdLayout(title=title_str), opts.Scatter(title=title_str))
+        ).opts(hv.opts.NdLayout(title=title_str), hv.opts.Scatter(title=title_str))
         # Title of NdLayout
         title = bokeh_renderer.get_plot(layout).handles['title']
         assert isinstance(title, Div)
         text = 'Label: the_label, group: the_group, dims: , type: NdLayout'
         assert re.split('>|</', title.text)[1] == text
         # Titles of subplots
-        plot = render(layout)
+        plot = hv.render(layout)
         titles = {
             title.text for title in list(plot.select({'type': Title}))
         }
@@ -142,9 +129,9 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert titles_correct == titles
 
     def test_layout_title_fontsize(self):
-        hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
-        hmap2 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
-        layout = Layout([hmap1, hmap2]).opts(fontsize={'title': '12pt'})
+        hmap1 = hv.HoloMap({a: hv.Image(np.random.rand(10,10)) for a in range(3)})
+        hmap2 = hv.HoloMap({a: hv.Image(np.random.rand(10,10)) for a in range(3)})
+        layout = hv.Layout([hmap1, hmap2]).opts(fontsize={'title': '12pt'})
         plot = bokeh_renderer.get_plot(layout)
         title = plot.handles['title']
         assert isinstance(title, Div)
@@ -153,15 +140,15 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert title.text == text
 
     def test_layout_title_show_title_false(self):
-        hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
-        hmap2 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
-        layout = Layout([hmap1, hmap2]).opts(show_title=False)
+        hmap1 = hv.HoloMap({a: hv.Image(np.random.rand(10,10)) for a in range(3)})
+        hmap2 = hv.HoloMap({a: hv.Image(np.random.rand(10,10)) for a in range(3)})
+        layout = hv.Layout([hmap1, hmap2]).opts(show_title=False)
         plot = bokeh_renderer.get_plot(layout)
         assert 'title' not in plot.handles
 
     def test_layout_title_update(self):
-        hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
-        hmap2 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
+        hmap1 = hv.HoloMap({a: hv.Image(np.random.rand(10,10)) for a in range(3)})
+        hmap2 = hv.HoloMap({a: hv.Image(np.random.rand(10,10)) for a in range(3)})
         plot = bokeh_renderer.get_plot(hmap1+hmap2)
         plot.update(1)
         title = plot.handles['title']
@@ -171,11 +158,11 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert title.text == text
 
     def test_layout_gridspaces(self):
-        layout = (GridSpace({(i, j): Curve(range(i+j)) for i in range(1, 3)
+        layout = (hv.GridSpace({(i, j): hv.Curve(range(i+j)) for i in range(1, 3)
                              for j in range(2,4)}) +
-                  GridSpace({(i, j): Curve(range(i+j)) for i in range(1, 3)
+                  hv.GridSpace({(i, j): hv.Curve(range(i+j)) for i in range(1, 3)
                              for j in range(2,4)}) +
-                  Curve(range(10))).cols(2)
+                  hv.Curve(range(10))).cols(2)
         layout_plot = bokeh_renderer.get_plot(layout)
         plot = layout_plot.state
 
@@ -202,21 +189,21 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
                 assert isinstance(gfig, figure)
 
     def test_layout_instantiate_subplots(self):
-        layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
-                  Curve(range(10)) + Curve(range(10)))
+        layout = (hv.Curve(range(10)) + hv.Curve(range(10)) + hv.Image(np.random.rand(10,10)) +
+                  hv.Curve(range(10)) + hv.Curve(range(10)))
         plot = bokeh_renderer.get_plot(layout)
         positions = [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0)]
         assert sorted(plot.subplots.keys()) == positions
 
     def test_layout_instantiate_subplots_transposed(self):
-        layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
-                  Curve(range(10)) + Curve(range(10)))
+        layout = (hv.Curve(range(10)) + hv.Curve(range(10)) + hv.Image(np.random.rand(10,10)) +
+                  hv.Curve(range(10)) + hv.Curve(range(10)))
         plot = bokeh_renderer.get_plot(layout.opts(transpose=True))
         positions = [(0, 0), (0, 1), (1, 0), (2, 0), (3, 0)]
         assert sorted(plot.subplots.keys()) == positions
 
     def test_empty_adjoint_plot(self):
-        adjoint = Curve([0,1,1,2,3]) << Empty() << Curve([0,1,1,0,1])
+        adjoint = hv.Curve([0,1,1,2,3]) << hv.Empty() << hv.Curve([0,1,1,0,1])
         plot = bokeh_renderer.get_plot(adjoint)
         adjoint_plot = plot.subplots[(0, 0)]
         assert len(adjoint_plot.subplots) == 3
@@ -231,14 +218,14 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
 
     def test_empty_adjoint_plot_with_renderer(self):
         # https://github.com/holoviz/holoviews/pull/5584
-        scatter = Scatter(range(10))
-        adjoin_layout_plot = scatter << Empty() << scatter.hist(adjoin=False)
+        scatter = hv.Scatter(range(10))
+        adjoin_layout_plot = scatter << hv.Empty() << scatter.hist(adjoin=False)
 
         # To render the plot
         bokeh_renderer(adjoin_layout_plot)
 
     def test_layout_plot_with_adjoints(self):
-        layout = (Curve([]) + Curve([]).hist()).cols(1)
+        layout = (hv.Curve([]) + hv.Curve([]).hist()).cols(1)
         plot = bokeh_renderer.get_plot(layout)
         grid = plot.state
         toolbar = grid.toolbar
@@ -250,7 +237,7 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert output == [1, 1, 1]
 
     def test_layout_plot_tabs_with_adjoints(self):
-        layout = (Curve([]) + Curve([]).hist()).opts(tabs=True)
+        layout = (hv.Curve([]) + hv.Curve([]).hist()).opts(tabs=True)
         plot = bokeh_renderer.get_plot(layout)
         assert isinstance(plot.state, Tabs)
         panel1, panel2 = plot.state.tabs
@@ -260,13 +247,13 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert panel2.title == 'AdjointLayout I'
 
     def test_layout_shared_source_synced_update(self):
-        hmap = HoloMap({i: Dataset({chr(65+j): np.random.rand(i+2)
+        hmap = hv.HoloMap({i: hv.Dataset({chr(65+j): np.random.rand(i+2)
                                     for j in range(4)}, kdims=['A', 'B', 'C', 'D'])
                         for i in range(3)})
 
         # Create two holomaps of points sharing the same data source
-        hmap1=  hmap.map(lambda x: Points(x.clone(kdims=['A', 'B'])), Dataset)
-        hmap2 = hmap.map(lambda x: Points(x.clone(kdims=['D', 'C'])), Dataset)
+        hmap1=  hmap.map(lambda x: hv.Points(x.clone(kdims=['A', 'B'])), hv.Dataset)
+        hmap2 = hmap.map(lambda x: hv.Points(x.clone(kdims=['D', 'C'])), hv.Dataset)
 
         # Pop key (1,) for one of the HoloMaps and make Layout
         hmap2.pop((1,))
@@ -297,8 +284,8 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert_data_equal(data['D'], np.full_like(hmap1[1].dimension_values(0), np.nan))
 
     def test_shared_axes(self):
-        curve = Curve(range(10), )
-        img = Image(np.random.rand(10,10))
+        curve = hv.Curve(range(10), )
+        img = hv.Image(np.random.rand(10,10))
         plot = bokeh_renderer.get_plot(curve+img)
         plot1 = plot.subplots[(0, 0)].subplots['main']
         plot2 = plot.subplots[(0, 1)].subplots['main']
@@ -308,8 +295,8 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert y_range1 is y_range2
 
     def test_shared_axes_different_dimension_names(self):
-        curve = Curve(range(10), ('x1', 'foo'), ('y1', 'bar'))
-        img = Image(np.random.rand(10,10), [('x2', 'foo'), ('y2', 'bar')])
+        curve = hv.Curve(range(10), ('x1', 'foo'), ('y1', 'bar'))
+        img = hv.Image(np.random.rand(10,10), [('x2', 'foo'), ('y2', 'bar')])
         plot = bokeh_renderer.get_plot(curve+img)
         plot1 = plot.subplots[(0, 0)].subplots['main']
         plot2 = plot.subplots[(0, 1)].subplots['main']
@@ -319,8 +306,8 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert y_range1 is y_range2
 
     def test_shared_axes_disable(self):
-        curve = Curve(range(10))
-        img = Image(np.random.rand(10,10)).opts(shared_axes=False)
+        curve = hv.Curve(range(10))
+        img = hv.Image(np.random.rand(10,10)).opts(shared_axes=False)
         plot = bokeh_renderer.get_plot(curve+img)
         plot = plot.subplots[(0, 1)].subplots['main']
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
@@ -328,26 +315,26 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert (y_range.start, y_range.end) == (-.5, .5)
 
     def test_layout_empty_subplots(self):
-        layout = Curve(range(10)) + NdOverlay() + HoloMap() + HoloMap({1: Image(np.random.rand(10,10))})
+        layout = hv.Curve(range(10)) + hv.NdOverlay() + hv.HoloMap() + hv.HoloMap({1: hv.Image(np.random.rand(10,10))})
         plot = bokeh_renderer.get_plot(layout)
         assert len(plot.subplots.values()) == 2
         self.log_handler.assert_contains('WARNING', 'skipping subplot')
         self.log_handler.assert_contains('WARNING', 'skipping subplot')
 
     def test_layout_set_toolbar_location(self):
-        layout = (Curve([]) + Points([])).opts(toolbar='left')
+        layout = (hv.Curve([]) + hv.Points([])).opts(toolbar='left')
         plot = bokeh_renderer.get_plot(layout)
         assert isinstance(plot.state, GridPlot)
         assert isinstance(plot.state.toolbar, Toolbar)
 
     def test_layout_disable_toolbar(self):
-        layout = (Curve([]) + Points([])).opts(toolbar=None)
+        layout = (hv.Curve([]) + hv.Points([])).opts(toolbar=None)
         plot = bokeh_renderer.get_plot(layout)
         assert isinstance(plot.state, GridPlot)
         assert len(plot.state.children) == 2
 
     def test_layout_shared_inverted_yaxis(self):
-        layout = (Curve([]) + Curve([])).opts('Curve', invert_yaxis=True)
+        layout = (hv.Curve([]) + hv.Curve([])).opts('Curve', invert_yaxis=True)
         plot = bokeh_renderer.get_plot(layout)
         subplot = next(iter(plot.subplots.values())).subplots['main']
         assert subplot.handles['y_range'].start == 1
@@ -355,8 +342,8 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
 
     def test_layout_dimensioned_stream_title_update(self):
         stream = Stream.define('Test', test=0)()
-        dmap = DynamicMap(lambda test: Curve([]), kdims=['test'], streams=[stream])
-        layout = dmap + Curve([])
+        dmap = hv.DynamicMap(lambda test: hv.Curve([]), kdims=['test'], streams=[stream])
+        layout = dmap + hv.Curve([])
         plot = bokeh_renderer.get_plot(layout)
         assert 'test: 0' in plot.handles['title'].text
         stream.event(test=1)
@@ -365,27 +352,27 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert stream._subscribers == []
 
     def test_layout_axis_link_matching_name_label(self):
-        layout = Curve([1, 2, 3], vdims=('a', 'A')) + Curve([1, 2, 3], vdims=('a', 'A'))
+        layout = hv.Curve([1, 2, 3], vdims=('a', 'A')) + hv.Curve([1, 2, 3], vdims=('a', 'A'))
         plot = bokeh_renderer.get_plot(layout)
         p1, p2 = (sp.subplots['main'] for sp in plot.subplots.values())
         assert p1.handles['y_range'] is p2.handles['y_range']
 
     def test_layout_axis_not_linked_mismatching_label(self):
-        layout = Curve([1, 2, 3], vdims=('a', 'A')) + Curve([1, 2, 3], vdims=('a', 'B'))
+        layout = hv.Curve([1, 2, 3], vdims=('a', 'A')) + hv.Curve([1, 2, 3], vdims=('a', 'B'))
         plot = bokeh_renderer.get_plot(layout)
         p1, p2 = (sp.subplots['main'] for sp in plot.subplots.values())
         assert p1.handles['y_range'] is not p2.handles['y_range']
 
     def test_layout_axis_linked_unit_and_no_unit(self):
-        layout = (Curve([1, 2, 3], vdims=Dimension('length', unit='m')) +
-                  Curve([1, 2, 3], vdims='length'))
+        layout = (hv.Curve([1, 2, 3], vdims=hv.Dimension('length', unit='m')) +
+                  hv.Curve([1, 2, 3], vdims='length'))
         plot = bokeh_renderer.get_plot(layout)
         p1, p2 = (sp.subplots['main'] for sp in plot.subplots.values())
         assert p1.handles['y_range'] is p2.handles['y_range']
 
     def test_layout_axis_not_linked_mismatching_unit(self):
-        layout = (Curve([1, 2, 3], vdims=Dimension('length', unit='m')) +
-                  Curve([1, 2, 3], vdims=Dimension('length', unit='cm')))
+        layout = (hv.Curve([1, 2, 3], vdims=hv.Dimension('length', unit='m')) +
+                  hv.Curve([1, 2, 3], vdims=hv.Dimension('length', unit='cm')))
         plot = bokeh_renderer.get_plot(layout)
         p1, p2 = (sp.subplots['main'] for sp in plot.subplots.values())
         assert p1.handles['y_range'] is not p2.handles['y_range']
@@ -395,10 +382,10 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         def cb(aname):
             x = np.linspace(0, 1, 10)
             y = np.random.randn(10)
-            curve = Curve((x, y), group=aname)
-            hist = Histogram(y)
+            curve = hv.Curve((x, y), group=aname)
+            hist = hv.Histogram(y)
             return (curve + hist).opts(shared_axes=False)
-        m = DynamicMap(cb, kdims=['aname'], streams=[stream])
+        m = hv.DynamicMap(cb, kdims=['aname'], streams=[stream])
         p = bokeh_renderer.get_plot(m)
         T = 'XYZT'
         stream.event(aname=T)
@@ -407,7 +394,7 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert stream._subscribers == []
 
     def test_layout_shared_axes_disabled(self):
-        layout = (Curve([1, 2, 3]) + Curve([10, 20, 30])).opts(shared_axes=False)
+        layout = (hv.Curve([1, 2, 3]) + hv.Curve([10, 20, 30])).opts(shared_axes=False)
         plot = bokeh_renderer.get_plot(layout)
         cp1, cp2 = plot.subplots[(0, 0)].subplots['main'], plot.subplots[(0, 1)].subplots['main']
         assert cp1.handles['y_range'] is not cp2.handles['y_range']
@@ -417,8 +404,8 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert cp2.handles['y_range'].end == 30
 
     def test_layout_categorical_numeric_type_axes_not_linked(self):
-        curve1 = Curve([1, 2, 3])
-        curve2 = Curve([('A', 0), ('B', 1), ('C', 2)])
+        curve1 = hv.Curve([1, 2, 3])
+        curve2 = hv.Curve([('A', 0), ('B', 1), ('C', 2)])
         layout = curve1 + curve2
         plot = bokeh_renderer.get_plot(layout)
         cp1, cp2 = plot.subplots[(0, 0)].subplots['main'], plot.subplots[(0, 1)].subplots['main']
@@ -426,8 +413,8 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert cp1.handles['y_range'] is cp2.handles['y_range']
 
     def test_layout_datetime_numeric_type_axes_not_linked(self):
-        curve1 = Curve([1, 2, 3])
-        curve2 = Curve([(dt.datetime(2020, 1, 1), 0), (dt.datetime(2020, 1, 2), 1), (dt.datetime(2020, 1, 3), 2)])
+        curve1 = hv.Curve([1, 2, 3])
+        curve2 = hv.Curve([(dt.datetime(2020, 1, 1), 0), (dt.datetime(2020, 1, 2), 1), (dt.datetime(2020, 1, 3), 2)])
         layout = curve1 + curve2
         plot = bokeh_renderer.get_plot(layout)
         cp1, cp2 = plot.subplots[(0, 0)].subplots['main'], plot.subplots[(0, 1)].subplots['main']

--- a/holoviews/tests/plotting/bokeh/test_links.py
+++ b/holoviews/tests/plotting/bokeh/test_links.py
@@ -3,8 +3,6 @@ import pytest
 from bokeh.models import ColumnDataSource, RangeTool
 
 import holoviews as hv
-from holoviews.core.spaces import DynamicMap
-from holoviews.element import Curve, Image, Path, Points, Polygons, Scatter, Table
 from holoviews.plotting.links import DataLink, Link, RangeToolLink
 from holoviews.testing import assert_data_equal
 
@@ -15,8 +13,8 @@ class TestLinkCallbacks(TestBokehPlot):
 
     def test_range_tool_link_callback_single_axis(self):
         array = np.random.rand(100, 2)
-        src = Curve(array)
-        target = Scatter(array)
+        src = hv.Curve(array)
+        target = hv.Scatter(array)
         RangeToolLink(src, target)
         layout = target + src
         plot = bokeh_renderer.get_plot(layout)
@@ -28,8 +26,8 @@ class TestLinkCallbacks(TestBokehPlot):
 
     def test_range_tool_link_callback_single_axis_overlay_target(self):
         array = np.random.rand(100, 2)
-        src = Curve(array)
-        target = Scatter(array, label='a') * Scatter(array, label='b')
+        src = hv.Curve(array)
+        target = hv.Scatter(array, label='a') * hv.Scatter(array, label='b')
         RangeToolLink(src, target)
         layout = target + src
         plot = bokeh_renderer.get_plot(layout)
@@ -41,8 +39,8 @@ class TestLinkCallbacks(TestBokehPlot):
 
     def test_range_tool_link_callback_single_axis_overlay_target_image_source(self):
         data = np.random.rand(50, 50)
-        target = Curve(data) * Curve(data)
-        source = Image(np.random.rand(50, 50), bounds=(0, 0, 1, 1))
+        target = hv.Curve(data) * hv.Curve(data)
+        source = hv.Image(np.random.rand(50, 50), bounds=(0, 0, 1, 1))
         RangeToolLink(source, target)
         layout = target + source
         plot = bokeh_renderer.get_plot(layout)
@@ -54,11 +52,11 @@ class TestLinkCallbacks(TestBokehPlot):
 
     def test_range_tool_link_callback_single_axis_curve_target_image_dmap_source(self):
         # Choosing Image to exert the apply_nodata compositor
-        src = DynamicMap(
-            lambda a: Image(a*np.random.random((20, 20)), bounds=[0, 0, 9, 9]),
+        src = hv.DynamicMap(
+            lambda a: hv.Image(a*np.random.random((20, 20)), bounds=[0, 0, 9, 9]),
             kdims=['a']
         ).redim.range(a=(0.1,1))
-        target = Curve(np.arange(10))
+        target = hv.Curve(np.arange(10))
         RangeToolLink(src, target)
         layout = target + src
         plot = bokeh_renderer.get_plot(layout)
@@ -70,12 +68,12 @@ class TestLinkCallbacks(TestBokehPlot):
 
     def test_range_tool_link_callback_single_axis_overlay_target_image_dmap_source(self):
         # Choosing Image to exert the apply_nodata compositor
-        src = DynamicMap(
-            lambda a: Image(a*np.random.random((20, 20)), bounds=[0, 0, 9, 9]),
+        src = hv.DynamicMap(
+            lambda a: hv.Image(a*np.random.random((20, 20)), bounds=[0, 0, 9, 9]),
             kdims=['a']
         ).redim.range(a=(0.1,1))
         data = np.random.rand(50, 50)
-        target = Curve(data) * Curve(data)
+        target = hv.Curve(data) * hv.Curve(data)
         RangeToolLink(src, target)
         layout = target + src
         plot = bokeh_renderer.get_plot(layout)
@@ -87,8 +85,8 @@ class TestLinkCallbacks(TestBokehPlot):
 
     def test_range_tool_link_callback_both_axes(self):
         array = np.random.rand(100, 2)
-        src = Curve(array)
-        target = Scatter(array)
+        src = hv.Curve(array)
+        target = hv.Scatter(array)
         RangeToolLink(src, target, axes=['x', 'y'])
         layout = target + src
         plot = bokeh_renderer.get_plot(layout)
@@ -100,8 +98,8 @@ class TestLinkCallbacks(TestBokehPlot):
 
     def test_range_tool_link_callback_boundsx_arg(self):
         array = np.random.rand(100, 2)
-        src = Curve(array)
-        target = Scatter(array)
+        src = hv.Curve(array)
+        target = hv.Scatter(array)
         x_start = 0.2
         x_end = 0.3
         RangeToolLink(src, target, axes=['x', 'y'], boundsx=(x_start, x_end))
@@ -115,8 +113,8 @@ class TestLinkCallbacks(TestBokehPlot):
 
     def test_range_tool_link_callback_boundsy_arg(self):
         array = np.random.rand(100, 2)
-        src = Curve(array)
-        target = Scatter(array)
+        src = hv.Curve(array)
+        target = hv.Scatter(array)
         y_start = 0.8
         y_end = 0.9
         RangeToolLink(src, target, axes=['x', 'y'], boundsy=(y_start, y_end))
@@ -129,8 +127,8 @@ class TestLinkCallbacks(TestBokehPlot):
         assert tgt_plot.handles['y_range'].reset_end == y_end
 
     def test_data_link_dynamicmap_table(self):
-        dmap = DynamicMap(lambda X: Points([(0, X)]), kdims='X').redim.range(X=(-1, 1))
-        table = Table([(-1,)], vdims='y')
+        dmap = hv.DynamicMap(lambda X: hv.Points([(0, X)]), kdims='X').redim.range(X=(-1, 1))
+        table = hv.Table([(-1,)], vdims='y')
         DataLink(dmap, table)
         layout = dmap + table
         plot = bokeh_renderer.get_plot(layout)
@@ -143,8 +141,8 @@ class TestLinkCallbacks(TestBokehPlot):
     def test_data_link_poly_table(self):
         arr1 = np.random.rand(10, 2)
         arr2 = np.random.rand(10, 2)
-        polys = Polygons([arr1, arr2])
-        table = Table([('A', 1), ('B', 2)], 'A', 'B')
+        polys = hv.Polygons([arr1, arr2])
+        table = hv.Table([('A', 1), ('B', 2)], 'A', 'B')
         DataLink(polys, table)
         layout = polys + table
         plot = bokeh_renderer.get_plot(layout)
@@ -161,8 +159,8 @@ class TestLinkCallbacks(TestBokehPlot):
     def test_data_link_poly_table_on_clone(self):
         arr1 = np.random.rand(10, 2)
         arr2 = np.random.rand(10, 2)
-        polys = Polygons([arr1, arr2])
-        table = Table([('A', 1), ('B', 2)], 'A', 'B')
+        polys = hv.Polygons([arr1, arr2])
+        table = hv.Table([('A', 1), ('B', 2)], 'A', 'B')
         DataLink(polys, table)
         layout = polys.clone() + table.clone()
         plot = bokeh_renderer.get_plot(layout)
@@ -172,8 +170,8 @@ class TestLinkCallbacks(TestBokehPlot):
     def test_data_link_poly_table_on_unlinked_clone(self):
         arr1 = np.random.rand(10, 2)
         arr2 = np.random.rand(10, 2)
-        polys = Polygons([arr1, arr2])
-        table = Table([('A', 1), ('B', 2)], 'A', 'B')
+        polys = hv.Polygons([arr1, arr2])
+        table = hv.Table([('A', 1), ('B', 2)], 'A', 'B')
         DataLink(polys, table)
         layout = polys.clone() + table.clone(link=False)
         plot = bokeh_renderer.get_plot(layout)
@@ -181,8 +179,8 @@ class TestLinkCallbacks(TestBokehPlot):
         assert len(cds) == 2
 
     def test_data_link_mismatch(self):
-        polys = Polygons([np.random.rand(10, 2)])
-        table = Table([('A', 1), ('B', 2)], 'A', 'B')
+        polys = hv.Polygons([np.random.rand(10, 2)])
+        table = hv.Table([('A', 1), ('B', 2)], 'A', 'B')
         DataLink(polys, table)
         layout = polys + table
         msg = "DataLink source data length must match target"
@@ -190,8 +188,8 @@ class TestLinkCallbacks(TestBokehPlot):
             bokeh_renderer.get_plot(layout)
 
     def test_data_link_list(self):
-        path = Path([[(0, 0, 0), (1, 1, 1), (2, 2, 2)]], vdims='color').opts(color='color')
-        table = Table([('A', 1), ('B', 2)], 'A', 'B')
+        path = hv.Path([[(0, 0, 0), (1, 1, 1), (2, 2, 2)]], vdims='color').opts(color='color')
+        table = hv.Table([('A', 1), ('B', 2)], 'A', 'B')
         DataLink(path, table)
         layout = path + table
         plot = bokeh_renderer.get_plot(layout)
@@ -199,8 +197,8 @@ class TestLinkCallbacks(TestBokehPlot):
         assert path_plot.handles['source'] is table_plot.handles['source']
 
     def test_data_link_idempotent(self):
-        table1 = Table([], 'A', 'B')
-        table2 = Table([], 'C', 'D')
+        table1 = hv.Table([], 'A', 'B')
+        table2 = hv.Table([], 'C', 'D')
         link1 = DataLink(table1, table2)
         DataLink(table1, table2)
         assert len(Link.registry[table1]) == 1
@@ -210,8 +208,8 @@ class TestLinkCallbacks(TestBokehPlot):
         arr = np.random.rand(3, 5)
         arr[0, 0] = np.nan
         data = {k: v for k, v in zip(['x', 'y', 'z'], arr, strict=True)}
-        a = Scatter(data, 'x', 'z')
-        b = Scatter(data, 'x', 'y')
+        a = hv.Scatter(data, 'x', 'z')
+        b = hv.Scatter(data, 'x', 'y')
         DataLink(a, b)
         try:
             bokeh_renderer.get_plot(a+b)
@@ -221,8 +219,8 @@ class TestLinkCallbacks(TestBokehPlot):
 def test_range_tool_link_clones_axis():
     x = np.linspace(0, 10, 100)
     y = np.sin(x)
-    c0 = Curve((x, y)).opts(title="Source")
-    c1 = Curve((x, y)).opts(title="Target")
+    c0 = hv.Curve((x, y)).opts(title="Source")
+    c1 = hv.Curve((x, y)).opts(title="Target")
 
     bk_grid = hv.render(c0 + c1)
     bk_plot0 = bk_grid.children[0][0]

--- a/holoviews/tests/plotting/bokeh/test_multiaxis.py
+++ b/holoviews/tests/plotting/bokeh/test_multiaxis.py
@@ -1,6 +1,6 @@
 from bokeh.models import LinearAxis, LinearScale, LogAxis, LogScale
 
-from holoviews.element import Curve
+import holoviews as hv
 
 from ...utils import LoggingComparison
 from .test_plot import TestBokehPlot, bokeh_renderer
@@ -9,18 +9,18 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
     def test_multi_y_disabled(self):
-        overlay = (Curve(range(10)) * Curve(range(10)))
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10)))
         plot = bokeh_renderer.get_plot(overlay).state
         assert len(plot.yaxis) == 1
 
     def test_multi_y_enabled_two_curves_one_vdim(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(multi_y=True)
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay).state
         assert len(plot.yaxis) == 1
 
     def test_multi_y_enabled_two_curves_two_vdim(self):
-        overlay = (Curve(range(10), vdims=['A'])
-                   * Curve(range(10), vdims=['B'])).opts(multi_y=True)
+        overlay = (hv.Curve(range(10), vdims=['A'])
+                   * hv.Curve(range(10), vdims=['B'])).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         assert len(plot.state.yaxis) == 2
         y_range = plot.handles['y_range']
@@ -32,9 +32,9 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
         assert extra_y_ranges['B'].end == 9
 
     def test_multi_y_enabled_three_curves_two_vdim(self):
-        curve_1A = Curve(range(10), vdims=['A'])
-        curve_2B = Curve(range(11), vdims=['B'])
-        curve_3A = Curve(range(12), vdims=['A'])
+        curve_1A = hv.Curve(range(10), vdims=['A'])
+        curve_2B = hv.Curve(range(11), vdims=['B'])
+        curve_3A = hv.Curve(range(12), vdims=['A'])
         overlay = (curve_1A * curve_2B * curve_3A ).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay).state
         assert len(plot.yaxis) == 2
@@ -42,8 +42,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
     # Testing independent y-lims
 
     def test_multi_y_lims_left_axis(self):
-        overlay = (Curve(range(10), vdims=['A']).opts(ylim=(-10,20))
-                   * Curve(range(10), vdims=['B'])).opts(multi_y=True)
+        overlay = (hv.Curve(range(10), vdims=['A']).opts(ylim=(-10,20))
+                   * hv.Curve(range(10), vdims=['B'])).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         y_range = plot.handles['y_range']
         assert y_range.start == -10
@@ -54,8 +54,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
         assert extra_y_ranges['B'].end == 9
 
     def test_multi_y_lims_right_axis(self):
-        overlay = (Curve(range(10), vdims=['A'])
-                   * Curve(range(10), vdims=['B']).opts(ylim=(-10,20))).opts(multi_y=True)
+        overlay = (hv.Curve(range(10), vdims=['A'])
+                   * hv.Curve(range(10), vdims=['B']).opts(ylim=(-10,20))).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         y_range = plot.handles['y_range']
         assert y_range.start == 0
@@ -66,8 +66,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
         assert extra_y_ranges['B'].end == 20
 
     def test_multi_y_lims_both_axes(self):
-        overlay = (Curve(range(10), vdims=['A']).opts(ylim=(-15,25))
-                   * Curve(range(10), vdims=['B']).opts(ylim=(-10,20))).opts(multi_y=True)
+        overlay = (hv.Curve(range(10), vdims=['A']).opts(ylim=(-15,25))
+                   * hv.Curve(range(10), vdims=['B']).opts(ylim=(-10,20))).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         y_range = plot.handles['y_range']
         assert y_range.start == -15
@@ -80,8 +80,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
     # Testing independent logy
 
     def test_multi_log_left_axis(self):
-        overlay = (Curve(range(1,9), vdims=['A']).opts(logy=True)
-                   * Curve(range(10), vdims=['B'])).opts(multi_y=True)
+        overlay = (hv.Curve(range(1,9), vdims=['A']).opts(logy=True)
+                   * hv.Curve(range(10), vdims=['B'])).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         assert len(plot.state.yaxis) == 2
         assert isinstance(plot.state.yaxis[0], LogAxis)
@@ -90,8 +90,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
         assert isinstance(extra_y_ranges['B'], LinearScale)
 
     def test_multi_log_right_axis(self):
-        overlay = (Curve(range(1,9), vdims=['A'])
-                   * Curve(range(1, 9), vdims=['B']).opts(logy=True)).opts(multi_y=True)
+        overlay = (hv.Curve(range(1,9), vdims=['A'])
+                   * hv.Curve(range(1, 9), vdims=['B']).opts(logy=True)).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         assert len(plot.state.yaxis) == 2
         assert isinstance(plot.state.yaxis[0], LinearAxis)
@@ -101,8 +101,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
 
     def test_multi_log_both_axes(self):
-        overlay = (Curve(range(1,9), vdims=['A']).opts(logy=True)
-                   * Curve(range(1, 9), vdims=['B']).opts(logy=True)).opts(multi_y=True)
+        overlay = (hv.Curve(range(1,9), vdims=['A']).opts(logy=True)
+                   * hv.Curve(range(1, 9), vdims=['B']).opts(logy=True)).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         assert len(plot.state.yaxis) == 2
         assert isinstance(plot.state.yaxis[0], LogAxis)
@@ -113,8 +113,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
     # BUG! left_axis is not warning (main axis)
 
     def test_multi_log_right_axis_warn(self):
-        overlay = (Curve(range(10), vdims=['A'])
-                   * Curve(range(10), vdims=['B']).opts(logy=True)).opts(multi_y=True)
+        overlay = (hv.Curve(range(10), vdims=['A'])
+                   * hv.Curve(range(10), vdims=['B']).opts(logy=True)).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         assert len(plot.state.yaxis) == 2
         assert isinstance(plot.state.yaxis[0], LinearAxis)
@@ -128,8 +128,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
     # Testing invert_yaxis
 
     def test_multi_invert_left_axis(self):
-        overlay = (Curve(range(10), vdims=['A']).opts(invert_yaxis=True)
-                   * Curve(range(10), vdims=['B'])).opts(multi_y=True)
+        overlay = (hv.Curve(range(10), vdims=['A']).opts(invert_yaxis=True)
+                   * hv.Curve(range(10), vdims=['B'])).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         y_range = plot.handles['y_range']
         assert y_range.start == 9
@@ -140,8 +140,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
         assert extra_y_ranges['B'].end == 9
 
     def test_multi_invert_right_axis(self):
-        overlay = (Curve(range(10), vdims=['A'])
-                   * Curve(range(10), vdims=['B']).opts(invert_yaxis=True)).opts(multi_y=True)
+        overlay = (hv.Curve(range(10), vdims=['A'])
+                   * hv.Curve(range(10), vdims=['B']).opts(invert_yaxis=True)).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         y_range = plot.handles['y_range']
         assert y_range.start == 0
@@ -153,8 +153,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
 
     def test_multi_invert_both_axes(self):
-        overlay = (Curve(range(10), vdims=['A']).opts(invert_yaxis=True)
-                   * Curve(range(10), vdims=['B']).opts(invert_yaxis=True)).opts(multi_y=True)
+        overlay = (hv.Curve(range(10), vdims=['A']).opts(invert_yaxis=True)
+                   * hv.Curve(range(10), vdims=['B']).opts(invert_yaxis=True)).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         y_range = plot.handles['y_range']
         assert y_range.start == 9
@@ -168,8 +168,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
     # Combination test
 
     def test_inverted_log_ylim_right_axis(self):
-        overlay = (Curve(range(10), vdims=['A'])
-                   * Curve(range(10), vdims=['B']
+        overlay = (hv.Curve(range(10), vdims=['A'])
+                   * hv.Curve(range(10), vdims=['B']
                            ).opts(invert_yaxis=True, logy=True, ylim=(2,20))).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         y_range = plot.handles['y_range']
@@ -186,12 +186,12 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
     # Test axis sharing in layouts
 
     def test_shared_multi_axes(self):
-        curve1A = Curve([9, 8, 7, 6, 5], vdims='A')
-        curve2B = Curve([1, 2, 3], vdims='B')
+        curve1A = hv.Curve([9, 8, 7, 6, 5], vdims='A')
+        curve2B = hv.Curve([1, 2, 3], vdims='B')
         overlay1 = (curve1A * curve2B).opts(multi_y=True)
 
-        curve3A = Curve([19, 18, 17, 16, 15], vdims='A')
-        curve4B = Curve([11, 12, 13], vdims='B')
+        curve3A = hv.Curve([19, 18, 17, 16, 15], vdims='A')
+        curve4B = hv.Curve([11, 12, 13], vdims='B')
         overlay2 = (curve3A * curve4B).opts(multi_y=True)
 
         plot = bokeh_renderer.get_plot(overlay1 + overlay2)
@@ -204,8 +204,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
     def test_invisible_main_axis(self):
         overlay = (
-            Curve(range(10), vdims=['A']).opts(yaxis=None) *
-            Curve(range(10), vdims=['B'])
+            hv.Curve(range(10), vdims=['A']).opts(yaxis=None) *
+            hv.Curve(range(10), vdims=['B'])
         ).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         assert len(plot.state.yaxis) == 2
@@ -214,8 +214,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
     def test_invisible_extra_axis(self):
         overlay = (
-            Curve(range(10), vdims=['A']) *
-            Curve(range(10), vdims=['B']).opts(yaxis=None)
+            hv.Curve(range(10), vdims=['A']) *
+            hv.Curve(range(10), vdims=['B']).opts(yaxis=None)
         ).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         assert len(plot.state.yaxis) == 2
@@ -224,8 +224,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
     def test_axis_labels(self):
         overlay = (
-            Curve(range(10), vdims=['A']) *
-            Curve(range(10), vdims=['B'])
+            hv.Curve(range(10), vdims=['A']) *
+            hv.Curve(range(10), vdims=['B'])
         ).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
 
@@ -235,8 +235,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
     def test_custom_axis_labels(self):
         overlay = (
-            Curve(range(10), vdims=['A']).opts(xlabel='x-custom', ylabel='A-custom') *
-            Curve(range(10), vdims=['B']).opts(ylabel='B-custom')
+            hv.Curve(range(10), vdims=['A']).opts(xlabel='x-custom', ylabel='A-custom') *
+            hv.Curve(range(10), vdims=['B']).opts(ylabel='B-custom')
         ).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
 
@@ -246,8 +246,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
     def test_only_x_axis_labels(self):
         overlay = (
-            Curve(range(10), vdims=['A']) *
-            Curve(range(10), vdims=['B'])
+            hv.Curve(range(10), vdims=['A']) *
+            hv.Curve(range(10), vdims=['B'])
         ).opts(multi_y=True, labelled=['x'])
         plot = bokeh_renderer.get_plot(overlay)
 
@@ -257,8 +257,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
     def test_none_x_axis_labels(self):
         overlay = (
-            Curve(range(10), vdims=['A']) *
-            Curve(range(10), vdims=['B'])
+            hv.Curve(range(10), vdims=['A']) *
+            hv.Curve(range(10), vdims=['B'])
         ).opts(multi_y=True, labelled=['y'])
         plot = bokeh_renderer.get_plot(overlay)
 
@@ -268,8 +268,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
     def test_swapped_position_label(self):
         overlay = (
-            Curve(range(10), vdims=['A']).opts(yaxis='right') *
-            Curve(range(10), vdims=['B']).opts(yaxis='left')
+            hv.Curve(range(10), vdims=['A']).opts(yaxis='right') *
+            hv.Curve(range(10), vdims=['B']).opts(yaxis='left')
         ).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
 
@@ -277,8 +277,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
         assert plot.state.yaxis[1].axis_label == 'A'
 
     def test_swapped_position_custom_y_labels(self):
-        overlay = (Curve(range(10), vdims=['A']).opts(yaxis='right', ylabel='A-custom')
-                   * Curve(range(10), vdims=['B']).opts(yaxis='left', ylabel='B-custom')
+        overlay = (hv.Curve(range(10), vdims=['A']).opts(yaxis='right', ylabel='A-custom')
+                   * hv.Curve(range(10), vdims=['B']).opts(yaxis='left', ylabel='B-custom')
                    ).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
 
@@ -287,8 +287,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
     def test_position_custom_size_label(self):
         overlay = (
-            Curve(range(10), vdims='A').opts(fontsize={'ylabel': '13pt'}) *
-            Curve(range(10), vdims='B').opts(fontsize={'ylabel': '15pt'})
+            hv.Curve(range(10), vdims='A').opts(fontsize={'ylabel': '13pt'}) *
+            hv.Curve(range(10), vdims='B').opts(fontsize={'ylabel': '15pt'})
         ).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         assert plot.state.yaxis[0].axis_label == 'A'
@@ -298,8 +298,8 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
     def test_swapped_position_custom_size_label(self):
         overlay = (
-            Curve(range(10), vdims='A').opts(yaxis='right', fontsize={'ylabel': '13pt'}) *
-            Curve(range(10), vdims='B').opts(yaxis='left', fontsize={'ylabel': '15pt'})
+            hv.Curve(range(10), vdims='A').opts(yaxis='right', fontsize={'ylabel': '13pt'}) *
+            hv.Curve(range(10), vdims='B').opts(yaxis='left', fontsize={'ylabel': '15pt'})
         ).opts(multi_y=True)
         plot = bokeh_renderer.get_plot(overlay)
         assert plot.state.yaxis[0].axis_label == 'B'
@@ -309,7 +309,7 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
     def test_multi_y_on_curve(self):
         # Test for https://github.com/holoviz/holoviews/issues/6322
-        overlay = Curve(range(10), vdims='A').opts(multi_y=True)
+        overlay = hv.Curve(range(10), vdims='A').opts(multi_y=True)
 
         # Should not error
         bokeh_renderer.get_plot(overlay)

--- a/holoviews/tests/plotting/bokeh/test_overlayplot.py
+++ b/holoviews/tests/plotting/bokeh/test_overlayplot.py
@@ -4,18 +4,7 @@ import panel as pn
 import pytest
 from bokeh.models import FactorRange, FixedTicker, HoverTool, Range1d, Span
 
-from holoviews.core import DynamicMap, HoloMap, NdOverlay, Overlay
-from holoviews.element import (
-    Bars,
-    Box,
-    Curve,
-    ErrorBars,
-    HLine,
-    Points,
-    Scatter,
-    Text,
-    VLine,
-)
+import holoviews as hv
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.streams import Pipe, Stream, Tap
 from holoviews.testing import assert_data_equal
@@ -28,13 +17,13 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestOverlayPlot(LoggingComparison, TestBokehPlot):
 
     def test_overlay_apply_ranges_disabled(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts('Curve', apply_ranges=False)
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts('Curve', apply_ranges=False)
         plot = bokeh_renderer.get_plot(overlay)
         assert all(np.isnan(e) for e in plot.get_extents(overlay, {}))
 
     def test_overlay_update_sources(self):
-        hmap = HoloMap({i: (Curve(np.arange(i), label='A') *
-                            Curve(np.arange(i)*2, label='B'))
+        hmap = hv.HoloMap({i: (hv.Curve(np.arange(i), label='A') *
+                            hv.Curve(np.arange(i)*2, label='B'))
                         for i in range(10, 13)})
         plot = bokeh_renderer.get_plot(hmap)
         plot.update((12,))
@@ -53,8 +42,8 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
             'Y': [0, 10, 20],
             'Z': [50, 50, 150]
         }
-        sa = Scatter(a, 'X', ['Y', 'Z']).opts(color='Z', framewise=True)
-        sb = Scatter(b, 'X', ['Y', 'Z']).opts(color='Z', framewise=True)
+        sa = hv.Scatter(a, 'X', ['Y', 'Z']).opts(color='Z', framewise=True)
+        sb = hv.Scatter(b, 'X', ['Y', 'Z']).opts(color='Z', framewise=True)
         plot = bokeh_renderer.get_plot(sa * sb)
         sa_plot, sb_plot = plot.subplots.values()
         sa_cmapper = sa_plot.handles['color_color_mapper']
@@ -65,8 +54,8 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
         assert sb_cmapper.high == 150
 
     def test_overlay_update_visible(self):
-        hmap = HoloMap({i: Curve(np.arange(i), label='A') for i in range(1, 3)})
-        hmap2 = HoloMap({i: Curve(np.arange(i), label='B') for i in range(3, 5)})
+        hmap = hv.HoloMap({i: hv.Curve(np.arange(i), label='A') for i in range(1, 3)})
+        hmap2 = hv.HoloMap({i: hv.Curve(np.arange(i), label='B') for i in range(3, 5)})
         plot = bokeh_renderer.get_plot(hmap*hmap2)
         subplot1, subplot2 = plot.subplots.values()
         assert subplot1.handles['glyph_renderer'].visible
@@ -78,7 +67,7 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
     def test_hover_tool_instance_renderer_association(self):
         tooltips = [("index", "$index")]
         hover = HoverTool(tooltips=tooltips)
-        overlay = Curve(np.random.rand(10,2)).opts(tools=[hover]) * Points(np.random.rand(10,2))
+        overlay = hv.Curve(np.random.rand(10,2)).opts(tools=[hover]) * hv.Points(np.random.rand(10,2))
         plot = bokeh_renderer.get_plot(overlay)
         curve_plot = plot.subplots[('Curve', 'I')]
         assert len(curve_plot.handles['hover'].renderers) == 1
@@ -92,80 +81,80 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
     #     assert plot.handles['hover'].tooltips == [('x', '@{x}'), ('y', '@{y}')]
 
     def test_hover_tool_nested_overlay_renderers(self):
-        overlay1 = NdOverlay({0: Curve(range(2)), 1: Curve(range(3))}, kdims=['Test'])
-        overlay2 = NdOverlay({0: Curve(range(4)), 1: Curve(range(5))}, kdims=['Test'])
+        overlay1 = hv.NdOverlay({0: hv.Curve(range(2)), 1: hv.Curve(range(3))}, kdims=['Test'])
+        overlay2 = hv.NdOverlay({0: hv.Curve(range(4)), 1: hv.Curve(range(5))}, kdims=['Test'])
         nested_overlay = (overlay1 * overlay2).opts('Curve', tools=['hover'])
         plot = bokeh_renderer.get_plot(nested_overlay)
         assert len(plot.handles['hover'].renderers) == 4
         assert plot.handles['hover'].tooltips == [('Test', '@{Test}'), ('x', '@{x}'), ('y', '@{y}')]
 
     def test_overlay_empty_layers(self):
-        overlay = Curve(range(10)) * NdOverlay()
+        overlay = hv.Curve(range(10)) * hv.NdOverlay()
         plot = bokeh_renderer.get_plot(overlay)
         assert len(plot.subplots) == 1
         self.log_handler.assert_contains('WARNING', 'is empty and will be skipped during plotting')
 
     def test_overlay_show_frame_disabled(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(show_frame=False)
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(show_frame=False)
         plot = bokeh_renderer.get_plot(overlay).state
         assert plot.outline_line_alpha == 0
 
     def test_overlay_no_xaxis(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(xaxis=None)
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(xaxis=None)
         plot = bokeh_renderer.get_plot(overlay).state
         assert not plot.xaxis[0].visible
 
     def test_overlay_no_yaxis(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(yaxis=None)
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(yaxis=None)
         plot = bokeh_renderer.get_plot(overlay).state
         assert not plot.yaxis[0].visible
 
     def test_overlay_xlabel_override(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(xlabel='custom x-label')
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(xlabel='custom x-label')
         plot = bokeh_renderer.get_plot(overlay).state
         assert plot.xaxis[0].axis_label == 'custom x-label'
 
     def test_overlay_ylabel_override(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(ylabel='custom y-label')
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(ylabel='custom y-label')
         plot = bokeh_renderer.get_plot(overlay).state
         assert plot.yaxis[0].axis_label == 'custom y-label'
 
     def test_overlay_xlabel_override_propagated(self):
-        overlay = (Curve(range(10)).opts(xlabel='custom x-label') * Curve(range(10)))
+        overlay = (hv.Curve(range(10)).opts(xlabel='custom x-label') * hv.Curve(range(10)))
         plot = bokeh_renderer.get_plot(overlay).state
         assert plot.xaxis[0].axis_label == 'custom x-label'
 
     def test_overlay_ylabel_override_propagated(self):
-        overlay = (Curve(range(10)).opts(ylabel='custom y-label') * Curve(range(10)))
+        overlay = (hv.Curve(range(10)).opts(ylabel='custom y-label') * hv.Curve(range(10)))
         plot = bokeh_renderer.get_plot(overlay).state
         assert plot.yaxis[0].axis_label == 'custom y-label'
 
     def test_overlay_xrotation(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(xrotation=90)
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(xrotation=90)
         plot = bokeh_renderer.get_plot(overlay).state
         assert plot.xaxis[0].major_label_orientation == np.pi/2
 
     def test_overlay_yrotation(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(yrotation=90)
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(yrotation=90)
         plot = bokeh_renderer.get_plot(overlay).state
         assert plot.yaxis[0].major_label_orientation == np.pi/2
 
     def test_overlay_xticks_list(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(xticks=[0, 5, 10])
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(xticks=[0, 5, 10])
         plot = bokeh_renderer.get_plot(overlay).state
         assert isinstance(plot.xaxis[0].ticker, FixedTicker)
         assert plot.xaxis[0].ticker.ticks == [0, 5, 10]
 
     def test_overlay_yticks_list(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(yticks=[0, 5, 10])
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(yticks=[0, 5, 10])
         plot = bokeh_renderer.get_plot(overlay).state
         assert isinstance(plot.yaxis[0].ticker, FixedTicker)
         assert plot.yaxis[0].ticker.ticks == [0, 5, 10]
 
     def test_overlay_update_plot_opts(self):
-        hmap = HoloMap(
-            {0: (Curve([]) * Curve([])).opts(title='A'),
-             1: (Curve([]) * Curve([])).opts(title='B')}
+        hmap = hv.HoloMap(
+            {0: (hv.Curve([]) * hv.Curve([])).opts(title='A'),
+             1: (hv.Curve([]) * hv.Curve([])).opts(title='B')}
         )
         plot = bokeh_renderer.get_plot(hmap)
         assert plot.state.title.text == 'A'
@@ -173,9 +162,9 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.title.text == 'B'
 
     def test_overlay_update_plot_opts_inherited(self):
-        hmap = HoloMap(
-            {0: (Curve([]).opts(title='A') * Curve([])),
-             1: (Curve([]).opts(title='B') * Curve([]))}
+        hmap = hv.HoloMap(
+            {0: (hv.Curve([]).opts(title='A') * hv.Curve([])),
+             1: (hv.Curve([]).opts(title='B') * hv.Curve([]))}
         )
         plot = bokeh_renderer.get_plot(hmap)
         assert plot.state.title.text == 'A'
@@ -183,11 +172,11 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.title.text == 'B'
 
     def test_points_errorbars_text_ndoverlay_categorical_xaxis(self):
-        overlay = NdOverlay({i: Points(([chr(65+i)]*10,np.random.randn(10)))
+        overlay = hv.NdOverlay({i: hv.Points(([chr(65+i)]*10,np.random.randn(10)))
                              for i in range(5)})
-        error = ErrorBars([(el['x'][0], np.mean(el['y']), np.std(el['y']))
+        error = hv.ErrorBars([(el['x'][0], np.mean(el['y']), np.std(el['y']))
                            for el in overlay])
-        text = Text('C', 0, 'Test')
+        text = hv.Text('C', 0, 'Test')
         plot = bokeh_renderer.get_plot(overlay*error*text)
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
@@ -200,21 +189,21 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
             assert factor == xs
 
     def test_overlay_categorical_two_level(self):
-        bars = Bars([('A', 'a', 1), ('B', 'b', 2), ('A', 'b', 3), ('B', 'a', 4)],
+        bars = hv.Bars([('A', 'a', 1), ('B', 'b', 2), ('A', 'b', 3), ('B', 'a', 4)],
                     kdims=['Upper', 'Lower'])
 
-        plot = bokeh_renderer.get_plot(bars * HLine(2))
+        plot = bokeh_renderer.get_plot(bars * hv.HLine(2))
         x_range = plot.handles['x_range']
         assert isinstance(x_range, FactorRange)
         assert x_range.factors == [('A', 'a'), ('A', 'b'), ('B', 'a'), ('B', 'b')]
         assert isinstance(plot.state.renderers[-1], Span)
 
     def test_points_errorbars_text_ndoverlay_categorical_xaxis_invert_axes(self):
-        overlay = NdOverlay({i: Points(([chr(65+i)]*10,np.random.randn(10)))
+        overlay = hv.NdOverlay({i: hv.Points(([chr(65+i)]*10,np.random.randn(10)))
                              for i in range(5)})
-        error = ErrorBars([(el['x'][0], np.mean(el['y']), np.std(el['y']))
+        error = hv.ErrorBars([(el['x'][0], np.mean(el['y']), np.std(el['y']))
                            for el in overlay]).opts(invert_axes=True)
-        text = Text('C', 0, 'Test')
+        text = hv.Text('C', 0, 'Test')
         plot = bokeh_renderer.get_plot(overlay*error*text)
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
@@ -223,15 +212,15 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
         assert y_range.factors == ['A', 'B', 'C', 'D', 'E']
 
     def test_overlay_empty_element_extent(self):
-        overlay = Curve([]).redim.range(x=(-10, 10)) * Points([]).redim.range(y=(-20, 20))
+        overlay = hv.Curve([]).redim.range(x=(-10, 10)) * hv.Points([]).redim.range(y=(-20, 20))
         plot = bokeh_renderer.get_plot(overlay)
         extents = plot.get_extents(overlay, {})
         assert extents == (-10, -20, 10, 20)
 
     def test_dynamic_subplot_creation(self):
         def cb(X):
-            return NdOverlay({i: Curve(np.arange(10)+i) for i in range(X)})
-        dmap = DynamicMap(cb, kdims=['X']).redim.range(X=(1, 10))
+            return hv.NdOverlay({i: hv.Curve(np.arange(10)+i) for i in range(X)})
+        dmap = hv.DynamicMap(cb, kdims=['X']).redim.range(X=(1, 10))
         plot = bokeh_renderer.get_plot(dmap)
         assert len(plot.subplots) == 1
         plot.update((3,))
@@ -241,8 +230,8 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
 
     def test_complex_range_example(self):
         errors = [(0.1*i, np.sin(0.1*i), (i+1)/3., (i+1)/5.) for i in np.linspace(0, 100, 11)]
-        errors = ErrorBars(errors, vdims=['y', 'yerrneg', 'yerrpos']).redim.range(y=(0, None))
-        overlay = Curve(errors) * errors * VLine(4)
+        errors = hv.ErrorBars(errors, vdims=['y', 'yerrneg', 'yerrpos']).redim.range(y=(0, None))
+        overlay = hv.Curve(errors) * errors * hv.VLine(4)
         plot = bokeh_renderer.get_plot(overlay)
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
@@ -252,7 +241,7 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
         assert y_range.end == 19.655978889110628
 
     def test_overlay_muted_renderer(self):
-        overlay = Curve((np.arange(5)), label='increase') * Curve((np.arange(5)*-1+5), label='decrease').opts(muted=True)
+        overlay = hv.Curve((np.arange(5)), label='increase') * hv.Curve((np.arange(5)*-1+5), label='decrease').opts(muted=True)
         plot = bokeh_renderer.get_plot(overlay)
         unmuted, muted = plot.subplots.values()
         assert not unmuted.handles['glyph_renderer'].muted
@@ -261,8 +250,8 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
     def test_overlay_params_bind_linked_stream(self):
         tap = Tap()
         def test(x):
-            return Curve([1, 2, 3]) * VLine(x or 0)
-        dmap = DynamicMap(pn.bind(test, x=tap.param.x))
+            return hv.Curve([1, 2, 3]) * hv.VLine(x or 0)
+        dmap = hv.DynamicMap(pn.bind(test, x=tap.param.x))
         plot = bokeh_renderer.get_plot(dmap)
 
         tap.event(x=1)
@@ -272,8 +261,8 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
     def test_overlay_params_dict_linked_stream(self):
         tap = Tap()
         def test(x):
-            return Curve([1, 2, 3]) * VLine(x or 0)
-        dmap = DynamicMap(test, streams={'x': tap.param.x})
+            return hv.Curve([1, 2, 3]) * hv.VLine(x or 0)
+        dmap = hv.DynamicMap(test, streams={'x': tap.param.x})
         plot = bokeh_renderer.get_plot(dmap)
 
         tap.event(x=1)
@@ -281,8 +270,8 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
         assert vline_plot.handles['glyph'].location == 1
 
     def test_ndoverlay_subcoordinate_y_no_batching(self):
-        overlay = NdOverlay({
-            i: Curve(np.arange(10)*i).opts(subcoordinate_y=True) for i in range(10)
+        overlay = hv.NdOverlay({
+            i: hv.Curve(np.arange(10)*i).opts(subcoordinate_y=True) for i in range(10)
         }).opts(legend_limit=1)
         plot = bokeh_renderer.get_plot(overlay)
 
@@ -296,10 +285,10 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
             'B': np.arange(10)*2,
             'C': np.arange(10)*3
         }
-        overlay = NdOverlay({
-            'A': Curve(data, 'x', ('A', 'y')).opts(subcoordinate_y=True),
-            'B': Curve(data, 'x', ('B', 'y')).opts(subcoordinate_y=True),
-            'C': Curve(data, 'x', ('C', 'y')).opts(subcoordinate_y=True),
+        overlay = hv.NdOverlay({
+            'A': hv.Curve(data, 'x', ('A', 'y')).opts(subcoordinate_y=True),
+            'B': hv.Curve(data, 'x', ('B', 'y')).opts(subcoordinate_y=True),
+            'C': hv.Curve(data, 'x', ('C', 'y')).opts(subcoordinate_y=True),
         })
         plot = bokeh_renderer.get_plot(overlay)
 
@@ -311,10 +300,10 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
 
     def test_ndoverlay_subcoordinate_y_ranges_update(self):
         def lines(data):
-            return NdOverlay({
-                'A': Curve(data, 'x', ('A', 'y1')).opts(subcoordinate_y=True, framewise=True),
-                'B': Curve(data, 'x', ('B', 'y2')).opts(subcoordinate_y=True, framewise=True),
-                'C': Curve(data, 'x', ('C', 'y3')).opts(subcoordinate_y=True, framewise=True),
+            return hv.NdOverlay({
+                'A': hv.Curve(data, 'x', ('A', 'y1')).opts(subcoordinate_y=True, framewise=True),
+                'B': hv.Curve(data, 'x', ('B', 'y2')).opts(subcoordinate_y=True, framewise=True),
+                'C': hv.Curve(data, 'x', ('C', 'y3')).opts(subcoordinate_y=True, framewise=True),
             })
         data = {
             'x': np.arange(10),
@@ -323,7 +312,7 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
             'C': np.arange(10)*3
         }
         stream = Pipe(data=data)
-        dmap = DynamicMap(lines, streams=[stream])
+        dmap = hv.DynamicMap(lines, streams=[stream])
         plot = bokeh_renderer.get_plot(dmap)
 
         assert plot.state.y_range.start == -0.5
@@ -353,10 +342,10 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
             'B': np.arange(10)*2,
             'C': np.arange(10)*3
         }
-        overlay = Overlay([
-            Curve(data, 'x', ('A', 'y'), label='A').opts(subcoordinate_y=True),
-            Curve(data, 'x', ('B', 'y'), label='B').opts(subcoordinate_y=True),
-            Curve(data, 'x', ('C', 'y'), label='C').opts(subcoordinate_y=True),
+        overlay = hv.Overlay([
+            hv.Curve(data, 'x', ('A', 'y'), label='A').opts(subcoordinate_y=True),
+            hv.Curve(data, 'x', ('B', 'y'), label='B').opts(subcoordinate_y=True),
+            hv.Curve(data, 'x', ('C', 'y'), label='C').opts(subcoordinate_y=True),
         ])
         plot = bokeh_renderer.get_plot(overlay)
 
@@ -368,10 +357,10 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
 
     def test_overlay_subcoordinate_y_ranges_update(self):
         def lines(data):
-            return Overlay([
-                Curve(data, 'x', ('A', 'y1'), label='A').opts(subcoordinate_y=True, framewise=True),
-                Curve(data, 'x', ('B', 'y2'), label='B').opts(subcoordinate_y=True, framewise=True),
-                Curve(data, 'x', ('C', 'y3'), label='C').opts(subcoordinate_y=True, framewise=True),
+            return hv.Overlay([
+                hv.Curve(data, 'x', ('A', 'y1'), label='A').opts(subcoordinate_y=True, framewise=True),
+                hv.Curve(data, 'x', ('B', 'y2'), label='B').opts(subcoordinate_y=True, framewise=True),
+                hv.Curve(data, 'x', ('C', 'y3'), label='C').opts(subcoordinate_y=True, framewise=True),
             ])
         data = {
             'x': np.arange(10),
@@ -380,7 +369,7 @@ class TestOverlayPlot(LoggingComparison, TestBokehPlot):
             'C': np.arange(10)*3
         }
         stream = Pipe(data=data)
-        dmap = DynamicMap(lines, streams=[stream])
+        dmap = hv.DynamicMap(lines, streams=[stream])
         plot = bokeh_renderer.get_plot(dmap)
 
         assert plot.state.y_range.start == -0.5
@@ -414,8 +403,8 @@ def test_ndoverlay_categorical_y_ranges(order):
             ),
         }
     )
-    overlay = NdOverlay(
-        {col: Scatter(df, kdims="index", vdims=col) for col in order}
+    overlay = hv.NdOverlay(
+        {col: hv.Scatter(df, kdims="index", vdims=col) for col in order}
     )
     plot = bokeh_renderer.get_plot(overlay)
     output = plot.handles["y_range"].factors
@@ -426,20 +415,20 @@ def test_ndoverlay_categorical_y_ranges(order):
 class TestLegends(TestBokehPlot):
 
     def test_overlay_legend(self):
-        overlay = Curve(range(10), label='A') * Curve(range(10), label='B')
+        overlay = hv.Curve(range(10), label='A') * hv.Curve(range(10), label='B')
         plot = bokeh_renderer.get_plot(overlay)
         legend_labels = [l.label['value'] for l in plot.state.legend[0].items]
         assert legend_labels == ['A', 'B']
 
     def test_overlay_legend_with_labels(self):
-        overlay = (Curve(range(10), label='A') * Curve(range(10), label='B')).opts(
+        overlay = (hv.Curve(range(10), label='A') * hv.Curve(range(10), label='B')).opts(
             legend_labels={'A': 'A Curve', 'B': 'B Curve'})
         plot = bokeh_renderer.get_plot(overlay)
         legend_labels = [l.label['value'] for l in plot.state.legend[0].items]
         assert legend_labels == ['A Curve', 'B Curve']
 
     def test_holomap_legend_updates(self):
-        hmap = HoloMap({i: Curve([1, 2, 3], label=chr(65+i+2)) * Curve([1, 2, 3], label='B')
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, 3], label=chr(65+i+2)) * hv.Curve([1, 2, 3], label='B')
                         for i in range(3)})
         plot = bokeh_renderer.get_plot(hmap)
         legend_labels = [property_to_dict(item.label) for item in plot.state.legend[0].items]
@@ -452,7 +441,7 @@ class TestLegends(TestBokehPlot):
         assert legend_labels == [{'value': 'B'}, {'value': 'E'}]
 
     def test_holomap_legend_updates_varying_lengths(self):
-        hmap = HoloMap({i: Overlay([Curve([1, 2, j], label=chr(65+j)) for j in range(i)]) for i in range(1, 4)})
+        hmap = hv.HoloMap({i: hv.Overlay([hv.Curve([1, 2, j], label=chr(65+j)) for j in range(i)]) for i in range(1, 4)})
         plot = bokeh_renderer.get_plot(hmap)
         legend_labels = [property_to_dict(item.label) for item in plot.state.legend[0].items]
         assert legend_labels == [{'value': 'A'}]
@@ -464,7 +453,7 @@ class TestLegends(TestBokehPlot):
         assert legend_labels == [{'value': 'A'}, {'value': 'B'}, {'value': 'C'}]
 
     def test_dynamicmap_legend_updates(self):
-        hmap = HoloMap({i: Curve([1, 2, 3], label=chr(65+i+2)) * Curve([1, 2, 3], label='B')
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, 3], label=chr(65+i+2)) * hv.Curve([1, 2, 3], label='B')
                         for i in range(3)})
         dmap = Dynamic(hmap)
         plot = bokeh_renderer.get_plot(dmap)
@@ -478,7 +467,7 @@ class TestLegends(TestBokehPlot):
         assert legend_labels == [{'value': 'B'}, {'value': 'E'}]
 
     def test_dynamicmap_legend_updates_add_dynamic_plots(self):
-        hmap = HoloMap({i: Overlay([Curve([1, 2, j], label=chr(65+j)) for j in range(i)]) for i in range(1, 4)})
+        hmap = hv.HoloMap({i: hv.Overlay([hv.Curve([1, 2, j], label=chr(65+j)) for j in range(i)]) for i in range(1, 4)})
         dmap = Dynamic(hmap)
         plot = bokeh_renderer.get_plot(dmap)
         legend_labels = [property_to_dict(item.label) for item in plot.state.legend[0].items]
@@ -493,8 +482,8 @@ class TestLegends(TestBokehPlot):
     def test_dynamicmap_ndoverlay_shrink_number_of_items(self):
         selected = Stream.define('selected', items=3)()
         def callback(items):
-            return NdOverlay({j: Overlay([Curve([1, 2, j])]) for j in range(items)})
-        dmap = DynamicMap(callback, streams=[selected])
+            return hv.NdOverlay({j: hv.Overlay([hv.Curve([1, 2, j])]) for j in range(items)})
+        dmap = hv.DynamicMap(callback, streams=[selected])
         plot = bokeh_renderer.get_plot(dmap)
         selected.event(items=2)
         assert len([r for r in plot.state.renderers if r.visible]) == 2
@@ -502,8 +491,8 @@ class TestLegends(TestBokehPlot):
     def test_dynamicmap_variable_length_overlay(self):
         selected = Stream.define('selected', items=[1])()
         def callback(items):
-            return Overlay([Box(0, 0, radius*2) for radius in items])
-        dmap = DynamicMap(callback, streams=[selected])
+            return hv.Overlay([hv.Box(0, 0, radius*2) for radius in items])
+        dmap = hv.DynamicMap(callback, streams=[selected])
         plot = bokeh_renderer.get_plot(dmap)
         assert len(plot.subplots) == 1
         selected.event(items=[1, 2, 4])

--- a/holoviews/tests/plotting/bokeh/test_pathplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pathplot.py
@@ -11,13 +11,10 @@ from bokeh.models import (
     Patches,
 )
 
-from holoviews.core import HoloMap, NdOverlay
-from holoviews.core.options import Cycle
-from holoviews.element import Contours, Dendrogram, Path, Polygons, Scatter
+import holoviews as hv
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.streams import PolyDraw
 from holoviews.testing import assert_data_equal
-from holoviews.util.transform import dim
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
@@ -33,8 +30,8 @@ class TestPathPlot(TestBokehPlot):
 
     def test_batched_path_line_color_and_color(self):
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Path': dict(line_color=Cycle(values=['red', 'blue']))}
-        overlay = NdOverlay({i: Path([[(i, j) for j in range(2)]])
+                'Path': dict(line_color=hv.Cycle(values=['red', 'blue']))}
+        overlay = hv.NdOverlay({i: hv.Path([[(i, j) for j in range(2)]])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         line_color = ['red', 'blue']
@@ -42,8 +39,8 @@ class TestPathPlot(TestBokehPlot):
 
     def test_batched_path_alpha_and_color(self):
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Path': dict(alpha=Cycle(values=[0.5, 1]))}
-        overlay = NdOverlay({i: Path([[(i, j) for j in range(2)]])
+                'Path': dict(alpha=hv.Cycle(values=[0.5, 1]))}
+        overlay = hv.NdOverlay({i: hv.Path([[(i, j) for j in range(2)]])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         alpha = [0.5, 1.]
@@ -53,8 +50,8 @@ class TestPathPlot(TestBokehPlot):
 
     def test_batched_path_line_width_and_color(self):
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Path': dict(line_width=Cycle(values=[0.5, 1]))}
-        overlay = NdOverlay({i: Path([[(i, j) for j in range(2)]])
+                'Path': dict(line_width=hv.Cycle(values=[0.5, 1]))}
+        overlay = hv.NdOverlay({i: hv.Path([[(i, j) for j in range(2)]])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         line_width = [0.5, 1.]
@@ -63,7 +60,7 @@ class TestPathPlot(TestBokehPlot):
         assert plot.handles['source'].data['color'] == color
 
     def test_path_overlay_hover(self):
-        obj = NdOverlay({i: Path([np.random.rand(10,2)]) for i in range(5)},
+        obj = hv.NdOverlay({i: hv.Path([np.random.rand(10,2)]) for i in range(5)},
                         kdims=['Test'])
         opts = {'Path': {'tools': ['hover']},
                 'NdOverlay': {'legend_limit': 0}}
@@ -76,7 +73,7 @@ class TestPathPlot(TestBokehPlot):
         color = [0, 0.25, 0.5, 0.75]
         other = ['A', 'B', 'C', 'D']
         data = {'x': xs, 'y': ys, 'color': color, 'other': other}
-        path = Path([data], vdims=['color','other']).opts(
+        path = hv.Path([data], vdims=['color','other']).opts(
             color_index='color', tools=['hover']
         )
         plot = bokeh_renderer.get_plot(path)
@@ -93,8 +90,8 @@ class TestPathPlot(TestBokehPlot):
         color = [0, 0.25, 0.5, 0.75]
         other = ['A', 'B', 'C', 'D']
         data = {'x': xs, 'y': ys, 'color': color, 'other': other}
-        path = Path([data], vdims=['color','other']).opts(
-            color=dim('color')*2, tools=['hover']
+        path = hv.Path([data], vdims=['color','other']).opts(
+            color=hv.dim('color')*2, tools=['hover']
         )
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
@@ -112,7 +109,7 @@ class TestPathPlot(TestBokehPlot):
         data = {'x': xs, 'y': ys, 'color': color, 'date': date}
         levels = [0, 38, 73, 95, 110, 130, 156, 999]
         colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']
-        path = Path([data], vdims=['color', 'date']).opts(
+        path = hv.Path([data], vdims=['color', 'date']).opts(
             color_index='color', color_levels=levels, cmap=colors, tools=['hover'])
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
@@ -134,7 +131,7 @@ class TestPathPlot(TestBokehPlot):
         data = {'x': xs, 'y': ys, 'color': color, 'date': date}
         levels = [0, 38, 73, 95, 110, 130, 156, 999]
         colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']
-        path = Path([data], vdims=['color', 'date']).opts(
+        path = hv.Path([data], vdims=['color', 'date']).opts(
             color='color', color_levels=levels, cmap=colors, tools=['hover'])
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
@@ -153,7 +150,7 @@ class TestPathPlot(TestBokehPlot):
         ys = xs[::-1]
         alpha = [0.1, 0.7, 0.3, 0.2]
         data = {'x': xs, 'y': ys, 'alpha': alpha}
-        path = Path([data], vdims='alpha').opts(alpha='alpha')
+        path = hv.Path([data], vdims='alpha').opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
         np.testing.assert_array_equal(source.data['xs'], [np.array([1, 2]), np.array([2, 3]), np.array([3, 4])])
@@ -165,7 +162,7 @@ class TestPathPlot(TestBokehPlot):
         ys = xs[::-1]
         line_width = [1, 7, 3, 2]
         data = {'x': xs, 'y': ys, 'line_width': line_width}
-        path = Path([data], vdims='line_width').opts(line_width='line_width')
+        path = hv.Path([data], vdims='line_width').opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
         np.testing.assert_array_equal(source.data['xs'], np.array([np.array([1, 2]), np.array([2, 3]), np.array([3, 4])]))
@@ -182,7 +179,7 @@ class TestPathPlot(TestBokehPlot):
         colors = ["#FF0000", "#00FF00", "#0000FF"]
         levels=[0,1,2]
 
-        path = Path(data, vdims="cat").opts(color="cat", cmap=dict(zip(levels, colors, strict=True)), line_width=4, show_legend=True)
+        path = hv.Path(data, vdims="cat").opts(color="cat", cmap=dict(zip(levels, colors, strict=True)), line_width=4, show_legend=True)
         plot = bokeh_renderer.get_plot(path)
         item = plot.state.legend[0].items[0]
         legend = {'field': 'color_str__'}
@@ -199,7 +196,7 @@ class TestPathPlot(TestBokehPlot):
         colors = ["#FF0000", "#00FF00", "#0000FF"]
         levels=[0,1,2]
 
-        path = Path(data, vdims="cat").opts(color="cat", cmap=dict(zip(levels, colors, strict=True)), line_width=4, show_legend=True, legend_labels={0: 'A', 1: 'B', 2: 'C'})
+        path = hv.Path(data, vdims="cat").opts(color="cat", cmap=dict(zip(levels, colors, strict=True)), line_width=4, show_legend=True, legend_labels={0: 'A', 1: 'B', 2: 'C'})
         plot = bokeh_renderer.get_plot(path)
         cds = plot.handles['cds']
         item = plot.state.legend[0].items[0]
@@ -221,7 +218,7 @@ class TestPathPlot(TestBokehPlot):
             'color': '#0000FF',
         }]
 
-        path = Path(data, vdims='color').opts(line_color='color')
+        path = hv.Path(data, vdims='color').opts(line_color='color')
         plot = bokeh_renderer.get_plot(path)
         cds = plot.handles['cds']
         source = plot.handles['source']
@@ -238,7 +235,7 @@ class TestPathPlot(TestBokehPlot):
              'c': x * 10}
             for x in range(5)
         ]
-        path = Path(data, vdims=['c']).opts(color='c', cmap='Turbo', colorbar=True)
+        path = hv.Path(data, vdims=['c']).opts(color='c', cmap='Turbo', colorbar=True)
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
         glyph = plot.handles['glyph']
@@ -262,7 +259,7 @@ class TestPathPlot(TestBokehPlot):
              'c': np.full(n_pts, x * 10)}
             for x in range(5)
         ]
-        path = Path(data, vdims=['c']).opts(color='c', cmap='Turbo', colorbar=True)
+        path = hv.Path(data, vdims=['c']).opts(color='c', cmap='Turbo', colorbar=True)
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
 
@@ -280,7 +277,7 @@ class TestPathPlot(TestBokehPlot):
              'c': x * 10}
             for x in range(5)
         ]
-        path = Path(data, vdims=["c"]).opts(color="c", cmap="Turbo", colorbar=True)
+        path = hv.Path(data, vdims=["c"]).opts(color="c", cmap="Turbo", colorbar=True)
 
         plot = bokeh_renderer.get_plot(path)
         source = plot.handles['source']
@@ -298,7 +295,7 @@ class TestPathPlot(TestBokehPlot):
 class TestPolygonPlot(TestBokehPlot):
 
     def test_polygons_overlay_hover(self):
-        obj = NdOverlay({i: Polygons([{('x', 'y'): np.random.rand(10,2), 'z': 0}], vdims=['z'])
+        obj = hv.NdOverlay({i: hv.Polygons([{('x', 'y'): np.random.rand(10,2), 'z': 0}], vdims=['z'])
                          for i in range(5)}, kdims=['Test'])
         opts = {'Polygons': {'tools': ['hover']},
                 'NdOverlay': {'legend_limit': 0}}
@@ -306,7 +303,7 @@ class TestPolygonPlot(TestBokehPlot):
         self._test_hover_info(obj, [('Test', '@{Test}'), ('z', '@{z}')])
 
     def test_polygons_colored(self):
-        polygons = NdOverlay({j: Polygons([[(i**j, i, j) for i in range(10)]], vdims='Value')
+        polygons = hv.NdOverlay({j: hv.Polygons([[(i**j, i, j) for i in range(10)]], vdims='Value')
                               for j in range(5)})
         plot = bokeh_renderer.get_plot(polygons)
         for i, splot in enumerate(plot.subplots.values()):
@@ -317,7 +314,7 @@ class TestPolygonPlot(TestBokehPlot):
             assert_data_equal(source.data['Value'], np.array([i]))
 
     def test_polygons_colored_batched(self):
-        polygons = NdOverlay({j: Polygons([[(i**j, i, j) for i in range(10)]], vdims='Value')
+        polygons = hv.NdOverlay({j: hv.Polygons([[(i**j, i, j) for i in range(10)]], vdims='Value')
                               for j in range(5)}).opts(legend_limit=0)
         plot = next(iter(bokeh_renderer.get_plot(polygons).subplots.values()))
         cmapper = plot.handles['color_mapper']
@@ -328,7 +325,7 @@ class TestPolygonPlot(TestBokehPlot):
         assert source.data['Value'] == list(range(5))
 
     def test_polygons_colored_batched_unsanitized(self):
-        polygons = NdOverlay({j: Polygons([[(i**j, i, j) for i in range(10)] for i in range(2)],
+        polygons = hv.NdOverlay({j: hv.Polygons([[(i**j, i, j) for i in range(10)] for i in range(2)],
                                           vdims=['some ? unescaped name'])
                               for j in range(5)}).opts(legend_limit=0)
         plot = next(iter(bokeh_renderer.get_plot(polygons).subplots.values()))
@@ -339,7 +336,7 @@ class TestPolygonPlot(TestBokehPlot):
         assert source.data['some_question_mark_unescaped_name'] == [j for i in range(5) for j in [i, i]]
 
     def test_empty_polygons_plot(self):
-        poly = Polygons([], vdims=['Intensity'])
+        poly = hv.Polygons([], vdims=['Intensity'])
         plot = bokeh_renderer.get_plot(poly)
         source = plot.handles['source']
         assert len(source.data['xs']) == 0
@@ -350,7 +347,7 @@ class TestPolygonPlot(TestBokehPlot):
         xs = [1, 2, 3]
         ys = [2, 0, 7]
         holes = [[[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]]]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes}])
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes}])
         plot = bokeh_renderer.get_plot(poly)
         source = plot.handles['source']
         np.testing.assert_array_equal(source.data['xs'], [[[np.array([1, 2, 3, 1]), np.array([1.5, 2, 1.6, 1.5]),
@@ -365,7 +362,7 @@ class TestPolygonPlot(TestBokehPlot):
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes}])
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes}])
         plot = bokeh_renderer.get_plot(poly)
         source = plot.handles['source']
         expected_x = [
@@ -384,7 +381,7 @@ class TestPolygonPlot(TestBokehPlot):
         assert_inhomogeneous_array_equal(source.data['ys'], expected_y)
 
     def test_polygons_hover_color_op(self):
-        polygons = Polygons([
+        polygons = hv.Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
         ], vdims='color').opts(fill_color='color', tools=['hover'])
@@ -397,7 +394,7 @@ class TestPolygonPlot(TestBokehPlot):
         assert cds.data['fill_color'] == ['green', 'red']
 
     def test_polygons_color_op(self):
-        polygons = Polygons([
+        polygons = hv.Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
         ], vdims='color').opts(color='color')
@@ -409,7 +406,7 @@ class TestPolygonPlot(TestBokehPlot):
         assert cds.data['color'] == ['green', 'red']
 
     def test_polygons_linear_color_op(self):
-        polygons = Polygons([
+        polygons = hv.Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 3}
         ], vdims='color').opts(color='color')
@@ -425,7 +422,7 @@ class TestPolygonPlot(TestBokehPlot):
         assert cmapper.high == 7
 
     def test_polygons_categorical_color_op(self):
-        polygons = Polygons([
+        polygons = hv.Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'b'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'a'}
         ], vdims='color').opts(color='color')
@@ -440,7 +437,7 @@ class TestPolygonPlot(TestBokehPlot):
         assert cmapper.factors == ['b', 'a']
 
     def test_polygons_alpha_op(self):
-        polygons = Polygons([
+        polygons = hv.Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'alpha': 0.7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'alpha': 0.3}
         ], vdims='alpha').opts(alpha='alpha')
@@ -452,7 +449,7 @@ class TestPolygonPlot(TestBokehPlot):
         assert_data_equal(cds.data['alpha'], np.array([0.7, 0.3]))
 
     def test_polygons_line_width_op(self):
-        polygons = Polygons([
+        polygons = hv.Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'line_width': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'line_width': 3}
         ], vdims='line_width').opts(line_width='line_width')
@@ -469,8 +466,8 @@ class TestPolygonPlot(TestBokehPlot):
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = HoloMap({0: Polygons([{'x': xs, 'y': ys, 'holes': holes}]),
-                        1: Polygons([{'x': xs, 'y': ys}])})
+        poly = hv.HoloMap({0: hv.Polygons([{'x': xs, 'y': ys, 'holes': holes}]),
+                        1: hv.Polygons([{'x': xs, 'y': ys}])})
         plot = bokeh_renderer.get_plot(poly)
         glyph = plot.handles['glyph']
         assert plot._has_holes
@@ -483,8 +480,8 @@ class TestPolygonPlot(TestBokehPlot):
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = HoloMap({0: Polygons([{'x': xs, 'y': ys, 'holes': holes}]),
-                        1: Polygons([{'x': xs, 'y': ys}])})
+        poly = hv.HoloMap({0: hv.Polygons([{'x': xs, 'y': ys, 'holes': holes}]),
+                        1: hv.Polygons([{'x': xs, 'y': ys}])})
         PolyDraw(source=poly)
         plot = bokeh_renderer.get_plot(poly)
         glyph = plot.handles['glyph']
@@ -496,7 +493,7 @@ class TestPolygonPlot(TestBokehPlot):
 class TestContoursPlot(TestBokehPlot):
 
     def test_empty_contours_plot(self):
-        contours = Contours([], vdims=['Intensity'])
+        contours = hv.Contours([], vdims=['Intensity'])
         plot = bokeh_renderer.get_plot(contours)
         source = plot.handles['source']
         assert len(source.data['xs']) == 0
@@ -504,7 +501,7 @@ class TestContoursPlot(TestBokehPlot):
         assert len(source.data['Intensity']) == 0
 
     def test_contours_color_op(self):
-        contours = Contours([
+        contours = hv.Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
         ], vdims='color').opts(color='color')
@@ -515,7 +512,7 @@ class TestContoursPlot(TestBokehPlot):
         assert cds.data['color'] == ['green', 'red']
 
     def test_contours_linear_color_op(self):
-        contours = Contours([
+        contours = hv.Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 3}
         ], vdims='color').opts(color='color')
@@ -530,7 +527,7 @@ class TestContoursPlot(TestBokehPlot):
         assert cmapper.high == 7
 
     def test_contours_empty_path(self):
-        contours = Contours([
+        contours = hv.Contours([
             pd.DataFrame([], columns=['x', 'y', 'color', 'line_width']),
             pd.DataFrame({'x': np.random.rand(10), 'y': np.random.rand(10),
                           'color': ['red']*10, 'line_width': [3]*10},
@@ -544,12 +541,12 @@ class TestContoursPlot(TestBokehPlot):
 
 
     def test_contours_linear_color_op_update(self):
-        contours = HoloMap({
-            0: Contours([
+        contours = hv.HoloMap({
+            0: hv.Contours([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 7},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 3}
             ], vdims='color'),
-            1: Contours([
+            1: hv.Contours([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 5},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 2}
             ], vdims='color')}).opts(color='color', framewise=True)
@@ -568,7 +565,7 @@ class TestContoursPlot(TestBokehPlot):
         assert cmapper.high == 5
 
     def test_contours_categorical_color_op(self):
-        contours = Contours([
+        contours = hv.Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'b'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'a'}
         ], vdims='color').opts(color='color')
@@ -582,7 +579,7 @@ class TestContoursPlot(TestBokehPlot):
         assert cmapper.factors == ['b', 'a']
 
     def test_contours_alpha_op(self):
-        contours = Contours([
+        contours = hv.Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'alpha': 0.7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'alpha': 0.3}
         ], vdims='alpha').opts(alpha='alpha')
@@ -593,7 +590,7 @@ class TestContoursPlot(TestBokehPlot):
         assert list(cds.data['alpha']) == [0.7, 0.3]
 
     def test_contours_line_width_op(self):
-        contours = Contours([
+        contours = hv.Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'line_width': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'line_width': 3}
         ], vdims='line_width').opts(line_width='line_width')
@@ -634,36 +631,36 @@ class TestDendrogramPlot(TestBokehPlot):
         return top, main, right
 
     def test_empty_plot(self):
-        dendrogram = Dendrogram([])
+        dendrogram = hv.Dendrogram([])
         plot = bokeh_renderer.get_plot(dendrogram)
         source = plot.handles['source']
         assert len(source.data['xs']) == 0
         assert len(source.data['ys']) == 0
 
     def test_empty_plot_xy(self):
-        dendrogram = Dendrogram(x=[], y=[])
+        dendrogram = hv.Dendrogram(x=[], y=[])
         plot = bokeh_renderer.get_plot(dendrogram)
         source = plot.handles['source']
         assert len(source.data['xs']) == 0
         assert len(source.data['ys']) == 0
 
     def test_plot(self):
-        dendrogram = Dendrogram(zip(self.x, self.y, strict=True))
+        dendrogram = hv.Dendrogram(zip(self.x, self.y, strict=True))
         plot = bokeh_renderer.get_plot(dendrogram)
         source = plot.handles['source']
         assert len(source.data['xs']) == 4
         assert len(source.data['ys']) == 4
 
     def test_plot_xy(self):
-        dendrogram = Dendrogram(self.x, self.y)
+        dendrogram = hv.Dendrogram(self.x, self.y)
         plot = bokeh_renderer.get_plot(dendrogram)
         source = plot.handles['source']
         assert len(source.data['xs']) == 4
         assert len(source.data['ys']) == 4
 
     def test_plot_equals_path_zip(self):
-        dendrogram = Dendrogram(self.x, self.y)
-        path = Path(zip(self.x, self.y, strict=True))
+        dendrogram = hv.Dendrogram(self.x, self.y)
+        path = hv.Path(zip(self.x, self.y, strict=True))
         dendro_plot = bokeh_renderer.get_plot(dendrogram)
         dendro_source = dendro_plot.handles['source']
         path_plot = bokeh_renderer.get_plot(path)
@@ -672,8 +669,8 @@ class TestDendrogramPlot(TestBokehPlot):
         np.testing.assert_array_equal(dendro_source.data["ys"], path_source.data["ys"])
 
     def test_1_adjoint_plot_1_kdims_empty_main(self):
-        dendrogram = Dendrogram(self.x, self.y)
-        main = Scatter([])
+        dendrogram = hv.Dendrogram(self.x, self.y)
+        main = hv.Scatter([])
         adjoint = main << dendrogram
         top, main, right = self.get_childrens(adjoint)
         assert top is None
@@ -682,8 +679,8 @@ class TestDendrogramPlot(TestBokehPlot):
         assert main.y_scale is right.y_scale
 
     def test_1_adjoint_plot_1_kdims(self):
-        dendrogram = Dendrogram(self.x, self.y)
-        main = Scatter([1, 2, 3])
+        dendrogram = hv.Dendrogram(self.x, self.y)
+        main = hv.Scatter([1, 2, 3])
         adjoint = main << dendrogram
         top, main, right = self.get_childrens(adjoint)
         assert top is None
@@ -692,9 +689,9 @@ class TestDendrogramPlot(TestBokehPlot):
         assert main.y_scale is right.y_scale
 
     def test_2_adjoint_plot_1_kdims(self):
-        dendrogram1 = Dendrogram(self.x, self.y)
-        dendrogram2 = Dendrogram(self.y, self.x)
-        main = Scatter([1, 2, 3])
+        dendrogram1 = hv.Dendrogram(self.x, self.y)
+        dendrogram2 = hv.Dendrogram(self.y, self.x)
+        main = hv.Scatter([1, 2, 3])
         adjoint = main << dendrogram1 << dendrogram2
         top, main, right = self.get_childrens(adjoint)
         assert top.height == 80
@@ -703,8 +700,8 @@ class TestDendrogramPlot(TestBokehPlot):
         assert right.width == 80
 
     def test_1_adjoint_plot_2_kdims(self):
-        dendrogram = Dendrogram(self.x, self.y)
-        main = Path(zip(self.x, self.y, strict=True))
+        dendrogram = hv.Dendrogram(self.x, self.y)
+        main = hv.Path(zip(self.x, self.y, strict=True))
         adjoint = main << dendrogram
         top, main, right = self.get_childrens(adjoint)
         assert top is None
@@ -713,7 +710,7 @@ class TestDendrogramPlot(TestBokehPlot):
         assert main.y_scale is right.y_scale
 
     def test_adjoint_plot_in_layout(self):
-        layout = (Scatter([]) << Dendrogram(self.x, self.y)) + Scatter([])
+        layout = (hv.Scatter([]) << hv.Dendrogram(self.x, self.y)) + hv.Scatter([])
         msg = "Adjoined dendrogram in a Layout, does not currently support `.opts(shared_axes=True)`"
         with pytest.raises(NotImplementedError, match=re.escape(msg)):
             bokeh_renderer(layout)

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -11,15 +11,12 @@ from bokeh.models import (
 )
 from param import concrete_descendents
 
-from holoviews import Curve
-from holoviews.core.element import Element
-from holoviews.core.options import Store
-from holoviews.core.spaces import DynamicMap
+import holoviews as hv
 from holoviews.plotting.bokeh.callbacks import Callback
 from holoviews.plotting.bokeh.element import ElementPlot
 from holoviews.streams import Pipe
 
-bokeh_renderer = Store.renderers['bokeh']
+bokeh_renderer = hv.Store.renderers['bokeh']
 
 from .. import option_intersections
 
@@ -36,17 +33,17 @@ class TestPlotDefinitions:
 class TestBokehPlot:
 
     def setup_method(self):
-        self.previous_backend = Store.current_backend
+        self.previous_backend = hv.Store.current_backend
         self.comm_manager = bokeh_renderer.comm_manager
         bokeh_renderer.comm_manager = comms.CommManager
-        Store.set_current_backend('bokeh')
+        hv.Store.set_current_backend('bokeh')
         self._padding = {}
         for plot in concrete_descendents(ElementPlot).values():
             self._padding[plot] = plot.padding
             plot.padding = 0
 
     def teardown_method(self):
-        Store.current_backend = self.previous_backend
+        hv.Store.current_backend = self.previous_backend
         bokeh_renderer.comm_manager = self.comm_manager
         Callback._callbacks = {}
         for plot, padding in self._padding.items():
@@ -76,7 +73,7 @@ class TestBokehPlot:
         assert hover[0].formatters == formatters
         assert hover[0].line_policy == line_policy
 
-        if isinstance(element, Element):
+        if isinstance(element, hv.Element):
             cds = fig.select_one(dict(type=ColumnDataSource))
             for label, lookup in hover[0].tooltips:
                 if label in element.dimensions():
@@ -90,7 +87,7 @@ class TestBokehPlot:
 def test_element_plot_stream_cleanup():
     stream = Pipe()
 
-    dmap = DynamicMap(Curve, streams=[stream])
+    dmap = hv.DynamicMap(hv.Curve, streams=[stream])
 
     plot = bokeh_renderer.get_plot(dmap)
 
@@ -105,8 +102,8 @@ def test_overlay_plot_stream_cleanup():
     stream1 = Pipe()
     stream2 = Pipe()
 
-    dmap1 = DynamicMap(Curve, streams=[stream1])
-    dmap2 = DynamicMap(Curve, streams=[stream2])
+    dmap1 = hv.DynamicMap(hv.Curve, streams=[stream1])
+    dmap2 = hv.DynamicMap(hv.Curve, streams=[stream2])
 
     plot = bokeh_renderer.get_plot(dmap1 * dmap2)
 
@@ -123,8 +120,8 @@ def test_layout_plot_stream_cleanup():
     stream1 = Pipe()
     stream2 = Pipe()
 
-    dmap1 = DynamicMap(Curve, streams=[stream1])
-    dmap2 = DynamicMap(Curve, streams=[stream2])
+    dmap1 = hv.DynamicMap(hv.Curve, streams=[stream1])
+    dmap2 = hv.DynamicMap(hv.Curve, streams=[stream2])
 
     plot = bokeh_renderer.get_plot(dmap1 + dmap2)
 
@@ -138,7 +135,7 @@ def test_layout_plot_stream_cleanup():
 
 
 def test_sync_two_plots():
-    curve = lambda i: Curve(np.arange(10) * i, label="ABC"[i])
+    curve = lambda i: hv.Curve(np.arange(10) * i, label="ABC"[i])
     plot1 = curve(0) * curve(1)
     plot2 = curve(0) * curve(1) * curve(2)
     combined_plot = plot1 + plot2
@@ -157,7 +154,7 @@ def test_sync_two_plots():
 
 
 def test_sync_three_plots():
-    curve = lambda i: Curve(np.arange(10) * i, label="ABC"[i])
+    curve = lambda i: hv.Curve(np.arange(10) * i, label="ABC"[i])
     plot1 = curve(0) * curve(1)
     plot2 = curve(0) * curve(1) * curve(2)
     plot3 = curve(0) * curve(1)
@@ -183,7 +180,7 @@ def test_span_not_cloned_crosshair():
     height = Span(dimension="height")
     cht = CrosshairTool(overlay=height)
 
-    layout = Curve([]).opts(tools=[cht]) + Curve([]).opts(tools=[cht])
+    layout = hv.Curve([]).opts(tools=[cht]) + hv.Curve([]).opts(tools=[cht])
 
     (fig1, *_), (fig2, *_) = bokeh_renderer.get_plot(layout).handles["plot"].children
     tool1 = next(t for t in fig1.tools if isinstance(t, CrosshairTool))
@@ -193,7 +190,7 @@ def test_span_not_cloned_crosshair():
 
 
 def test_autohide_toolbar_single_plot():
-    curve = Curve([1, 2, 3])
+    curve = hv.Curve([1, 2, 3])
 
     # Test with autohide_toolbar=False (default)
     plot = bokeh_renderer.get_plot(curve)
@@ -207,7 +204,7 @@ def test_autohide_toolbar_single_plot():
 
 
 def test_autohide_toolbar_overlay():
-    overlay = Curve([1, 2, 3]) * Curve([2, 3, 4])
+    overlay = hv.Curve([1, 2, 3]) * hv.Curve([2, 3, 4])
 
     # Test with autohide_toolbar=False (default)
     plot = bokeh_renderer.get_plot(overlay)
@@ -221,7 +218,7 @@ def test_autohide_toolbar_overlay():
 
 
 def test_autohide_toolbar_layout():
-    layout = Curve([1, 2, 3]) + Curve([2, 3, 4])
+    layout = hv.Curve([1, 2, 3]) + hv.Curve([2, 3, 4])
 
     # Test with autohide_toolbar=False (default)
     plot = bokeh_renderer.get_plot(layout)
@@ -237,10 +234,10 @@ def test_autohide_toolbar_layout():
     assert grid.toolbar.autohide is True
 
 def test_autohide_toolbar_nested():
-    overlay = Curve([1, 2, 3]) * Curve([2, 3, 4])
+    overlay = hv.Curve([1, 2, 3]) * hv.Curve([2, 3, 4])
 
     # Test with different settings for components
-    mixed_layout = overlay.opts(autohide_toolbar=True) + Curve([3, 4, 5]).opts(autohide_toolbar=False)
+    mixed_layout = overlay.opts(autohide_toolbar=True) + hv.Curve([3, 4, 5]).opts(autohide_toolbar=False)
     plot = bokeh_renderer.get_plot(mixed_layout)
     grid = plot.handles['plot']
     child1, child2 = [child for child, *_ in grid.children]

--- a/holoviews/tests/plotting/bokeh/test_pointplot.py
+++ b/holoviews/tests/plotting/bokeh/test_pointplot.py
@@ -13,9 +13,6 @@ from bokeh.models import (
 )
 
 import holoviews as hv
-from holoviews.core import NdOverlay
-from holoviews.core.options import Cycle
-from holoviews.element import Points
 from holoviews.plotting.bokeh.chart import SizebarMixin
 from holoviews.plotting.bokeh.util import BOKEH_GE_3_8_0, property_to_dict
 from holoviews.streams import Stream
@@ -28,16 +25,16 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestPointPlot(TestBokehPlot):
 
     def test_points_colormapping(self):
-        points = Points(np.random.rand(10, 4), vdims=['a', 'b']).opts(color_index=3)
+        points = hv.Points(np.random.rand(10, 4), vdims=['a', 'b']).opts(color_index=3)
         self._test_colormapping(points, 3)
 
     def test_points_colormapping_with_nonselection(self):
         opts = dict(color_index=3, nonselection_color='red')
-        points = Points(np.random.rand(10, 4), vdims=['a', 'b']).opts(**opts)
+        points = hv.Points(np.random.rand(10, 4), vdims=['a', 'b']).opts(**opts)
         self._test_colormapping(points, 3)
 
     def test_points_colormapping_categorical(self):
-        points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
+        points = hv.Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
                          vdims=['a', 'b']).opts(color_index='b')
         plot = bokeh_renderer.get_plot(points)
         plot.initialize_plot()
@@ -47,7 +44,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_points_color_selection_nonselection(self):
         opts = dict(color='green', selection_color='red', nonselection_color='blue')
-        points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
+        points = hv.Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
                          vdims=['a', 'b']).opts(**opts)
         plot = bokeh_renderer.get_plot(points)
         glyph_renderer = plot.handles['glyph_renderer']
@@ -60,7 +57,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_points_alpha_selection_nonselection(self):
         opts = dict(alpha=0.8, selection_alpha=1.0, nonselection_alpha=0.2)
-        points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
+        points = hv.Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
                          vdims=['a', 'b']).opts(**opts)
         plot = bokeh_renderer.get_plot(points)
         glyph_renderer = plot.handles['glyph_renderer']
@@ -73,7 +70,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_points_alpha_selection_partial(self):
         opts = dict(selection_alpha=1.0, selection_fill_alpha=0.2)
-        points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
+        points = hv.Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
                          vdims=['a', 'b']).opts(**opts)
         plot = bokeh_renderer.get_plot(points)
         glyph_renderer = plot.handles['glyph_renderer']
@@ -83,15 +80,15 @@ class TestPointPlot(TestBokehPlot):
         assert glyph_renderer.selection_glyph.line_alpha == 1
 
     def test_batched_points(self):
-        overlay = NdOverlay({i: Points(np.arange(i)) for i in range(1, 100)})
+        overlay = hv.NdOverlay({i: hv.Points(np.arange(i)) for i in range(1, 100)})
         plot = bokeh_renderer.get_plot(overlay)
         extents = plot.get_extents(overlay, {})
         assert extents == (0, 0, 98, 98)
 
     def test_batched_points_size_and_color(self):
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Points': dict(size=Cycle(values=[1, 2]))}
-        overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
+                'Points': dict(size=hv.Cycle(values=[1, 2]))}
+        overlay = hv.NdOverlay({i: hv.Points([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         size = np.array([1, 1, 2, 2])
@@ -101,8 +98,8 @@ class TestPointPlot(TestBokehPlot):
 
     def test_batched_points_line_color_and_color(self):
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Points': dict(line_color=Cycle(values=['red', 'blue']))}
-        overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
+                'Points': dict(line_color=hv.Cycle(values=['red', 'blue']))}
+        overlay = hv.NdOverlay({i: hv.Points([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         line_color = ['red', 'red', 'blue', 'blue']
@@ -112,8 +109,8 @@ class TestPointPlot(TestBokehPlot):
 
     def test_batched_points_alpha_and_color(self):
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Points': dict(alpha=Cycle(values=[0.5, 1]))}
-        overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
+                'Points': dict(alpha=hv.Cycle(values=[0.5, 1]))}
+        overlay = hv.NdOverlay({i: hv.Points([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         alpha = np.array([0.5, 0.5, 1., 1.])
@@ -123,8 +120,8 @@ class TestPointPlot(TestBokehPlot):
 
     def test_batched_points_line_width_and_color(self):
         opts = {'NdOverlay': dict(legend_limit=0),
-                'Points': dict(line_width=Cycle(values=[0.5, 1]))}
-        overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
+                'Points': dict(line_width=hv.Cycle(values=[0.5, 1]))}
+        overlay = hv.NdOverlay({i: hv.Points([(i, j) for j in range(2)])
                              for i in range(2)}).opts(opts)
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         line_width = np.array([0.5, 0.5, 1., 1.])
@@ -133,7 +130,7 @@ class TestPointPlot(TestBokehPlot):
         assert plot.handles['source'].data['color'] == color
 
     def test_points_overlay_datetime_hover(self):
-        obj = NdOverlay({i: Points((list(pd.date_range('2016-01-01', '2016-01-31')), range(31))) for i in range(5)},
+        obj = hv.NdOverlay({i: hv.Points((list(pd.date_range('2016-01-01', '2016-01-31')), range(31))) for i in range(5)},
                         kdims=['Test'])
         opts = {'Points': {'tools': ['hover']}}
         obj = obj.opts(opts)
@@ -141,7 +138,7 @@ class TestPointPlot(TestBokehPlot):
                               formatters={'@{x}': "datetime"})
 
     def test_points_overlay_hover_batched(self):
-        obj = NdOverlay({i: Points(np.random.rand(10,2)) for i in range(5)},
+        obj = hv.NdOverlay({i: hv.Points(np.random.rand(10,2)) for i in range(5)},
                         kdims=['Test'])
         opts = {'Points': {'tools': ['hover']},
                 'NdOverlay': {'legend_limit': 0}}
@@ -149,7 +146,7 @@ class TestPointPlot(TestBokehPlot):
         self._test_hover_info(obj, [('Test', '@{Test}'), ('x', '@{x}'), ('y', '@{y}')])
 
     def test_points_overlay_hover(self):
-        obj = NdOverlay({i: Points(np.random.rand(10,2)) for i in range(5)},
+        obj = hv.NdOverlay({i: hv.Points(np.random.rand(10,2)) for i in range(5)},
                         kdims=['Test'])
         opts = {'Points': {'tools': ['hover']},
                 'NdOverlay': {'legend_limit': 0}}
@@ -158,7 +155,7 @@ class TestPointPlot(TestBokehPlot):
                                     ('y', '@{y}')])
 
     def test_points_no_single_item_legend(self):
-        points = Points([('A', 1), ('B', 2)], label='A')
+        points = hv.Points([('A', 1), ('B', 2)], label='A')
         plot = bokeh_renderer.get_plot(points)
         plot.initialize_plot()
         fig = plot.state
@@ -166,7 +163,7 @@ class TestPointPlot(TestBokehPlot):
 
     @pytest.mark.parametrize("marker", MarkerType)
     def test_native_marker_legend(self, marker):
-        points = Points([(0, 0, "A"), (0, 1, "B")], vdims="color").opts(
+        points = hv.Points([(0, 0, "A"), (0, 1, "B")], vdims="color").opts(
             color="color", marker=marker
         )
         plot = bokeh_renderer.get_plot(points)
@@ -174,7 +171,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_points_non_numeric_size_warning(self):
         data = (np.arange(10), np.arange(10), list(map(chr, range(94,104))))
-        points = Points(data, vdims=['z']).opts(size_index=2)
+        points = hv.Points(data, vdims=['z']).opts(size_index=2)
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(points)
         log_msg = log.stream.read()
@@ -185,53 +182,53 @@ class TestPointPlot(TestBokehPlot):
         assert log_msg == warning
 
     def test_points_categorical_xaxis(self):
-        points = Points((['A', 'B', 'C'], (1,2,3)))
+        points = hv.Points((['A', 'B', 'C'], (1,2,3)))
         plot = bokeh_renderer.get_plot(points)
         x_range = plot.handles['x_range']
         assert isinstance(x_range, FactorRange)
         assert x_range.factors == ['A', 'B', 'C']
 
     def test_points_categorical_xaxis_mixed_type(self):
-        points = Points(range(10))
-        points2 = Points((['A', 'B', 'C', 1, 2.0], (1, 2, 3, 4, 5)))
+        points = hv.Points(range(10))
+        points2 = hv.Points((['A', 'B', 'C', 1, 2.0], (1, 2, 3, 4, 5)))
         plot = bokeh_renderer.get_plot(points*points2)
         x_range = plot.handles['x_range']
         assert isinstance(x_range, FactorRange)
         assert x_range.factors == [*map(str, range(10)), 'A', 'B', 'C', '2.0']
 
     def test_points_categorical_xaxis_invert_axes(self):
-        points = Points((['A', 'B', 'C'], (1,2,3))).opts(invert_axes=True)
+        points = hv.Points((['A', 'B', 'C'], (1,2,3))).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(points)
         y_range = plot.handles['y_range']
         assert isinstance(y_range, FactorRange)
         assert y_range.factors == ['A', 'B', 'C']
 
     def test_points_overlay_categorical_xaxis(self):
-        points = Points((['A', 'B', 'C'], (1,2,3)))
-        points2 = Points((['B', 'C', 'D'], (1,2,3)))
+        points = hv.Points((['A', 'B', 'C'], (1,2,3)))
+        points2 = hv.Points((['B', 'C', 'D'], (1,2,3)))
         plot = bokeh_renderer.get_plot(points*points2)
         x_range = plot.handles['x_range']
         assert isinstance(x_range, FactorRange)
         assert x_range.factors == ['A', 'B', 'C', 'D']
 
     def test_points_overlay_categorical_xaxis_invert_axis(self):
-        points = Points((['A', 'B', 'C'], (1,2,3))).opts(invert_xaxis=True)
-        points2 = Points((['B', 'C', 'D'], (1,2,3)))
+        points = hv.Points((['A', 'B', 'C'], (1,2,3))).opts(invert_xaxis=True)
+        points2 = hv.Points((['B', 'C', 'D'], (1,2,3)))
         plot = bokeh_renderer.get_plot(points*points2)
         x_range = plot.handles['x_range']
         assert isinstance(x_range, FactorRange)
         assert x_range.factors == ['A', 'B', 'C', 'D'][::-1]
 
     def test_points_overlay_categorical_xaxis_invert_axes(self):
-        points = Points((['A', 'B', 'C'], (1,2,3))).opts(invert_axes=True)
-        points2 = Points((['B', 'C', 'D'], (1,2,3)))
+        points = hv.Points((['A', 'B', 'C'], (1,2,3))).opts(invert_axes=True)
+        points2 = hv.Points((['B', 'C', 'D'], (1,2,3)))
         plot = bokeh_renderer.get_plot(points*points2)
         y_range = plot.handles['y_range']
         assert isinstance(y_range, FactorRange)
         assert y_range.factors == ['A', 'B', 'C', 'D']
 
     def test_points_padding_square(self):
-        points = Points([1, 2, 3]).opts(padding=0.1)
+        points = hv.Points([1, 2, 3]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == -0.2
@@ -240,7 +237,7 @@ class TestPointPlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_curve_padding_square_per_axis(self):
-        curve = Points([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
+        curve = hv.Points([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = bokeh_renderer.get_plot(curve)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0
@@ -249,7 +246,7 @@ class TestPointPlot(TestBokehPlot):
         assert y_range.end == 3.4
 
     def test_points_padding_unequal(self):
-        points = Points([1, 2, 3]).opts(padding=(0.05, 0.1))
+        points = hv.Points([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == -0.1
@@ -258,7 +255,7 @@ class TestPointPlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_points_padding_nonsquare(self):
-        points = Points([1, 2, 3]).opts(padding=0.1, width=600)
+        points = hv.Points([1, 2, 3]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == -0.1
@@ -267,7 +264,7 @@ class TestPointPlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_points_padding_logx(self):
-        points = Points([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
+        points = hv.Points([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.89595845984076228
@@ -276,7 +273,7 @@ class TestPointPlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_points_padding_logy(self):
-        points = Points([1, 2, 3]).opts(padding=0.1, logy=True)
+        points = hv.Points([1, 2, 3]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == -0.2
@@ -285,7 +282,7 @@ class TestPointPlot(TestBokehPlot):
         assert y_range.end == 3.3483695221017129
 
     def test_points_padding_datetime_square(self):
-        points = Points([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
+        points = hv.Points([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = bokeh_renderer.get_plot(points)
@@ -296,7 +293,7 @@ class TestPointPlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_points_padding_datetime_nonsquare(self):
-        points = Points([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
+        points = hv.Points([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
             padding=0.1, width=600
         )
         plot = bokeh_renderer.get_plot(points)
@@ -307,7 +304,7 @@ class TestPointPlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_points_padding_hard_xrange(self):
-        points = Points([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
+        points = hv.Points([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0
@@ -316,7 +313,7 @@ class TestPointPlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_points_padding_soft_xrange(self):
-        points = Points([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
+        points = hv.Points([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(points)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0
@@ -325,7 +322,7 @@ class TestPointPlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_points_datetime_hover(self):
-        points = Points([(0, 1, dt.datetime(2017, 1, 1))], vdims='date').opts(tools=['hover'])
+        points = hv.Points([(0, 1, dt.datetime(2017, 1, 1))], vdims='date').opts(tools=['hover'])
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         assert cds.data['date'] == np.datetime64("2017-01-01", "ns")
@@ -333,14 +330,14 @@ class TestPointPlot(TestBokehPlot):
         assert hover.tooltips == [('x', '@{x}'), ('y', '@{y}'), ('date', '@{date}{%F %T}')]
 
     def test_points_selected(self):
-        points = Points([(0, 0), (1, 1), (2, 2)]).opts(selected=[0, 2])
+        points = hv.Points([(0, 0), (1, 1), (2, 2)]).opts(selected=[0, 2])
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         assert cds.selected.indices == [0, 2]
 
     def test_points_update_selected(self):
         stream = Stream.define('Selected', selected=[])()
-        points = Points([(0, 0), (1, 1), (2, 2)]).apply.opts(selected=stream.param.selected)
+        points = hv.Points([(0, 0), (1, 1), (2, 2)]).apply.opts(selected=stream.param.selected)
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         assert cds.selected.indices == []
@@ -352,7 +349,7 @@ class TestPointPlot(TestBokehPlot):
     ###########################
 
     def test_point_color_op(self):
-        points = Points([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        points = hv.Points([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                         vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -362,7 +359,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color'}
 
     def test_point_linear_color_op(self):
-        points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        points = hv.Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -376,7 +373,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color', 'transform': cmapper}
 
     def test_point_categorical_color_op(self):
-        points = Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
+        points = hv.Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
                         vdims='color').opts(color='color')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -390,7 +387,7 @@ class TestPointPlot(TestBokehPlot):
 
     def test_point_categorical_color_op_legend_with_labels(self):
         labels = {'A': 'A point', 'B': 'B point', 'C': 'C point'}
-        points = Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
+        points = hv.Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
                         vdims='color').opts(color='color', show_legend=True, legend_labels=labels)
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -401,7 +398,7 @@ class TestPointPlot(TestBokehPlot):
     def test_point_categorical_dtype_color_op(self):
         df = pd.DataFrame(dict(sample_id=['subject 1', 'subject 2', 'subject 3', 'subject 4'], category=['apple', 'pear', 'apple', 'pear'], value=[1, 2, 3, 4]))
         df['category'] = df['category'].astype('category')
-        points = Points(df, ['sample_id', 'value']).opts(color='category')
+        points = hv.Points(df, ['sample_id', 'value']).opts(color='category')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         glyph = plot.handles['glyph']
@@ -413,7 +410,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color', 'transform': cmapper}
 
     def test_point_explicit_cmap_color_op(self):
-        points = Points([(0, 0), (0, 1), (0, 2)]).opts(
+        points = hv.Points([(0, 0), (0, 1), (0, 2)]).opts(
             color='y', cmap={0: 'red', 1: 'green', 2: 'blue'})
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -427,7 +424,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color_str__', 'transform': cmapper}
 
     def test_point_line_color_op(self):
-        points = Points([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        points = hv.Points([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                         vdims='color').opts(line_color='color')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -437,7 +434,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'line_color'}
 
     def test_point_fill_color_op(self):
-        points = Points([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        points = hv.Points([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                         vdims='color').opts(fill_color='color')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -447,7 +444,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) != {'field': 'fill_color'}
 
     def test_point_angle_op(self):
-        points = Points([(0, 0, 0), (0, 1, 45), (0, 2, 90)],
+        points = hv.Points([(0, 0, 0), (0, 1, 45), (0, 2, 90)],
                         vdims='angle').opts(angle='angle')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -456,7 +453,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.angle) == {'field': 'angle'}
 
     def test_point_alpha_op(self):
-        points = Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        points = hv.Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                         vdims='alpha').opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -465,7 +462,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.fill_alpha) == {'field': 'alpha'}
 
     def test_point_line_alpha_op(self):
-        points = Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        points = hv.Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                         vdims='alpha').opts(line_alpha='alpha')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -475,7 +472,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.fill_alpha) != {'field': 'line_alpha'}
 
     def test_point_fill_alpha_op(self):
-        points = Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        points = hv.Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                         vdims='alpha').opts(fill_alpha='alpha')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -485,7 +482,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.fill_alpha) == {'field': 'fill_alpha'}
 
     def test_point_size_op(self):
-        points = Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
+        points = hv.Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
                         vdims='size').opts(size='size')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -494,7 +491,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.size) == {'field': 'size'}
 
     def test_point_line_width_op(self):
-        points = Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
+        points = hv.Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
                         vdims='line_width').opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -503,7 +500,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_width) == {'field': 'line_width'}
 
     def test_point_marker_op(self):
-        points = Points([(0, 0, 'circle'), (0, 1, 'triangle'), (0, 2, 'square')],
+        points = hv.Points([(0, 0, 'circle'), (0, 1, 'triangle'), (0, 2, 'square')],
                         vdims='marker').opts(marker='marker')
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -513,14 +510,14 @@ class TestPointPlot(TestBokehPlot):
 
     def test_op_ndoverlay_value(self):
         markers = ['circle', 'triangle']
-        overlay = NdOverlay({marker: Points(np.arange(i)) for i, marker in enumerate(markers)}, 'Marker').opts('Points', marker='Marker')
+        overlay = hv.NdOverlay({marker: hv.Points(np.arange(i)) for i, marker in enumerate(markers)}, 'Marker').opts('Points', marker='Marker')
         plot = bokeh_renderer.get_plot(overlay)
         for subplot, glyph_type, marker in zip(plot.subplots.values(), [Scatter, Scatter], markers, strict=True):
             assert isinstance(subplot.handles['glyph'], glyph_type)
             assert subplot.handles['glyph'].marker == marker
 
     def test_point_color_index_color_clash(self):
-        points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        points = hv.Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(color='color', color_index='color')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(points)
@@ -533,7 +530,7 @@ class TestPointPlot(TestBokehPlot):
         assert log_msg == warning
 
     def test_point_color_index_color_no_clash(self):
-        points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        points = hv.Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(fill_color='color', color_index='color')
         plot = bokeh_renderer.get_plot(points)
         glyph = plot.handles['glyph']
@@ -543,7 +540,7 @@ class TestPointPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color', 'transform': cmapper2}
 
     def test_point_size_index_size_clash(self):
-        points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        points = hv.Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='size').opts(size='size', size_index='size')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(points)
@@ -560,7 +557,7 @@ class TestPointPlot(TestBokehPlot):
         xs = np.arange(x)
         ys = np.arange(y)
         zs = np.arange(x * y).reshape(y, x)
-        plot = Points((xs, ys, zs,), kdims=["xs", "ys"], vdims="zs")
+        plot = hv.Points((xs, ys, zs,), kdims=["xs", "ys"], vdims="zs")
         plot.opts(radius=hv.dim("zs").norm() / 2)
 
         handles = bokeh_renderer.get_plot(plot).handles
@@ -572,7 +569,7 @@ class TestPointPlot(TestBokehPlot):
         np.testing.assert_array_equal(handles["cds"].data["radius"], norm)
 
     def test_point_radius_then_size_then_radius(self):
-        plot = Points([1, 2, 3])
+        plot = hv.Points([1, 2, 3])
         plot.opts(radius=1)
 
         handles = bokeh_renderer.get_plot(plot).handles

--- a/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/bokeh/test_quadmeshplot.py
@@ -1,7 +1,7 @@
 import numpy as np
 from bokeh.models import ColorBar
 
-from holoviews.element import Image, QuadMesh
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestBokehPlot, bokeh_renderer
@@ -13,12 +13,12 @@ class TestQuadMeshPlot(TestBokehPlot):
         n = 21
         xs = np.logspace(1, 3, n)
         ys = np.linspace(1, 10, n)
-        qmesh = QuadMesh((xs, ys, np.random.rand(n-1, n-1)))
+        qmesh = hv.QuadMesh((xs, ys, np.random.rand(n-1, n-1)))
         self._test_colormapping(qmesh, 2)
 
     def test_quadmesh_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
-        qmesh = QuadMesh(Image(arr)).opts(invert_axes=True, tools=['hover'])
+        qmesh = hv.QuadMesh(hv.Image(arr)).opts(invert_axes=True, tools=['hover'])
         plot = bokeh_renderer.get_plot(qmesh)
         source = plot.handles['source']
         assert_data_equal(source.data['z'], qmesh.dimension_values(2, flat=False).flatten())
@@ -29,7 +29,7 @@ class TestQuadMeshPlot(TestBokehPlot):
         n = 21
         xs = np.logspace(1, 3, n)
         ys = np.linspace(1, 10, n)
-        qmesh = QuadMesh((xs, ys, np.random.rand(n-1, n-1))).opts(colorbar=True)
+        qmesh = hv.QuadMesh((xs, ys, np.random.rand(n-1, n-1))).opts(colorbar=True)
         plot = bokeh_renderer.get_plot(qmesh)
         assert isinstance(plot.handles['colorbar'], ColorBar)
         assert plot.handles['colorbar'].color_mapper is plot.handles['color_mapper']
@@ -37,7 +37,7 @@ class TestQuadMeshPlot(TestBokehPlot):
     def test_quadmesh_inverted_coords(self):
         xs = [0, 1, 2]
         ys = [2, 1, 0]
-        qmesh = QuadMesh((xs, ys, np.random.rand(3, 3)))
+        qmesh = hv.QuadMesh((xs, ys, np.random.rand(3, 3)))
         plot = bokeh_renderer.get_plot(qmesh)
         source = plot.handles['source']
         assert_data_equal(source.data['z'], qmesh.dimension_values(2, flat=False).T.flatten())
@@ -51,7 +51,7 @@ class TestQuadMeshPlot(TestBokehPlot):
         ys = [2, 1, 0]
         data = np.array([[0,1,2], [3,4,5], [6,7,8]])
         flattened = np.array([6, 3, np.nan, 7, 4, 1, 8, 5, 2])
-        qmesh = QuadMesh((xs, ys, data)).opts(nodata=0)
+        qmesh = hv.QuadMesh((xs, ys, data)).opts(nodata=0)
         plot = bokeh_renderer.get_plot(qmesh)
         source = plot.handles['source']
         assert_data_equal(source.data['z'], flattened)
@@ -61,7 +61,7 @@ class TestQuadMeshPlot(TestBokehPlot):
         xs = [0, 1, 2]
         ys = [2, 1, 0]
         data = np.array([[0,1,2], [3,4,5], [6,7,8]])
-        qmesh = QuadMesh((xs, ys, data), vdims="z (x,y)")
+        qmesh = hv.QuadMesh((xs, ys, data), vdims="z (x,y)")
         plot = bokeh_renderer.get_plot(qmesh)
         source = plot.handles['source']
 
@@ -75,7 +75,7 @@ class TestQuadMeshPlot(TestBokehPlot):
         ys = [2, 1, 0]
         data = np.array([[0,1,2], [3,4,5], [6,7,8]])
         XX, YY = np.meshgrid(xs, ys)
-        qmesh = QuadMesh((XX, YY, data), vdims="z (x,y)")
+        qmesh = hv.QuadMesh((XX, YY, data), vdims="z (x,y)")
         plot = bokeh_renderer.get_plot(qmesh)
         source = plot.handles['source']
 
@@ -88,7 +88,7 @@ class TestQuadMeshPlot(TestBokehPlot):
         ys = [2, 1, 0]
         data = np.array([[0,1,2], [3,4,5], [6,7,8]], dtype='uint32')
         flattened = np.array([6, 3, np.nan, 7, 4, 1, 8, 5, 2])
-        qmesh = QuadMesh((xs, ys, data)).opts(nodata=0)
+        qmesh = hv.QuadMesh((xs, ys, data)).opts(nodata=0)
         plot = bokeh_renderer.get_plot(qmesh)
         source = plot.handles['source']
         assert_data_equal(source.data['z'], flattened)
@@ -98,7 +98,7 @@ class TestQuadMeshPlot(TestBokehPlot):
         Y = [0.5, 1.5, 2.5]
         Z = np.array([[1., 2., 3.], [4., 5., np.nan]]).T
         LABELS = np.array([['0-0', '0-1', '0-2'], ['1-0', '1-1', '1-2']]).T
-        qmesh = QuadMesh((X, Y, Z, LABELS), vdims=['Value', 'Label'])
+        qmesh = hv.QuadMesh((X, Y, Z, LABELS), vdims=['Value', 'Label'])
         plot = bokeh_renderer.get_plot(qmesh.opts(tools=['hover']))
         source = plot.handles['source']
         expected = {
@@ -119,7 +119,7 @@ class TestQuadMeshPlot(TestBokehPlot):
         Y = [[0.5, 1.5, 2.5], [0.5, 1.5, 2.5]]
         Z = np.array([[1., 2., 3.], [4., 5., np.nan]])
         LABELS = np.array([['0-0', '0-1', '0-2'], ['1-0', '1-1', '1-2']])
-        qmesh = QuadMesh((X, Y, Z, LABELS), vdims=['Value', 'Label'])
+        qmesh = hv.QuadMesh((X, Y, Z, LABELS), vdims=['Value', 'Label'])
         plot = bokeh_renderer.get_plot(qmesh.opts(tools=['hover']))
         source = plot.handles['source']
         expected = {'xs': [[0., 1., 1., 0.], [0., 1., 1., 0.], [0., 1., 1., 0.],
@@ -139,7 +139,7 @@ class TestQuadMeshPlot(TestBokehPlot):
         Y = [[0., 1., 2., 3.], [0., 1., 2., 3.], [0., 1., 2., 3.]]
         Z = np.array([[1., 2., 3.], [4., 5., np.nan]])
         LABELS = np.array([['0-0', '0-1', '0-2'], ['1-0', '1-1', '1-2']])
-        qmesh = QuadMesh((X, Y, Z, LABELS), vdims=['Value', 'Label'])
+        qmesh = hv.QuadMesh((X, Y, Z, LABELS), vdims=['Value', 'Label'])
         plot = bokeh_renderer.get_plot(qmesh.opts(tools=['hover']))
         source = plot.handles['source']
         expected = {'xs': [[0., 1., 1., 0.], [0., 1., 1., 0.], [0., 1., 1., 0.],

--- a/holoviews/tests/plotting/bokeh/test_radialheatmap.py
+++ b/holoviews/tests/plotting/bokeh/test_radialheatmap.py
@@ -3,8 +3,7 @@ from itertools import product
 import numpy as np
 from bokeh.models import ColorBar
 
-from holoviews.core.spaces import HoloMap
-from holoviews.element.raster import HeatMap
+import holoviews as hv
 from holoviews.plotting.bokeh import RadialHeatMapPlot
 from holoviews.testing import assert_data_equal, assert_dict_equal
 
@@ -37,7 +36,7 @@ class BokehRadialHeatMapPlotTests(TestBokehPlot):
         opts = dict(HeatMap=plot_opts)
 
         # provide element and plot instances for tests
-        self.element = HeatMap((self.x, self.y, self.z)).opts(opts)
+        self.element = hv.HeatMap((self.x, self.y, self.z)).opts(opts)
         self.plot = bokeh_renderer.get_plot(self.element)
 
 
@@ -274,18 +273,18 @@ class BokehRadialHeatMapPlotTests(TestBokehPlot):
         assert list(source_ann["z"]) == self.z
 
     def test_heatmap_holomap(self):
-        hm = HoloMap({'A': HeatMap(np.random.randint(0, 10, (100, 3))),
-                      'B': HeatMap(np.random.randint(0, 10, (100, 3)))})
+        hm = hv.HoloMap({'A': hv.HeatMap(np.random.randint(0, 10, (100, 3))),
+                      'B': hv.HeatMap(np.random.randint(0, 10, (100, 3)))})
         plot = bokeh_renderer.get_plot(hm.opts(radial=True))
         assert isinstance(plot, RadialHeatMapPlot)
 
     def test_radial_heatmap_colorbar(self):
-        hm = HeatMap([(0, 0, 1), (0, 1, 2), (1, 0, 3)]).opts(radial=True, colorbar=True)
+        hm = hv.HeatMap([(0, 0, 1), (0, 1, 2), (1, 0, 3)]).opts(radial=True, colorbar=True)
         plot = bokeh_renderer.get_plot(hm)
         assert isinstance(plot.handles.get('colorbar'), ColorBar)
 
     def test_radial_heatmap_ranges(self):
-        hm = HeatMap([(0, 0, 1), (0, 1, 2), (1, 0, 3)]).opts(radial=True, colorbar=True)
+        hm = hv.HeatMap([(0, 0, 1), (0, 1, 2), (1, 0, 3)]).opts(radial=True, colorbar=True)
         plot = bokeh_renderer.get_plot(hm)
         assert plot.handles['x_range'].start == -0.05
         assert plot.handles['x_range'].end == 1.05

--- a/holoviews/tests/plotting/bokeh/test_rasterplot.py
+++ b/holoviews/tests/plotting/bokeh/test_rasterplot.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 from bokeh.models import CustomJSHover, HoverTool
 
-from holoviews.element import RGB, Image, ImageStack, Points, Raster
+import holoviews as hv
 from holoviews.plotting.bokeh.raster import ImageStackPlot
 from holoviews.plotting.bokeh.util import BOKEH_GE_3_4_0
 
@@ -12,11 +12,11 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 
 class TestRasterPlot(TestBokehPlot):
     def test_image_colormapping(self):
-        img = Image(np.random.rand(10, 10)).opts(logz=True)
+        img = hv.Image(np.random.rand(10, 10)).opts(logz=True)
         self._test_colormapping(img, 2, True)
 
     def test_image_boolean_array(self):
-        img = Image(np.array([[True, False], [False, True]]))
+        img = hv.Image(np.array([[True, False], [False, True]]))
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles["color_mapper"]
         source = plot.handles["source"]
@@ -25,7 +25,7 @@ class TestRasterPlot(TestBokehPlot):
         np.testing.assert_equal(source.data["image"][0], np.array([[0, 1], [1, 0]]))
 
     def test_nodata_array(self):
-        img = Image(np.array([[0, 1], [2, 0]])).opts(nodata=0)
+        img = hv.Image(np.array([[0, 1], [2, 0]])).opts(nodata=0)
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles["color_mapper"]
         source = plot.handles["source"]
@@ -36,7 +36,7 @@ class TestRasterPlot(TestBokehPlot):
         )
 
     def test_nodata_array_uint(self):
-        img = Image(np.array([[0, 1], [2, 0]], dtype="uint32")).opts(nodata=0)
+        img = hv.Image(np.array([[0, 1], [2, 0]], dtype="uint32")).opts(nodata=0)
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles["color_mapper"]
         source = plot.handles["source"]
@@ -49,14 +49,14 @@ class TestRasterPlot(TestBokehPlot):
     def test_nodata_rgb(self):
         N = 2
         rgb_d = np.linspace(0, 1, N * N * 3).reshape(N, N, 3)
-        rgb = RGB(rgb_d).redim.nodata(R=0)
+        rgb = hv.RGB(rgb_d).redim.nodata(R=0)
         plot = bokeh_renderer.get_plot(rgb)
         image_data = plot.handles["source"].data["image"][0]
         assert (image_data == 0).sum() == 1
 
     def test_raster_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
-        raster = Raster(arr).opts(invert_axes=True)
+        raster = hv.Raster(arr).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(raster)
         source = plot.handles["source"]
 
@@ -68,7 +68,7 @@ class TestRasterPlot(TestBokehPlot):
 
     def test_image_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
-        raster = Image(arr).opts(invert_axes=True)
+        raster = hv.Image(arr).opts(invert_axes=True)
         plot = bokeh_renderer.get_plot(raster)
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0], np.rot90(arr)[::-1, ::-1])
@@ -79,7 +79,7 @@ class TestRasterPlot(TestBokehPlot):
 
     def test_image_invert_xaxis(self):
         arr = np.random.rand(10, 10)
-        img = Image(arr).opts(invert_xaxis=True)
+        img = hv.Image(arr).opts(invert_xaxis=True)
         plot = bokeh_renderer.get_plot(img)
         x_range = plot.handles["x_range"]
         assert x_range.start == 0.5
@@ -94,7 +94,7 @@ class TestRasterPlot(TestBokehPlot):
 
     def test_image_invert_yaxis(self):
         arr = np.random.rand(10, 10)
-        img = Image(arr).opts(invert_yaxis=True)
+        img = hv.Image(arr).opts(invert_yaxis=True)
         plot = bokeh_renderer.get_plot(img)
         y_range = plot.handles["y_range"]
         assert y_range.start == 0.5
@@ -108,7 +108,7 @@ class TestRasterPlot(TestBokehPlot):
         np.testing.assert_equal(cdata["image"][0], arr[::-1])
 
     def test_rgb_invert_xaxis(self):
-        rgb = RGB(np.random.rand(10, 10, 3)).opts(invert_xaxis=True)
+        rgb = hv.RGB(np.random.rand(10, 10, 3)).opts(invert_xaxis=True)
         plot = bokeh_renderer.get_plot(rgb)
         x_range = plot.handles["x_range"]
         assert x_range.start == 0.5
@@ -120,7 +120,7 @@ class TestRasterPlot(TestBokehPlot):
         assert cdata["x"] == [-0.5]
 
     def test_rgb_invert_yaxis(self):
-        rgb = RGB(np.random.rand(10, 10, 3)).opts(invert_yaxis=True)
+        rgb = hv.RGB(np.random.rand(10, 10, 3)).opts(invert_yaxis=True)
         plot = bokeh_renderer.get_plot(rgb)
         y_range = plot.handles["y_range"]
         assert y_range.start == 0.5
@@ -141,7 +141,7 @@ class TestRasterPlot(TestBokehPlot):
                 "Timestamp": (["y", "x"], [[ts, pd.NaT], [ts, ts]]),
             },
         )
-        img = Image(data).opts(tools=["hover"])
+        img = hv.Image(data).opts(tools=["hover"])
         plot = bokeh_renderer.get_plot(img)
 
         hover = plot.handles["hover"]
@@ -158,7 +158,7 @@ class TestRasterPlot(TestBokehPlot):
         hover_tool = HoverTool(
             tooltips=[("x", "$x{custom}")], formatters={"x": CustomJSHover(code="return value + '2'")}
         )
-        img = Image(np.ones(100).reshape(10, 10)).opts(tools=[hover_tool])
+        img = hv.Image(np.ones(100).reshape(10, 10)).opts(tools=[hover_tool])
         plot = bokeh_renderer.get_plot(img)
 
         hover = plot.handles["hover"]
@@ -171,7 +171,7 @@ class _ImageStackBase(TestRasterPlot):
         x = np.arange(self.xsize)
         y = np.arange(self.ysize) + 5
         a, b, c = self.a, self.b, self.c
-        img_stack = ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["a", "b", "c"])
+        img_stack = hv.ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["a", "b", "c"])
         plot = bokeh_renderer.get_plot(img_stack)
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0][:, :, 0], a)
@@ -188,7 +188,7 @@ class _ImageStackBase(TestRasterPlot):
         y = np.arange(self.ysize) + 5
         a, b, c = self.a, self.b, self.c
 
-        img_stack = ImageStack((x, y, a, b, c), kdims=["x", "y"])
+        img_stack = hv.ImageStack((x, y, a, b, c), kdims=["x", "y"])
         assert img_stack.vdims == ["level_0", "level_1", "level_2"]
         plot = bokeh_renderer.get_plot(img_stack)
         source = plot.handles["source"]
@@ -207,7 +207,7 @@ class _ImageStackBase(TestRasterPlot):
         a, b, c = self.a, self.b, self.c
 
         ds = {"x": x, "y": y, "a": a, "b": b, "c": c}
-        img_stack = ImageStack(ds, kdims=["x", "y"], vdims=["a", "b", "c"])
+        img_stack = hv.ImageStack(ds, kdims=["x", "y"], vdims=["a", "b", "c"])
         plot = bokeh_renderer.get_plot(img_stack)
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0][:, :, 0], a)
@@ -225,7 +225,7 @@ class _ImageStackBase(TestRasterPlot):
         a, b, c = self.a, self.b, self.c
 
         ds = {"x": x, "y": y, "a": a, "b": b, "c": c}
-        img_stack = ImageStack(ds)
+        img_stack = hv.ImageStack(ds)
         plot = bokeh_renderer.get_plot(img_stack)
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0][:, :, 0], a)
@@ -241,7 +241,7 @@ class _ImageStackBase(TestRasterPlot):
         a, b, c = self.a, self.b, self.c
 
         ds = {"a": a, "b": b, "c": c}
-        img_stack = ImageStack(ds)
+        img_stack = hv.ImageStack(ds)
         plot = bokeh_renderer.get_plot(img_stack)
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0][:, :, 0], a)
@@ -257,7 +257,7 @@ class _ImageStackBase(TestRasterPlot):
         a, b, c = self.a, self.b, self.c
 
         ds = [a, b, c]
-        img_stack = ImageStack(ds)
+        img_stack = hv.ImageStack(ds)
         plot = bokeh_renderer.get_plot(img_stack)
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0][:, :, 0], a)
@@ -280,7 +280,7 @@ class _ImageStackBase(TestRasterPlot):
             {"a": (["y", "x"], a), "b": (["y", "x"], b), "c": (["y", "x"], c)},
             coords={"x": x, "y": y},
         )
-        img_stack = ImageStack(ds, kdims=["x", "y"])
+        img_stack = hv.ImageStack(ds, kdims=["x", "y"])
         plot = bokeh_renderer.get_plot(img_stack)
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0][:, :, 0], a)
@@ -303,7 +303,7 @@ class _ImageStackBase(TestRasterPlot):
             {"a": (["y", "x"], a), "b": (["y", "x"], b), "c": (["y", "x"], c)},
             coords={"x": x, "y": y},
         ).to_array("level")
-        img_stack = ImageStack(da, vdims=["level"])
+        img_stack = hv.ImageStack(da, vdims=["level"])
         plot = bokeh_renderer.get_plot(img_stack)
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0][:, :, 0], a)
@@ -320,7 +320,7 @@ class _ImageStackBase(TestRasterPlot):
         y = np.arange(self.ysize) + 5
         a, b, c = self.a, self.b, self.c
 
-        img_stack = ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["a", "b", "c"])
+        img_stack = hv.ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["a", "b", "c"])
         plot = bokeh_renderer.get_plot(img_stack.opts(invert_xaxis=True))
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0][:, :, 0], a)
@@ -336,7 +336,7 @@ class _ImageStackBase(TestRasterPlot):
         y = np.arange(self.ysize) + 5
         a, b, c = self.a, self.b, self.c
 
-        img_stack = ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["a", "b", "c"])
+        img_stack = hv.ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["a", "b", "c"])
         plot = bokeh_renderer.get_plot(img_stack.opts(invert_yaxis=True))
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0][:, :, 0], a)
@@ -352,7 +352,7 @@ class _ImageStackBase(TestRasterPlot):
         y = np.arange(self.ysize) + 5
         a, b, c = self.a, self.b, self.c
 
-        img_stack = ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["a", "b", "c"])
+        img_stack = hv.ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["a", "b", "c"])
         plot = bokeh_renderer.get_plot(img_stack.opts(invert_axes=True))
         source = plot.handles["source"]
 
@@ -369,7 +369,7 @@ class _ImageStackBase(TestRasterPlot):
 
         data = np.dstack((a, b, c))
 
-        img_stack = ImageStack(data, kdims=["x", "y"], vdims=["a", "b", "c"])
+        img_stack = hv.ImageStack(data, kdims=["x", "y"], vdims=["a", "b", "c"])
         plot = bokeh_renderer.get_plot(img_stack)
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0][:, :, 0], a)
@@ -388,7 +388,7 @@ class _ImageStackBase(TestRasterPlot):
 
         data = (x, y, np.dstack((a, b, c)))
 
-        img_stack = ImageStack(data, kdims=["x", "y"], vdims=["a", "b", "c"])
+        img_stack = hv.ImageStack(data, kdims=["x", "y"], vdims=["a", "b", "c"])
         plot = bokeh_renderer.get_plot(img_stack)
         source = plot.handles["source"]
         np.testing.assert_equal(source.data["image"][0][:, :, 0], a)
@@ -407,7 +407,7 @@ class _ImageStackBase(TestRasterPlot):
         b = np.array([[np.nan] * 3, [1, 1, np.nan], [np.nan] * 3])
         c = np.array([[np.nan] * 3, [np.nan] * 3, [1, 1, 1]])
 
-        img_stack = ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["b", "a", "c"])
+        img_stack = hv.ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["b", "a", "c"])
         img_stack.opts(cmap={"c": "yellow", "a": "red", "b": "green"})
         plot = bokeh_renderer.get_plot(img_stack)
         source = plot.handles["source"]
@@ -423,7 +423,7 @@ class _ImageStackBase(TestRasterPlot):
         b = np.array([[np.nan] * 3, [1, 1, np.nan], [np.nan] * 3])
         c = np.array([[np.nan] * 3, [np.nan] * 3, [1, 1, 1]])
 
-        img_stack = ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["b", "a", "c"])
+        img_stack = hv.ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["b", "a", "c"])
         img_stack.opts(cmap={"c": "yellow", "a": "red"})
         with pytest.raises(ValueError, match="must have the same value dimensions"):
             bokeh_renderer.get_plot(img_stack)
@@ -475,7 +475,7 @@ class TestSyntheticLegendPlot(TestBokehPlot):
         super().setup_method()
 
         from holoviews.operation.datashader import datashade, rasterize
-        points = Points([(0, 0, 'A'), (1, 1, 'B'), (2, 2, 'C')], vdims=['Label'])
+        points = hv.Points([(0, 0, 'A'), (1, 1, 'B'), (2, 2, 'C')], vdims=['Label'])
         kwargs = dict(aggregator=ds.by('Label'), dynamic=False, width=10, height=10)
         self.img_stack = rasterize(points, **kwargs).opts(show_legend=True)
         self.rgb = datashade(points, **kwargs).opts(show_legend=True)

--- a/holoviews/tests/plotting/bokeh/test_renderer.py
+++ b/holoviews/tests/plotting/bokeh/test_renderer.py
@@ -10,7 +10,7 @@ from bokeh.themes.theme import Theme
 from panel.widgets import DiscreteSlider, FloatSlider, Player
 from pyviz_comms import CommManager
 
-from holoviews import Curve, DynamicMap, GridSpace, HoloMap, Image, Table
+import holoviews as hv
 from holoviews.plotting import Renderer
 from holoviews.plotting.bokeh import BokehRenderer
 from holoviews.streams import Stream
@@ -20,9 +20,9 @@ from holoviews.streams import Stream
 class BokehRendererTest:
 
     def setup_method(self):
-        self.image1 = Image(np.array([[0,1],[2,3]]), label='Image1')
-        self.image2 = Image(np.array([[1,0],[4,-2]]), label='Image2')
-        self.map1 = HoloMap({1:self.image1, 2:self.image2}, label='TestMap')
+        self.image1 = hv.Image(np.array([[0,1],[2,3]]), label='Image1')
+        self.image2 = hv.Image(np.array([[1,0],[4,-2]]), label='Image2')
+        self.map1 = hv.HoloMap({1:self.image1, 2:self.image2}, label='TestMap')
         self.renderer = BokehRenderer.instance()
         self.nbcontext = Renderer.notebook_context
         self.comm_manager = Renderer.comm_manager
@@ -60,19 +60,19 @@ class BokehRendererTest:
         assert (w, h) == (300, 600)
 
     def test_get_size_grid_plot(self):
-        grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
+        grid = hv.GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
         plot = self.renderer.get_plot(grid)
         w, h = self.renderer.get_size(plot)
         assert (w, h) == (446, 437)
 
     def test_get_size_table(self):
-        table = Table(range(10), kdims=['x'])
+        table = hv.Table(range(10), kdims=['x'])
         plot = self.renderer.get_plot(table)
         w, h = self.renderer.get_size(plot)
         assert (w, h) == (400, 300)
 
     def test_get_size_tables_in_layout(self):
-        table = Table(range(10), kdims=['x'])
+        table = hv.Table(range(10), kdims=['x'])
         plot = self.renderer.get_plot(table+table)
         w, h = self.renderer.get_size(plot)
         assert (w, h) == (800, 300)
@@ -81,21 +81,21 @@ class BokehRendererTest:
         attrs = {'figure': {'outline_line_color': '#444444'}}
         theme = Theme(json={'attrs' : attrs})
         self.renderer.theme = theme
-        plot = self.renderer.get_plot(Curve([]))
+        plot = self.renderer.get_plot(hv.Curve([]))
         self.renderer.components(plot, 'html')
         assert plot.state.outline_line_color == '#444444'
 
     @pytest.mark.skipif(sys.platform == "linux", reason="2025-03: Flaky test on Linux")
     def test_render_to_png(self):
         pytest.importorskip("selenium")
-        curve = Curve([])
+        curve = hv.Curve([])
         renderer = BokehRenderer.instance(fig='png')
         png, info = renderer(curve)
         assert isinstance(png, bytes)
         assert info['file-ext'] == 'png'
 
     def test_render_static(self):
-        curve = Curve([])
+        curve = hv.Curve([])
         obj, _ = self.renderer._validate(curve, None)
         assert isinstance(obj, pn.pane.HoloViews)
         assert obj.center is True
@@ -103,7 +103,7 @@ class BokehRendererTest:
         assert obj.backend == 'bokeh'
 
     def test_render_holomap_individual(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer._validate(hmap, None)
         assert isinstance(obj, pn.pane.HoloViews)
         assert obj.center is True
@@ -115,7 +115,7 @@ class BokehRendererTest:
         assert slider.options == dict([(str(i), i) for i in range(5)])
 
     def test_render_holomap_embedded(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         data, _ = self.renderer.components(hmap)
         assert 'State"' in data['text/html']
 
@@ -125,7 +125,7 @@ class BokehRendererTest:
     #     self.assertNotIn('State"', data['text/html'])
 
     def test_render_holomap_scrubber(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer._validate(hmap, 'scrubber')
         assert isinstance(obj, pn.pane.HoloViews)
         assert obj.center is True
@@ -138,7 +138,7 @@ class BokehRendererTest:
         assert player.end == 4
 
     def test_render_holomap_scrubber_fps(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer.instance(fps=2)._validate(hmap, 'scrubber')
         assert isinstance(obj, pn.pane.HoloViews)
         widgets = obj.layout.select(Player)
@@ -147,7 +147,7 @@ class BokehRendererTest:
         assert player.interval == 500
 
     def test_render_holomap_individual_widget_position(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer.instance(widget_location='top')._validate(hmap, None)
         assert isinstance(obj, pn.pane.HoloViews)
         assert obj.center is True
@@ -156,7 +156,7 @@ class BokehRendererTest:
 
     @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm')
     def test_render_dynamicmap_with_dims(self):
-        dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
+        dmap = hv.DynamicMap(lambda y: hv.Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
         obj, _ = self.renderer._validate(dmap, None)
         self.renderer.components(obj)
         [(plot, _pane)] = obj._plots.values()
@@ -170,7 +170,7 @@ class BokehRendererTest:
     @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm')
     def test_render_dynamicmap_with_stream(self):
         stream = Stream.define('Custom', y=2)()
-        dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y'], streams=[stream])
+        dmap = hv.DynamicMap(lambda y: hv.Curve([1, 2, y]), kdims=['y'], streams=[stream])
         obj, _ = self.renderer._validate(dmap, None)
         self.renderer.components(obj)
         [(plot, _pane)] = obj._plots.values()
@@ -183,7 +183,7 @@ class BokehRendererTest:
     @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm')
     def test_render_dynamicmap_with_stream_dims(self):
         stream = Stream.define('Custom', y=2)()
-        dmap = DynamicMap(lambda x, y: Curve([x, 1, y]), kdims=['x', 'y'],
+        dmap = hv.DynamicMap(lambda x, y: hv.Curve([x, 1, y]), kdims=['x', 'y'],
                           streams=[stream]).redim.values(x=[1, 2, 3])
         obj, _ = self.renderer._validate(dmap, None)
         self.renderer.components(obj)

--- a/holoviews/tests/plotting/bokeh/test_sankey.py
+++ b/holoviews/tests/plotting/bokeh/test_sankey.py
@@ -1,9 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from holoviews import render
-from holoviews.core.data import Dataset, Dimension
-from holoviews.element import Sankey
+import holoviews as hv
 from holoviews.testing import assert_data_equal, assert_dict_equal
 
 from .test_plot import TestBokehPlot, bokeh_renderer
@@ -12,7 +10,7 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestSankeyPlot(TestBokehPlot):
 
     def test_sankey_simple(self):
-        sankey = Sankey([
+        sankey = hv.Sankey([
             ('A', 'X', 5), ('A', 'Y', 7), ('A', 'Z', 6),
             ('B', 'X', 2), ('B', 'Y', 9), ('B', 'Z', 4)]
         )
@@ -50,10 +48,10 @@ class TestSankeyPlot(TestBokehPlot):
 
 
     def test_sankey_label_index(self):
-        sankey = Sankey(([
+        sankey = hv.Sankey(([
             (0, 2, 5), (0, 3, 7), (0, 4, 6),
             (1, 2, 2), (1, 3, 9), (1, 4, 4)],
-            Dataset(enumerate('ABXYZ'), 'index', 'label'))
+            hv.Dataset(enumerate('ABXYZ'), 'index', 'label'))
         ).opts(label_index='label', tools=['hover'])
         plot = bokeh_renderer.get_plot(sankey)
 
@@ -90,9 +88,9 @@ class TestSankeyPlot(TestBokehPlot):
         ]
         df = pd.DataFrame(data, columns=["Source", "Dest", "Count"])
 
-        kdims = [Dimension("Source"), Dimension("Dest", label="Dest Label")]
-        plot = Sankey(df, kdims=kdims, vdims=["Count"])
+        kdims = [hv.Dimension("Source"), hv.Dimension("Dest", label="Dest Label")]
+        plot = hv.Sankey(df, kdims=kdims, vdims=["Count"])
         plot = plot.opts(edge_color="Dest Label")
 
         # To provoke the error in the issue
-        render(plot)
+        hv.render(plot)

--- a/holoviews/tests/plotting/bokeh/test_server.py
+++ b/holoviews/tests/plotting/bokeh/test_server.py
@@ -11,9 +11,7 @@ from panel import serve
 from panel.io.state import state
 from panel.widgets import DiscreteSlider, FloatSlider
 
-from holoviews.core.options import Store
-from holoviews.core.spaces import DynamicMap
-from holoviews.element import Curve, HLine, Path, Polygons
+import holoviews as hv
 from holoviews.plotting import Renderer
 from holoviews.plotting.bokeh.callbacks import Callback, RangeXYCallback, ResetCallback
 from holoviews.plotting.bokeh.renderer import BokehRenderer
@@ -26,8 +24,8 @@ bokeh_renderer = BokehRenderer.instance(mode='server')
 class TestBokehServerSetup:
 
     def setup_method(self):
-        self.previous_backend = Store.current_backend
-        Store.current_backend = 'bokeh'
+        self.previous_backend = hv.Store.current_backend
+        hv.Store.current_backend = 'bokeh'
         self.doc = curdoc()
         set_curdoc(Document())
         self.nbcontext = Renderer.notebook_context
@@ -35,7 +33,7 @@ class TestBokehServerSetup:
             Renderer.notebook_context = False
 
     def teardown_method(self):
-        Store.current_backend = self.previous_backend
+        hv.Store.current_backend = self.previous_backend
         bokeh_renderer.last_plot = None
         Callback._callbacks = {}
         with param.logging_level('ERROR'):
@@ -46,7 +44,7 @@ class TestBokehServerSetup:
         time.sleep(1)
 
     def test_render_server_doc_element(self):
-        obj = Curve([])
+        obj = hv.Curve([])
         doc = bokeh_renderer.server_doc(obj)
         if not BOKEH_GE_3_8_0:
             # Updating the config which is introduced in Bokeh 3.8 changes the curdoc()
@@ -56,14 +54,14 @@ class TestBokehServerSetup:
         assert bokeh_renderer.last_plot.document == doc
 
     def test_render_explicit_server_doc_element(self):
-        obj = Curve([])
+        obj = hv.Curve([])
         doc = Document()
         server_doc = bokeh_renderer.server_doc(obj, doc)
         assert server_doc is doc
         assert bokeh_renderer.last_plot.document is doc
 
     def test_set_up_linked_change_stream_on_server_doc(self):
-        obj = Curve([])
+        obj = hv.Curve([])
         stream = RangeXY(source=obj)
         server_doc = bokeh_renderer.server_doc(obj)
         assert isinstance(server_doc, Document)
@@ -74,7 +72,7 @@ class TestBokehServerSetup:
         assert 'rangesupdate' in bokeh_renderer.last_plot.state._event_callbacks
 
     def test_set_up_linked_event_stream_on_server_doc(self):
-        obj = Curve([])
+        obj = hv.Curve([])
         stream = PlotReset(source=obj)
         server_doc = bokeh_renderer.server_doc(obj)
         assert isinstance(server_doc, Document)
@@ -88,12 +86,12 @@ class TestBokehServerSetup:
 class TestBokehServer:
 
     def setup_method(self):
-        self.previous_backend = Store.current_backend
-        Store.current_backend = 'bokeh'
+        self.previous_backend = hv.Store.current_backend
+        hv.Store.current_backend = 'bokeh'
         self._port = None
 
     def teardown_method(self):
-        Store.current_backend = self.previous_backend
+        hv.Store.current_backend = self.previous_backend
         Callback._callbacks = {}
         state.kill_all_servers()
         time.sleep(1)
@@ -117,11 +115,11 @@ class TestBokehServer:
         return pull_session(session_id='Test', url=url)
 
     def test_launch_simple_server(self):
-        obj = Curve([])
+        obj = hv.Curve([])
         self._launcher(obj, port=6001)
 
     def test_launch_server_with_stream(self):
-        el = Curve([])
+        el = hv.Curve([])
         stream = RangeXY(source=el)
 
         obj, _ = bokeh_renderer._validate(el, None)
@@ -134,15 +132,15 @@ class TestBokehServer:
         assert 'rangesupdate' in plot.state._event_callbacks
 
     def test_launch_server_with_complex_plot(self):
-        dmap = DynamicMap(lambda x_range, y_range: Curve([]), streams=[RangeXY()])
-        overlay = dmap * HLine(0)
-        static = Polygons([]) * Path([]) * Curve([])
+        dmap = hv.DynamicMap(lambda x_range, y_range: hv.Curve([]), streams=[RangeXY()])
+        overlay = dmap * hv.HLine(0)
+        static = hv.Polygons([]) * hv.Path([]) * hv.Curve([])
         layout = overlay + static
 
         self._launcher(layout, port=6003)
 
     def test_server_dynamicmap_with_dims(self):
-        dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
+        dmap = hv.DynamicMap(lambda y: hv.Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
         obj, _ = bokeh_renderer._validate(dmap, None)
         _, session = self._launcher(obj, port=6004)
         [(_plot, _)] = obj._plots.values()
@@ -160,7 +158,7 @@ class TestBokehServer:
 
     def test_server_dynamicmap_with_stream(self):
         stream = Stream.define('Custom', y=2)()
-        dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y'], streams=[stream])
+        dmap = hv.DynamicMap(lambda y: hv.Curve([1, 2, y]), kdims=['y'], streams=[stream])
         obj, _ = bokeh_renderer._validate(dmap, None)
         _, session = self._launcher(obj, port=6005)
         [(doc, _)] = obj._documents.items()
@@ -179,7 +177,7 @@ class TestBokehServer:
 
     def test_server_dynamicmap_with_stream_dims(self):
         stream = Stream.define('Custom', y=2)()
-        dmap = DynamicMap(lambda x, y: Curve([x, 1, y]), kdims=['x', 'y'],
+        dmap = hv.DynamicMap(lambda x, y: hv.Curve([x, 1, y]), kdims=['x', 'y'],
                           streams=[stream]).redim.values(x=[1, 2, 3])
         obj, _ = bokeh_renderer._validate(dmap, None)
         _, session = self._launcher(obj, port=6006)

--- a/holoviews/tests/plotting/bokeh/test_spikesplot.py
+++ b/holoviews/tests/plotting/bokeh/test_spikesplot.py
@@ -3,8 +3,7 @@ import datetime as dt
 import numpy as np
 from bokeh.models import CategoricalColorMapper, LinearColorMapper
 
-from holoviews.core import NdOverlay
-from holoviews.element import Spikes
+import holoviews as hv
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal
 
@@ -15,12 +14,12 @@ from .test_plot import TestBokehPlot, bokeh_renderer
 class TestSpikesPlot(TestBokehPlot):
 
     def test_spikes_colormapping(self):
-        spikes = Spikes(np.random.rand(20, 2), vdims=['Intensity'])
+        spikes = hv.Spikes(np.random.rand(20, 2), vdims=['Intensity'])
         color_spikes = spikes.opts(color_index=1)
         self._test_colormapping(color_spikes, 1)
 
     def test_empty_spikes_plot(self):
-        spikes = Spikes([], vdims=['Intensity'])
+        spikes = hv.Spikes([], vdims=['Intensity'])
         plot = bokeh_renderer.get_plot(spikes)
         source = plot.handles['source']
         assert len(source.data['x']) == 0
@@ -28,8 +27,8 @@ class TestSpikesPlot(TestBokehPlot):
         assert len(source.data['y1']) == 0
 
     def test_batched_spike_plot(self):
-        overlay = NdOverlay({
-            i: Spikes([i], kdims=['Time']).opts(
+        overlay = hv.NdOverlay({
+            i: hv.Spikes([i], kdims=['Time']).opts(
                 position=0.1*i, spike_length=0.1, show_legend=False)
             for i in range(10)
         })
@@ -38,14 +37,14 @@ class TestSpikesPlot(TestBokehPlot):
         assert extents == (0, 0, 9, 1)
 
     def test_spikes_padding_square(self):
-        spikes = Spikes([1, 2, 3]).opts(padding=0.1)
+        spikes = hv.Spikes([1, 2, 3]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         assert x_range.start == 0.8
         assert x_range.end == 3.2
 
     def test_spikes_padding_square_heights(self):
-        spikes = Spikes([(1, 1), (2, 2), (3, 3)], vdims=['Height']).opts(padding=0.1)
+        spikes = hv.Spikes([(1, 1), (2, 2), (3, 3)], vdims=['Height']).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spikes)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -54,42 +53,42 @@ class TestSpikesPlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_spikes_padding_hard_xrange(self):
-        spikes = Spikes([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
+        spikes = hv.Spikes([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         assert x_range.start == 0
         assert x_range.end == 3
 
     def test_spikes_padding_soft_xrange(self):
-        spikes = Spikes([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
+        spikes = hv.Spikes([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         assert x_range.start == 0
         assert x_range.end == 3
 
     def test_spikes_padding_unequal(self):
-        spikes = Spikes([1, 2, 3]).opts(padding=(0.05, 0.1))
+        spikes = hv.Spikes([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         assert x_range.start == 0.9
         assert x_range.end == 3.1
 
     def test_spikes_padding_nonsquare(self):
-        spikes = Spikes([1, 2, 3]).opts(padding=0.1, width=600)
+        spikes = hv.Spikes([1, 2, 3]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         assert x_range.start == 0.9
         assert x_range.end == 3.1
 
     def test_spikes_padding_logx(self):
-        spikes = Spikes([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
+        spikes = hv.Spikes([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(spikes)
         x_range = plot.handles['x_range']
         assert x_range.start == 0.89595845984076228
         assert x_range.end == 3.3483695221017129
 
     def test_spikes_padding_datetime_square(self):
-        spikes = Spikes([np.datetime64(f'2016-04-0{i}') for i in range(1, 4)]).opts(
+        spikes = hv.Spikes([np.datetime64(f'2016-04-0{i}') for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = bokeh_renderer.get_plot(spikes)
@@ -98,7 +97,7 @@ class TestSpikesPlot(TestBokehPlot):
         assert x_range.end == np.datetime64('2016-04-03T04:48:00.000000000')
 
     def test_spikes_padding_datetime_square_heights(self):
-        spikes = Spikes([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)], vdims=['Height']).opts(
+        spikes = hv.Spikes([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)], vdims=['Height']).opts(
             padding=0.1
         )
         plot = bokeh_renderer.get_plot(spikes)
@@ -109,7 +108,7 @@ class TestSpikesPlot(TestBokehPlot):
         assert y_range.end == 3.2
 
     def test_spikes_padding_datetime_nonsquare(self):
-        spikes = Spikes([np.datetime64(f'2016-04-0{i}') for i in range(1, 4)]).opts(
+        spikes = hv.Spikes([np.datetime64(f'2016-04-0{i}') for i in range(1, 4)]).opts(
             padding=0.1, width=600
         )
         plot = bokeh_renderer.get_plot(spikes)
@@ -118,7 +117,7 @@ class TestSpikesPlot(TestBokehPlot):
         assert x_range.end == np.datetime64('2016-04-03T02:24:00.000000000')
 
     def test_spikes_datetime_vdim_hover(self):
-        points = Spikes([(0, 1, dt.datetime(2017, 1, 1))], vdims=['value', 'date']).opts(tools=['hover'])
+        points = hv.Spikes([(0, 1, dt.datetime(2017, 1, 1))], vdims=['value', 'date']).opts(tools=['hover'])
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         assert cds.data['date'] == np.datetime64("2017-01-01", "ns")
@@ -127,7 +126,7 @@ class TestSpikesPlot(TestBokehPlot):
         assert hover.formatters == {'@{date}': "datetime"}
 
     def test_spikes_datetime_kdim_hover(self):
-        points = Spikes([(dt.datetime(2017, 1, 1), 1)], 'x', 'y').opts(tools=['hover'])
+        points = hv.Spikes([(dt.datetime(2017, 1, 1), 1)], 'x', 'y').opts(tools=['hover'])
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
         assert cds.data['x'] == np.datetime64("2017-01-01", "ns")
@@ -139,7 +138,7 @@ class TestSpikesPlot(TestBokehPlot):
         assert hover.formatters == {'@{x}': "datetime"}
 
     def test_spikes_datetime_kdim_hover_spike_length_override(self):
-        points = Spikes([(dt.datetime(2017, 1, 1), 1)], 'x', 'y').opts(
+        points = hv.Spikes([(dt.datetime(2017, 1, 1), 1)], 'x', 'y').opts(
             tools=['hover'], spike_length=0.75)
         plot = bokeh_renderer.get_plot(points)
         cds = plot.handles['cds']
@@ -155,7 +154,7 @@ class TestSpikesPlot(TestBokehPlot):
     ###########################
 
     def test_spikes_color_op(self):
-        spikes = Spikes([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        spikes = hv.Spikes([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                               vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
@@ -164,7 +163,7 @@ class TestSpikesPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color'}
 
     def test_spikes_linear_color_op(self):
-        spikes = Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        spikes = hv.Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                               vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
@@ -177,7 +176,7 @@ class TestSpikesPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color', 'transform': cmapper}
 
     def test_spikes_categorical_color_op(self):
-        spikes = Spikes([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
+        spikes = hv.Spikes([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
                               vdims=['y', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
@@ -189,7 +188,7 @@ class TestSpikesPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color', 'transform': cmapper}
 
     def test_spikes_line_color_op(self):
-        spikes = Spikes([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        spikes = hv.Spikes([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                               vdims=['y', 'color']).opts(line_color='color')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
@@ -198,7 +197,7 @@ class TestSpikesPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'line_color'}
 
     def test_spikes_alpha_op(self):
-        spikes = Spikes([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        spikes = hv.Spikes([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
@@ -207,7 +206,7 @@ class TestSpikesPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_alpha) == {'field': 'alpha'}
 
     def test_spikes_line_alpha_op(self):
-        spikes = Spikes([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        spikes = hv.Spikes([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(line_alpha='alpha')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
@@ -216,7 +215,7 @@ class TestSpikesPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_alpha) == {'field': 'line_alpha'}
 
     def test_spikes_line_width_op(self):
-        spikes = Spikes([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
+        spikes = hv.Spikes([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
                               vdims=['y', 'line_width']).opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(spikes)
         cds = plot.handles['cds']
@@ -226,13 +225,13 @@ class TestSpikesPlot(TestBokehPlot):
 
     def test_op_ndoverlay_value(self):
         colors = ['blue', 'red']
-        overlay = NdOverlay({color: Spikes(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Spikes', color='Color')
+        overlay = hv.NdOverlay({color: hv.Spikes(np.arange(i+2)) for i, color in enumerate(colors)}, 'Color').opts('Spikes', color='Color')
         plot = bokeh_renderer.get_plot(overlay)
         for subplot, color in zip(plot.subplots.values(),  colors, strict=True):
             assert subplot.handles['glyph'].line_color == color
 
     def test_spikes_color_index_color_clash(self):
-        spikes = Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        spikes = hv.Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                     vdims=['y', 'color']).opts(color='color', color_index='color')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(spikes)

--- a/holoviews/tests/plotting/bokeh/test_spreadplot.py
+++ b/holoviews/tests/plotting/bokeh/test_spreadplot.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from holoviews.core.spaces import DynamicMap
-from holoviews.element import Spread
+import holoviews as hv
 from holoviews.streams import Buffer
 from holoviews.testing import assert_data_equal
 
@@ -12,7 +11,7 @@ class TestSpreadPlot(TestBokehPlot):
 
     def test_spread_stream_data(self):
         buffer = Buffer({'y': np.array([]), 'yerror': np.array([]), 'x': np.array([])})
-        dmap = DynamicMap(Spread, streams=[buffer])
+        dmap = hv.DynamicMap(hv.Spread, streams=[buffer])
         plot = bokeh_renderer.get_plot(dmap)
         buffer.send({'y': [1, 2, 1, 4], 'yerror': [.5, .2, .1, .5], 'x': [0,1,2,3]})
         cds = plot.handles['cds']
@@ -20,7 +19,7 @@ class TestSpreadPlot(TestBokehPlot):
         assert_data_equal(cds.data['y'], np.array([0.5, 1.8, 0.9, 3.5, 4.5, 1.1, 2.2, 1.5]))
 
     def test_spread_with_nans(self):
-        spread = Spread([(0, 0, 0, 1), (1, 0, 0, 2), (2, 0, 0, 3), (3, np.nan, np.nan, np.nan),
+        spread = hv.Spread([(0, 0, 0, 1), (1, 0, 0, 2), (2, 0, 0, 3), (3, np.nan, np.nan, np.nan),
                          (4, 0, 0, 5), (5, 0, 0, 6), (6, 0, 0, 7)], vdims=['y', 'neg', 'pos'])
         plot = bokeh_renderer.get_plot(spread)
         cds = plot.handles['cds']
@@ -30,14 +29,14 @@ class TestSpreadPlot(TestBokehPlot):
                                                   0., 0., 0., 7., 6., 5.]))
 
     def test_spread_empty(self):
-        spread = Spread([])
+        spread = hv.Spread([])
         plot = bokeh_renderer.get_plot(spread)
         cds = plot.handles['cds']
         assert cds.data['x'] == []
         assert cds.data['y'] == []
 
     def test_spread_padding_square(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1)
+        spread = hv.Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -46,7 +45,7 @@ class TestSpreadPlot(TestBokehPlot):
         assert y_range.end == 3.8
 
     def test_spread_padding_hard_range(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.range(y=(0, 4)).opts(padding=0.1)
+        spread = hv.Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.range(y=(0, 4)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -55,7 +54,7 @@ class TestSpreadPlot(TestBokehPlot):
         assert y_range.end == 4
 
     def test_spread_padding_soft_range(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
+        spread = hv.Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8
@@ -64,7 +63,7 @@ class TestSpreadPlot(TestBokehPlot):
         assert y_range.end == 3.5
 
     def test_spread_padding_nonsquare(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, width=600)
+        spread = hv.Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, width=600)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.9
@@ -73,7 +72,7 @@ class TestSpreadPlot(TestBokehPlot):
         assert y_range.end == 3.8
 
     def test_spread_padding_logx(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3,3, 0.5)]).opts(padding=0.1, logx=True)
+        spread = hv.Spread([(1, 1, 0.5), (2, 2, 0.5), (3,3, 0.5)]).opts(padding=0.1, logx=True)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.89595845984076228
@@ -82,7 +81,7 @@ class TestSpreadPlot(TestBokehPlot):
         assert y_range.end == 3.8
 
     def test_spread_padding_logy(self):
-        spread = Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, logy=True)
+        spread = hv.Spread([(1, 1, 0.5), (2, 2, 0.5), (3, 3, 0.5)]).opts(padding=0.1, logy=True)
         plot = bokeh_renderer.get_plot(spread)
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         assert x_range.start == 0.8

--- a/holoviews/tests/plotting/bokeh/test_streaming.py
+++ b/holoviews/tests/plotting/bokeh/test_streaming.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from holoviews.core import DynamicMap
-from holoviews.element import Curve
+import holoviews as hv
 from holoviews.streams import Buffer
 
 from .test_plot import TestBokehPlot, bokeh_renderer
@@ -11,7 +10,7 @@ class TestBufferStreamPlot(TestBokehPlot):
 
     def test_buffer_stream_following(self):
         stream = Buffer(data={'x': np.array([1]), 'y': np.array([1])}, following=True)
-        dmap = DynamicMap(Curve, streams=[stream])
+        dmap = hv.DynamicMap(hv.Curve, streams=[stream])
 
         plot = bokeh_renderer.get_plot(dmap)
 

--- a/holoviews/tests/plotting/bokeh/test_subcoordy.py
+++ b/holoviews/tests/plotting/bokeh/test_subcoordy.py
@@ -2,9 +2,7 @@ import numpy as np
 import pytest
 from bokeh.models.tools import WheelZoomTool, ZoomInTool, ZoomOutTool
 
-from holoviews.core import NdOverlay, Overlay
-from holoviews.element import Curve
-from holoviews.element.annotation import VSpan
+import holoviews as hv
 from holoviews.operation.normalization import subcoordinate_group_ranges
 from holoviews.plotting.bokeh.util import BOKEH_GE_3_5_0
 
@@ -16,7 +14,7 @@ class TestSubcoordinateY(TestBokehPlot):
     # With subcoordinate_y set to True
 
     def test_bool_base(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         plot = bokeh_renderer.get_plot(overlay)
         # subcoordinate_y is propagated to the overlay
         assert plot.subcoordinate_y is True
@@ -43,8 +41,8 @@ class TestSubcoordinateY(TestBokehPlot):
         assert plot.state.yaxis.major_label_overrides == {0: 'Data 0', 1: 'Data 1'}
 
     def test_renderers_reversed(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
-        overlay = VSpan(0, 1, label='back') * overlay * VSpan(2, 3, label='front')
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.VSpan(0, 1, label='back') * overlay * hv.VSpan(2, 3, label='front')
         plot = bokeh_renderer.get_plot(overlay)
         renderers = plot.handles['plot'].renderers
         assert (renderers[0].left, renderers[0].right) == (0, 1)
@@ -61,8 +59,8 @@ class TestSubcoordinateY(TestBokehPlot):
             (5, (-2.5, 2.5), (-1.5, 3.5), (-2.5, 3.5)),
         ]
         for scale, ytarget1, ytarget2, ytarget in test_data:
-            overlay = Overlay([
-                Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True, subcoordinate_scale=scale)
+            overlay = hv.Overlay([
+                hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True, subcoordinate_scale=scale)
                 for i in range(2)
             ])
             plot = bokeh_renderer.get_plot(overlay)
@@ -78,8 +76,8 @@ class TestSubcoordinateY(TestBokehPlot):
             assert plot.handles['y_range'].end == ytarget[1]
 
     def test_ndoverlay_labels(self):
-        overlay = NdOverlay({
-            f'Data {i}': Curve(np.arange(10)*i).opts(subcoordinate_y=True)
+        overlay = hv.NdOverlay({
+            f'Data {i}': hv.Curve(np.arange(10)*i).opts(subcoordinate_y=True)
             for i in range(3)
         }, 'Channel')
         plot = bokeh_renderer.get_plot(overlay)
@@ -90,8 +88,8 @@ class TestSubcoordinateY(TestBokehPlot):
             assert sp.handles['glyph_renderer'].coordinates.y_target.end == (i+0.5)
 
     def test_ndoverlay_nd_labels(self):
-        overlay = NdOverlay({
-            ('A', f'Data {i}'): Curve(np.arange(10)*i).opts(subcoordinate_y=True)
+        overlay = hv.NdOverlay({
+            ('A', f'Data {i}'): hv.Curve(np.arange(10)*i).opts(subcoordinate_y=True)
             for i in range(3)
         }, ['Group', 'Channel'])
         plot = bokeh_renderer.get_plot(overlay)
@@ -102,7 +100,7 @@ class TestSubcoordinateY(TestBokehPlot):
             assert sp.handles['glyph_renderer'].coordinates.y_target.end == (i+0.5)
 
     def test_no_label(self):
-        overlay = Overlay([Curve(range(10)).opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10)).opts(subcoordinate_y=True) for i in range(2)])
         with pytest.raises(
             ValueError,
             match=r'Every Element plotted on a subcoordinate_y axis must have a label or be part of an NdOverlay.'
@@ -110,26 +108,26 @@ class TestSubcoordinateY(TestBokehPlot):
             bokeh_renderer.get_plot(overlay)
 
     def test_overlaid_without_label_no_error(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
-        with_span = overlay * VSpan(1, 2)
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        with_span = overlay * hv.VSpan(1, 2)
         bokeh_renderer.get_plot(with_span)
 
     def test_underlaid_ytick_alignment(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
-        with_span = VSpan(1, 2) * overlay
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        with_span = hv.VSpan(1, 2) * overlay
         plot = bokeh_renderer.get_plot(with_span)
         # the yticks are aligned with their subcoordinate_y axis
         assert plot.state.yaxis.ticker.ticks == [0, 1]
 
     def test_overlaid_ytick_alignment(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
-        with_span = overlay * VSpan(1, 2)
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        with_span = overlay * hv.VSpan(1, 2)
         plot = bokeh_renderer.get_plot(with_span)
         # the yticks are aligned with their subcoordinate_y axis
         assert plot.state.yaxis.ticker.ticks == [0, 1]
 
     def test_custom_ylabel(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         overlay.opts(ylabel='Y label')
         plot = bokeh_renderer.get_plot(overlay)
         # the figure axis has the label set
@@ -139,15 +137,15 @@ class TestSubcoordinateY(TestBokehPlot):
         assert plot.state.yaxis.major_label_overrides == {0: 'Data 0', 1: 'Data 1'}
 
     def test_legend_label(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         plot = bokeh_renderer.get_plot(overlay)
         legend_labels = [l.label['value'] for l in plot.state.legend[0].items]
         # the legend displays the labels
         assert legend_labels == ['Data 0', 'Data 1']
 
     def test_shared_multi_axes(self):
-        overlay1 = Overlay([Curve(np.arange(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
-        overlay2 = Overlay([Curve(np.arange(10) + 5, label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay1 = hv.Overlay([hv.Curve(np.arange(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay2 = hv.Overlay([hv.Curve(np.arange(10) + 5, label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
 
         plot = bokeh_renderer.get_plot(overlay1 + overlay2)
 
@@ -159,28 +157,28 @@ class TestSubcoordinateY(TestBokehPlot):
         assert oplot2.handles['extra_y_ranges'] == {}
 
     def test_invisible_yaxis(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         overlay.opts(yaxis=None)
         plot = bokeh_renderer.get_plot(overlay)
         assert not plot.state.yaxis.visible
 
     def test_overlay_set_ylim(self):
         ylim = (1, 2.5)
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         overlay.opts(ylim=ylim)
         plot = bokeh_renderer.get_plot(overlay)
         y_range = plot.handles['y_range']
         assert (y_range.start, y_range.end) == ylim
 
     def test_axis_labels(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         plot = bokeh_renderer.get_plot(overlay)
 
         assert plot.state.xaxis.axis_label == 'x'
         assert plot.state.yaxis.axis_label == 'y'
 
     def test_only_x_axis_labels(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         overlay.opts(labelled=['x'])
         plot = bokeh_renderer.get_plot(overlay)
 
@@ -188,7 +186,7 @@ class TestSubcoordinateY(TestBokehPlot):
         assert plot.state.yaxis.axis_label == ''
 
     def test_none_x_axis_labels(self):
-        overlay = Overlay([Curve(range(10), vdims=['A'], label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), vdims=['A'], label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         plot = bokeh_renderer.get_plot(overlay)
 
         assert plot.state.xaxis.axis_label == 'x'
@@ -197,9 +195,9 @@ class TestSubcoordinateY(TestBokehPlot):
     # With subcoordinate_y set to a range
 
     def test_range_base(self):
-        overlay = Overlay([
-            Curve(range(10), label='Data 0').opts(subcoordinate_y=(0, 0.5)),
-            Curve(range(10), label='Data 1').opts(subcoordinate_y=(0.5, 1)),
+        overlay = hv.Overlay([
+            hv.Curve(range(10), label='Data 0').opts(subcoordinate_y=(0, 0.5)),
+            hv.Curve(range(10), label='Data 1').opts(subcoordinate_y=(0.5, 1)),
         ])
         plot = bokeh_renderer.get_plot(overlay)
         # subcoordinate_y is propagated to the overlay, just the first one though :(
@@ -227,13 +225,13 @@ class TestSubcoordinateY(TestBokehPlot):
         assert plot.state.yaxis.major_label_overrides == {0.25: 'Data 0', 0.75: 'Data 1'}
 
     def test_plot_standalone(self):
-        standalone = Curve(range(10), label='Data 0').opts(subcoordinate_y=True)
+        standalone = hv.Curve(range(10), label='Data 0').opts(subcoordinate_y=True)
         plot = bokeh_renderer.get_plot(standalone)
         assert (plot.state.x_range.start, plot.state.x_range.end) == (0, 9)
         assert (plot.state.y_range.start, plot.state.y_range.end) == (0, 9)
 
     def test_multi_y_error(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         overlay.opts(multi_y=True)
         with pytest.raises(
             ValueError,
@@ -242,7 +240,7 @@ class TestSubcoordinateY(TestBokehPlot):
             bokeh_renderer.get_plot(overlay)
 
     def test_same_label_error(self):
-        overlay = Overlay([Curve(range(10), label='Same').opts(subcoordinate_y=True) for _ in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), label='Same').opts(subcoordinate_y=True) for _ in range(2)])
         with pytest.raises(
             ValueError,
             match='Elements wrapped in a subcoordinate_y overlay must all have a unique label',
@@ -250,7 +248,7 @@ class TestSubcoordinateY(TestBokehPlot):
             bokeh_renderer.get_plot(overlay)
 
     def test_tools_default_wheel_zoom_configured(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True) for i in range(2)])
         plot = bokeh_renderer.get_plot(overlay)
         zoom_subcoordy = plot.handles['zooms_subcoordy']['wheel_zoom']
         assert len(zoom_subcoordy.renderers) == 2
@@ -260,7 +258,7 @@ class TestSubcoordinateY(TestBokehPlot):
 
     def test_tools_string_zoom_in_out_configured(self):
         for zoom in ['zoom_in', 'zoom_out', 'yzoom_in', 'yzoom_out', 'ywheel_zoom']:
-            overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True, tools=[zoom]) for i in range(2)])
+            overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True, tools=[zoom]) for i in range(2)])
             plot = bokeh_renderer.get_plot(overlay)
             zoom_subcoordy = plot.handles['zooms_subcoordy'][zoom]
             assert len(zoom_subcoordy.renderers) == 2
@@ -274,7 +272,7 @@ class TestSubcoordinateY(TestBokehPlot):
             ('xzoom_out', ZoomOutTool),
             ('xwheel_zoom', WheelZoomTool),
         ]:
-            overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True, tools=[zoom]) for i in range(2)])
+            overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True, tools=[zoom]) for i in range(2)])
             plot = bokeh_renderer.get_plot(overlay)
             for tool in plot.state.tools:
                 if isinstance(tool, zoom_type) and tool.tags == ['hv_created']:
@@ -286,7 +284,7 @@ class TestSubcoordinateY(TestBokehPlot):
 
     def test_tools_instance_zoom_untouched(self):
         for zoom in [WheelZoomTool(), ZoomInTool(), ZoomOutTool()]:
-            overlay = Overlay([Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True, tools=[zoom]) for i in range(2)])
+            overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}').opts(subcoordinate_y=True, tools=[zoom]) for i in range(2)])
             plot = bokeh_renderer.get_plot(overlay)
             for tool in plot.state.tools:
                 if isinstance(tool, type(zoom)) and 'hv_created' not in tool.tags:
@@ -300,7 +298,7 @@ class TestSubcoordinateY(TestBokehPlot):
         # Same as test_bool_base, to check nothing is affected by defining
         # a single group.
 
-        overlay = Overlay([Curve(range(10), label=f'Data {i}', group='Group').opts(subcoordinate_y=True) for i in range(2)])
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}', group='Group').opts(subcoordinate_y=True) for i in range(2)])
         plot = bokeh_renderer.get_plot(overlay)
         # subcoordinate_y is propagated to the overlay
         assert plot.subcoordinate_y is True
@@ -327,8 +325,8 @@ class TestSubcoordinateY(TestBokehPlot):
         assert plot.state.yaxis.major_label_overrides == {0: 'Data 0', 1: 'Data 1'}
 
     def test_multiple_groups(self):
-        overlay = Overlay([
-            Curve(range(10), label=f'{group} / {i}', group=group).opts(subcoordinate_y=True)
+        overlay = hv.Overlay([
+            hv.Curve(range(10), label=f'{group} / {i}', group=group).opts(subcoordinate_y=True)
             for group in ['A', 'B']
             for i in range(2)
         ])
@@ -373,8 +371,8 @@ class TestSubcoordinateY(TestBokehPlot):
         # Same as test_tools_default_wheel_zoom_configured
 
         groups = ['A', 'B']
-        overlay = Overlay([
-            Curve(range(10), label=f'{group} / {i}', group=group).opts(subcoordinate_y=True)
+        overlay = hv.Overlay([
+            hv.Curve(range(10), label=f'{group} / {i}', group=group).opts(subcoordinate_y=True)
             for group in groups
             for i in range(2)
         ])
@@ -394,8 +392,8 @@ class TestSubcoordinateY(TestBokehPlot):
         # Same as test_tools_default_wheel_zoom_configured
 
         groups = ['A', 'B']
-        overlay = Overlay([
-            Curve(range(10), label=f'{group} / {i}', group=group).opts(subcoordinate_y=True)
+        overlay = hv.Overlay([
+            hv.Curve(range(10), label=f'{group} / {i}', group=group).opts(subcoordinate_y=True)
             for group in groups
             for i in range(2)
         ])
@@ -412,17 +410,17 @@ class TestSubcoordinateY(TestBokehPlot):
         assert len(zoom_tool.hit_test_behavior.groups) == 2
 
     def test_single_group_overlaid_no_error(self):
-        overlay = Overlay([Curve(range(10), label=f'Data {i}', group='Group').opts(subcoordinate_y=True) for i in range(2)])
-        with_span = VSpan(1, 2) * overlay * VSpan(3, 4)
+        overlay = hv.Overlay([hv.Curve(range(10), label=f'Data {i}', group='Group').opts(subcoordinate_y=True) for i in range(2)])
+        with_span = hv.VSpan(1, 2) * overlay * hv.VSpan(3, 4)
         bokeh_renderer.get_plot(with_span)
 
     def test_multiple_groups_overlaid_no_error(self):
-        overlay = Overlay([
-            Curve(range(10), label=f'{group} / {i}', group=group).opts(subcoordinate_y=True)
+        overlay = hv.Overlay([
+            hv.Curve(range(10), label=f'{group} / {i}', group=group).opts(subcoordinate_y=True)
             for group in ['A', 'B']
             for i in range(2)
         ])
-        with_span = VSpan(1, 2) * overlay * VSpan(3, 4)
+        with_span = hv.VSpan(1, 2) * overlay * hv.VSpan(3, 4)
         bokeh_renderer.get_plot(with_span)
 
     def test_missing_group_error(self):
@@ -431,11 +429,11 @@ class TestSubcoordinateY(TestBokehPlot):
             for i in range(2):
                 label = f'{group}{i}'
                 if group == "B":
-                    curve = Curve(range(10), label=label, group=group).opts(
+                    curve = hv.Curve(range(10), label=label, group=group).opts(
                         subcoordinate_y=True
                     )
                 else:
-                    curve = Curve(range(10), label=label).opts(
+                    curve = hv.Curve(range(10), label=label).opts(
                         subcoordinate_y=True
                     )
                 curves.append(curve)
@@ -447,7 +445,7 @@ class TestSubcoordinateY(TestBokehPlot):
                 r'subcoordinate_y element in the overlay must have a defined group.'
             )
         ):
-            bokeh_renderer.get_plot(Overlay(curves))
+            bokeh_renderer.get_plot(hv.Overlay(curves))
 
     def test_norm_subcoordinate_group_ranges(self):
         x = np.linspace(0, 10 * np.pi, 21)
@@ -457,11 +455,11 @@ class TestSubcoordinateY(TestBokehPlot):
             for i in range(2):
                 yvals = j * np.sin(x)
                 curves.append(
-                    Curve((x + np.pi/2, yvals), label=f'{group}{i}', group=group).opts(subcoordinate_y=True)
+                    hv.Curve((x + np.pi/2, yvals), label=f'{group}{i}', group=group).opts(subcoordinate_y=True)
                 )
                 j += 1
 
-        overlay = Overlay(curves)
+        overlay = hv.Overlay(curves)
         noverlay = subcoordinate_group_ranges(overlay)
 
         expected = [

--- a/holoviews/tests/plotting/bokeh/test_tabular.py
+++ b/holoviews/tests/plotting/bokeh/test_tabular.py
@@ -10,9 +10,7 @@ from bokeh.models.widgets import (
     StringFormatter,
 )
 
-from holoviews.core.options import Store
-from holoviews.core.spaces import DynamicMap
-from holoviews.element import Table
+import holoviews as hv
 from holoviews.plotting.bokeh.callbacks import CDSCallback
 from holoviews.plotting.bokeh.renderer import BokehRenderer
 from holoviews.streams import CDSStream, Stream
@@ -23,15 +21,15 @@ bokeh_renderer = BokehRenderer.instance(mode='server')
 class TestBokehTablePlot:
 
     def setup_method(self):
-        self.previous_backend = Store.current_backend
-        Store.current_backend = 'bokeh'
+        self.previous_backend = hv.Store.current_backend
+        hv.Store.current_backend = 'bokeh'
 
     def teardown_method(self):
-        Store.current_backend = self.previous_backend
+        hv.Store.current_backend = self.previous_backend
         bokeh_renderer.last_plot = None
 
     def test_table_plot(self):
-        table = Table(([1, 2, 3], [1., 2., 3.], ['A', 'B', 'C']), ['x', 'y'], 'z')
+        table = hv.Table(([1, 2, 3], [1., 2., 3.], ['A', 'B', 'C']), ['x', 'y'], 'z')
         plot = bokeh_renderer.get_plot(table)
         dims = table.dimensions()
         formatters = (NumberFormatter, NumberFormatter, StringFormatter)
@@ -42,14 +40,14 @@ class TestBokehTablePlot:
             assert isinstance(column.editor, edit)
 
     def test_table_plot_escaped_dimension(self):
-        table = Table([1, 2, 3], ['A Dimension'])
+        table = hv.Table([1, 2, 3], ['A Dimension'])
         plot = bokeh_renderer.get_plot(table)
         source = plot.handles['source']
         renderer = plot.handles['glyph_renderer']
         assert next(iter(source.data.keys())) == renderer.columns[0].field
 
     def test_table_plot_datetimes(self):
-        table = Table([dt.now(), dt.now()], 'Date')
+        table = hv.Table([dt.now(), dt.now()], 'Date')
         plot = bokeh_renderer.get_plot(table)
         column = plot.state.columns[0]
         assert column.title == 'Date'
@@ -57,7 +55,7 @@ class TestBokehTablePlot:
         assert isinstance(column.editor, DateEditor)
 
     def test_table_plot_callback(self):
-        table = Table(([1, 2, 3], [1., 2., 3.], ['A', 'B', 'C']), ['x', 'y'], 'z')
+        table = hv.Table(([1, 2, 3], [1., 2., 3.], ['A', 'B', 'C']), ['x', 'y'], 'z')
         CDSStream(source=table)
         plot = bokeh_renderer.get_plot(table)
         assert len(plot.callbacks) == 1
@@ -65,7 +63,7 @@ class TestBokehTablePlot:
 
     def test_table_change_columns(self):
         lengths = {'a': 1, 'b': 2, 'c': 3}
-        table = DynamicMap(lambda a: Table(range(lengths[a]), a), kdims=['a']).redim.values(a=['a', 'b', 'c'])
+        table = hv.DynamicMap(lambda a: hv.Table(range(lengths[a]), a), kdims=['a']).redim.values(a=['a', 'b', 'c'])
         plot = bokeh_renderer.get_plot(table)
         assert sorted(plot.handles['source'].data.keys()) == ['a']
         assert plot.handles['table'].columns[0].title == 'a'
@@ -74,14 +72,14 @@ class TestBokehTablePlot:
         assert plot.handles['table'].columns[0].title == 'b'
 
     def test_table_selected(self):
-        table = Table([(0, 0), (1, 1), (2, 2)], ['x', 'y']).opts(selected=[0, 2])
+        table = hv.Table([(0, 0), (1, 1), (2, 2)], ['x', 'y']).opts(selected=[0, 2])
         plot = bokeh_renderer.get_plot(table)
         cds = plot.handles['cds']
         assert cds.selected.indices == [0, 2]
 
     def test_table_update_selected(self):
         stream = Stream.define('Selected', selected=[])()
-        table = Table([(0, 0), (1, 1), (2, 2)], ['x', 'y']).apply.opts(selected=stream.param.selected)
+        table = hv.Table([(0, 0), (1, 1), (2, 2)], ['x', 'y']).apply.opts(selected=stream.param.selected)
         plot = bokeh_renderer.get_plot(table)
         cds = plot.handles['cds']
         assert cds.selected.indices == []

--- a/holoviews/tests/plotting/bokeh/test_tiles.py
+++ b/holoviews/tests/plotting/bokeh/test_tiles.py
@@ -1,6 +1,6 @@
 import pytest
 
-from holoviews.element import Tiles
+import holoviews as hv
 
 from .test_plot import TestBokehPlot, bokeh_renderer
 
@@ -11,7 +11,7 @@ class TestTilePlot(TestBokehPlot):
         xyzservices = pytest.importorskip("xyzservices")
         osm = xyzservices.providers.OpenStreetMap.Mapnik
 
-        tiles = Tiles(osm)
+        tiles = hv.Tiles(osm)
         plot = bokeh_renderer.get_plot(tiles)
         glyph = plot.handles["glyph"]
         assert glyph.attribution == osm.html_attribution

--- a/holoviews/tests/plotting/bokeh/test_utils.py
+++ b/holoviews/tests/plotting/bokeh/test_utils.py
@@ -2,7 +2,6 @@ import pytest
 from bokeh.models import Tool
 
 import holoviews as hv
-from holoviews.core import Store
 from holoviews.plotting.bokeh.styles import expand_batched_style
 from holoviews.plotting.bokeh.util import (
     TOOL_TYPES,
@@ -11,7 +10,7 @@ from holoviews.plotting.bokeh.util import (
     select_legends,
 )
 
-bokeh_renderer = Store.renderers['bokeh']
+bokeh_renderer = hv.Store.renderers['bokeh']
 
 
 class TestBokehUtilsInstantiation:

--- a/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/bokeh/test_vectorfieldplot.py
@@ -1,7 +1,7 @@
 import numpy as np
 from bokeh.models import CategoricalColorMapper, LinearColorMapper
 
-from holoviews.element import VectorField
+import holoviews as hv
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal
 
@@ -16,7 +16,7 @@ class TestVectorFieldPlot(TestBokehPlot):
     ###########################
 
     def test_vectorfield_color_op(self):
-        vectorfield = VectorField([(0, 0, 0, 1, '#000'), (0, 1, 0, 1,'#F00'), (0, 2, 0, 1,'#0F0')],
+        vectorfield = hv.VectorField([(0, 0, 0, 1, '#000'), (0, 1, 0, 1,'#F00'), (0, 2, 0, 1,'#0F0')],
                                   vdims=['A', 'M', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(vectorfield)
         cds = plot.handles['cds']
@@ -25,7 +25,7 @@ class TestVectorFieldPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color'}
 
     def test_vectorfield_linear_color_op(self):
-        vectorfield = VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 1), (0, 2, 0, 1, 2)],
+        vectorfield = hv.VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 1), (0, 2, 0, 1, 2)],
                                   vdims=['A', 'M', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(vectorfield)
         cds = plot.handles['cds']
@@ -38,7 +38,7 @@ class TestVectorFieldPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color', 'transform': cmapper}
 
     def test_vectorfield_categorical_color_op(self):
-        vectorfield = VectorField([(0, 0, 0, 1, 'A'), (0, 1, 0, 1, 'B'), (0, 2, 0, 1, 'C')],
+        vectorfield = hv.VectorField([(0, 0, 0, 1, 'A'), (0, 1, 0, 1, 'B'), (0, 2, 0, 1, 'C')],
                                   vdims=['A', 'M', 'color']).opts(color='color')
         plot = bokeh_renderer.get_plot(vectorfield)
         cds = plot.handles['cds']
@@ -50,7 +50,7 @@ class TestVectorFieldPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_color) == {'field': 'color', 'transform': cmapper}
 
     def test_vectorfield_alpha_op(self):
-        vectorfield = VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 0.2), (0, 2, 0, 1, 0.7)],
+        vectorfield = hv.VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 0.2), (0, 2, 0, 1, 0.7)],
                                   vdims=['A', 'M', 'alpha']).opts(alpha='alpha')
         plot = bokeh_renderer.get_plot(vectorfield)
         cds = plot.handles['cds']
@@ -59,7 +59,7 @@ class TestVectorFieldPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_alpha) == {'field': 'alpha'}
 
     def test_vectorfield_line_width_op(self):
-        vectorfield = VectorField([(0, 0, 0, 1, 1), (0, 1, 0, 1, 4), (0, 2, 0, 1, 8)],
+        vectorfield = hv.VectorField([(0, 0, 0, 1, 1), (0, 1, 0, 1, 4), (0, 2, 0, 1, 8)],
                                   vdims=['A', 'M', 'line_width']).opts(line_width='line_width')
         plot = bokeh_renderer.get_plot(vectorfield)
         cds = plot.handles['cds']
@@ -68,7 +68,7 @@ class TestVectorFieldPlot(TestBokehPlot):
         assert property_to_dict(glyph.line_width) == {'field': 'line_width'}
 
     def test_vectorfield_color_index_color_clash(self):
-        vectorfield = VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        vectorfield = hv.VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(line_color='color', color_index='color')
         with ParamLogStream() as log:
             bokeh_renderer.get_plot(vectorfield)
@@ -81,14 +81,14 @@ class TestVectorFieldPlot(TestBokehPlot):
         assert log_msg == warning
 
     def test_vectorfield_no_hover_columns(self):
-        vectorfield = VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        vectorfield = hv.VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(tools=[])
         plot = bokeh_renderer.get_plot(vectorfield)
         keys = sorted(plot.handles["cds"].data)
         assert keys == ["x0", "x1", "y0", "y1"]
 
     def test_vectorfield_hover_columns(self):
-        vectorfield = VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        vectorfield = hv.VectorField([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(tools=["hover"])
         plot = bokeh_renderer.get_plot(vectorfield)
         keys = sorted(plot.handles["cds"].data)

--- a/holoviews/tests/plotting/bokeh/test_violinplot.py
+++ b/holoviews/tests/plotting/bokeh/test_violinplot.py
@@ -1,11 +1,10 @@
 import numpy as np
 from bokeh.models import CategoricalColorMapper, LinearColorMapper
 
-from holoviews.element import Violin
+import holoviews as hv
 from holoviews.operation.stats import univariate_kde
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal
-from holoviews.util.transform import dim
 
 from ...utils import optional_dependencies
 from .test_plot import TestBokehPlot, bokeh_renderer
@@ -18,7 +17,7 @@ class TestBokehViolinPlot(TestBokehPlot):
 
     def test_violin_simple(self):
         values = np.random.rand(100)
-        violin = Violin(values).opts(violin_width=0.7)
+        violin = hv.Violin(values).opts(violin_width=0.7)
         _qmin, q1, q2, q3, _qmax = (np.percentile(values, q=q)
                                   for q in range(0,125,25))
         iqr = q3 - q1
@@ -49,7 +48,7 @@ class TestBokehViolinPlot(TestBokehPlot):
         np.testing.assert_array_equal(patch_source.data['ys'], [kde['x']])
 
     def test_violin_multi_level(self):
-        box= Violin((['A', 'B']*15, [3, 10, 1]*10, np.random.randn(30)),
+        box= hv.Violin((['A', 'B']*15, [3, 10, 1]*10, np.random.randn(30)),
                     ['Group', 'Category'], 'Value')
         plot = bokeh_renderer.get_plot(box)
         x_range = plot.handles['x_range']
@@ -58,7 +57,7 @@ class TestBokehViolinPlot(TestBokehPlot):
 
     def test_violin_inner_quartiles(self):
         values = np.random.rand(100)
-        violin = Violin(values).opts(inner='quartiles')
+        violin = hv.Violin(values).opts(inner='quartiles')
         kde = univariate_kde(violin, cut=5)
         xs = kde.dimension_values(0)
         plot = bokeh_renderer.get_plot(violin)
@@ -70,7 +69,7 @@ class TestBokehViolinPlot(TestBokehPlot):
 
     def test_violin_inner_stick(self):
         values = np.random.rand(100)
-        violin = Violin(values).opts(inner='stick')
+        violin = hv.Violin(values).opts(inner='stick')
         kde = univariate_kde(violin, cut=5)
         xs = kde.dimension_values(0)
         plot = bokeh_renderer.get_plot(violin)
@@ -79,12 +78,12 @@ class TestBokehViolinPlot(TestBokehPlot):
         assert_data_equal(plot.handles['segment_1_source'].data['x'], segments)
 
     def test_violin_multi(self):
-        violin = Violin((np.random.randint(0, 2, 100), np.random.rand(100)), kdims=['A']).sort()
+        violin = hv.Violin((np.random.randint(0, 2, 100), np.random.rand(100)), kdims=['A']).sort()
         plot = bokeh_renderer.get_plot(violin)
         assert plot.handles['x_range'].factors == ['0', '1']
 
     def test_violin_empty(self):
-        violin = Violin([])
+        violin = hv.Violin([])
         plot = bokeh_renderer.get_plot(violin)
         patch_source = plot.handles['patches_1_source']
         assert patch_source.data['xs'] == [[]]
@@ -92,7 +91,7 @@ class TestBokehViolinPlot(TestBokehPlot):
 
     def test_violin_single_point(self):
         data = {'x': [1], 'y': [1]}
-        violin = Violin(data=data, kdims='x', vdims='y').opts(inner='box')
+        violin = hv.Violin(data=data, kdims='x', vdims='y').opts(inner='box')
 
         plot = bokeh_renderer.get_plot(violin)
         assert plot.handles['x_range'].factors == ['1']
@@ -104,7 +103,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_linear_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_color='b')
+        violin = hv.Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_color='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['patches_1_source']
         cmapper = plot.handles['violin_color_color_mapper']
@@ -118,7 +117,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_categorical_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(['A', 'B', 'C', 'D', 'E'], 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_color='b')
+        violin = hv.Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_color='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['patches_1_source']
         glyph = plot.handles['patches_1_glyph']
@@ -131,7 +130,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_alpha_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5)/10., 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_alpha='b')
+        violin = hv.Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_alpha='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['patches_1_source']
         glyph = plot.handles['patches_1_glyph']
@@ -141,7 +140,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_line_width_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_line_width='b')
+        violin = hv.Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(violin_line_width='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['multi_line_1_source']
         glyph = plot.handles['multi_line_1_glyph']
@@ -151,7 +150,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_split_op_multi(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(split=dim('b')>2)
+        violin = hv.Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(split=hv.dim('b')>2)
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['patches_1_source']
         glyph = plot.handles['patches_1_glyph']
@@ -162,7 +161,7 @@ class TestBokehViolinPlot(TestBokehPlot):
 
     def test_violin_split_op_single(self):
         a = np.repeat(np.arange(2), 5)
-        violin = Violin((a, np.arange(10)), ['a'], 'd').opts(split='a')
+        violin = hv.Violin((a, np.arange(10)), ['a'], 'd').opts(split='a')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['patches_1_source']
         glyph = plot.handles['patches_1_glyph']
@@ -173,7 +172,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_box_linear_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
+        violin = hv.Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['vbar_1_source']
         cmapper = plot.handles['box_color_color_mapper']
@@ -187,7 +186,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_box_categorical_color_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(['A', 'B', 'C', 'D', 'E'], 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
+        violin = hv.Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_color='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']
@@ -200,7 +199,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_box_alpha_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5)/10., 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_alpha='b')
+        violin = hv.Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_alpha='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']
@@ -210,7 +209,7 @@ class TestBokehViolinPlot(TestBokehPlot):
     def test_violin_box_line_width_op(self):
         a = np.repeat(np.arange(5), 5)
         b = np.repeat(np.arange(5), 5)
-        violin = Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_line_width='b')
+        violin = hv.Violin((a, b, np.arange(25)), ['a', 'b'], 'd').opts(box_line_width='b')
         plot = bokeh_renderer.get_plot(violin)
         source = plot.handles['vbar_1_source']
         glyph = plot.handles['vbar_1_glyph']

--- a/holoviews/tests/plotting/matplotlib/test_annotationplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_annotationplot.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import holoviews as hv
-from holoviews.element import HLines, HSpans, VLines, VSpans
 from holoviews.plotting.mpl.util import MPL_GE_3_9_0
 
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -9,7 +8,7 @@ from .test_plot import TestMPLPlot, mpl_renderer
 
 class TestHVLinesPlot(TestMPLPlot):
     def test_hlines_plot(self):
-        hlines = HLines(
+        hlines = hv.HLines(
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
         plot = mpl_renderer.get_plot(hlines)
@@ -27,7 +26,7 @@ class TestHVLinesPlot(TestMPLPlot):
             assert source.get_data() == ([0, 1], [val, val])
 
     def test_hlines_array(self):
-        hlines = HLines(np.array([0, 1, 2, 5.5]))
+        hlines = hv.HLines(np.array([0, 1, 2, 5.5]))
         plot = mpl_renderer.get_plot(hlines)
         assert plot.handles["fig"].axes[0].get_xlabel() == "x"
         assert plot.handles["fig"].axes[0].get_ylabel() == "y"
@@ -43,7 +42,7 @@ class TestHVLinesPlot(TestMPLPlot):
             assert source.get_data() == ([0, 1], [val, val])
 
     def test_hlines_plot_invert_axes(self):
-        hlines = HLines(
+        hlines = hv.HLines(
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         ).opts(invert_axes=True)
         plot = mpl_renderer.get_plot(hlines)
@@ -61,7 +60,7 @@ class TestHVLinesPlot(TestMPLPlot):
             assert source.get_data() == ([val, val], [0, 1])
 
     def test_hlines_nondefault_kdim(self):
-        hlines = HLines({"other": [0, 1, 2, 5.5]}, kdims=["other"])
+        hlines = hv.HLines({"other": [0, 1, 2, 5.5]}, kdims=["other"])
         plot = mpl_renderer.get_plot(hlines)
         assert plot.handles["fig"].axes[0].get_xlabel() == "x"
         assert plot.handles["fig"].axes[0].get_ylabel() == "y"
@@ -77,7 +76,7 @@ class TestHVLinesPlot(TestMPLPlot):
             assert source.get_data() == ([0, 1], [val, val])
 
     def test_vlines_plot(self):
-        vlines = VLines(
+        vlines = hv.VLines(
             {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
         plot = mpl_renderer.get_plot(vlines)
@@ -95,7 +94,7 @@ class TestHVLinesPlot(TestMPLPlot):
             assert source.get_data() == ([val, val], [0, 1])
 
     def test_vlines_plot_invert_axes(self):
-        vlines = VLines(
+        vlines = hv.VLines(
             {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         ).opts(invert_axes=True)
         plot = mpl_renderer.get_plot(vlines)
@@ -113,7 +112,7 @@ class TestHVLinesPlot(TestMPLPlot):
             assert source.get_data() == ([0, 1], [val, val])
 
     def test_vlines_nondefault_kdim(self):
-        vlines = VLines({"other": [0, 1, 2, 5.5]}, kdims=["other"])
+        vlines = hv.VLines({"other": [0, 1, 2, 5.5]}, kdims=["other"])
         plot = mpl_renderer.get_plot(vlines)
         assert plot.handles["fig"].axes[0].get_xlabel() == "x"
         assert plot.handles["fig"].axes[0].get_ylabel() == "y"
@@ -129,10 +128,10 @@ class TestHVLinesPlot(TestMPLPlot):
             assert source.get_data() == ([val, val], [0, 1])
 
     def test_vlines_hlines_overlay(self):
-        hlines = HLines(
+        hlines = hv.HLines(
             {"y": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
-        vlines = VLines(
+        vlines = hv.VLines(
             {"x": [0, 1, 2, 5.5], "extra": [-1, -2, -3, -44]}, vdims=["extra"]
         )
 
@@ -174,7 +173,7 @@ class TestHVSpansPlot(TestMPLPlot):
             assert np.allclose(source.xy[:, 0], [v0, v0, v1, v1, v0])
 
     def test_hspans_plot(self):
-        hspans = HSpans(
+        hspans = hv.HSpans(
             {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]},
             vdims=["extra"],
         )
@@ -193,7 +192,7 @@ class TestHVSpansPlot(TestMPLPlot):
             self._hspans_check(source, v0, v1)
 
     def test_hspans_inverse_plot(self):
-        hspans = HSpans(
+        hspans = hv.HSpans(
             {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]},
             vdims=["extra"],
         ).opts(invert_axes=True)
@@ -212,7 +211,7 @@ class TestHVSpansPlot(TestMPLPlot):
             self._vspans_check(source, v0, v1)
 
     def test_dynamicmap_overlay_hspans(self):
-        el = HSpans(data=[[1, 3], [2, 4]])
+        el = hv.HSpans(data=[[1, 3], [2, 4]])
         dmap = hv.DynamicMap(lambda: hv.Overlay([el]))
 
         plot_el = mpl_renderer.get_plot(el)
@@ -227,7 +226,7 @@ class TestHVSpansPlot(TestMPLPlot):
         assert np.allclose(ylim_el, ylim_dmap)
 
     def test_hspans_nondefault_kdim(self):
-        hspans = HSpans(
+        hspans = hv.HSpans(
             {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
         )
         plot = mpl_renderer.get_plot(hspans)
@@ -247,7 +246,7 @@ class TestHVSpansPlot(TestMPLPlot):
             self._hspans_check(source, v0, v1)
 
     def test_vspans_plot(self):
-        vspans = VSpans(
+        vspans = hv.VSpans(
             {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]},
             vdims=["extra"],
         )
@@ -266,7 +265,7 @@ class TestHVSpansPlot(TestMPLPlot):
             self._vspans_check(source, v0, v1)
 
     def test_vspans_inverse_plot(self):
-        vspans = VSpans(
+        vspans = hv.VSpans(
             {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]},
             vdims=["extra"],
         ).opts(invert_axes=True)
@@ -285,7 +284,7 @@ class TestHVSpansPlot(TestMPLPlot):
             self._hspans_check(source, v0, v1)
 
     def test_vspans_nondefault_kdims(self):
-        vspans = VSpans(
+        vspans = hv.VSpans(
             {"other0": [0, 3, 5.5], "other1": [1, 4, 6.5]}, kdims=["other0", "other1"]
         )
         plot = mpl_renderer.get_plot(vspans)
@@ -305,11 +304,11 @@ class TestHVSpansPlot(TestMPLPlot):
             self._vspans_check(source, v0, v1)
 
     def test_vspans_hspans_overlay(self):
-        hspans = HSpans(
+        hspans = hv.HSpans(
             {"y0": [0, 3, 5.5], "y1": [1, 4, 6.5], "extra": [-1, -2, -3]},
             vdims=["extra"],
         )
-        vspans = VSpans(
+        vspans = hv.VSpans(
             {"x0": [0, 3, 5.5], "x1": [1, 4, 6.5], "extra": [-1, -2, -3]},
             vdims=["extra"],
         )
@@ -330,7 +329,7 @@ class TestHVSpansPlot(TestMPLPlot):
             self._vspans_check(source, v0, v1)
 
     def test_dynamicmap_overlay_vspans(self):
-        el = VSpans(data=[[1, 3], [2, 4]])
+        el = hv.VSpans(data=[[1, 3], [2, 4]])
         dmap = hv.DynamicMap(lambda: hv.Overlay([el]))
 
         plot_el = mpl_renderer.get_plot(el)

--- a/holoviews/tests/plotting/matplotlib/test_areaplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_areaplot.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from holoviews.core import Overlay
-from holoviews.element import Area
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from ...utils import LoggingComparison
@@ -12,7 +11,7 @@ from .test_plot import TestMPLPlot, mpl_renderer
 class TestAreaPlot(LoggingComparison, TestMPLPlot):
 
     def test_area_padding_square(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1)
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.8
@@ -21,7 +20,7 @@ class TestAreaPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_area_padding_square_per_axis(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=((0, 0.1), (0.1, 0.2)))
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 1
@@ -30,7 +29,7 @@ class TestAreaPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.4
 
     def test_area_with_lower_vdim(self):
-        area = Area([(1, 0.5, 1), (2, 1.5, 2), (3, 2.5, 3)], vdims=['y', 'y2']).opts(padding=0.1)
+        area = hv.Area([(1, 0.5, 1), (2, 1.5, 2), (3, 2.5, 3)], vdims=['y', 'y2']).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.8
@@ -39,7 +38,7 @@ class TestAreaPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.25
 
     def test_area_padding_negative(self):
-        area = Area([(1, -1), (2, -2), (3, -3)]).opts(padding=0.1)
+        area = hv.Area([(1, -1), (2, -2), (3, -3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.8
@@ -48,7 +47,7 @@ class TestAreaPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 0
 
     def test_area_padding_mixed(self):
-        area = Area([(1, 1), (2, -2), (3, 3)]).opts(padding=0.1)
+        area = hv.Area([(1, 1), (2, -2), (3, 3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.8
@@ -57,7 +56,7 @@ class TestAreaPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.5
 
     def test_area_padding_hard_range(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).redim.range(y=(0, 4)).opts(padding=0.1)
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).redim.range(y=(0, 4)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.8
@@ -66,7 +65,7 @@ class TestAreaPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 4
 
     def test_area_padding_soft_range(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).redim.soft_range(y=(0, 3.5)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.8
@@ -75,7 +74,7 @@ class TestAreaPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.5
 
     def test_area_padding_nonsquare(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, aspect=2)
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.9
@@ -84,7 +83,7 @@ class TestAreaPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_area_padding_logx(self):
-        area = Area([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
+        area = hv.Area([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.89595845984076228
@@ -93,7 +92,7 @@ class TestAreaPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_area_padding_logy(self):
-        area = Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, logy=True)
+        area = hv.Area([(1, 1), (2, 2), (3, 3)]).opts(padding=0.1, logy=True)
         plot = mpl_renderer.get_plot(area)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.8
@@ -104,8 +103,8 @@ class TestAreaPlot(LoggingComparison, TestMPLPlot):
 
     def test_area_stack_vdims(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y_1': [1, 2, 3], 'y_2': [6, 4, 2], 'y_3': [8, 1, 2]})
-        overlay = Overlay([Area(df, kdims='x', vdims=col, label=col) for col in ['y_1', 'y_2', 'y_3']])
-        plot = Area.stack(overlay)
+        overlay = hv.Overlay([hv.Area(df, kdims='x', vdims=col, label=col) for col in ['y_1', 'y_2', 'y_3']])
+        plot = hv.Area.stack(overlay)
         baselines = [np.array([0, 0, 0]), np.array([1., 2., 3.]), np.array([7., 6., 5.])]
         for n, baseline in zip(plot.data, baselines, strict=True):
             assert_data_equal(plot.data[n].data.Baseline.to_numpy(), baseline)

--- a/holoviews/tests/plotting/matplotlib/test_barplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_barplot.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 from matplotlib.text import Text
 
-from holoviews.element import Bars
+import holoviews as hv
 
 from ...utils import LoggingComparison
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -12,14 +12,14 @@ from .test_plot import TestMPLPlot, mpl_renderer
 class TestBarPlot(LoggingComparison, TestMPLPlot):
 
     def test_bars_continuous_data_list_same_interval(self):
-        bars = Bars(([0, 1, 2], [10, 20, 30]))
+        bars = hv.Bars(([0, 1, 2], [10, 20, 30]))
         plot = mpl_renderer.get_plot(bars)
         ax = plot.handles["axis"]
         np.testing.assert_almost_equal(ax.get_xlim(), (-0.4, 2.4))
         assert ax.patches[0].get_width() == 0.8
 
     def test_bars_continuous_data_list_diff_interval(self):
-        bars = Bars(([0, 3, 10], [10, 20, 30]))
+        bars = hv.Bars(([0, 3, 10], [10, 20, 30]))
         plot = mpl_renderer.get_plot(bars)
         ax = plot.handles["axis"]
         np.testing.assert_almost_equal(ax.get_xlim(), (-1.2, 11.2))
@@ -27,7 +27,7 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         assert len(ax.get_xticks()) > 3
 
     def test_bars_continuous_datetime(self):
-        bars = Bars((pd.date_range("1/1/2000", periods=10), np.random.rand(10)))
+        bars = hv.Bars((pd.date_range("1/1/2000", periods=10), np.random.rand(10)))
         plot = mpl_renderer.get_plot(bars)
         ax = plot.handles["axis"]
         assert ax.get_xticklabels()[0].get_text() == "2000-01-01"
@@ -42,7 +42,7 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         assert ax.get_xticklabels()[-1].get_text() == "10"
 
     def test_bars_not_continuous_data_list(self):
-        bars = Bars([("A", 1), ("B", 2), ("C", 3)])
+        bars = hv.Bars([("A", 1), ("B", 2), ("C", 3)])
         plot = mpl_renderer.get_plot(bars)
         ax = plot.handles["axis"]
         np.testing.assert_almost_equal(ax.get_xlim(), (-0.4, 2.4))
@@ -63,7 +63,7 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         pets_sample = np.random.choice(pets, samples)
         gender_sample = np.random.choice(genders, samples)
 
-        bars = Bars(
+        bars = hv.Bars(
             (pets_sample, gender_sample, np.ones(samples)), ["Pets", "Gender"]
         ).aggregate(function=np.sum)
         plot = mpl_renderer.get_plot(bars)
@@ -106,7 +106,7 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         gender_sample = np.random.choice(genders, samples)
 
         bars = (
-            Bars((pets_sample, gender_sample, np.ones(samples)), ["Pets", "Gender"])
+            hv.Bars((pets_sample, gender_sample, np.ones(samples)), ["Pets", "Gender"])
             .aggregate(function=np.sum)
             .opts(stacked=True)
         )
@@ -128,7 +128,7 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
             assert ticklabel.get_position() == expected[i].get_position()
 
     def test_group_dim(self):
-        bars = Bars(
+        bars = hv.Bars(
             ([3, 10, 1] * 10, ["A", "B"] * 15, np.random.randn(30)),
             ["Group", "Category"],
             "Value",

--- a/holoviews/tests/plotting/matplotlib/test_boxwhisker.py
+++ b/holoviews/tests/plotting/matplotlib/test_boxwhisker.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import BoxWhisker
+import holoviews as hv
 from holoviews.plotting.mpl.util import MPL_GE_3_9_0
 from holoviews.testing import assert_data_equal
 
@@ -11,7 +11,7 @@ class TestMPLBoxWhiskerPlot(TestMPLPlot):
 
     def test_boxwhisker_simple(self):
         values = np.random.rand(100)
-        boxwhisker = BoxWhisker(values)
+        boxwhisker = hv.BoxWhisker(values)
         plot = mpl_renderer.get_plot(boxwhisker)
         data, style, _axis_opts = plot.get_data(boxwhisker, {}, {})
         assert_data_equal(data[0][0], values)
@@ -22,14 +22,14 @@ class TestMPLBoxWhiskerPlot(TestMPLPlot):
 
     def test_boxwhisker_simple_overlay(self):
         values = np.random.rand(100)
-        boxwhisker = BoxWhisker(values) * BoxWhisker(values)
+        boxwhisker = hv.BoxWhisker(values) * hv.BoxWhisker(values)
         plot = mpl_renderer.get_plot(boxwhisker)
         p1, p2 = plot.subplots.values()
         assert_data_equal(p1.handles['boxes'][0].get_path().vertices,
                          p2.handles['boxes'][0].get_path().vertices)
 
     def test_box_whisker_padding_square(self):
-        curve = BoxWhisker([1, 2, 3]).opts(padding=0.1)
+        curve = hv.BoxWhisker([1, 2, 3]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(curve)
         y_range = plot.handles['axis'].get_ylim()
         assert y_range[0] == 0.8

--- a/holoviews/tests/plotting/matplotlib/test_callbacks.py
+++ b/holoviews/tests/plotting/matplotlib/test_callbacks.py
@@ -2,8 +2,7 @@ from collections import deque
 
 import numpy as np
 
-from holoviews.core import DynamicMap
-from holoviews.element import Curve, Points
+import holoviews as hv
 from holoviews.streams import PointerX, PointerXY
 from holoviews.testing import assert_data_equal
 
@@ -14,7 +13,7 @@ class TestCallbackPlot(TestMPLPlot):
 
     def test_dynamic_streams_refresh(self):
         stream = PointerXY(x=0, y=0)
-        dmap = DynamicMap(lambda x, y: Points([(x, y)]),
+        dmap = hv.DynamicMap(lambda x, y: hv.Points([(x, y)]),
                              kdims=[], streams=[stream])
         plot = mpl_renderer.get_plot(dmap)
         pre = mpl_renderer(plot, fmt='png')
@@ -27,9 +26,9 @@ class TestCallbackPlot(TestMPLPlot):
         history = deque(maxlen=10)
         def history_callback(x):
             history.append(x)
-            return Curve(list(history))
+            return hv.Curve(list(history))
         stream = PointerX(x=0)
-        dmap = DynamicMap(history_callback, kdims=[], streams=[stream])
+        dmap = hv.DynamicMap(history_callback, kdims=[], streams=[stream])
         plot = mpl_renderer.get_plot(dmap)
         mpl_renderer(plot)
         for i in range(20):

--- a/holoviews/tests/plotting/matplotlib/test_curveplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_curveplot.py
@@ -4,10 +4,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import holoviews as hv
 from holoviews.core.options import AbbreviatedException
-from holoviews.core.overlay import NdOverlay
-from holoviews.element import Curve
-from holoviews.util.transform import dim
 
 from .test_plot import TestMPLPlot, mpl_renderer
 
@@ -16,27 +14,27 @@ class TestCurvePlot(TestMPLPlot):
 
     def test_curve_datetime64(self):
         dates = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]
-        curve = Curve((dates, np.random.rand(10)))
+        curve = hv.Curve((dates, np.random.rand(10)))
         plot = mpl_renderer.get_plot(curve)
         assert plot.handles['axis'].get_xlim() == (16801.0, 16810.0)
 
     def test_curve_pandas_timestamps(self):
         dates = pd.date_range('2016-01-01', '2016-01-10', freq='D')
-        curve = Curve((dates, np.random.rand(10)))
+        curve = hv.Curve((dates, np.random.rand(10)))
         plot = mpl_renderer.get_plot(curve)
         assert plot.handles['axis'].get_xlim() == (16801.0, 16810.0)
 
     def test_curve_dt_datetime(self):
         dates = [dt.datetime(2016,1,i) for i in range(1, 11)]
-        curve = Curve((dates, np.random.rand(10)))
+        curve = hv.Curve((dates, np.random.rand(10)))
         plot = mpl_renderer.get_plot(curve)
         assert tuple(map(round, plot.handles['axis'].get_xlim())) == (16801.0, 16810.0)
 
     def test_curve_heterogeneous_datetime_types_overlay(self):
         dates64 = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]
         dates = [dt.datetime(2016,1,i) for i in range(2, 12)]
-        curve_dt64 = Curve((dates64, np.random.rand(10)))
-        curve_dt = Curve((dates, np.random.rand(10)))
+        curve_dt64 = hv.Curve((dates64, np.random.rand(10)))
+        curve_dt = hv.Curve((dates, np.random.rand(10)))
         plot = mpl_renderer.get_plot(curve_dt*curve_dt64)
         assert tuple(map(round, plot.handles['axis'].get_xlim())) == (16801.0, 16811.0)
 
@@ -44,14 +42,14 @@ class TestCurvePlot(TestMPLPlot):
         dates_pd = pd.date_range('2016-01-04', '2016-01-13', freq='D')
         dates64 = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]
         dates = [dt.datetime(2016,1,i) for i in range(2, 12)]
-        curve_dt64 = Curve((dates64, np.random.rand(10)))
-        curve_dt = Curve((dates, np.random.rand(10)))
-        curve_pd = Curve((dates_pd, np.random.rand(10)))
+        curve_dt64 = hv.Curve((dates64, np.random.rand(10)))
+        curve_dt = hv.Curve((dates, np.random.rand(10)))
+        curve_pd = hv.Curve((dates_pd, np.random.rand(10)))
         plot = mpl_renderer.get_plot(curve_dt*curve_dt64*curve_pd)
         assert plot.handles['axis'].get_xlim() == (16801.0, 16813.0)
 
     def test_curve_padding_square(self):
-        curve = Curve([1, 2, 3]).opts(padding=0.1)
+        curve = hv.Curve([1, 2, 3]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == -0.2
@@ -60,7 +58,7 @@ class TestCurvePlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_curve_padding_square_per_axis(self):
-        curve = Curve([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
+        curve = hv.Curve([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0
@@ -69,7 +67,7 @@ class TestCurvePlot(TestMPLPlot):
         assert y_range[1] == 3.4
 
     def test_curve_padding_hard_xrange(self):
-        curve = Curve([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
+        curve = hv.Curve([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0
@@ -78,7 +76,7 @@ class TestCurvePlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_curve_padding_soft_xrange(self):
-        curve = Curve([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
+        curve = hv.Curve([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0
@@ -87,7 +85,7 @@ class TestCurvePlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_curve_padding_unequal(self):
-        curve = Curve([1, 2, 3]).opts(padding=(0.05, 0.1))
+        curve = hv.Curve([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == -0.1
@@ -96,7 +94,7 @@ class TestCurvePlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_curve_padding_nonsquare(self):
-        curve = Curve([1, 2, 3]).opts(padding=0.1, aspect=2)
+        curve = hv.Curve([1, 2, 3]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == -0.1
@@ -105,7 +103,7 @@ class TestCurvePlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_curve_padding_logx(self):
-        curve = Curve([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
+        curve = hv.Curve([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.89595845984076228
@@ -114,7 +112,7 @@ class TestCurvePlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_curve_padding_logy(self):
-        curve = Curve([1, 2, 3]).opts(padding=0.1, logy=True)
+        curve = hv.Curve([1, 2, 3]).opts(padding=0.1, logy=True)
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == -0.2
@@ -123,7 +121,7 @@ class TestCurvePlot(TestMPLPlot):
         assert y_range[1] == 3.3483695221017129
 
     def test_curve_padding_datetime_square(self):
-        curve = Curve([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
+        curve = hv.Curve([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = mpl_renderer.get_plot(curve)
@@ -134,7 +132,7 @@ class TestCurvePlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_curve_padding_datetime_nonsquare(self):
-        curve = Curve([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
+        curve = hv.Curve([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
             padding=0.1, aspect=2
         )
         plot = mpl_renderer.get_plot(curve)
@@ -149,7 +147,7 @@ class TestCurvePlot(TestMPLPlot):
     ###########################
 
     def test_curve_scalar_color_op(self):
-        curve = Curve([(0, 0, 'red'), (0, 1, 'red'), (0, 2, 'red')],
+        curve = hv.Curve([(0, 0, 'red'), (0, 1, 'red'), (0, 2, 'red')],
                        vdims=['y', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(curve)
         artist = plot.handles['artist']
@@ -157,7 +155,7 @@ class TestCurvePlot(TestMPLPlot):
 
     def test_op_ndoverlay_color_value(self):
         colors = ['blue', 'red']
-        overlay = NdOverlay({color: Curve(np.arange(i))
+        overlay = hv.NdOverlay({color: hv.Curve(np.arange(i))
                              for i, color in enumerate(colors)},
                             'color').opts('Curve', color='color')
         plot = mpl_renderer.get_plot(overlay)
@@ -167,35 +165,35 @@ class TestCurvePlot(TestMPLPlot):
             assert style['color'] == color
 
     def test_curve_color_op(self):
-        curve = Curve([(0, 0, 'red'), (0, 1, 'blue'), (0, 2, 'red')],
+        curve = hv.Curve([(0, 0, 'red'), (0, 1, 'blue'), (0, 2, 'red')],
                        vdims=['y', 'color']).opts(color='color')
         msg = 'ValueError: Mapping a dimension to the "color" style'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(curve)
 
     def test_curve_alpha_op(self):
-        curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
+        curve = hv.Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
                        vdims=['y', 'alpha']).opts(alpha='alpha')
         msg = 'ValueError: Mapping a dimension to the "alpha" style'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(curve)
 
     def test_curve_linewidth_op(self):
-        curve = Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
+        curve = hv.Curve([(0, 0, 0.1), (0, 1, 0.3), (0, 2, 1)],
                        vdims=['y', 'linewidth']).opts(linewidth='linewidth')
         msg = 'ValueError: Mapping a dimension to the "linewidth" style'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(curve)
 
     def test_curve_style_mapping_ndoverlay_dimensions(self):
-        ndoverlay = NdOverlay({
-            (0, 'A'): Curve([1, 2, 0]), (0, 'B'): Curve([1, 2, 1]),
-            (1, 'A'): Curve([1, 2, 2]), (1, 'B'): Curve([1, 2, 3])},
+        ndoverlay = hv.NdOverlay({
+            (0, 'A'): hv.Curve([1, 2, 0]), (0, 'B'): hv.Curve([1, 2, 1]),
+            (1, 'A'): hv.Curve([1, 2, 2]), (1, 'B'): hv.Curve([1, 2, 3])},
                               ['num', 'cat']
         ).opts({
             'Curve': dict(
-                color=dim('num').categorize({0: 'red', 1: 'blue'}),
-                linestyle=dim('cat').categorize({'A': '-.', 'B': '-'})
+                color=hv.dim('num').categorize({0: 'red', 1: 'blue'}),
+                linestyle=hv.dim('cat').categorize({'A': '-.', 'B': '-'})
             )
         })
         plot = mpl_renderer.get_plot(ndoverlay)
@@ -214,15 +212,15 @@ class TestCurvePlot(TestMPLPlot):
 
     def test_curve_style_mapping_constant_value_dimensions(self):
         vdims = ['y', 'num', 'cat']
-        ndoverlay = NdOverlay({
-            0: Curve([(0, 1, 0, 'A'), (1, 0, 0, 'A')], vdims=vdims),
-            1: Curve([(0, 1, 0, 'B'), (1, 1, 0, 'B')], vdims=vdims),
-            2: Curve([(0, 1, 1, 'A'), (1, 2, 1, 'A')], vdims=vdims),
-            3: Curve([(0, 1, 1, 'B'), (1, 3, 1, 'B')], vdims=vdims)}
+        ndoverlay = hv.NdOverlay({
+            0: hv.Curve([(0, 1, 0, 'A'), (1, 0, 0, 'A')], vdims=vdims),
+            1: hv.Curve([(0, 1, 0, 'B'), (1, 1, 0, 'B')], vdims=vdims),
+            2: hv.Curve([(0, 1, 1, 'A'), (1, 2, 1, 'A')], vdims=vdims),
+            3: hv.Curve([(0, 1, 1, 'B'), (1, 3, 1, 'B')], vdims=vdims)}
         ).opts({
             'Curve': dict(
-                color=dim('num').categorize({0: 'red', 1: 'blue'}),
-                linestyle=dim('cat').categorize({'A': '-.', 'B': '-'})
+                color=hv.dim('num').categorize({0: 'red', 1: 'blue'}),
+                linestyle=hv.dim('cat').categorize({'A': '-.', 'B': '-'})
             )
         })
         plot = mpl_renderer.get_plot(ndoverlay)

--- a/holoviews/tests/plotting/matplotlib/test_elementplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_elementplot.py
@@ -7,9 +7,7 @@ from matplotlib import style
 from matplotlib.projections import PolarAxes
 from matplotlib.ticker import FormatStrFormatter, FuncFormatter, PercentFormatter
 
-from holoviews.core.dimension import Dimension
-from holoviews.core.spaces import DynamicMap
-from holoviews.element import Curve, HeatMap, Image, QuadMesh, Scatter, Scatter3D
+import holoviews as hv
 from holoviews.streams import Stream
 from holoviews.testing import assert_data_equal
 
@@ -21,7 +19,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
 
     def test_stream_cleanup(self):
         stream = Stream.define('Test', test=1)()
-        dmap = DynamicMap(lambda test: Curve([]), streams=[stream])
+        dmap = hv.DynamicMap(lambda test: hv.Curve([]), streams=[stream])
         plot = mpl_renderer.get_plot(dmap)
         assert bool(stream._subscribers)
         plot.cleanup()
@@ -30,12 +28,12 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
     def test_element_hooks(self):
         def hook(plot, element):
             plot.handles['title'].set_text('Called')
-        curve = Curve(range(10), label='Not Called').opts(hooks=[hook])
+        curve = hv.Curve(range(10), label='Not Called').opts(hooks=[hook])
         plot = mpl_renderer.get_plot(curve)
         assert plot.handles['title'].get_text() == 'Called'
 
     def test_element_font_scaling(self):
-        curve = Curve(range(10)).options(fontscale=2, title='A title')
+        curve = hv.Curve(range(10)).options(fontscale=2, title='A title')
         with style.context(
             {
                 "axes.labelsize": 10,
@@ -53,7 +51,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert ax.yaxis._major_tick_kw['labelsize'] == 20
 
     def test_element_font_scaling_fontsize_override_common(self):
-        curve = Curve(range(10)).options(fontscale=2, fontsize=14, title='A title')
+        curve = hv.Curve(range(10)).options(fontscale=2, fontsize=14, title='A title')
         with style.context(
             {
                 "axes.labelsize": 10,
@@ -72,7 +70,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert ax.yaxis._major_tick_kw['labelsize'] == 20
 
     def test_element_font_scaling_fontsize_override_specific(self):
-        curve = Curve(range(10)).opts(
+        curve = hv.Curve(range(10)).opts(
             fontscale=2, fontsize={'title': 16, 'xticks': 12, 'xlabel': 6}, title='A title')
         with style.context(
             {
@@ -91,7 +89,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert ax.yaxis._major_tick_kw['labelsize'] == 20
 
     def test_element_no_xaxis_yaxis(self):
-        element = Curve(range(10)).opts(xaxis=None, yaxis=None)
+        element = hv.Curve(range(10)).opts(xaxis=None, yaxis=None)
         axes = mpl_renderer.get_plot(element).handles['axis']
         xaxis = axes.get_xaxis()
         yaxis = axes.get_yaxis()
@@ -99,17 +97,17 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert yaxis.get_visible() is False
 
     def test_element_xlabel(self):
-        element = Curve(range(10)).opts(xlabel='custom x-label')
+        element = hv.Curve(range(10)).opts(xlabel='custom x-label')
         axes = mpl_renderer.get_plot(element).handles['axis']
         assert axes.get_xlabel() == 'custom x-label'
 
     def test_element_ylabel(self):
-        element = Curve(range(10)).opts(ylabel='custom y-label')
+        element = hv.Curve(range(10)).opts(ylabel='custom y-label')
         axes = mpl_renderer.get_plot(element).handles['axis']
         assert axes.get_ylabel() == 'custom y-label'
 
     def test_element_xformatter_string(self):
-        curve = Curve(range(10)).opts(xformatter='%d')
+        curve = hv.Curve(range(10)).opts(xformatter='%d')
         plot = mpl_renderer.get_plot(curve)
         xaxis = plot.handles['axis'].xaxis
         xformatter = xaxis.get_major_formatter()
@@ -117,7 +115,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert xformatter.fmt == '%d'
 
     def test_element_yformatter_string(self):
-        curve = Curve(range(10)).opts(yformatter='%d')
+        curve = hv.Curve(range(10)).opts(yformatter='%d')
         plot = mpl_renderer.get_plot(curve)
         yaxis = plot.handles['axis'].yaxis
         yformatter = yaxis.get_major_formatter()
@@ -125,7 +123,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert yformatter.fmt == '%d'
 
     def test_element_zformatter_string(self):
-        curve = Scatter3D([]).opts(zformatter='%d')
+        curve = hv.Scatter3D([]).opts(zformatter='%d')
         plot = mpl_renderer.get_plot(curve)
         zaxis = plot.handles['axis'].zaxis
         zformatter = zaxis.get_major_formatter()
@@ -135,7 +133,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
     def test_element_xformatter_function(self):
         def formatter(value):
             return str(value) + ' %'
-        curve = Curve(range(10)).opts(xformatter=formatter)
+        curve = hv.Curve(range(10)).opts(xformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         xaxis = plot.handles['axis'].xaxis
         xformatter = xaxis.get_major_formatter()
@@ -144,7 +142,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
     def test_element_yformatter_function(self):
         def formatter(value):
             return str(value) + ' %'
-        curve = Curve(range(10)).opts(yformatter=formatter)
+        curve = hv.Curve(range(10)).opts(yformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         yaxis = plot.handles['axis'].yaxis
         yformatter = yaxis.get_major_formatter()
@@ -153,7 +151,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
     def test_element_zformatter_function(self):
         def formatter(value):
             return str(value) + ' %'
-        curve = Scatter3D([]).opts(zformatter=formatter)
+        curve = hv.Scatter3D([]).opts(zformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         zaxis = plot.handles['axis'].zaxis
         zformatter = zaxis.get_major_formatter()
@@ -161,7 +159,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
 
     def test_element_xformatter_instance(self):
         formatter = PercentFormatter()
-        curve = Curve(range(10)).opts(xformatter=formatter)
+        curve = hv.Curve(range(10)).opts(xformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         xaxis = plot.handles['axis'].xaxis
         xformatter = xaxis.get_major_formatter()
@@ -169,7 +167,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
 
     def test_element_yformatter_instance(self):
         formatter = PercentFormatter()
-        curve = Curve(range(10)).opts(yformatter=formatter)
+        curve = hv.Curve(range(10)).opts(yformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         yaxis = plot.handles['axis'].yaxis
         yformatter = yaxis.get_major_formatter()
@@ -177,7 +175,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
 
     def test_element_zformatter_instance(self):
         formatter = PercentFormatter()
-        curve = Scatter3D([]).opts(zformatter=formatter)
+        curve = hv.Scatter3D([]).opts(zformatter=formatter)
         plot = mpl_renderer.get_plot(curve)
         zaxis = plot.handles['axis'].zaxis
         zformatter = zaxis.get_major_formatter()
@@ -186,7 +184,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
     def test_element_polar_xlimits(self):
         theta = np.arange(0, 5.4, 0.1)
         r = np.ones(len(theta))
-        scatter = Scatter((theta, r), 'theta', 'r').opts(projection='polar')
+        scatter = hv.Scatter((theta, r), 'theta', 'r').opts(projection='polar')
         plot = mpl_renderer.get_plot(scatter)
         ax = plot.handles['axis']
         assert isinstance(ax, PolarAxes)
@@ -197,7 +195,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
     #################################################################
 
     def test_element_backend_opts(self):
-        heat_map = HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
+        heat_map = hv.HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
             colorbar=True,
             backend_opts={
                 "colorbar.set_label": "Testing",
@@ -213,7 +211,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert ticklabels == ["A", "B"]
 
     def test_element_backend_opts_alias(self):
-        heat_map = HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
+        heat_map = hv.HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
             colorbar=True,
             backend_opts={
                 "cbar.set_label": "Testing",
@@ -229,8 +227,8 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert ticklabels == ["A", "B"]
 
     def test_element_backend_opts_method(self):
-        a = Curve([1, 2, 3], label="a")
-        b = Curve([1, 4, 9], label="b")
+        a = hv.Curve([1, 2, 3], label="a")
+        b = hv.Curve([1, 4, 9], label="b")
         curve = (a * b).opts(
             show_legend=True,
             backend_opts={
@@ -242,8 +240,8 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert not legend.get_frame_on()
 
     def test_element_backend_opts_sequential_method(self):
-        a = Curve([1, 2, 3], label="a")
-        b = Curve([1, 4, 9], label="b")
+        a = hv.Curve([1, 2, 3], label="a")
+        b = hv.Curve([1, 4, 9], label="b")
         curve = (a * b).opts(
             show_legend=True,
             backend_opts={
@@ -255,11 +253,11 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert legend.get_title().get_fontsize() == 188
 
     def test_element_backend_opts_getitem(self):
-        a = Curve([1, 2, 3], label="a")
-        b = Curve([1, 4, 9], label="b")
-        c = Curve([1, 4, 18], label="c")
-        d = Curve([1, 4, 36], label="d")
-        e = Curve([1, 4, 36], label="e")
+        a = hv.Curve([1, 2, 3], label="a")
+        b = hv.Curve([1, 4, 9], label="b")
+        c = hv.Curve([1, 4, 18], label="c")
+        d = hv.Curve([1, 4, 36], label="d")
+        e = hv.Curve([1, 4, 36], label="e")
         curve = (a * b * c * d * e).opts(
             show_legend=True,
             backend_opts={
@@ -277,7 +275,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert legend.get_texts()[4].get_fontsize() == 388
 
     def test_element_backend_opts_two_accessors(self):
-        heat_map = HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
+        heat_map = hv.HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
             colorbar=True, backend_opts={"colorbar": "Testing"},
         )
         mpl_renderer.get_plot(heat_map)
@@ -286,7 +284,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         )
 
     def test_element_backend_opts_model_not_resolved(self):
-        heat_map = HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
+        heat_map = hv.HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(
             colorbar=True, backend_opts={"cb.title": "Testing"},
         )
         mpl_renderer.get_plot(heat_map)
@@ -295,8 +293,8 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         )
 
     def test_element_backend_opts_model_invalid_method(self):
-        a = Curve([1, 2, 3], label="a")
-        b = Curve([1, 4, 9], label="b")
+        a = hv.Curve([1, 2, 3], label="a")
+        b = hv.Curve([1, 4, 9], label="b")
         curve = (a * b).opts(
             show_legend=True,
             backend_opts={
@@ -313,7 +311,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         X = pd.date_range(start="1/1/2018", end="1/08/2018", periods=100)
         Y = np.linspace(1, 100, 100)
         Z = np.random.randn(100, 100)
-        qm = QuadMesh((X, Y, Z)).opts(aspect='equal')
+        qm = hv.QuadMesh((X, Y, Z)).opts(aspect='equal')
         msg = (
             "The aspect is set to 'equal', but the axes does not have the same type: "
             "x-axis timedelta64 and y-axis float64. "
@@ -325,7 +323,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
 
     ### Grid ###
     def test_grid_both(self):
-        curve = Curve(range(10)).opts(gridstyle={'grid_color': 'red', 'grid_linestyle': '--', 'grid_alpha': 0.5, 'grid_linewidth': 2}, show_grid=True)
+        curve = hv.Curve(range(10)).opts(gridstyle={'grid_color': 'red', 'grid_linestyle': '--', 'grid_alpha': 0.5, 'grid_linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         gridlines = ax.get_xgridlines() + ax.get_ygridlines()
@@ -336,13 +334,13 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
             assert line.get_linewidth() == 2
 
     def test_grid_both_show_grid_False(self):
-        curve = Curve(range(10)).opts(gridstyle={'grid_color': 'red', 'grid_linestyle': '--', 'grid_alpha': 0.5, 'grid_linewidth': 2}, show_grid=False)
+        curve = hv.Curve(range(10)).opts(gridstyle={'grid_color': 'red', 'grid_linestyle': '--', 'grid_alpha': 0.5, 'grid_linewidth': 2}, show_grid=False)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         assert not any(line.get_visible() for line in ax.get_xgridlines() + ax.get_ygridlines())
 
     def test_grid_both_no_grid_prefix(self):
-        curve = Curve(range(10)).opts(gridstyle={'color': 'red', 'linestyle': '--', 'alpha': 0.5, 'linewidth': 2}, show_grid=True)
+        curve = hv.Curve(range(10)).opts(gridstyle={'color': 'red', 'linestyle': '--', 'alpha': 0.5, 'linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         gridlines = ax.get_xgridlines() + ax.get_ygridlines()
@@ -353,7 +351,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
             assert line.get_linewidth() == 2
 
     def test_grid_x(self):
-        curve = Curve(range(10)).opts(gridstyle={'xgrid_color': 'blue', 'xgrid_linestyle': '--', 'xgrid_alpha': 0.5, 'xgrid_linewidth': 2}, show_grid=True)
+        curve = hv.Curve(range(10)).opts(gridstyle={'xgrid_color': 'blue', 'xgrid_linestyle': '--', 'xgrid_alpha': 0.5, 'xgrid_linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         xgridlines = ax.get_xgridlines()
@@ -370,7 +368,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
             assert line.get_linewidth() != 2
 
     def test_grid_x_no_grid_prefix(self):
-        curve = Curve(range(10)).opts(gridstyle={'color': 'blue', 'linestyle': '--', 'alpha': 0.5, 'linewidth': 2}, show_grid=True)
+        curve = hv.Curve(range(10)).opts(gridstyle={'color': 'blue', 'linestyle': '--', 'alpha': 0.5, 'linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         xgridlines = ax.get_xgridlines()
@@ -387,7 +385,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
             assert line.get_linewidth() == 2
 
     def test_grid_y(self):
-        curve = Curve(range(10)).opts(gridstyle={'ygrid_color': 'green', 'ygrid_linestyle': '--', 'ygrid_alpha': 0.5, 'ygrid_linewidth': 2}, show_grid=True)
+        curve = hv.Curve(range(10)).opts(gridstyle={'ygrid_color': 'green', 'ygrid_linestyle': '--', 'ygrid_alpha': 0.5, 'ygrid_linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         ygridlines = ax.get_ygridlines()
@@ -404,7 +402,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
             assert line.get_linewidth() != 2
 
     def test_grid_y_no_grid_prefix(self):
-        curve = Curve(range(10)).opts(gridstyle={'color': 'green', 'linestyle': '--', 'alpha': 0.5, 'linewidth': 2}, show_grid=True)
+        curve = hv.Curve(range(10)).opts(gridstyle={'color': 'green', 'linestyle': '--', 'alpha': 0.5, 'linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         ygridlines = ax.get_ygridlines()
@@ -421,7 +419,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
             assert line.get_linewidth() == 2
 
     def test_grid_mix(self):
-        curve = Curve(range(10)).opts(gridstyle={'grid_color': 'red', 'ygrid_linestyle': '--', 'ygrid_alpha': 0.5, 'ygrid_linewidth': 2}, show_grid=True)
+        curve = hv.Curve(range(10)).opts(gridstyle={'grid_color': 'red', 'ygrid_linestyle': '--', 'ygrid_alpha': 0.5, 'ygrid_linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         xgridlines = ax.get_xgridlines()
@@ -438,7 +436,7 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
             assert line.get_linewidth() == 2
 
     def test_grid_mix_no_grid_prefix(self):
-        curve = Curve(range(10)).opts(gridstyle={'color': 'red', 'y_linestyle': '--', 'y_alpha': 0.5, 'y_linewidth': 2}, show_grid=True)
+        curve = hv.Curve(range(10)).opts(gridstyle={'color': 'red', 'y_linestyle': '--', 'y_alpha': 0.5, 'y_linewidth': 2}, show_grid=True)
         plot = mpl_renderer.get_plot(curve)
         ax = plot.handles['axis']
         xgridlines = ax.get_xgridlines()
@@ -458,64 +456,64 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
 class TestColorbarPlot(TestMPLPlot):
 
     def test_colormapper_unsigned_int(self):
-        img = Image(np.array([[1, 1, 1, 2], [2, 2, 3, 4]]).astype('uint16'))
+        img = hv.Image(np.array([[1, 1, 1, 2], [2, 2, 3, 4]]).astype('uint16'))
         plot = mpl_renderer.get_plot(img)
         artist = plot.handles['artist']
         assert artist.get_clim() == (1, 4)
 
     def test_colormapper_symmetric(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(symmetric=True)
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(symmetric=True)
         plot = mpl_renderer.get_plot(img)
         artist = plot.handles['artist']
         assert artist.get_clim() == (-3, 3)
 
     def test_colormapper_clims(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(clims=(0, 4))
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(clims=(0, 4))
         plot = mpl_renderer.get_plot(img)
         artist = plot.handles['artist']
         assert artist.get_clim() == (0, 4)
 
     def test_colormapper_color_levels(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(color_levels=5)
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(color_levels=5)
         plot = mpl_renderer.get_plot(img)
         artist = plot.handles['artist']
         assert len(artist.cmap.colors) == 5
 
     def test_colormapper_transparent_nan(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'NaN': 'transparent'})
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'NaN': 'transparent'})
         plot = mpl_renderer.get_plot(img)
         cmap = plot.handles['artist'].cmap
         assert cmap._rgba_bad == (1.0, 1.0, 1.0, 0)
 
     def test_colormapper_min_max_colors(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'min': 'red', 'max': 'blue'})
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(clipping_colors={'min': 'red', 'max': 'blue'})
         plot = mpl_renderer.get_plot(img)
         cmap = plot.handles['artist'].cmap
         assert cmap._rgba_under == (1.0, 0, 0, 1)
         assert cmap._rgba_over == (0, 0, 1.0, 1)
 
     def test_colorbar_label(self):
-        scatter = Scatter(np.random.rand(100, 3), vdims=["y", "color"]).opts(color_index=2, colorbar=True)
+        scatter = hv.Scatter(np.random.rand(100, 3), vdims=["y", "color"]).opts(color_index=2, colorbar=True)
         plot = mpl_renderer.get_plot(scatter)
         cbar_ax = plot.handles['cax']
         assert cbar_ax.get_ylabel() == 'color'
 
     def test_colorbar_empty_clabel(self):
-        img = Image(np.array([[1, 1, 1, 2], [2, 2, 3, 4]])).opts(clabel='', colorbar=True)
+        img = hv.Image(np.array([[1, 1, 1, 2], [2, 2, 3, 4]])).opts(clabel='', colorbar=True)
         plot = mpl_renderer.get_plot(img)
         colorbar = plot.handles['cax']
         assert colorbar.get_label() == ''
 
     def test_colorbar_label_style_mapping(self):
-        scatter = Scatter(np.random.rand(100, 3), vdims=["y", "color"]).opts(color='color', colorbar=True)
+        scatter = hv.Scatter(np.random.rand(100, 3), vdims=["y", "color"]).opts(color='color', colorbar=True)
         plot = mpl_renderer.get_plot(scatter)
         cbar_ax = plot.handles['cax']
         assert cbar_ax.get_ylabel() == 'color'
 
     def test_style_map_dimension_object(self):
-        x = Dimension('x')
-        y = Dimension('y')
-        scatter = Scatter([1, 2, 3], kdims=[x], vdims=[y]).opts(color=x)
+        x = hv.Dimension('x')
+        y = hv.Dimension('y')
+        scatter = hv.Scatter([1, 2, 3], kdims=[x], vdims=[y]).opts(color=x)
         plot = mpl_renderer.get_plot(scatter)
         artist = plot.handles['artist']
         assert artist.get_clim() == (0, 2)
@@ -525,8 +523,8 @@ class TestOverlayPlot(TestMPLPlot):
 
     def test_overlay_legend_opts(self):
         overlay = (
-            Curve(np.random.randn(10).cumsum(), label='A') *
-            Curve(np.random.randn(10).cumsum(), label='B')
+            hv.Curve(np.random.randn(10).cumsum(), label='A') *
+            hv.Curve(np.random.randn(10).cumsum(), label='B')
         ).opts(legend_opts={'framealpha': 0.5, 'facecolor': 'red'})
         plot = mpl_renderer.get_plot(overlay)
         legend_frame = plot.handles['legend'].get_frame()

--- a/holoviews/tests/plotting/matplotlib/test_errorbarplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_errorbarplot.py
@@ -1,9 +1,8 @@
 import numpy as np
 import pytest
 
+import holoviews as hv
 from holoviews.core.options import AbbreviatedException
-from holoviews.core.spaces import HoloMap
-from holoviews.element import ErrorBars
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -17,7 +16,7 @@ class TestErrorBarPlot(TestMPLPlot):
     ###########################
 
     def test_errorbars_color_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, '#000000'), (0, 1, 0.2, 0.4, '#FF0000'), (0, 2, 0.6, 1.2, '#00FF00')],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, '#000000'), (0, 1, 0.2, 0.4, '#FF0000'), (0, 2, 0.6, 1.2, '#00FF00')],
                               vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(errorbars)
         artist = plot.handles['artist']
@@ -25,10 +24,10 @@ class TestErrorBarPlot(TestMPLPlot):
                          np.array([[0, 0, 0, 1], [1, 0, 0, 1], [0, 1, 0, 1]]))
 
     def test_errorbars_color_op_update(self):
-        errorbars = HoloMap({
-            0: ErrorBars([(0, 0, 0.1, 0.2, '#000000'), (0, 1, 0.2, 0.4, '#FF0000'),
+        errorbars = hv.HoloMap({
+            0: hv.ErrorBars([(0, 0, 0.1, 0.2, '#000000'), (0, 1, 0.2, 0.4, '#FF0000'),
                           (0, 2, 0.6, 1.2, '#00FF00')], vdims=['y', 'perr', 'nerr', 'color']),
-            1: ErrorBars([(0, 0, 0.1, 0.2, '#FF0000'), (0, 1, 0.2, 0.4, '#00FF00'),
+            1: hv.ErrorBars([(0, 0, 0.1, 0.2, '#FF0000'), (0, 1, 0.2, 0.4, '#00FF00'),
                           (0, 2, 0.6, 1.2, '#0000FF')], vdims=['y', 'perr', 'nerr', 'color'])
         }).opts(color='color')
         plot = mpl_renderer.get_plot(errorbars)
@@ -40,21 +39,21 @@ class TestErrorBarPlot(TestMPLPlot):
                          np.array([[1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1, 1]]))
 
     def test_errorbars_linear_color_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 1), (0, 2, 0.6, 1.2, 2)],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, 0), (0, 1, 0.2, 0.4, 1), (0, 2, 0.6, 1.2, 2)],
                               vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         msg = 'ValueError: Mapping a continuous or categorical dimension to a color'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(errorbars)
 
     def test_errorbars_categorical_color_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, 'A'), (0, 1, 0.2, 0.4, 'B'), (0, 2, 0.6, 1.2, 'C')],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, 'A'), (0, 1, 0.2, 0.4, 'B'), (0, 2, 0.6, 1.2, 'C')],
                               vdims=['y', 'perr', 'nerr', 'color']).opts(color='color')
         msg = 'ValueError: Mapping a continuous or categorical dimension to a color'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(errorbars)
 
     def test_errorbars_line_color_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, '#000000'), (0, 1, 0.2, 0.4, '#FF0000'), (0, 2, 0.6, 1.2, '#00FF00')],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, '#000000'), (0, 1, 0.2, 0.4, '#FF0000'), (0, 2, 0.6, 1.2, '#00FF00')],
                               vdims=['y', 'perr', 'nerr', 'color']).opts(edgecolor='color')
         plot = mpl_renderer.get_plot(errorbars)
         artist = plot.handles['artist']
@@ -63,24 +62,24 @@ class TestErrorBarPlot(TestMPLPlot):
         ))
 
     def test_errorbars_alpha_op(self):
-        errorbars = ErrorBars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        errorbars = hv.ErrorBars([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(alpha='alpha')
         msg = 'ValueError: Mapping a dimension to the "alpha" style'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(errorbars)
 
     def test_errorbars_line_width_op(self):
-        errorbars = ErrorBars([(0, 0, 0.1, 0.2, 1), (0, 1, 0.2, 0.4, 4), (0, 2, 0.6, 1.2, 8)],
+        errorbars = hv.ErrorBars([(0, 0, 0.1, 0.2, 1), (0, 1, 0.2, 0.4, 4), (0, 2, 0.6, 1.2, 8)],
                               vdims=['y', 'perr', 'nerr', 'line_width']).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(errorbars)
         artist = plot.handles['artist']
         assert artist.get_linewidths() == [1, 4, 8]
 
     def test_errorbars_line_width_op_update(self):
-        errorbars = HoloMap({
-            0: ErrorBars([(0, 0, 0.1, 0.2, 1), (0, 1, 0.2, 0.4, 4),
+        errorbars = hv.HoloMap({
+            0: hv.ErrorBars([(0, 0, 0.1, 0.2, 1), (0, 1, 0.2, 0.4, 4),
                           (0, 2, 0.6, 1.2, 8)], vdims=['y', 'perr', 'nerr', 'line_width']),
-            1: ErrorBars([(0, 0, 0.1, 0.2, 2), (0, 1, 0.2, 0.4, 6),
+            1: hv.ErrorBars([(0, 0, 0.1, 0.2, 2), (0, 1, 0.2, 0.4, 6),
                           (0, 2, 0.6, 1.2, 4)], vdims=['y', 'perr', 'nerr', 'line_width'])
         }).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(errorbars)

--- a/holoviews/tests/plotting/matplotlib/test_graphplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_graphplot.py
@@ -2,12 +2,10 @@ import numpy as np
 import pytest
 from matplotlib.collections import LineCollection, PolyCollection
 
-from holoviews.core.data import Dataset
-from holoviews.core.options import AbbreviatedException, Cycle
-from holoviews.core.spaces import HoloMap
-from holoviews.element import Chord, Graph, Nodes, TriMesh, circular_layout
+import holoviews as hv
+from holoviews.core.options import AbbreviatedException
+from holoviews.element import circular_layout
 from holoviews.testing import assert_data_equal
-from holoviews.util.transform import dim
 
 from .test_plot import MPL_GE_3_4_0, TestMPLPlot, mpl_renderer
 
@@ -22,12 +20,12 @@ class TestMplGraphPlot(TestMPLPlot):
         self.source = np.arange(N, dtype=np.int32)
         self.target = np.zeros(N, dtype=np.int32)
         self.weights = np.random.rand(N)
-        self.graph = Graph(((self.source, self.target),))
-        self.node_info = Dataset(['Output']+['Input']*(N-1), vdims=['Label'])
-        self.node_info2 = Dataset(self.weights, vdims='Weight')
-        self.graph2 = Graph(((self.source, self.target), self.node_info))
-        self.graph3 = Graph(((self.source, self.target), self.node_info2))
-        self.graph4 = Graph(((self.source, self.target, self.weights),), vdims='Weight')
+        self.graph = hv.Graph(((self.source, self.target),))
+        self.node_info = hv.Dataset(['Output']+['Input']*(N-1), vdims=['Label'])
+        self.node_info2 = hv.Dataset(self.weights, vdims='Weight')
+        self.graph2 = hv.Graph(((self.source, self.target), self.node_info))
+        self.graph3 = hv.Graph(((self.source, self.target), self.node_info2))
+        self.graph4 = hv.Graph(((self.source, self.target, self.weights),), vdims='Weight')
 
     def test_plot_simple_graph(self):
         plot = mpl_renderer.get_plot(self.graph)
@@ -91,9 +89,9 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_node_color(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, '#000000'), (0, 1, 1, '#FF0000'), (1, 1, 2, '#00FF00')],
+        nodes = hv.Nodes([(0, 0, 0, '#000000'), (0, 1, 1, '#FF0000'), (1, 1, 2, '#00FF00')],
                       vdims='color')
-        graph = Graph((edges, nodes)).opts(node_color='color')
+        graph = hv.Graph((edges, nodes)).opts(node_color='color')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         assert_data_equal(artist.get_facecolors(),
@@ -104,10 +102,10 @@ class TestMplGraphPlot(TestMPLPlot):
         def get_graph(i):
             c1, c2, c3 = {0: ('#00FF00', '#0000FF', '#FF0000'),
                           1: ('#FF0000', '#00FF00', '#0000FF')}[i]
-            nodes = Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
+            nodes = hv.Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
                       vdims='color')
-            return Graph((edges, nodes))
-        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_color='color')
+            return hv.Graph((edges, nodes))
+        graph = hv.HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_color='color')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         assert_data_equal(artist.get_facecolors(),
@@ -118,9 +116,9 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_node_color_linear(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 0.5), (0, 1, 1, 1.5), (1, 1, 2, 2.5)],
+        nodes = hv.Nodes([(0, 0, 0, 0.5), (0, 1, 1, 1.5), (1, 1, 2, 2.5)],
                       vdims='color')
-        graph = Graph((edges, nodes)).opts(node_color='color')
+        graph = hv.Graph((edges, nodes)).opts(node_color='color')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         assert_data_equal(np.asarray(artist.get_array()), np.array([0.5, 1.5, 2.5]))
@@ -131,10 +129,10 @@ class TestMplGraphPlot(TestMPLPlot):
         def get_graph(i):
             c1, c2, c3 = {0: (0.5, 1.5, 2.5),
                           1: (3, 2, 1)}[i]
-            nodes = Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
+            nodes = hv.Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
                       vdims='color')
-            return Graph((edges, nodes))
-        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_color='color', framewise=True)
+            return hv.Graph((edges, nodes))
+        graph = hv.HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_color='color', framewise=True)
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         assert_data_equal(np.asarray(artist.get_array()), np.array([0.5, 1.5, 2.5]))
@@ -145,18 +143,18 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_node_color_categorical(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 'A'), (0, 1, 1, 'B'), (1, 1, 2, 'A')],
+        nodes = hv.Nodes([(0, 0, 0, 'A'), (0, 1, 1, 'B'), (1, 1, 2, 'A')],
                       vdims='color')
-        graph = Graph((edges, nodes)).opts(node_color='color')
+        graph = hv.Graph((edges, nodes)).opts(node_color='color')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         assert_data_equal(np.asarray(artist.get_array()), np.array([0, 1, 0]))
 
     def test_graph_op_node_size(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 6)],
+        nodes = hv.Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 6)],
                       vdims='size')
-        graph = Graph((edges, nodes)).opts(node_size='size')
+        graph = hv.Graph((edges, nodes)).opts(node_size='size')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         assert_data_equal(artist.get_sizes(), np.array([4, 16, 36]))
@@ -166,10 +164,10 @@ class TestMplGraphPlot(TestMPLPlot):
         def get_graph(i):
             c1, c2, c3 = {0: (2, 4, 6),
                           1: (12, 3, 5)}[i]
-            nodes = Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
+            nodes = hv.Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
                       vdims='size')
-            return Graph((edges, nodes))
-        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_size='size')
+            return hv.Graph((edges, nodes))
+        graph = hv.HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_size='size')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         assert_data_equal(artist.get_sizes(), np.array([4, 16, 36]))
@@ -178,8 +176,8 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_node_linewidth(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 3.5)], vdims='line_width')
-        graph = Graph((edges, nodes)).opts(node_linewidth='line_width')
+        nodes = hv.Nodes([(0, 0, 0, 2), (0, 1, 1, 4), (1, 1, 2, 3.5)], vdims='line_width')
+        graph = hv.Graph((edges, nodes)).opts(node_linewidth='line_width')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         assert artist.get_linewidths() == [2, 4, 3.5]
@@ -189,10 +187,10 @@ class TestMplGraphPlot(TestMPLPlot):
         def get_graph(i):
             c1, c2, c3 = {0: (2, 4, 6),
                           1: (12, 3, 5)}[i]
-            nodes = Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
+            nodes = hv.Nodes([(0, 0, 0, c1), (0, 1, 1, c2), (1, 1, 2, c3)],
                       vdims='line_width')
-            return Graph((edges, nodes))
-        graph = HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_linewidth='line_width')
+            return hv.Graph((edges, nodes))
+        graph = hv.HoloMap({0: get_graph(0), 1: get_graph(1)}).opts(node_linewidth='line_width')
         plot = mpl_renderer.get_plot(graph)
         artist = plot.handles['nodes']
         assert artist.get_linewidths() == [2, 4, 6]
@@ -201,8 +199,8 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_node_alpha(self):
         edges = [(0, 1), (0, 2)]
-        nodes = Nodes([(0, 0, 0, 0.2), (0, 1, 1, 0.6), (1, 1, 2, 1)], vdims='alpha')
-        graph = Graph((edges, nodes)).opts(node_alpha='alpha')
+        nodes = hv.Nodes([(0, 0, 0, 0.2), (0, 1, 1, 0.6), (1, 1, 2, 1)], vdims='alpha')
+        graph = hv.Graph((edges, nodes)).opts(node_alpha='alpha')
 
         if MPL_GE_3_4_0:
             plot = mpl_renderer.get_plot(graph)
@@ -216,7 +214,7 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_edge_color(self):
         edges = [(0, 1, 'red'), (0, 2, 'green'), (1, 3, 'blue')]
-        graph = Graph(edges, vdims='color').opts(edge_color='color')
+        graph = hv.Graph(edges, vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
         assert_data_equal(edges.get_edgecolors(), np.array([
@@ -225,10 +223,10 @@ class TestMplGraphPlot(TestMPLPlot):
         ))
 
     def test_graph_op_edge_color_update(self):
-        graph = HoloMap({
-            0: Graph([(0, 1, 'red'), (0, 2, 'green'), (1, 3, 'blue')],
+        graph = hv.HoloMap({
+            0: hv.Graph([(0, 1, 'red'), (0, 2, 'green'), (1, 3, 'blue')],
                     vdims='color'),
-            1: Graph([(0, 1, 'green'), (0, 2, 'blue'), (1, 3, 'red')],
+            1: hv.Graph([(0, 1, 'green'), (0, 2, 'blue'), (1, 3, 'red')],
                      vdims='color')}).opts(edge_color='color')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
@@ -244,17 +242,17 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_edge_color_linear(self):
         edges = [(0, 1, 2), (0, 2, 0.5), (1, 3, 3)]
-        graph = Graph(edges, vdims='color').opts(edge_color='color')
+        graph = hv.Graph(edges, vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
         assert_data_equal(np.asarray(edges.get_array()), np.array([2, 0.5, 3]))
         assert edges.get_clim() == (0.5, 3)
 
     def test_graph_op_edge_color_linear_update(self):
-        graph = HoloMap({
-            0: Graph([(0, 1, 2), (0, 2, 0.5), (1, 3, 3)],
+        graph = hv.HoloMap({
+            0: hv.Graph([(0, 1, 2), (0, 2, 0.5), (1, 3, 3)],
                     vdims='color'),
-            1: Graph([(0, 1, 4.3), (0, 2, 1.4), (1, 3, 2.6)],
+            1: hv.Graph([(0, 1, 4.3), (0, 2, 1.4), (1, 3, 2.6)],
                      vdims='color')}).opts(edge_color='color', framewise=True)
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
@@ -266,7 +264,7 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_edge_color_categorical(self):
         edges = [(0, 1, 'C'), (0, 2, 'B'), (1, 3, 'A')]
-        graph = Graph(edges, vdims='color').opts(edge_color='color')
+        graph = hv.Graph(edges, vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
         assert_data_equal(np.asarray(edges.get_array()), np.array([0, 1, 2]))
@@ -274,23 +272,23 @@ class TestMplGraphPlot(TestMPLPlot):
 
     def test_graph_op_edge_alpha(self):
         edges = [(0, 1, 0.1), (0, 2, 0.5), (1, 3, 0.3)]
-        graph = Graph(edges, vdims='alpha').opts(edge_alpha='alpha')
+        graph = hv.Graph(edges, vdims='alpha').opts(edge_alpha='alpha')
         msg = 'ValueError: Mapping a dimension to the "edge_alpha" style'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(graph)
 
     def test_graph_op_edge_linewidth(self):
         edges = [(0, 1, 2), (0, 2, 10), (1, 3, 6)]
-        graph = Graph(edges, vdims='line_width').opts(edge_linewidth='line_width')
+        graph = hv.Graph(edges, vdims='line_width').opts(edge_linewidth='line_width')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
         assert edges.get_linewidths() == [2, 10, 6]
 
     def test_graph_op_edge_line_width_update(self):
-        graph = HoloMap({
-            0: Graph([(0, 1, 2), (0, 2, 0.5), (1, 3, 3)],
+        graph = hv.HoloMap({
+            0: hv.Graph([(0, 1, 2), (0, 2, 0.5), (1, 3, 3)],
                     vdims='line_width'),
-            1: Graph([(0, 1, 4.3), (0, 2, 1.4), (1, 3, 2.6)],
+            1: hv.Graph([(0, 1, 4.3), (0, 2, 1.4), (1, 3, 2.6)],
                      vdims='line_width')}).opts(edge_linewidth='line_width')
         plot = mpl_renderer.get_plot(graph)
         edges = plot.handles['edges']
@@ -307,8 +305,8 @@ class TestMplTriMeshPlot(TestMPLPlot):
 
         self.nodes = [(0, 0, 0), (0.5, 1, 1), (1., 0, 2), (1.5, 1, 3)]
         self.simplices = [(0, 1, 2, 0), (1, 2, 3, 1)]
-        self.trimesh = TriMesh((self.simplices, self.nodes))
-        self.trimesh_weighted = TriMesh((self.simplices, self.nodes), vdims='weight')
+        self.trimesh = hv.TriMesh((self.simplices, self.nodes))
+        self.trimesh_weighted = hv.TriMesh((self.simplices, self.nodes), vdims='weight')
 
     def test_plot_simple_trimesh(self):
         plot = mpl_renderer.get_plot(self.trimesh)
@@ -339,7 +337,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
         assert_data_equal(edges.get_edgecolors(), colors)
 
     def test_plot_trimesh_categorically_colored_edges(self):
-        opts = dict(edge_color_index='node1', edge_color=Cycle('Set1'))
+        opts = dict(edge_color_index='node1', edge_color=hv.Cycle('Set1'))
         plot = mpl_renderer.get_plot(self.trimesh_weighted.opts(**opts))
         edges = plot.handles['edges']
         colors = np.array([[0.894118, 0.101961, 0.109804, 1.],
@@ -347,7 +345,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
         assert_data_equal(edges.get_edgecolors(), colors)
 
     def test_plot_trimesh_categorically_colored_edges_filled(self):
-        opts = dict(edge_color_index='node1', filled=True, edge_color=Cycle('Set1'))
+        opts = dict(edge_color_index='node1', filled=True, edge_color=hv.Cycle('Set1'))
         plot = mpl_renderer.get_plot(self.trimesh_weighted.opts(**opts))
         edges = plot.handles['edges']
         colors = np.array([[0.894118, 0.101961, 0.109804, 1.],
@@ -361,7 +359,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_node_color(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 'red'), (0, 0, 1, 'green'), (0, 1, 2, 'blue'), (1, 0, 3, 'black')]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['nodes']
         assert_data_equal(artist.get_facecolors(),
@@ -370,7 +368,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_node_color_linear(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 2), (0, 0, 1, 1), (0, 1, 2, 3), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['nodes']
         assert_data_equal(np.asarray(artist.get_array()), np.array([2, 1, 3, 4]))
@@ -379,7 +377,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_node_color_categorical(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 'B'), (0, 0, 1, 'C'), (0, 1, 2, 'A'), (1, 0, 3, 'B')]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(node_color='color')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='color'))).opts(node_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['nodes']
         assert_data_equal(np.asarray(artist.get_array()), np.array([0, 1, 2, 0]))
@@ -388,7 +386,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_node_size(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 3), (0, 0, 1, 2), (0, 1, 2, 8), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='size'))).opts(node_size='size')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='size'))).opts(node_size='size')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['nodes']
         assert_data_equal(artist.get_sizes(), np.array([9, 4, 64, 16]))
@@ -396,7 +394,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_node_alpha(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 0.2), (0, 0, 1, 0.6), (0, 1, 2, 1), (1, 0, 3, 0.3)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='alpha'))).opts(node_alpha='alpha')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='alpha'))).opts(node_alpha='alpha')
 
         if MPL_GE_3_4_0:
             plot = mpl_renderer.get_plot(trimesh)
@@ -411,7 +409,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_node_line_width(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 0.2), (0, 0, 1, 0.6), (0, 1, 2, 1), (1, 0, 3, 0.3)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='line_width'))).opts(node_linewidth='line_width')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='line_width'))).opts(node_linewidth='line_width')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['nodes']
         assert artist.get_linewidths() == [0.2, 0.6, 1, 0.3]
@@ -419,7 +417,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_edge_color_linear_mean_node(self):
         edges = [(0, 1, 2), (1, 2, 3)]
         nodes = [(-1, -1, 0, 2), (0, 0, 1, 1), (0, 1, 2, 3), (1, 0, 3, 4)]
-        trimesh = TriMesh((edges, Nodes(nodes, vdims='color'))).opts(edge_color='color')
+        trimesh = hv.TriMesh((edges, hv.Nodes(nodes, vdims='color'))).opts(edge_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['edges']
         assert_data_equal(np.asarray(artist.get_array()), np.array([2, 8/3.]))
@@ -428,7 +426,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_edge_color(self):
         edges = [(0, 1, 2, 'red'), (1, 2, 3, 'blue')]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
+        trimesh = hv.TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['edges']
         assert_data_equal(artist.get_edgecolors(), np.array([
@@ -437,7 +435,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_edge_color_linear(self):
         edges = [(0, 1, 2, 2.4), (1, 2, 3, 3.6)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
+        trimesh = hv.TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['edges']
         assert_data_equal(np.asarray(artist.get_array()), np.array([2.4, 3.6]))
@@ -446,7 +444,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_edge_color_categorical(self):
         edges = [(0, 1, 2, 'A'), (1, 2, 3, 'B')]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
+        trimesh = hv.TriMesh((edges, nodes), vdims='color').opts(edge_color='color')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['edges']
         assert_data_equal(np.asarray(artist.get_array()), np.array([0, 1]))
@@ -455,7 +453,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_edge_alpha(self):
         edges = [(0, 1, 2, 0.7), (1, 2, 3, 0.3)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='alpha').opts(edge_alpha='alpha')
+        trimesh = hv.TriMesh((edges, nodes), vdims='alpha').opts(edge_alpha='alpha')
         msg = 'ValueError: Mapping a dimension to the "edge_alpha" style'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(trimesh)
@@ -463,7 +461,7 @@ class TestMplTriMeshPlot(TestMPLPlot):
     def test_trimesh_op_edge_line_width(self):
         edges = [(0, 1, 2, 7), (1, 2, 3, 3)]
         nodes = [(-1, -1, 0), (0, 0, 1), (0, 1, 2), (1, 0, 3)]
-        trimesh = TriMesh((edges, nodes), vdims='line_width').opts(edge_linewidth='line_width')
+        trimesh = hv.TriMesh((edges, nodes), vdims='line_width').opts(edge_linewidth='line_width')
         plot = mpl_renderer.get_plot(trimesh)
         artist = plot.handles['edges']
         assert artist.get_linewidths() == [7, 3]
@@ -475,13 +473,13 @@ class TestMplChordPlot(TestMPLPlot):
     def setup_method(self):
         super().setup_method()
         self.edges = [(0, 1, 1), (0, 2, 2), (1, 2, 3)]
-        self.nodes = Dataset([(0, 'A'), (1, 'B'), (2, 'C')], 'index', 'Label')
-        self.chord = Chord((self.edges, self.nodes))
+        self.nodes = hv.Dataset([(0, 'A'), (1, 'B'), (2, 'C')], 'index', 'Label')
+        self.chord = hv.Chord((self.edges, self.nodes))
 
     def make_chord(self, i):
         edges = [(0, 1, 1+i), (0, 2, 2+i), (1, 2, 3+i)]
-        nodes = Dataset([(0, 0+i), (1, 1+i), (2, 2+i)], 'index', 'Label')
-        return Chord((edges, nodes), vdims='weight')
+        nodes = hv.Dataset([(0, 0+i), (1, 1+i), (2, 2+i)], 'index', 'Label')
+        return hv.Chord((edges, nodes), vdims='weight')
 
     def test_chord_nodes_label_text(self):
         g = self.chord.opts(label_index='Label')
@@ -526,14 +524,14 @@ class TestMplChordPlot(TestMPLPlot):
         assert_data_equal(edges.get_edgecolors(), colors)
 
     def test_chord_edge_color_style_mapping(self):
-        g = self.chord.opts(edge_color=dim('start').astype(str), edge_cmap=['#FFFFFF', '#000000'])
+        g = self.chord.opts(edge_color=hv.dim('start').astype(str), edge_cmap=['#FFFFFF', '#000000'])
         plot = mpl_renderer.get_plot(g)
         edges = plot.handles['edges']
         assert_data_equal(np.asarray(edges.get_array()), np.array([0, 0, 1]))
         assert edges.get_clim() == (0, 2)
 
     def test_chord_edge_color_linear_style_mapping_update(self):
-        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(edge_color='weight', framewise=True)
+        hmap = hv.HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(edge_color='weight', framewise=True)
         plot = mpl_renderer.get_plot(hmap)
         edges = plot.handles['edges']
         assert_data_equal(np.asarray(edges.get_array()), np.array([1, 2, 3]))
@@ -543,7 +541,7 @@ class TestMplChordPlot(TestMPLPlot):
         assert edges.get_clim() == (2, 4)
 
     def test_chord_node_color_linear_style_mapping_update(self):
-        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(node_color='Label', framewise=True)
+        hmap = hv.HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(node_color='Label', framewise=True)
         plot = mpl_renderer.get_plot(hmap)
         arcs = plot.handles['arcs']
         nodes = plot.handles['nodes']
@@ -558,8 +556,8 @@ class TestMplChordPlot(TestMPLPlot):
         assert arcs.get_clim() == (1, 3)
 
     def test_chord_edge_color_style_mapping_update(self):
-        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(
-            edge_color=dim('weight').categorize({1: 'red', 2: 'green', 3: 'blue', 4: 'black'})
+        hmap = hv.HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(
+            edge_color=hv.dim('weight').categorize({1: 'red', 2: 'green', 3: 'blue', 4: 'black'})
         )
         plot = mpl_renderer.get_plot(hmap)
         edges = plot.handles['edges']
@@ -572,8 +570,8 @@ class TestMplChordPlot(TestMPLPlot):
         ]))
 
     def test_chord_node_color_style_mapping_update(self):
-        hmap = HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(
-            node_color=dim('Label').categorize({0: 'red', 1: 'green', 2: 'blue', 3: 'black'})
+        hmap = hv.HoloMap({0: self.make_chord(0), 1: self.make_chord(1)}).opts(
+            node_color=hv.dim('Label').categorize({0: 'red', 1: 'green', 2: 'blue', 3: 'black'})
         )
         plot = mpl_renderer.get_plot(hmap)
         arcs = plot.handles['arcs']

--- a/holoviews/tests/plotting/matplotlib/test_heatmapplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_heatmapplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import HeatMap, Image
+import holoviews as hv
 
 from .test_plot import MPL_GE_3_8_0, TestMPLPlot, mpl_renderer
 
@@ -9,7 +9,7 @@ class TestHeatMapPlot(TestMPLPlot):
 
     def test_heatmap_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
-        hm = HeatMap(Image(arr)).opts(invert_axes=True)
+        hm = hv.HeatMap(hv.Image(arr)).opts(invert_axes=True)
         plot = mpl_renderer.get_plot(hm)
         artist = plot.handles['artist']
         if MPL_GE_3_8_0:
@@ -18,12 +18,12 @@ class TestHeatMapPlot(TestMPLPlot):
             np.testing.assert_equal(artist.get_array().data, arr.T[::-1].flatten())
 
     def test_heatmap_extents(self):
-        hmap = HeatMap([('A', 50, 1), ('B', 2, 2), ('C', 50, 1)])
+        hmap = hv.HeatMap([('A', 50, 1), ('B', 2, 2), ('C', 50, 1)])
         plot = mpl_renderer.get_plot(hmap)
         assert plot.get_extents(hmap, {}) == (-.5, -22, 2.5, 74)
 
     def test_heatmap_invert_xaxis(self):
-        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).opts(invert_xaxis=True)
+        hmap = hv.HeatMap([('A',1, 1), ('B', 2, 2)]).opts(invert_xaxis=True)
         plot = mpl_renderer.get_plot(hmap)
         array = plot.handles['artist'].get_array()
         if MPL_GE_3_8_0:
@@ -34,7 +34,7 @@ class TestHeatMapPlot(TestMPLPlot):
         np.testing.assert_equal(array, masked)
 
     def test_heatmap_invert_yaxis(self):
-        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).opts(invert_yaxis=True)
+        hmap = hv.HeatMap([('A',1, 1), ('B', 2, 2)]).opts(invert_yaxis=True)
         plot = mpl_renderer.get_plot(hmap)
         array = plot.handles['artist'].get_array()
         expected = np.array([1, np.inf, np.inf, 2])

--- a/holoviews/tests/plotting/matplotlib/test_hextilesplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_hextilesplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import HexTiles
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -9,12 +9,12 @@ from .test_plot import TestMPLPlot, mpl_renderer
 class TestHexTilesPlot(TestMPLPlot):
 
     def test_hex_tiles_empty(self):
-        tiles = HexTiles([])
+        tiles = hv.HexTiles([])
         mpl_renderer.get_plot(tiles)
 
     def test_hex_tiles_opts(self):
         from holoviews.plotting.util import process_cmap
-        tiles = HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)])
+        tiles = hv.HexTiles([(0, 0), (0.5, 0.5), (-0.5, -0.5), (-0.4, -0.4)])
         plot = mpl_renderer.get_plot(tiles)
         args, style, _ = plot.get_data(tiles, {}, {})
         assert_data_equal(args[0], tiles['x'])

--- a/holoviews/tests/plotting/matplotlib/test_histogramplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_histogramplot.py
@@ -3,9 +3,8 @@ import datetime as dt
 import numpy as np
 import pytest
 
+import holoviews as hv
 from holoviews.core.options import AbbreviatedException
-from holoviews.core.overlay import NdOverlay
-from holoviews.element import Dataset, Histogram
 from holoviews.operation import histogram
 from holoviews.plotting.util import hex2rgb
 
@@ -17,7 +16,7 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
 
     def test_histogram_datetime64_plot(self):
         dates = np.array([dt.datetime(2017, 1, i) for i in range(1, 5)])
-        hist = histogram(Dataset(dates, 'Date'), num_bins=4)
+        hist = histogram(hv.Dataset(dates, 'Date'), num_bins=4)
         plot = mpl_renderer.get_plot(hist)
         artist = plot.handles['artist']
         ax = plot.handles['axis']
@@ -26,7 +25,7 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
         assert [p.get_x() for p in artist.patches] == bounds
 
     def test_histogram_padding_square(self):
-        points = Histogram([(1, 2), (2, -1), (3, 3)]).opts(padding=0.1)
+        points = hv.Histogram([(1, 2), (2, -1), (3, 3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.19999999999999996
@@ -35,7 +34,7 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.4
 
     def test_histogram_padding_square_positive(self):
-        points = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1)
+        points = hv.Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.19999999999999996
@@ -44,7 +43,7 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_histogram_padding_square_negative(self):
-        points = Histogram([(1, -2), (2, -1), (3, -3)]).opts(padding=0.1)
+        points = hv.Histogram([(1, -2), (2, -1), (3, -3)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.19999999999999996
@@ -53,7 +52,7 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 0
 
     def test_histogram_padding_nonsquare(self):
-        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, aspect=2)
+        histogram = hv.Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.35
@@ -62,7 +61,7 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_histogram_padding_logx(self):
-        histogram = Histogram([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
+        histogram = hv.Histogram([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = mpl_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.41158562699652224
@@ -71,7 +70,7 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_histogram_padding_logy(self):
-        histogram = Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, logy=True)
+        histogram = hv.Histogram([(1, 2), (2, 1), (3, 3)]).opts(padding=0.1, logy=True)
         plot = mpl_renderer.get_plot(histogram)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.19999999999999996
@@ -81,7 +80,7 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
         self.log_handler.assert_contains('WARNING', 'Logarithmic axis range encountered value less than')
 
     def test_histogram_padding_datetime_square(self):
-        histogram = Histogram([(np.datetime64(f'2016-04-0{i}', 'ns'), i) for i in range(1, 4)]).opts(
+        histogram = hv.Histogram([(np.datetime64(f'2016-04-0{i}', 'ns'), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = mpl_renderer.get_plot(histogram)
@@ -92,7 +91,7 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_histogram_padding_datetime_nonsquare(self):
-        histogram = Histogram([(np.datetime64(f'2016-04-0{i}', 'ns'), i) for i in range(1, 4)]).opts(
+        histogram = hv.Histogram([(np.datetime64(f'2016-04-0{i}', 'ns'), i) for i in range(1, 4)]).opts(
             padding=0.1, aspect=2
         )
         plot = mpl_renderer.get_plot(histogram)
@@ -107,7 +106,7 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
     ###########################
 
     def test_histogram_color_op(self):
-        histogram = Histogram([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
+        histogram = hv.Histogram([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                               vdims=['y', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(histogram)
         artist = plot.handles['artist']
@@ -116,21 +115,21 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
             assert c.get_facecolor() == (*(c / 255.0 for c in hex2rgb(w)), 1)
 
     def test_histogram_linear_color_op(self):
-        histogram = Histogram([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        histogram = hv.Histogram([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                               vdims=['y', 'color']).opts(color='color')
         msg = 'ValueError: Mapping a continuous dimension to a color'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(histogram)
 
     def test_histogram_categorical_color_op(self):
-        histogram = Histogram([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
+        histogram = hv.Histogram([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'C')],
                               vdims=['y', 'color']).opts(color='color')
         msg = 'ValueError: Mapping a continuous dimension to a color'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(histogram)
 
     def test_histogram_line_color_op(self):
-        histogram = Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
+        histogram = hv.Histogram([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                               vdims=['y', 'color']).opts(edgecolor='color')
         plot = mpl_renderer.get_plot(histogram)
         artist = plot.handles['artist']
@@ -140,14 +139,14 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
         assert children[2].get_edgecolor() == (0, 1, 0, 1)
 
     def test_histogram_alpha_op(self):
-        histogram = Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        histogram = hv.Histogram([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(alpha='alpha')
         msg = 'ValueError: Mapping a dimension to the "alpha" style'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(histogram)
 
     def test_histogram_line_width_op(self):
-        histogram = Histogram([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
+        histogram = hv.Histogram([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
                               vdims=['y', 'line_width']).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(histogram)
         artist = plot.handles['artist']
@@ -157,7 +156,7 @@ class TestHistogramPlot(LoggingComparison, TestMPLPlot):
 
     def test_op_ndoverlay_value(self):
         colors = ['blue', 'red']
-        overlay = NdOverlay({color: Histogram(np.arange(i+2))
+        overlay = hv.NdOverlay({color: hv.Histogram(np.arange(i+2))
                              for i, color in enumerate(colors)}, 'Color').opts(
                                      'Histogram', facecolor='Color'
                              )

--- a/holoviews/tests/plotting/matplotlib/test_labels.py
+++ b/holoviews/tests/plotting/matplotlib/test_labels.py
@@ -1,9 +1,6 @@
 import numpy as np
 
-from holoviews.core.dimension import Dimension
-from holoviews.core.options import Cycle
-from holoviews.core.spaces import HoloMap
-from holoviews.element import Labels
+import holoviews as hv
 from holoviews.plotting.util import rgb2hex
 
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -12,7 +9,7 @@ from .test_plot import TestMPLPlot, mpl_renderer
 class TestLabelsPlot(TestMPLPlot):
 
     def test_labels_simple(self):
-        labels = Labels([(0, 1, 'A'), (1, 0, 'B')])
+        labels = hv.Labels([(0, 1, 'A'), (1, 0, 'B')])
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         expected = {'x': np.array([0, 1]), 'y': np.array([1, 0]),
@@ -23,14 +20,14 @@ class TestLabelsPlot(TestMPLPlot):
             assert text.get_text() == expected['Label'][i]
 
     def test_labels_empty(self):
-        labels = Labels([])
+        labels = hv.Labels([])
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         assert artist == []
 
     def test_labels_formatter(self):
-        vdim = Dimension('text', value_format=lambda x: f'{x:.1f}')
-        labels = Labels([(0, 1, 0.33333), (1, 0, 0.66666)], vdims=vdim)
+        vdim = hv.Dimension('text', value_format=lambda x: f'{x:.1f}')
+        labels = hv.Labels([(0, 1, 0.33333), (1, 0, 0.66666)], vdims=vdim)
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         expected = {'x': np.array([0, 1]), 'y': np.array([1, 0]),
@@ -41,7 +38,7 @@ class TestLabelsPlot(TestMPLPlot):
             assert text.get_text() == expected['text'][i]
 
     def test_labels_inverted(self):
-        labels = Labels([(0, 1, 'A'), (1, 0, 'B')]).opts(invert_axes=True)
+        labels = hv.Labels([(0, 1, 'A'), (1, 0, 'B')]).opts(invert_axes=True)
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         expected = {'x': np.array([0, 1]), 'y': np.array([1, 0]), 'Label': ['A', 'B']}
@@ -51,7 +48,7 @@ class TestLabelsPlot(TestMPLPlot):
             assert text.get_text() == expected['Label'][i]
 
     def test_labels_color_mapped(self):
-        labels = Labels([(0, 1, 0.33333), (1, 0, 0.66666)]).opts(color_index=2)
+        labels = hv.Labels([(0, 1, 0.33333), (1, 0, 0.66666)]).opts(color_index=2)
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         expected = {'x': np.array([0, 1]), 'y': np.array([1, 0]),
@@ -69,17 +66,17 @@ class TestLabelsPlot(TestMPLPlot):
     ###########################
 
     def test_label_color_op(self):
-        labels = Labels([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
+        labels = hv.Labels([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                         vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         assert [a.get_color() for a in artist] == ['#000000', '#FF0000', '#00FF00']
 
     def test_label_color_op_update(self):
-        labels = HoloMap({
-            0: Labels([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
+        labels = hv.HoloMap({
+            0: hv.Labels([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                       vdims='color'),
-            1: Labels([(0, 0, '#FF0000'), (0, 1, '#00FF00'), (0, 2, '#0000FF')],
+            1: hv.Labels([(0, 0, '#FF0000'), (0, 1, '#00FF00'), (0, 2, '#0000FF')],
                       vdims='color')}).opts(color='color')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
@@ -89,31 +86,31 @@ class TestLabelsPlot(TestMPLPlot):
         assert [a.get_color() for a in artist] == ['#FF0000', '#00FF00', '#0000FF']
 
     def test_label_linear_color_op(self):
-        labels = Labels([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        labels = hv.Labels([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         assert [rgb2hex(a.get_color()) for a in artist] == ['#440154', '#20908c', '#fde724']
 
     def test_label_categorical_color_op(self):
-        labels = Labels([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
+        labels = hv.Labels([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
                         vdims='color').opts(color='color', cmap='tab10')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         assert [rgb2hex(a.get_color()) for a in artist] == ['#1f77b4', '#ff7f0e', '#1f77b4']
 
     def test_label_size_op(self):
-        labels = Labels([(0, 0, 8), (0, 1, 12), (0, 2, 6)],
+        labels = hv.Labels([(0, 0, 8), (0, 1, 12), (0, 2, 6)],
                         vdims='size').opts(size='size')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         assert [a.get_fontsize() for a in artist] == [8, 12, 6]
 
     def test_label_size_op_update(self):
-        labels = HoloMap({
-            0: Labels([(0, 0, 8), (0, 1, 6), (0, 2, 12)],
+        labels = hv.HoloMap({
+            0: hv.Labels([(0, 0, 8), (0, 1, 6), (0, 2, 12)],
                       vdims='size'),
-            1: Labels([(0, 0, 9), (0, 1, 4), (0, 2, 3)],
+            1: hv.Labels([(0, 0, 9), (0, 1, 4), (0, 2, 3)],
                       vdims='size')}).opts(size='size')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
@@ -123,17 +120,17 @@ class TestLabelsPlot(TestMPLPlot):
         assert [a.get_fontsize() for a in artist] == [9, 4, 3]
 
     def test_label_alpha_op(self):
-        labels = Labels([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        labels = hv.Labels([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                         vdims='alpha').opts(alpha='alpha')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         assert [a.get_alpha() for a in artist] == [0, 0.2, 0.7]
 
     def test_label_alpha_op_update(self):
-        labels = HoloMap({
-            0: Labels([(0, 0, 0.3), (0, 1, 1), (0, 2, 0.6)],
+        labels = hv.HoloMap({
+            0: hv.Labels([(0, 0, 0.3), (0, 1, 1), (0, 2, 0.6)],
                       vdims='alpha'),
-            1: Labels([(0, 0, 0.6), (0, 1, 0.1), (0, 2, 1)],
+            1: hv.Labels([(0, 0, 0.6), (0, 1, 0.1), (0, 2, 1)],
                       vdims='alpha')}).opts(alpha='alpha')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
@@ -143,17 +140,17 @@ class TestLabelsPlot(TestMPLPlot):
         assert [a.get_alpha() for a in artist] == [0.6, 0.1, 1]
 
     def test_label_rotation_op(self):
-        labels = Labels([(0, 0, 90), (0, 1, 180), (0, 2, 270)],
+        labels = hv.Labels([(0, 0, 90), (0, 1, 180), (0, 2, 270)],
                         vdims='rotation').opts(rotation='rotation')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
         assert [a.get_rotation() for a in artist] == [90, 180, 270]
 
     def test_label_rotation_op_update(self):
-        labels = HoloMap({
-            0: Labels([(0, 0, 45), (0, 1, 180), (0, 2, 90)],
+        labels = hv.HoloMap({
+            0: hv.Labels([(0, 0, 45), (0, 1, 180), (0, 2, 90)],
                       vdims='rotation'),
-            1: Labels([(0, 0, 30), (0, 1, 120), (0, 2, 60)],
+            1: hv.Labels([(0, 0, 30), (0, 1, 120), (0, 2, 60)],
                       vdims='rotation')}).opts(rotation='rotation')
         plot = mpl_renderer.get_plot(labels)
         artist = plot.handles['artist']
@@ -163,10 +160,10 @@ class TestLabelsPlot(TestMPLPlot):
         assert [a.get_rotation() for a in artist] == [30, 120, 60]
 
     def test_labels_text_color_cycle(self):
-        hm = HoloMap(
-            {i: Labels([
+        hm = hv.HoloMap(
+            {i: hv.Labels([
                 (0, 0 + i, "Label 1"),
                 (1, 1 + i, "Label 2")
             ]) for i in range(3)}
         ).overlay()
-        assert isinstance(hm[0].opts["color"], Cycle)
+        assert isinstance(hm[0].opts["color"], hv.Cycle)

--- a/holoviews/tests/plotting/matplotlib/test_layoutplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_layoutplot.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from holoviews.core import DynamicMap, HoloMap, NdOverlay
-from holoviews.element import Curve, Image
+import holoviews as hv
 from holoviews.streams import Stream
 
 from ...utils import LoggingComparison
@@ -11,8 +10,8 @@ from .test_plot import TestMPLPlot, mpl_renderer
 class TestLayoutPlot(LoggingComparison, TestMPLPlot):
 
     def test_layout_instantiate_subplots(self):
-        layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
-                  Curve(range(10)) + Curve(range(10)))
+        layout = (hv.Curve(range(10)) + hv.Curve(range(10)) + hv.Image(np.random.rand(10,10)) +
+                  hv.Curve(range(10)) + hv.Curve(range(10)))
         plot = mpl_renderer.get_plot(layout)
         positions = [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0)]
         assert sorted(plot.subplots.keys()) == positions
@@ -22,15 +21,15 @@ class TestLayoutPlot(LoggingComparison, TestMPLPlot):
                 assert adjoint.subplots['main'].layout_num == i+1
 
     def test_layout_empty_subplots(self):
-        layout = Curve(range(10)) + NdOverlay() + HoloMap() + HoloMap({1: Image(np.random.rand(10,10))})
+        layout = hv.Curve(range(10)) + hv.NdOverlay() + hv.HoloMap() + hv.HoloMap({1: hv.Image(np.random.rand(10,10))})
         plot = mpl_renderer.get_plot(layout)
         assert len(plot.subplots.values()) == 2
         self.log_handler.assert_contains('WARNING', 'skipping subplot')
         self.log_handler.assert_contains('WARNING', 'skipping subplot')
 
     def test_layout_instantiate_subplots_transposed(self):
-        layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
-                  Curve(range(10)) + Curve(range(10)))
+        layout = (hv.Curve(range(10)) + hv.Curve(range(10)) + hv.Image(np.random.rand(10,10)) +
+                  hv.Curve(range(10)) + hv.Curve(range(10)))
         plot = mpl_renderer.get_plot(layout.opts(transpose=True))
         positions = [(0, 0), (0, 1), (1, 0), (2, 0), (3, 0)]
         assert sorted(plot.subplots.keys()) == positions
@@ -42,8 +41,8 @@ class TestLayoutPlot(LoggingComparison, TestMPLPlot):
 
     def test_layout_dimensioned_stream_title_update(self):
         stream = Stream.define('Test', test=0)()
-        dmap = DynamicMap(lambda test: Curve([]), kdims=['test'], streams=[stream])
-        layout = dmap + Curve([])
+        dmap = hv.DynamicMap(lambda test: hv.Curve([]), kdims=['test'], streams=[stream])
+        layout = dmap + hv.Curve([])
         plot = mpl_renderer.get_plot(layout)
         assert 'test: 0' in plot.handles['title'].get_text()
         stream.event(test=1)
@@ -53,7 +52,7 @@ class TestLayoutPlot(LoggingComparison, TestMPLPlot):
 
     def test_layout_shared_axes_disabled(self):
         from holoviews.plotting.mpl import CurvePlot
-        layout = (Curve([1, 2, 3]) + Curve([10, 20, 30])).opts(shared_axes=False)
+        layout = (hv.Curve([1, 2, 3]) + hv.Curve([10, 20, 30])).opts(shared_axes=False)
         plot = mpl_renderer.get_plot(layout)
         cp1, cp2 = plot.traverse(lambda x: x, [CurvePlot])
         assert cp1.handles['axis'].get_ylim() == (1, 3)
@@ -61,7 +60,7 @@ class TestLayoutPlot(LoggingComparison, TestMPLPlot):
 
     def test_layout_sublabel_offset(self):
         from holoviews.plotting.mpl import CurvePlot
-        layout = Curve([]) + Curve([]) + Curve([]) + Curve([])
+        layout = hv.Curve([]) + hv.Curve([]) + hv.Curve([]) + hv.Curve([])
         layout.opts(sublabel_offset=1)
         plot = mpl_renderer.get_plot(layout)
         cps = plot.traverse(lambda x: x, [CurvePlot])
@@ -72,7 +71,7 @@ class TestLayoutPlot(LoggingComparison, TestMPLPlot):
 
     def test_layout_sublabel_skip(self):
         from holoviews.plotting.mpl import CurvePlot
-        layout = Curve([]) + Curve([]) + Curve([]) + Curve([])
+        layout = hv.Curve([]) + hv.Curve([]) + hv.Curve([]) + hv.Curve([])
         layout.opts(sublabel_skip=[1, 3])
         plot = mpl_renderer.get_plot(layout)
         cps = plot.traverse(lambda x: x, [CurvePlot])

--- a/holoviews/tests/plotting/matplotlib/test_overlayplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_overlayplot.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from holoviews.core import DynamicMap, HoloMap, NdOverlay, Overlay
-from holoviews.element import Curve, Scatter
+import holoviews as hv
 
 from ...utils import LoggingComparison, optional_dependencies
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -18,19 +17,19 @@ class TestOverlayPlot(LoggingComparison, TestMPLPlot):
         """
         Test to avoid regression after fix of https://github.com/holoviz/holoviews/issues/41
         """
-        o = Overlay([Curve(np.array([[0, 1]])) , Scatter([[1,1]]) , Curve(np.array([[0, 1]]))])
+        o = hv.Overlay([hv.Curve(np.array([[0, 1]])) , hv.Scatter([[1,1]]) , hv.Curve(np.array([[0, 1]]))])
         OverlayPlot(o)
 
     def test_overlay_empty_layers(self):
-        overlay = Curve(range(10)) * NdOverlay()
+        overlay = hv.Curve(range(10)) * hv.NdOverlay()
         plot = mpl_renderer.get_plot(overlay)
         assert len(plot.subplots) == 1
         self.log_handler.assert_contains('WARNING', 'is empty and will be skipped during plotting')
 
     def test_overlay_update_plot_opts(self):
-        hmap = HoloMap(
-            {0: (Curve([]) * Curve([])).opts(title='A'),
-             1: (Curve([]) * Curve([])).opts(title='B')}
+        hmap = hv.HoloMap(
+            {0: (hv.Curve([]) * hv.Curve([])).opts(title='A'),
+             1: (hv.Curve([]) * hv.Curve([])).opts(title='B')}
         )
         plot = mpl_renderer.get_plot(hmap)
         assert plot.handles['title'].get_text() == 'A'
@@ -38,9 +37,9 @@ class TestOverlayPlot(LoggingComparison, TestMPLPlot):
         assert plot.handles['title'].get_text() == 'B'
 
     def test_overlay_update_plot_opts_inherited(self):
-        hmap = HoloMap(
-            {0: (Curve([]).opts(title='A') * Curve([])),
-             1: (Curve([]).opts(title='B') * Curve([]))}
+        hmap = hv.HoloMap(
+            {0: (hv.Curve([]).opts(title='A') * hv.Curve([])),
+             1: (hv.Curve([]).opts(title='B') * hv.Curve([]))}
         )
         plot = mpl_renderer.get_plot(hmap)
         assert plot.handles['title'].get_text() == 'A'
@@ -48,12 +47,12 @@ class TestOverlayPlot(LoggingComparison, TestMPLPlot):
         assert plot.handles['title'].get_text() == 'B'
 
     def test_overlay_apply_ranges_disabled(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts('Curve', apply_ranges=False)
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts('Curve', apply_ranges=False)
         plot = mpl_renderer.get_plot(overlay)
         assert all(np.isnan(e) for e in plot.get_extents(overlay, {}))
 
     def test_overlay_empty_element_extent(self):
-        overlay = Curve([]).redim.range(x=(-10, 10)) * Scatter([]).redim.range(y=(-20, 20))
+        overlay = hv.Curve([]).redim.range(x=(-10, 10)) * hv.Scatter([]).redim.range(y=(-20, 20))
         plot = mpl_renderer.get_plot(overlay)
         extents = plot.get_extents(overlay, {})
         assert extents == (-10, -20, 10, 20)
@@ -61,8 +60,8 @@ class TestOverlayPlot(LoggingComparison, TestMPLPlot):
     def test_dynamic_subplot_remapping(self):
         # Checks that a plot is appropriately updated when reused
         def cb(X):
-            return NdOverlay({i: Curve(np.arange(10)+i) for i in range(X-2, X)})
-        dmap = DynamicMap(cb, kdims=['X']).redim.range(X=(1, 10))
+            return hv.NdOverlay({i: hv.Curve(np.arange(10)+i) for i in range(X-2, X)})
+        dmap = hv.DynamicMap(cb, kdims=['X']).redim.range(X=(1, 10))
         plot = mpl_renderer.get_plot(dmap)
         plot.update((3,))
         for i, subplot in enumerate(plot.subplots.values()):
@@ -71,8 +70,8 @@ class TestOverlayPlot(LoggingComparison, TestMPLPlot):
 
     def test_dynamic_subplot_creation(self):
         def cb(X):
-            return NdOverlay({i: Curve(np.arange(10)+i) for i in range(X)})
-        dmap = DynamicMap(cb, kdims=['X']).redim.range(X=(1, 10))
+            return hv.NdOverlay({i: hv.Curve(np.arange(10)+i) for i in range(X)})
+        dmap = hv.DynamicMap(cb, kdims=['X']).redim.range(X=(1, 10))
         plot = mpl_renderer.get_plot(dmap)
         assert len(plot.subplots) == 1
         plot.update((3,))
@@ -81,22 +80,22 @@ class TestOverlayPlot(LoggingComparison, TestMPLPlot):
             assert subplot.cyclic_index == i
 
     def test_overlay_xlabel(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(xlabel='custom x-label')
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(xlabel='custom x-label')
         axes = mpl_renderer.get_plot(overlay).handles['axis']
         assert axes.get_xlabel() == 'custom x-label'
 
     def test_overlay_ylabel(self):
-        overlay = (Curve(range(10)) * Curve(range(10))).opts(ylabel='custom y-label')
+        overlay = (hv.Curve(range(10)) * hv.Curve(range(10))).opts(ylabel='custom y-label')
         axes = mpl_renderer.get_plot(overlay).handles['axis']
         assert axes.get_ylabel() == 'custom y-label'
 
     def test_overlay_xlabel_override_propagated(self):
-        overlay = (Curve(range(10)).opts(xlabel='custom x-label') * Curve(range(10)))
+        overlay = (hv.Curve(range(10)).opts(xlabel='custom x-label') * hv.Curve(range(10)))
         axes = mpl_renderer.get_plot(overlay).handles['axis']
         assert axes.get_xlabel() == 'custom x-label'
 
     def test_overlay_ylabel_override(self):
-        overlay = (Curve(range(10)).opts(ylabel='custom y-label') * Curve(range(10)))
+        overlay = (hv.Curve(range(10)).opts(ylabel='custom y-label') * hv.Curve(range(10)))
         axes = mpl_renderer.get_plot(overlay).handles['axis']
         assert axes.get_ylabel() == 'custom y-label'
 
@@ -105,14 +104,14 @@ class TestOverlayPlot(LoggingComparison, TestMPLPlot):
 class TestLegends(TestMPLPlot):
 
     def test_overlay_legend(self):
-        overlay = Curve(range(10), label='A') * Curve(range(10), label='B')
+        overlay = hv.Curve(range(10), label='A') * hv.Curve(range(10), label='B')
         plot = mpl_renderer.get_plot(overlay)
         legend = plot.handles['legend']
         legend_labels = [l.get_text() for l in legend.texts]
         assert legend_labels == ['A', 'B']
 
     def test_overlay_legend_with_labels(self):
-        overlay = (Curve(range(10), label='A') * Curve(range(10), label='B')).opts(
+        overlay = (hv.Curve(range(10), label='A') * hv.Curve(range(10), label='B')).opts(
             legend_labels={'A': 'A Curve', 'B': 'B Curve'})
         plot = mpl_renderer.get_plot(overlay)
         legend = plot.handles['legend']

--- a/holoviews/tests/plotting/matplotlib/test_pathplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pathplot.py
@@ -1,10 +1,8 @@
 import numpy as np
 import pytest
 
-from holoviews.core import NdOverlay
+import holoviews as hv
 from holoviews.core.options import AbbreviatedException
-from holoviews.core.spaces import HoloMap
-from holoviews.element import Contours, Path, Polygons
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -19,7 +17,7 @@ class TestPathPlot(TestMPLPlot):
         data = {'x': xs, 'y': ys, 'color': color}
         levels = [0, 38, 73, 95, 110, 130, 156, 999]
         colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']
-        path = Path([data], vdims='color').opts(
+        path = hv.Path([data], vdims='color').opts(
             color='color', color_levels=levels, cmap=colors)
         plot = mpl_renderer.get_plot(path)
         artist = plot.handles['artist']
@@ -31,7 +29,7 @@ class TestPathPlot(TestMPLPlot):
         ys = xs[::-1]
         alpha = [0.1, 0.7, 0.3, 0.2]
         data = {'x': xs, 'y': ys, 'alpha': alpha}
-        path = Path([data], vdims='alpha').opts(alpha='alpha')
+        path = hv.Path([data], vdims='alpha').opts(alpha='alpha')
         msg = 'ValueError: Mapping a dimension to the "alpha" style'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(path)
@@ -41,7 +39,7 @@ class TestPathPlot(TestMPLPlot):
         ys = xs[::-1]
         line_width = [1, 7, 3, 2]
         data = {'x': xs, 'y': ys, 'line_width': line_width}
-        path = Path([data], vdims='line_width').opts(linewidth='line_width')
+        path = hv.Path([data], vdims='line_width').opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(path)
         artist = plot.handles['artist']
         assert artist.get_linewidths() == line_width
@@ -49,9 +47,9 @@ class TestPathPlot(TestMPLPlot):
     def test_path_continuously_varying_line_width_op_update(self):
         xs = [1, 2, 3, 4]
         ys = xs[::-1]
-        path = HoloMap({
-            0: Path([{'x': xs, 'y': ys, 'line_width': [1, 7, 3, 2]}], vdims='line_width'),
-            1: Path([{'x': xs, 'y': ys, 'line_width': [3, 8, 2, 3]}], vdims='line_width')
+        path = hv.HoloMap({
+            0: hv.Path([{'x': xs, 'y': ys, 'line_width': [1, 7, 3, 2]}], vdims='line_width'),
+            1: hv.Path([{'x': xs, 'y': ys, 'line_width': [3, 8, 2, 3]}], vdims='line_width')
         }).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(path)
         artist = plot.handles['artist']
@@ -68,7 +66,7 @@ class TestPathPlot(TestMPLPlot):
              'c': x * 10}
             for x in range(5)
         ]
-        path = Path(data, vdims=['c']).opts(color='c', cmap='viridis', colorbar=True)
+        path = hv.Path(data, vdims=['c']).opts(color='c', cmap='viridis', colorbar=True)
         plot = mpl_renderer.get_plot(path)
         artist = plot.handles['artist']
 
@@ -91,7 +89,7 @@ class TestPathPlot(TestMPLPlot):
              'c': np.full(n_pts, x * 10)}  # per-vertex constant per geometry
             for x in range(5)
         ]
-        path = Path(data, vdims=['c']).opts(color='c', cmap='viridis', colorbar=True)
+        path = hv.Path(data, vdims=['c']).opts(color='c', cmap='viridis', colorbar=True)
         plot = mpl_renderer.get_plot(path)
         artist = plot.handles['artist']
 
@@ -110,7 +108,7 @@ class TestPathPlot(TestMPLPlot):
              'c': x * 10}
             for x in range(5)
         ]
-        path = Path(data, vdims=["c"]).opts(color="c", cmap="viridis", colorbar=True)
+        path = hv.Path(data, vdims=["c"]).opts(color="c", cmap="viridis", colorbar=True)
 
         plot = mpl_renderer.get_plot(path)
         artist = plot.handles['artist']
@@ -129,7 +127,7 @@ class TestPathPlot(TestMPLPlot):
 class TestPolygonPlot(TestMPLPlot):
 
     def test_polygons_colored(self):
-        polygons = NdOverlay({j: Polygons([[(i**j, i, j) for i in range(10)]], vdims='Value')
+        polygons = hv.NdOverlay({j: hv.Polygons([[(i**j, i, j) for i in range(10)]], vdims='Value')
                               for j in range(5)})
         plot = mpl_renderer.get_plot(polygons)
         for j, splot in enumerate(plot.subplots.values()):
@@ -141,7 +139,7 @@ class TestPolygonPlot(TestMPLPlot):
         xs = [1, 2, 3]
         ys = [2, 0, 7]
         holes = [[[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]]]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes}])
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes}])
         plot = mpl_renderer.get_plot(poly)
         artist = plot.handles['artist']
         paths = artist.get_paths()
@@ -160,7 +158,7 @@ class TestPolygonPlot(TestMPLPlot):
             [[(1.5, 2), (2, 3), (1.6, 1.6)], [(2.1, 4.5), (2.5, 5), (2.3, 3.5)]],
             []
         ]
-        poly = Polygons([{'x': xs, 'y': ys, 'holes': holes, 'value': 1}], vdims=['value'])
+        poly = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes, 'value': 1}], vdims=['value'])
         plot = mpl_renderer.get_plot(poly)
         artist = plot.handles['artist']
         assert_data_equal(np.asarray(artist.get_array()), np.array([1, 1]))
@@ -177,7 +175,7 @@ class TestPolygonPlot(TestMPLPlot):
         assert_data_equal(path2.codes, np.array([1, 2, 2, 79]))
 
     def test_polygons_color_op(self):
-        polygons = Polygons([
+        polygons = hv.Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
         ], vdims='color').opts(color='color')
@@ -188,12 +186,12 @@ class TestPolygonPlot(TestMPLPlot):
         assert_data_equal(artist.get_facecolors(), colors)
 
     def test_polygons_color_op_update(self):
-        polygons = HoloMap({
-            0: Polygons([
+        polygons = hv.HoloMap({
+            0: hv.Polygons([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
             ], vdims='color'),
-            1: Polygons([
+            1: hv.Polygons([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'blue'},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'green'}
             ], vdims='color'),
@@ -209,7 +207,7 @@ class TestPolygonPlot(TestMPLPlot):
         assert_data_equal(artist.get_facecolors(), colors)
 
     def test_polygons_linear_color_op(self):
-        polygons = Polygons([
+        polygons = hv.Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 3}
         ], vdims='color').opts(color='color')
@@ -219,12 +217,12 @@ class TestPolygonPlot(TestMPLPlot):
         assert artist.get_clim() == (3, 7)
 
     def test_polygons_linear_color_op_update(self):
-        polygons = HoloMap({
-            0: Polygons([
+        polygons = hv.HoloMap({
+            0: hv.Polygons([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 7},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 3}
             ], vdims='color'),
-            1: Polygons([
+            1: hv.Polygons([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 2},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 5}
             ], vdims='color'),
@@ -238,7 +236,7 @@ class TestPolygonPlot(TestMPLPlot):
         assert artist.get_clim() == (2, 5)
 
     def test_polygons_categorical_color_op(self):
-        polygons = Polygons([
+        polygons = hv.Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'b'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'a'}
         ], vdims='color').opts(color='color')
@@ -248,7 +246,7 @@ class TestPolygonPlot(TestMPLPlot):
         assert artist.get_clim() == (0, 1)
 
     def test_polygons_alpha_op(self):
-        polygons = Polygons([
+        polygons = hv.Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'alpha': 0.7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'alpha': 0.3}
         ], vdims='alpha').opts(alpha='alpha')
@@ -257,7 +255,7 @@ class TestPolygonPlot(TestMPLPlot):
             mpl_renderer.get_plot(polygons)
 
     def test_polygons_line_width_op(self):
-        polygons = Polygons([
+        polygons = hv.Polygons([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'line_width': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'line_width': 3}
         ], vdims='line_width').opts(linewidth='line_width')
@@ -270,7 +268,7 @@ class TestPolygonPlot(TestMPLPlot):
 class TestContoursPlot(TestMPLPlot):
 
     def test_contours_categorical_color(self):
-        path = Contours([{('x', 'y'): np.random.rand(10, 2), 'z': cat}
+        path = hv.Contours([{('x', 'y'): np.random.rand(10, 2), 'z': cat}
                      for cat in ('B', 'A', 'B')],
                     vdims='z').opts(color_index='z')
         plot = mpl_renderer.get_plot(path)
@@ -279,7 +277,7 @@ class TestContoursPlot(TestMPLPlot):
         assert artist.get_clim() == (0, 1)
 
     def test_contours_color_op(self):
-        contours = Contours([
+        contours = hv.Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
         ], vdims='color').opts(color='color')
@@ -290,12 +288,12 @@ class TestContoursPlot(TestMPLPlot):
         assert_data_equal(artist.get_edgecolors(), colors)
 
     def test_contours_color_op_update(self):
-        contours = HoloMap({
-            0: Contours([
+        contours = hv.HoloMap({
+            0: hv.Contours([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'green'},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'red'}
             ], vdims='color'),
-            1: Contours([
+            1: hv.Contours([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'blue'},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'green'}
             ], vdims='color'),
@@ -311,7 +309,7 @@ class TestContoursPlot(TestMPLPlot):
         assert_data_equal(artist.get_edgecolors(), colors)
 
     def test_contours_linear_color_op(self):
-        contours = Contours([
+        contours = hv.Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 3}
         ], vdims='color').opts(color='color')
@@ -321,12 +319,12 @@ class TestContoursPlot(TestMPLPlot):
         assert artist.get_clim() == (3, 7)
 
     def test_contours_linear_color_op_update(self):
-        contours = HoloMap({
-            0: Contours([
+        contours = hv.HoloMap({
+            0: hv.Contours([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 7},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 3}
             ], vdims='color'),
-            1: Contours([
+            1: hv.Contours([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 2},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 5}
             ], vdims='color'),
@@ -340,7 +338,7 @@ class TestContoursPlot(TestMPLPlot):
         assert artist.get_clim() == (2, 5)
 
     def test_contours_categorical_color_op(self):
-        contours = Contours([
+        contours = hv.Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'color': 'b'},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'color': 'a'}
         ], vdims='color').opts(color='color')
@@ -350,7 +348,7 @@ class TestContoursPlot(TestMPLPlot):
         assert artist.get_clim() == (0, 1)
 
     def test_contours_alpha_op(self):
-        contours = Contours([
+        contours = hv.Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'alpha': 0.7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'alpha': 0.3}
         ], vdims='alpha').opts(alpha='alpha')
@@ -359,7 +357,7 @@ class TestContoursPlot(TestMPLPlot):
             mpl_renderer.get_plot(contours)
 
     def test_contours_line_width_op(self):
-        contours = Contours([
+        contours = hv.Contours([
             {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'line_width': 7},
             {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'line_width': 3}
         ], vdims='line_width').opts(linewidth='line_width')
@@ -368,12 +366,12 @@ class TestContoursPlot(TestMPLPlot):
         assert artist.get_linewidths() == [7, 3]
 
     def test_contours_line_width_op_update(self):
-        contours = HoloMap({
-            0: Contours([
+        contours = hv.HoloMap({
+            0: hv.Contours([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'line_width': 7},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'line_width': 3}
             ], vdims='line_width'),
-            1: Contours([
+            1: hv.Contours([
                 {('x', 'y'): [(0, 0), (0, 1), (1, 0)], 'line_width': 2},
                 {('x', 'y'): [(1, 0), (1, 1), (0, 1)], 'line_width': 5}
             ], vdims='line_width'),

--- a/holoviews/tests/plotting/matplotlib/test_plot.py
+++ b/holoviews/tests/plotting/matplotlib/test_plot.py
@@ -2,13 +2,13 @@ import matplotlib.pyplot as plt
 import pyviz_comms as comms
 from param import concrete_descendents
 
-from holoviews.core.options import Store
+import holoviews as hv
 from holoviews.plotting.mpl import MPL_VERSION
 from holoviews.plotting.mpl.element import ElementPlot
 
 from .. import option_intersections
 
-mpl_renderer = Store.renderers['matplotlib']
+mpl_renderer = hv.Store.renderers['matplotlib']
 MPL_GE_3_4_0 = MPL_VERSION >= (3, 4, 0)
 MPL_GE_3_8_0 = MPL_VERSION >= (3, 8, 0)
 
@@ -24,17 +24,17 @@ class TestPlotDefinitions:
 class TestMPLPlot:
 
     def setup_method(self):
-        self.previous_backend = Store.current_backend
+        self.previous_backend = hv.Store.current_backend
         self.comm_manager = mpl_renderer.comm_manager
         mpl_renderer.comm_manager = comms.CommManager
-        Store.set_current_backend('matplotlib')
+        hv.Store.set_current_backend('matplotlib')
         self._padding = {}
         for plot in concrete_descendents(ElementPlot).values():
             self._padding[plot] = plot.padding
             plot.padding = 0
 
     def teardown_method(self):
-        Store.current_backend = self.previous_backend
+        hv.Store.current_backend = self.previous_backend
         mpl_renderer.comm_manager = self.comm_manager
         plt.close(plt.gcf())
         for plot, padding in self._padding.items():

--- a/holoviews/tests/plotting/matplotlib/test_pointplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_pointplot.py
@@ -2,10 +2,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+import holoviews as hv
 from holoviews.core.options import AbbreviatedException
-from holoviews.core.overlay import NdOverlay
-from holoviews.core.spaces import HoloMap
-from holoviews.element import Points
 from holoviews.testing import assert_data_equal
 
 from ..utils import ParamLogStream
@@ -16,7 +14,7 @@ class TestPointPlot(TestMPLPlot):
 
     def test_points_non_numeric_size_warning(self):
         data = (np.arange(10), np.arange(10), list(map(chr, range(94,104))))
-        points = Points(data, vdims=['z']).opts(size_index=2)
+        points = hv.Points(data, vdims=['z']).opts(size_index=2)
         with ParamLogStream() as log:
             mpl_renderer.get_plot(points)
         log_msg = log.stream.read()
@@ -27,41 +25,41 @@ class TestPointPlot(TestMPLPlot):
         assert log_msg == warning
 
     def test_points_cbar_extend_both(self):
-        img = Points(([0, 1], [0, 3])).redim(y=dict(range=(1,2)))
+        img = hv.Points(([0, 1], [0, 3])).redim(y=dict(range=(1,2)))
         plot = mpl_renderer.get_plot(img.opts(colorbar=True, color_index=1))
         assert plot.handles['cbar'].extend == 'both'
 
     def test_points_cbar_extend_min(self):
-        img = Points(([0, 1], [0, 3])).redim(y=dict(range=(1, None)))
+        img = hv.Points(([0, 1], [0, 3])).redim(y=dict(range=(1, None)))
         plot = mpl_renderer.get_plot(img.opts(colorbar=True, color_index=1))
         assert plot.handles['cbar'].extend == 'min'
 
     def test_points_cbar_extend_max(self):
-        img = Points(([0, 1], [0, 3])).redim(y=dict(range=(None, 2)))
+        img = hv.Points(([0, 1], [0, 3])).redim(y=dict(range=(None, 2)))
         plot = mpl_renderer.get_plot(img.opts(colorbar=True, color_index=1))
         assert plot.handles['cbar'].extend == 'max'
 
     def test_points_cbar_extend_clim(self):
-        img = Points(([0, 1], [0, 3])).opts(clim=(None, None))
+        img = hv.Points(([0, 1], [0, 3])).opts(clim=(None, None))
         plot = mpl_renderer.get_plot(img.opts(colorbar=True, color_index=1))
         assert plot.handles['cbar'].extend == 'neither'
 
     def test_points_rcparams_do_not_persist(self):
         opts = dict(fig_rcparams={'text.usetex': True})
-        points = Points(([0, 1], [0, 3])).opts(**opts)
+        points = hv.Points(([0, 1], [0, 3])).opts(**opts)
         mpl_renderer.get_plot(points)
         assert not plt.rcParams['text.usetex']
 
     def test_points_rcparams_used(self):
         opts = dict(fig_rcparams={'grid.color': 'red'})
-        points = Points(([0, 1], [0, 3])).opts(**opts)
+        points = hv.Points(([0, 1], [0, 3])).opts(**opts)
         plot = mpl_renderer.get_plot(points)
         ax = plot.state.axes[0]
         lines = ax.get_xgridlines()
         assert lines[0].get_color() == 'red'
 
     def test_points_padding_square(self):
-        points = Points([1, 2, 3]).opts(padding=0.1)
+        points = hv.Points([1, 2, 3]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == -0.2
@@ -70,7 +68,7 @@ class TestPointPlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_curve_padding_square_per_axis(self):
-        curve = Points([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
+        curve = hv.Points([1, 2, 3]).opts(padding=((0, 0.1), (0.1, 0.2)))
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0
@@ -79,7 +77,7 @@ class TestPointPlot(TestMPLPlot):
         assert y_range[1] == 3.4
 
     def test_points_padding_hard_xrange(self):
-        points = Points([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
+        points = hv.Points([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0
@@ -88,7 +86,7 @@ class TestPointPlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_points_padding_soft_xrange(self):
-        points = Points([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
+        points = hv.Points([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0
@@ -97,7 +95,7 @@ class TestPointPlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_points_padding_unequal(self):
-        points = Points([1, 2, 3]).opts(padding=(0.05, 0.1))
+        points = hv.Points([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == -0.1
@@ -106,7 +104,7 @@ class TestPointPlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_points_padding_nonsquare(self):
-        points = Points([1, 2, 3]).opts(padding=0.1, aspect=2)
+        points = hv.Points([1, 2, 3]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == -0.1
@@ -115,7 +113,7 @@ class TestPointPlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_points_padding_logx(self):
-        points = Points([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
+        points = hv.Points([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.89595845984076228
@@ -124,7 +122,7 @@ class TestPointPlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_points_padding_logy(self):
-        points = Points([1, 2, 3]).opts(padding=0.1, logy=True)
+        points = hv.Points([1, 2, 3]).opts(padding=0.1, logy=True)
         plot = mpl_renderer.get_plot(points)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == -0.2
@@ -133,7 +131,7 @@ class TestPointPlot(TestMPLPlot):
         assert y_range[1] == 3.3483695221017129
 
     def test_points_padding_datetime_square(self):
-        points = Points([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
+        points = hv.Points([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = mpl_renderer.get_plot(points)
@@ -144,7 +142,7 @@ class TestPointPlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_points_padding_datetime_nonsquare(self):
-        points = Points([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
+        points = hv.Points([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)]).opts(
             padding=0.1, aspect=2
         )
         plot = mpl_renderer.get_plot(points)
@@ -155,7 +153,7 @@ class TestPointPlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_points_sizes_scalar_update(self):
-        hmap = HoloMap({i: Points([1, 2, 3]).opts(s=i*10) for i in range(1, 3)})
+        hmap = hv.HoloMap({i: hv.Points([1, 2, 3]).opts(s=i*10) for i in range(1, 3)})
         plot = mpl_renderer.get_plot(hmap)
         artist = plot.handles['artist']
         plot.update((1,))
@@ -168,7 +166,7 @@ class TestPointPlot(TestMPLPlot):
     ###########################
 
     def test_point_color_op(self):
-        points = Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
+        points = hv.Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                         vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
@@ -176,9 +174,9 @@ class TestPointPlot(TestMPLPlot):
                          np.array([[0, 0, 0, 1], [1, 0, 0, 1], [0, 1, 0, 1]]))
 
     def test_point_color_op_update(self):
-        points = HoloMap({0: Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
+        points = hv.HoloMap({0: hv.Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                                     vdims='color'),
-                          1: Points([(0, 0, '#0000FF'), (0, 1, '#00FF00'), (0, 2, '#FF0000')],
+                          1: hv.Points([(0, 0, '#0000FF'), (0, 1, '#00FF00'), (0, 2, '#FF0000')],
                                     vdims='color')}).opts(color='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
@@ -187,7 +185,7 @@ class TestPointPlot(TestMPLPlot):
                          np.array([[0, 0, 1, 1], [0, 1, 0, 1], [1, 0, 0, 1]]))
 
     def test_point_line_color_op(self):
-        points = Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
+        points = hv.Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                         vdims='color').opts(edgecolors='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
@@ -195,9 +193,9 @@ class TestPointPlot(TestMPLPlot):
                          np.array([[0, 0, 0, 1], [1, 0, 0, 1], [0, 1, 0, 1]]))
 
     def test_point_line_color_op_update(self):
-        points = HoloMap({0: Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
+        points = hv.HoloMap({0: hv.Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                                     vdims='color'),
-                          1: Points([(0, 0, '#0000FF'), (0, 1, '#00FF00'), (0, 2, '#FF0000')],
+                          1: hv.Points([(0, 0, '#0000FF'), (0, 1, '#00FF00'), (0, 2, '#FF0000')],
                                     vdims='color')}).opts(edgecolors='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
@@ -206,7 +204,7 @@ class TestPointPlot(TestMPLPlot):
                          np.array([[0, 0, 1, 1], [0, 1, 0, 1], [1, 0, 0, 1]]))
 
     def test_point_fill_color_op(self):
-        points = Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
+        points = hv.Points([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                         vdims='color').opts(facecolors='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
@@ -214,7 +212,7 @@ class TestPointPlot(TestMPLPlot):
                          np.array([[0, 0, 0, 1], [1, 0, 0, 1], [0, 1, 0, 1]]))
 
     def test_point_linear_color_op(self):
-        points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        points = hv.Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
@@ -222,9 +220,9 @@ class TestPointPlot(TestMPLPlot):
         assert artist.get_clim() == (0, 2)
 
     def test_point_linear_color_op_update(self):
-        points = HoloMap({0: Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        points = hv.HoloMap({0: hv.Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                                     vdims='color'),
-                          1: Points([(0, 0, 2.5), (0, 1, 3), (0, 2, 1.2)],
+                          1: hv.Points([(0, 0, 2.5), (0, 1, 3), (0, 2, 1.2)],
                                     vdims='color')}).opts(color='color', framewise=True)
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
@@ -234,7 +232,7 @@ class TestPointPlot(TestMPLPlot):
         assert artist.get_clim() == (1.2, 3)
 
     def test_point_categorical_color_op(self):
-        points = Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
+        points = hv.Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
                         vdims='color').opts(color='color')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
@@ -242,7 +240,7 @@ class TestPointPlot(TestMPLPlot):
         assert artist.get_clim() == (0, 1)
 
     def test_point_categorical_color_op_legend(self):
-        points = Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
+        points = hv.Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
                         vdims='color').opts(color='color', show_legend=True)
         plot = mpl_renderer.get_plot(points)
         leg = plot.handles['axis'].get_legend()
@@ -250,7 +248,7 @@ class TestPointPlot(TestMPLPlot):
         assert legend_labels == ['A', 'B']
 
     def test_point_categorical_color_op_legend_with_labels(self):
-        points = Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')], vdims='color').opts(
+        points = hv.Points([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')], vdims='color').opts(
             color='color', show_legend=True, legend_labels={'A': 'A point', 'B': 'B point'})
         plot = mpl_renderer.get_plot(points)
         leg = plot.handles['axis'].get_legend()
@@ -258,16 +256,16 @@ class TestPointPlot(TestMPLPlot):
         assert legend_labels == ['A point', 'B point']
 
     def test_point_size_op(self):
-        points = Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
+        points = hv.Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
                         vdims='size').opts(s='size')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         assert_data_equal(artist.get_sizes(), np.array([1, 4, 8]))
 
     def test_point_size_op_update(self):
-        points = HoloMap({0: Points([(0, 0, 3), (0, 1, 1), (0, 2, 2)],
+        points = hv.HoloMap({0: hv.Points([(0, 0, 3), (0, 1, 1), (0, 2, 2)],
                                     vdims='size'),
-                          1: Points([(0, 0, 2.5), (0, 1, 3), (0, 2, 1.2)],
+                          1: hv.Points([(0, 0, 2.5), (0, 1, 3), (0, 2, 1.2)],
                                     vdims='size')}).opts(s='size')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
@@ -276,16 +274,16 @@ class TestPointPlot(TestMPLPlot):
         assert_data_equal(artist.get_sizes(), np.array([2.5, 3, 1.2]))
 
     def test_point_line_width_op(self):
-        points = Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
+        points = hv.Points([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
                         vdims='line_width').opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
         assert artist.get_linewidths() == [1, 4, 8]
 
     def test_point_line_width_op_update(self):
-        points = HoloMap({0: Points([(0, 0, 3), (0, 1, 1), (0, 2, 2)],
+        points = hv.HoloMap({0: hv.Points([(0, 0, 3), (0, 1, 1), (0, 2, 2)],
                                     vdims='line_width'),
-                          1: Points([(0, 0, 2.5), (0, 1, 3), (0, 2, 1.2)],
+                          1: hv.Points([(0, 0, 2.5), (0, 1, 3), (0, 2, 1.2)],
                                     vdims='line_width')}).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(points)
         artist = plot.handles['artist']
@@ -294,14 +292,14 @@ class TestPointPlot(TestMPLPlot):
         assert artist.get_linewidths() == [2.5, 3, 1.2]
 
     def test_point_marker_op(self):
-        points = Points([(0, 0, 'circle'), (0, 1, 'triangle'), (0, 2, 'square')],
+        points = hv.Points([(0, 0, 'circle'), (0, 1, 'triangle'), (0, 2, 'square')],
                         vdims='marker').opts(marker='marker')
         msg = 'ValueError: Mapping a dimension to the "marker" style'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(points)
 
     def test_point_alpha_op(self):
-        points = Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        points = hv.Points([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                         vdims='alpha').opts(alpha='alpha')
         msg = 'ValueError: Mapping a dimension to the "alpha" style'
         with pytest.raises(AbbreviatedException, match=msg):
@@ -309,7 +307,7 @@ class TestPointPlot(TestMPLPlot):
 
     def test_op_ndoverlay_value(self):
         markers = ['d', 's']
-        overlay = NdOverlay({marker: Points(np.arange(i))
+        overlay = hv.NdOverlay({marker: hv.Points(np.arange(i))
                              for i, marker in enumerate(markers)},
                             'Marker').opts('Points', marker='Marker')
         plot = mpl_renderer.get_plot(overlay)
@@ -319,7 +317,7 @@ class TestPointPlot(TestMPLPlot):
             assert style['marker'] == marker
 
     def test_point_color_index_color_clash(self):
-        points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        points = hv.Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='color').opts(color='color', color_index='color')
         with ParamLogStream() as log:
             mpl_renderer.get_plot(points)
@@ -332,7 +330,7 @@ class TestPointPlot(TestMPLPlot):
         assert log_msg == warning
 
     def test_point_size_index_size_clash(self):
-        points = Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        points = hv.Points([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims='size').opts(s='size', size_index='size')
         with ParamLogStream() as log:
             mpl_renderer.get_plot(points)

--- a/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Dataset, Image, QuadMesh
+import holoviews as hv
 
 from .test_plot import MPL_GE_3_8_0, TestMPLPlot, mpl_renderer
 
@@ -9,7 +9,7 @@ class TestQuadMeshPlot(TestMPLPlot):
 
     def test_quadmesh_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
-        qmesh = QuadMesh(Image(arr)).opts(invert_axes=True)
+        qmesh = hv.QuadMesh(hv.Image(arr)).opts(invert_axes=True)
         plot = mpl_renderer.get_plot(qmesh)
         artist = plot.handles['artist']
         if MPL_GE_3_8_0:
@@ -19,7 +19,7 @@ class TestQuadMeshPlot(TestMPLPlot):
 
     def test_quadmesh_nodata(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
-        qmesh = QuadMesh(Image(arr)).opts(nodata=0)
+        qmesh = hv.QuadMesh(hv.Image(arr)).opts(nodata=0)
         plot = mpl_renderer.get_plot(qmesh)
         artist = plot.handles['artist']
         if MPL_GE_3_8_0:
@@ -31,7 +31,7 @@ class TestQuadMeshPlot(TestMPLPlot):
 
     def test_quadmesh_nodata_uint(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]], dtype='uint32')
-        qmesh = QuadMesh(Image(arr)).opts(nodata=0)
+        qmesh = hv.QuadMesh(hv.Image(arr)).opts(nodata=0)
         plot = mpl_renderer.get_plot(qmesh)
         artist = plot.handles['artist']
         if MPL_GE_3_8_0:
@@ -45,8 +45,8 @@ class TestQuadMeshPlot(TestMPLPlot):
         zs = np.linspace(1, 2, 5)
         XS, _YS, ZS = np.meshgrid(xs, ys, zs)
         values = np.sin(XS) * ZS
-        ds = Dataset((xs, ys, zs, values.T), ['x', 'y', 'z'], 'values')
-        hmap = ds.to(QuadMesh).opts(colorbar=True, framewise=True)
+        ds = hv.Dataset((xs, ys, zs, values.T), ['x', 'y', 'z'], 'values')
+        hmap = ds.to(hv.QuadMesh).opts(colorbar=True, framewise=True)
         plot = mpl_renderer.get_plot(hmap)
         cbar = plot.handles['cbar']
         np.testing.assert_allclose([cbar.vmin, cbar.vmax], [-0.9989549170979283, 0.9719379013633128])

--- a/holoviews/tests/plotting/matplotlib/test_radialheatmap.py
+++ b/holoviews/tests/plotting/matplotlib/test_radialheatmap.py
@@ -2,8 +2,7 @@ from itertools import product
 
 import numpy as np
 
-from holoviews.core.spaces import HoloMap
-from holoviews.element.raster import HeatMap
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from ...utils import optional_dependencies
@@ -43,7 +42,7 @@ class RadialHeatMapPlotTests(TestMPLPlot):
         opts = dict(HeatMap=plot_opts)
 
         # provide element and plot instances for tests
-        self.element = HeatMap((self.x, self.y, self.z)).opts(opts)
+        self.element = hv.HeatMap((self.x, self.y, self.z)).opts(opts)
 
     def test_get_data(self):
         plot = mpl_renderer.get_plot(self.element)
@@ -74,7 +73,7 @@ class RadialHeatMapPlotTests(TestMPLPlot):
 
     @mpl_skip
     def test_heatmap_holomap(self):
-        hm = HoloMap({'A': HeatMap(np.random.randint(0, 10, (100, 3))),
-                      'B': HeatMap(np.random.randint(0, 10, (100, 3)))})
+        hm = hv.HoloMap({'A': hv.HeatMap(np.random.randint(0, 10, (100, 3))),
+                      'B': hv.HeatMap(np.random.randint(0, 10, (100, 3)))})
         plot = mpl_renderer.get_plot(hm.opts(radial=True))
         assert isinstance(plot, RadialHeatMapPlot)

--- a/holoviews/tests/plotting/matplotlib/test_rasterplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_rasterplot.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from matplotlib.colors import ListedColormap
 
-from holoviews.element import Image, ImageStack, Raster
+import holoviews as hv
 from holoviews.plotting.mpl.raster import RGBPlot
 
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -12,7 +12,7 @@ class TestRasterPlot(TestMPLPlot):
 
     def test_raster_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
-        raster = Raster(arr).opts(invert_axes=True)
+        raster = hv.Raster(arr).opts(invert_axes=True)
         plot = mpl_renderer.get_plot(raster)
         artist = plot.handles['artist']
         np.testing.assert_equal(artist.get_array().data, arr.T[::-1])
@@ -23,7 +23,7 @@ class TestRasterPlot(TestMPLPlot):
         expected = np.array([[3, 4, 5],
                              [np.nan, 1, 2]])
 
-        raster = Raster(arr).opts(nodata=0)
+        raster = hv.Raster(arr).opts(nodata=0)
         plot = mpl_renderer.get_plot(raster)
         artist = plot.handles['artist']
         np.testing.assert_equal(artist.get_array().data, expected)
@@ -33,7 +33,7 @@ class TestRasterPlot(TestMPLPlot):
         expected = np.array([[3, 4, 5],
                              [np.nan, 1, 2]])
 
-        raster = Raster(arr).opts(nodata=0)
+        raster = hv.Raster(arr).opts(nodata=0)
         plot = mpl_renderer.get_plot(raster)
         artist = plot.handles['artist']
         np.testing.assert_equal(artist.get_array().data, expected)
@@ -41,7 +41,7 @@ class TestRasterPlot(TestMPLPlot):
 
     def test_image_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
-        raster = Image(arr).opts(invert_axes=True)
+        raster = hv.Image(arr).opts(invert_axes=True)
         plot = mpl_renderer.get_plot(raster)
         artist = plot.handles['artist']
         np.testing.assert_equal(artist.get_array().data, arr.T[::-1, ::-1])
@@ -49,7 +49,7 @@ class TestRasterPlot(TestMPLPlot):
 
     def test_image_listed_cmap(self):
         colors = ['#ffffff','#000000']
-        img = Image(np.array([[0, 1, 2], [3, 4, 5]])).opts(cmap=colors)
+        img = hv.Image(np.array([[0, 1, 2], [3, 4, 5]])).opts(cmap=colors)
         plot = mpl_renderer.get_plot(img)
         artist = plot.handles['artist']
         cmap = artist.get_cmap()
@@ -57,22 +57,22 @@ class TestRasterPlot(TestMPLPlot):
         assert cmap.colors == colors
 
     def test_image_cbar_extend_both(self):
-        img = Image(np.array([[0, 1], [2, 3]])).redim(z=dict(range=(1,2)))
+        img = hv.Image(np.array([[0, 1], [2, 3]])).redim(z=dict(range=(1,2)))
         plot = mpl_renderer.get_plot(img.opts(colorbar=True))
         assert plot.handles['cbar'].extend == 'both'
 
     def test_image_cbar_extend_min(self):
-        img = Image(np.array([[0, 1], [2, 3]])).redim(z=dict(range=(1, None)))
+        img = hv.Image(np.array([[0, 1], [2, 3]])).redim(z=dict(range=(1, None)))
         plot = mpl_renderer.get_plot(img.opts(colorbar=True))
         assert plot.handles['cbar'].extend == 'min'
 
     def test_image_cbar_extend_max(self):
-        img = Image(np.array([[0, 1], [2, 3]])).redim(z=dict(range=(None, 2)))
+        img = hv.Image(np.array([[0, 1], [2, 3]])).redim(z=dict(range=(None, 2)))
         plot = mpl_renderer.get_plot(img.opts(colorbar=True))
         assert plot.handles['cbar'].extend == 'max'
 
     def test_image_cbar_extend_clim(self):
-        img = Image(np.array([[0, 1], [2, 3]])).opts(
+        img = hv.Image(np.array([[0, 1], [2, 3]])).opts(
             clim=(np.nan, np.nan), colorbar=True)
         plot = mpl_renderer.get_plot(img)
         assert plot.handles['cbar'].extend == 'neither'
@@ -86,7 +86,7 @@ class TestRasterPlot(TestMPLPlot):
         b = np.array([[np.nan] * 3, [1, 1, np.nan], [np.nan] * 3])
         c = np.array([[np.nan] * 3, [np.nan] * 3, [1, 1, 1]])
 
-        img_stack = ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["a", "b", "c"])
+        img_stack = hv.ImageStack((x, y, a, b, c), kdims=["x", "y"], vdims=["a", "b", "c"])
         plot = mpl_renderer.get_plot(img_stack)
         artist = plot.handles['artist']
         array = artist.get_array().data

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -13,7 +13,7 @@ from matplotlib import style
 from panel.widgets import DiscreteSlider, FloatSlider, Player
 from pyviz_comms import CommManager
 
-from holoviews import Curve, DynamicMap, GridSpace, HoloMap, Image, ItemTable, Table
+import holoviews as hv
 from holoviews.plotting.mpl import CurvePlot, MPLRenderer
 from holoviews.plotting.renderer import Renderer
 from holoviews.streams import Stream
@@ -27,11 +27,11 @@ class MPLRendererTest:
 
     def setup_method(self):
         self.basename = 'no-file'
-        self.image1 = Image(np.array([[0,1],[2,3]]), label='Image1')
-        self.image2 = Image(np.array([[1,0],[4,-2]]), label='Image2')
-        self.map1 = HoloMap({1:self.image1, 2:self.image2}, label='TestMap')
+        self.image1 = hv.Image(np.array([[0,1],[2,3]]), label='Image1')
+        self.image2 = hv.Image(np.array([[1,0],[4,-2]]), label='Image2')
+        self.map1 = hv.HoloMap({1:self.image1, 2:self.image2}, label='TestMap')
 
-        self.unicode_table = ItemTable([('β','Δ1'), ('°C', '3×4')],
+        self.unicode_table = hv.ItemTable([('β','Δ1'), ('°C', '3×4')],
                                        label='Poincaré', group='α Festkörperphysik')
 
         self.renderer = MPLRenderer.instance()
@@ -66,13 +66,13 @@ class MPLRendererTest:
         assert (w, h) == (288, 509) or (w, h) == (288, 511)
 
     def test_get_size_grid_plot(self):
-        grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
+        grid = hv.GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
         plot = self.renderer.get_plot(grid)
         w, h = self.renderer.get_size(plot)
         assert (w, h) == (345, 345)
 
     def test_get_size_table(self):
-        table = Table(range(10), kdims=['x'])
+        table = hv.Table(range(10), kdims=['x'])
         plot = self.renderer.get_plot(table)
         w, h = self.renderer.get_size(plot)
         assert (w, h) == (288, 288)
@@ -92,12 +92,12 @@ class MPLRendererTest:
         assert "<source src='data:video/mp4" in data['text/html']
 
     def test_render_static(self):
-        curve = Curve([])
+        curve = hv.Curve([])
         obj, _ = self.renderer._validate(curve, None)
         assert isinstance(obj, CurvePlot)
 
     def test_render_holomap_individual(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer._validate(hmap, None)
         assert isinstance(obj, pn.pane.HoloViews)
         assert obj.center is True
@@ -109,7 +109,7 @@ class MPLRendererTest:
         assert slider.options == dict([(str(i), i) for i in range(5)])
 
     def test_render_holomap_embedded(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         data, _ = self.renderer.components(hmap)
         assert 'State"' in data['text/html']
 
@@ -119,7 +119,7 @@ class MPLRendererTest:
     #     self.assertNotIn('State"', data['text/html'])
 
     def test_render_holomap_scrubber(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer._validate(hmap, 'scrubber')
         assert isinstance(obj, pn.pane.HoloViews)
         assert obj.center is True
@@ -132,7 +132,7 @@ class MPLRendererTest:
         assert player.end == 4
 
     def test_render_holomap_scrubber_fps(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer.instance(fps=2)._validate(hmap, 'scrubber')
         assert isinstance(obj, pn.pane.HoloViews)
         widgets = obj.layout.select(Player)
@@ -141,7 +141,7 @@ class MPLRendererTest:
         assert player.interval == 500
 
     def test_render_holomap_individual_widget_position(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer.instance(widget_location='top')._validate(hmap, None)
         assert isinstance(obj, pn.pane.HoloViews)
         assert obj.center is True
@@ -150,7 +150,7 @@ class MPLRendererTest:
 
     @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_dims(self):
-        dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
+        dmap = hv.DynamicMap(lambda y: hv.Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
         obj, _ = self.renderer._validate(dmap, None)
         self.renderer.components(obj)
         [(plot, _pane)] = obj._plots.values()
@@ -166,7 +166,7 @@ class MPLRendererTest:
     @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_stream(self):
         stream = Stream.define('Custom', y=2)()
-        dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y'], streams=[stream])
+        dmap = hv.DynamicMap(lambda y: hv.Curve([1, 2, y]), kdims=['y'], streams=[stream])
         obj, _ = self.renderer._validate(dmap, None)
         self.renderer.components(obj)
         [(plot, _pane)] = obj._plots.values()
@@ -181,7 +181,7 @@ class MPLRendererTest:
     @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_stream_dims(self):
         stream = Stream.define('Custom', y=2)()
-        dmap = DynamicMap(lambda x, y: Curve([x, 1, y]), kdims=['x', 'y'],
+        dmap = hv.DynamicMap(lambda x, y: hv.Curve([x, 1, y]), kdims=['x', 'y'],
                           streams=[stream]).redim.values(x=[1, 2, 3])
         obj, _ = self.renderer._validate(dmap, None)
         self.renderer.components(obj)

--- a/holoviews/tests/plotting/matplotlib/test_sankey.py
+++ b/holoviews/tests/plotting/matplotlib/test_sankey.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from holoviews.core.data import Dataset
-from holoviews.element import Sankey
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestMPLPlot, mpl_renderer
@@ -10,7 +9,7 @@ from .test_plot import TestMPLPlot, mpl_renderer
 class TestSankeyPlot(TestMPLPlot):
 
     def test_sankey_simple(self):
-        sankey = Sankey([
+        sankey = hv.Sankey([
             ('A', 'X', 5), ('A', 'Y', 7), ('A', 'Z', 6),
             ('B', 'X', 2), ('B', 'Y', 9), ('B', 'Z', 4)]
         )
@@ -40,10 +39,10 @@ class TestSankeyPlot(TestMPLPlot):
 
 
     def test_sankey_label_index(self):
-        sankey = Sankey(([
+        sankey = hv.Sankey(([
             (0, 2, 5), (0, 3, 7), (0, 4, 6),
             (1, 2, 2), (1, 3, 9), (1, 4, 4)],
-            Dataset(enumerate('ABXYZ'), 'index', 'label'))
+            hv.Dataset(enumerate('ABXYZ'), 'index', 'label'))
         ).opts(label_index='label')
         plot = mpl_renderer.get_plot(sankey)
         labels = plot.handles['labels']

--- a/holoviews/tests/plotting/matplotlib/test_scatter3d.py
+++ b/holoviews/tests/plotting/matplotlib/test_scatter3d.py
@@ -1,4 +1,5 @@
-from holoviews.element import Scatter3D
+
+import holoviews as hv
 
 from .test_plot import TestMPLPlot, mpl_renderer
 
@@ -6,12 +7,12 @@ from .test_plot import TestMPLPlot, mpl_renderer
 class TestPointPlot(TestMPLPlot):
 
     def test_scatter3d_colorbar_label(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(color='z', colorbar=True)
+        scatter3d = hv.Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(color='z', colorbar=True)
         plot = mpl_renderer.get_plot(scatter3d)
         assert plot.handles['cax'].get_ylabel() == 'z'
 
     def test_scatter3d_padding_square(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=0.1)
+        scatter3d = hv.Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -23,7 +24,7 @@ class TestPointPlot(TestMPLPlot):
         assert z_range[1] == 4.2
 
     def test_curve_padding_square_per_axis(self):
-        curve = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=((0, 0.1), (0.1, 0.2), (0.2, 0.3)))
+        curve = hv.Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=((0, 0.1), (0.1, 0.2), (0.2, 0.3)))
         plot = mpl_renderer.get_plot(curve)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -35,7 +36,7 @@ class TestPointPlot(TestMPLPlot):
         assert z_range[1] == 4.6
 
     def test_scatter3d_padding_hard_zrange(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).redim.range(z=(0, 3)).opts(padding=0.1)
+        scatter3d = hv.Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).redim.range(z=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -47,7 +48,7 @@ class TestPointPlot(TestMPLPlot):
         assert z_range[1] == 3
 
     def test_scatter3d_padding_soft_zrange(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).redim.soft_range(z=(0, 3)).opts(padding=0.1)
+        scatter3d = hv.Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).redim.soft_range(z=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -59,7 +60,7 @@ class TestPointPlot(TestMPLPlot):
         assert z_range[1] == 4.2
 
     def test_scatter3d_padding_unequal(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=(0.05, 0.1, 0.2))
+        scatter3d = hv.Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=(0.05, 0.1, 0.2))
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -71,7 +72,7 @@ class TestPointPlot(TestMPLPlot):
         assert z_range[1] == 4.4
 
     def test_scatter3d_padding_nonsquare(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=0.1, aspect=2)
+        scatter3d = hv.Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()
@@ -83,7 +84,7 @@ class TestPointPlot(TestMPLPlot):
         assert z_range[1] == 4.2
 
     def test_scatter3d_padding_logz(self):
-        scatter3d = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=0.1, logz=True)
+        scatter3d = hv.Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 4)]).opts(padding=0.1, logz=True)
         plot = mpl_renderer.get_plot(scatter3d)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         z_range = plot.handles['axis'].get_zlim()

--- a/holoviews/tests/plotting/matplotlib/test_scatter3d.py
+++ b/holoviews/tests/plotting/matplotlib/test_scatter3d.py
@@ -1,4 +1,3 @@
-
 import holoviews as hv
 
 from .test_plot import TestMPLPlot, mpl_renderer

--- a/holoviews/tests/plotting/matplotlib/test_spikeplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_spikeplot.py
@@ -1,10 +1,8 @@
 import numpy as np
 import pytest
 
+import holoviews as hv
 from holoviews.core.options import AbbreviatedException
-from holoviews.core.overlay import NdOverlay
-from holoviews.core.spaces import HoloMap
-from holoviews.element import Spikes
 from holoviews.testing import assert_data_equal
 
 from ..utils import ParamLogStream
@@ -14,14 +12,14 @@ from .test_plot import TestMPLPlot, mpl_renderer
 class TestSpikesPlot(TestMPLPlot):
 
     def test_spikes_padding_square(self):
-        spikes = Spikes([1, 2, 3]).opts(padding=0.1)
+        spikes = hv.Spikes([1, 2, 3]).opts(padding=0.1)
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         assert x_range[0] == 0.8
         assert x_range[1] == 3.2
 
     def test_spikes_padding_square_heights(self):
-        spikes = Spikes([(1, 1), (2, 2), (3, 3)], vdims=['Height']).opts(padding=0.1)
+        spikes = hv.Spikes([(1, 1), (2, 2), (3, 3)], vdims=['Height']).opts(padding=0.1)
         plot = mpl_renderer.get_plot(spikes)
         x_range, y_range = plot.handles['axis'].get_xlim(), plot.handles['axis'].get_ylim()
         assert x_range[0] == 0.8
@@ -30,42 +28,42 @@ class TestSpikesPlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_spikes_padding_hard_xrange(self):
-        spikes = Spikes([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
+        spikes = hv.Spikes([1, 2, 3]).redim.range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         assert x_range[0] == 0
         assert x_range[1] == 3
 
     def test_spikes_padding_soft_xrange(self):
-        spikes = Spikes([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
+        spikes = hv.Spikes([1, 2, 3]).redim.soft_range(x=(0, 3)).opts(padding=0.1)
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         assert x_range[0] == 0
         assert x_range[1] == 3
 
     def test_spikes_padding_unequal(self):
-        spikes = Spikes([1, 2, 3]).opts(padding=(0.05, 0.1))
+        spikes = hv.Spikes([1, 2, 3]).opts(padding=(0.05, 0.1))
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         assert x_range[0] == 0.9
         assert x_range[1] == 3.1
 
     def test_spikes_padding_nonsquare(self):
-        spikes = Spikes([1, 2, 3]).opts(padding=0.1, aspect=2)
+        spikes = hv.Spikes([1, 2, 3]).opts(padding=0.1, aspect=2)
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         assert x_range[0] == 0.9
         assert x_range[1] == 3.1
 
     def test_spikes_padding_logx(self):
-        spikes = Spikes([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
+        spikes = hv.Spikes([(1, 1), (2, 2), (3,3)]).opts(padding=0.1, logx=True)
         plot = mpl_renderer.get_plot(spikes)
         x_range = plot.handles['axis'].get_xlim()
         assert x_range[0] == 0.89595845984076228
         assert x_range[1] == 3.3483695221017129
 
     def test_spikes_padding_datetime_square(self):
-        spikes = Spikes([np.datetime64(f'2016-04-0{i}') for i in range(1, 4)]).opts(
+        spikes = hv.Spikes([np.datetime64(f'2016-04-0{i}') for i in range(1, 4)]).opts(
             padding=0.1
         )
         plot = mpl_renderer.get_plot(spikes)
@@ -74,7 +72,7 @@ class TestSpikesPlot(TestMPLPlot):
         assert x_range[1] == 16894.2
 
     def test_spikes_padding_datetime_square_heights(self):
-        spikes = Spikes([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)], vdims=['Height']).opts(
+        spikes = hv.Spikes([(np.datetime64(f'2016-04-0{i}'), i) for i in range(1, 4)], vdims=['Height']).opts(
             padding=0.1
         )
         plot = mpl_renderer.get_plot(spikes)
@@ -85,7 +83,7 @@ class TestSpikesPlot(TestMPLPlot):
         assert y_range[1] == 3.2
 
     def test_spikes_padding_datetime_nonsquare(self):
-        spikes = Spikes([np.datetime64(f'2016-04-0{i}') for i in range(1, 4)]).opts(
+        spikes = hv.Spikes([np.datetime64(f'2016-04-0{i}') for i in range(1, 4)]).opts(
             padding=0.1, aspect=2
         )
         plot = mpl_renderer.get_plot(spikes)
@@ -98,7 +96,7 @@ class TestSpikesPlot(TestMPLPlot):
     ###########################
 
     def test_spikes_color_op(self):
-        spikes = Spikes([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
+        spikes = hv.Spikes([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                               vdims=['y', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
@@ -107,10 +105,10 @@ class TestSpikesPlot(TestMPLPlot):
         ))
 
     def test_spikes_color_op_update(self):
-        spikes = HoloMap({
-            0: Spikes([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
+        spikes = hv.HoloMap({
+            0: hv.Spikes([(0, 0, '#000000'), (0, 1, '#FF0000'), (0, 2, '#00FF00')],
                       vdims=['y', 'color']),
-            1: Spikes([(0, 0, '#FF0000'), (0, 1, '#00FF00'), (0, 2, '#0000FF')],
+            1: hv.Spikes([(0, 0, '#FF0000'), (0, 1, '#00FF00'), (0, 2, '#0000FF')],
                       vdims=['y', 'color'])}).opts(color='color')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
@@ -123,7 +121,7 @@ class TestSpikesPlot(TestMPLPlot):
         ))
 
     def test_spikes_linear_color_op(self):
-        spikes = Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        spikes = hv.Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims=['y', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
@@ -131,10 +129,10 @@ class TestSpikesPlot(TestMPLPlot):
         assert artist.get_clim() == (0, 2)
 
     def test_spikes_linear_color_op_update(self):
-        spikes = HoloMap({
-            0: Spikes([(0, 0, 0.5), (0, 1, 3.2), (0, 2, 1.8)],
+        spikes = hv.HoloMap({
+            0: hv.Spikes([(0, 0, 0.5), (0, 1, 3.2), (0, 2, 1.8)],
                       vdims=['y', 'color']),
-            1: Spikes([(0, 0, 0.1), (0, 1, 0.8), (0, 2, 0.3)],
+            1: hv.Spikes([(0, 0, 0.1), (0, 1, 0.8), (0, 2, 0.3)],
                       vdims=['y', 'color'])}).opts(color='color', framewise=True)
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
@@ -145,7 +143,7 @@ class TestSpikesPlot(TestMPLPlot):
         assert artist.get_clim() == (0.1, 0.8)
 
     def test_spikes_categorical_color_op(self):
-        spikes = Spikes([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
+        spikes = hv.Spikes([(0, 0, 'A'), (0, 1, 'B'), (0, 2, 'A')],
                         vdims=['y', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
@@ -153,14 +151,14 @@ class TestSpikesPlot(TestMPLPlot):
         assert artist.get_clim() == (0, 1)
 
     def test_spikes_alpha_op(self):
-        spikes = Spikes([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
+        spikes = hv.Spikes([(0, 0, 0), (0, 1, 0.2), (0, 2, 0.7)],
                               vdims=['y', 'alpha']).opts(alpha='alpha')
         msg = 'ValueError: Mapping a dimension to the "alpha" style'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(spikes)
 
     def test_spikes_line_width_op(self):
-        spikes = Spikes([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
+        spikes = hv.Spikes([(0, 0, 1), (0, 1, 4), (0, 2, 8)],
                               vdims=['y', 'line_width']).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
@@ -168,10 +166,10 @@ class TestSpikesPlot(TestMPLPlot):
 
 
     def test_spikes_line_width_op_update(self):
-        spikes = HoloMap({
-            0: Spikes([(0, 0, 0.5), (0, 1, 3.2), (0, 2, 1.8)],
+        spikes = hv.HoloMap({
+            0: hv.Spikes([(0, 0, 0.5), (0, 1, 3.2), (0, 2, 1.8)],
                       vdims=['y', 'line_width']),
-            1: Spikes([(0, 0, 0.1), (0, 1, 0.8), (0, 2, 0.3)],
+            1: hv.Spikes([(0, 0, 0.1), (0, 1, 0.8), (0, 2, 0.3)],
                       vdims=['y', 'line_width'])}).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(spikes)
         artist = plot.handles['artist']
@@ -181,7 +179,7 @@ class TestSpikesPlot(TestMPLPlot):
 
     def test_op_ndoverlay_value(self):
         colors = ['blue', 'red']
-        overlay = NdOverlay({color: Spikes(np.arange(i+2))
+        overlay = hv.NdOverlay({color: hv.Spikes(np.arange(i+2))
                              for i, color in enumerate(colors)}, 'Color').opts(
                                      'Spikes', color='Color'
                              )
@@ -193,7 +191,7 @@ class TestSpikesPlot(TestMPLPlot):
                 assert c.get_facecolor() == color
 
     def test_spikes_color_index_color_clash(self):
-        spikes = Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
+        spikes = hv.Spikes([(0, 0, 0), (0, 1, 1), (0, 2, 2)],
                         vdims=['y', 'color']).opts(color='color', color_index='color')
         with ParamLogStream() as log:
             mpl_renderer.get_plot(spikes)

--- a/holoviews/tests/plotting/matplotlib/test_utils.py
+++ b/holoviews/tests/plotting/matplotlib/test_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Polygons
+import holoviews as hv
 from holoviews.plotting.mpl.util import polygons_to_path_patches
 from holoviews.testing import assert_data_equal
 
@@ -18,7 +18,7 @@ class TestUtils(TestMPLPlot):
             [],
             []
         ]
-        polys = Polygons([{'x': xs, 'y': ys, 'holes': holes}])
+        polys = hv.Polygons([{'x': xs, 'y': ys, 'holes': holes}])
         paths = polygons_to_path_patches(polys)
 
 

--- a/holoviews/tests/plotting/matplotlib/test_vectorfieldplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_vectorfieldplot.py
@@ -1,9 +1,8 @@
 import numpy as np
 import pytest
 
+import holoviews as hv
 from holoviews.core.options import AbbreviatedException
-from holoviews.core.spaces import HoloMap
-from holoviews.element import VectorField
 from holoviews.testing import assert_data_equal
 
 from ..utils import ParamLogStream
@@ -17,7 +16,7 @@ class TestVectorFieldPlot(TestMPLPlot):
     ###########################
 
     def test_vectorfield_color_op(self):
-        vectorfield = VectorField([(0, 0, 0, 1, '#000000'), (0, 1, 0, 1,'#FF0000'), (0, 2, 0, 1,'#00FF00')],
+        vectorfield = hv.VectorField([(0, 0, 0, 1, '#000000'), (0, 1, 0, 1,'#FF0000'), (0, 2, 0, 1,'#00FF00')],
                                   vdims=['A', 'M', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
@@ -28,10 +27,10 @@ class TestVectorFieldPlot(TestMPLPlot):
         ]))
 
     def test_vectorfield_color_op_update(self):
-        vectorfield = HoloMap({
-            0: VectorField([(0, 0, 0, 1, '#000000'), (0, 1, 0, 1, '#FF0000'), (0, 2, 0, 1, '#00FF00')],
+        vectorfield = hv.HoloMap({
+            0: hv.VectorField([(0, 0, 0, 1, '#000000'), (0, 1, 0, 1, '#FF0000'), (0, 2, 0, 1, '#00FF00')],
                            vdims=['A', 'M', 'color']),
-            1: VectorField([(0, 0, 0, 1, '#0000FF'), (0, 1, 0, 1, '#00FF00'), (0, 2, 0, 1, '#FF0000')],
+            1: hv.VectorField([(0, 0, 0, 1, '#0000FF'), (0, 1, 0, 1, '#00FF00'), (0, 2, 0, 1, '#FF0000')],
                            vdims=['A', 'M', 'color'])}).opts(color='color')
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
@@ -48,10 +47,10 @@ class TestVectorFieldPlot(TestMPLPlot):
         ]))
 
     def test_vectorfield_linear_color_op_update(self):
-        vectorfield = HoloMap({
-            0: VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 1), (0, 2, 0, 1, 2)],
+        vectorfield = hv.HoloMap({
+            0: hv.VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 1), (0, 2, 0, 1, 2)],
                            vdims=['A', 'M', 'color']),
-            1: VectorField([(0, 0, 0, 1, 3.2), (0, 1, 0, 1, 2), (0, 2, 0, 1, 4)],
+            1: hv.VectorField([(0, 0, 0, 1, 3.2), (0, 1, 0, 1, 2), (0, 2, 0, 1, 4)],
                            vdims=['A', 'M', 'color'])}).opts(color='color', framewise=True)
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
@@ -62,7 +61,7 @@ class TestVectorFieldPlot(TestMPLPlot):
         assert artist.get_clim() == (2, 4)
 
     def test_vectorfield_categorical_color_op(self):
-        vectorfield = VectorField([(0, 0, 0, 1, 'A'), (0, 1, 0, 1, 'B'), (0, 2, 0, 1, 'C')],
+        vectorfield = hv.VectorField([(0, 0, 0, 1, 'A'), (0, 1, 0, 1, 'B'), (0, 2, 0, 1, 'C')],
                                   vdims=['A', 'M', 'color']).opts(color='color')
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
@@ -70,24 +69,24 @@ class TestVectorFieldPlot(TestMPLPlot):
         assert artist.get_clim() == (0, 2)
 
     def test_vectorfield_alpha_op(self):
-        vectorfield = VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 0.2), (0, 2, 0, 1, 0.7)],
+        vectorfield = hv.VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 0.2), (0, 2, 0, 1, 0.7)],
                                   vdims=['A', 'M', 'alpha']).opts(alpha='alpha')
         msg = 'ValueError: Mapping a dimension to the "alpha" style'
         with pytest.raises(AbbreviatedException, match=msg):
             mpl_renderer.get_plot(vectorfield)
 
     def test_vectorfield_line_width_op(self):
-        vectorfield = VectorField([(0, 0, 0, 1, 1), (0, 1, 0, 1, 4), (0, 2, 0, 1, 8)],
+        vectorfield = hv.VectorField([(0, 0, 0, 1, 1), (0, 1, 0, 1, 4), (0, 2, 0, 1, 8)],
                                   vdims=['A', 'M', 'line_width']).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
         assert artist.get_linewidths() == [1, 4, 8]
 
     def test_vectorfield_line_width_op_update(self):
-        vectorfield = HoloMap({
-            0: VectorField([(0, 0, 0, 1, 1), (0, 1, 0, 1, 4), (0, 2, 0, 1, 8)],
+        vectorfield = hv.HoloMap({
+            0: hv.VectorField([(0, 0, 0, 1, 1), (0, 1, 0, 1, 4), (0, 2, 0, 1, 8)],
                            vdims=['A', 'M', 'line_width']),
-            1: VectorField([(0, 0, 0, 1, 3), (0, 1, 0, 1, 2), (0, 2, 0, 1, 5)],
+            1: hv.VectorField([(0, 0, 0, 1, 3), (0, 1, 0, 1, 2), (0, 2, 0, 1, 5)],
                            vdims=['A', 'M', 'line_width'])}).opts(linewidth='line_width')
         plot = mpl_renderer.get_plot(vectorfield)
         artist = plot.handles['artist']
@@ -96,7 +95,7 @@ class TestVectorFieldPlot(TestMPLPlot):
         assert artist.get_linewidths() == [3, 2, 5]
 
     def test_vectorfield_color_index_color_clash(self):
-        vectorfield = VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 1), (0, 2, 0, 1, 2)],
+        vectorfield = hv.VectorField([(0, 0, 0, 1, 0), (0, 1, 0, 1, 1), (0, 2, 0, 1, 2)],
                                   vdims=['A', 'M', 'color']).opts(color='color', color_index='A')
         with ParamLogStream() as log:
             mpl_renderer.get_plot(vectorfield)

--- a/holoviews/tests/plotting/matplotlib/test_violinplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_violinplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Violin
+import holoviews as hv
 from holoviews.plotting.mpl.util import MPL_GE_3_9_0
 from holoviews.testing import assert_data_equal
 
@@ -11,7 +11,7 @@ class TestMPLViolinPlot(TestMPLPlot):
 
     def test_violin_simple(self):
         values = np.random.rand(100)
-        violin = Violin(values)
+        violin = hv.Violin(values)
         plot = mpl_renderer.get_plot(violin)
         data, style, _axis_opts = plot.get_data(violin, {}, {})
         assert_data_equal(data[0][0], values)
@@ -23,7 +23,7 @@ class TestMPLViolinPlot(TestMPLPlot):
 
     def test_violin_simple_overlay(self):
         values = np.random.rand(100)
-        violin = Violin(values) * Violin(values)
+        violin = hv.Violin(values) * hv.Violin(values)
         plot = mpl_renderer.get_plot(violin)
         p1, p2 = plot.subplots.values()
         assert_data_equal(p1.handles['boxes'][0].get_path().vertices,
@@ -32,7 +32,7 @@ class TestMPLViolinPlot(TestMPLPlot):
             assert_data_equal(b1.vertices, b2.vertices)
 
     def test_violin_multi(self):
-        violin = Violin((np.random.randint(0, 2, 100), np.random.rand(100)), kdims=['A']).sort()
+        violin = hv.Violin((np.random.randint(0, 2, 100), np.random.rand(100)), kdims=['A']).sort()
         plot = mpl_renderer.get_plot(violin)
         data, style, _axis_opts = plot.get_data(violin, {}, {})
         assert_data_equal(data[0][0], violin.select(A=0).dimension_values(1))

--- a/holoviews/tests/plotting/plotly/test_areaplot.py
+++ b/holoviews/tests/plotting/plotly/test_areaplot.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from holoviews.core import Overlay
-from holoviews.element import Area
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -11,7 +10,7 @@ from .test_plot import TestPlotlyPlot
 class TestAreaPlot(TestPlotlyPlot):
 
     def test_area_to_zero_y(self):
-        curve = Area([1, 2, 3])
+        curve = hv.Area([1, 2, 3])
         state = self._get_plot_state(curve)
         assert_data_equal(state['data'][0]['x'], np.array([0, 1, 2]))
         assert_data_equal(state['data'][0]['y'], np.array([1, 2, 3]))
@@ -20,7 +19,7 @@ class TestAreaPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['range'] == [0, 3]
 
     def test_area_to_zero_x(self):
-        curve = Area([1, 2, 3]).opts(invert_axes=True)
+        curve = hv.Area([1, 2, 3]).opts(invert_axes=True)
         state = self._get_plot_state(curve)
         assert_data_equal(state['data'][0]['x'], np.array([1, 2, 3]))
         assert_data_equal(state['data'][0]['y'], np.array([0, 1, 2]))
@@ -32,7 +31,7 @@ class TestAreaPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'x'
 
     def test_area_fill_between_ys(self):
-        area = Area([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2'])
+        area = hv.Area([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2'])
         state = self._get_plot_state(area)
         assert_data_equal(state['data'][0]['y'], np.array([0.5, 1, 2.25]))
         assert state['data'][0]['mode'] == 'lines'
@@ -43,7 +42,7 @@ class TestAreaPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['range'] == [0.5, 3]
 
     def test_area_fill_between_xs(self):
-        area = Area([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2']).opts(invert_axes=True)
+        area = hv.Area([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2']).opts(invert_axes=True)
         state = self._get_plot_state(area)
         assert_data_equal(state['data'][0]['x'], np.array([0.5, 1, 2.25]))
         assert state['data'][0]['mode'] == 'lines'
@@ -55,14 +54,14 @@ class TestAreaPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['range'] == [0, 2]
 
     def test_area_visible(self):
-        curve = Area([1, 2, 3]).opts(visible=False)
+        curve = hv.Area([1, 2, 3]).opts(visible=False)
         state = self._get_plot_state(curve)
         assert state['data'][0]['visible'] is False
 
     def test_area_stack_vdims(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y_1': [1, 2, 3], 'y_2': [6, 4, 2], 'y_3': [8, 1, 2]})
-        overlay = Overlay([Area(df, kdims='x', vdims=col, label=col) for col in ['y_1', 'y_2', 'y_3']])
-        plot = Area.stack(overlay)
+        overlay = hv.Overlay([hv.Area(df, kdims='x', vdims=col, label=col) for col in ['y_1', 'y_2', 'y_3']])
+        plot = hv.Area.stack(overlay)
         baselines = [np.array([0, 0, 0]), np.array([1., 2., 3.]), np.array([7., 6., 5.])]
         for n, baseline in zip(plot.data, baselines, strict=True):
             assert_data_equal(plot.data[n].data.Baseline.to_numpy(), baseline)

--- a/holoviews/tests/plotting/plotly/test_barplot.py
+++ b/holoviews/tests/plotting/plotly/test_barplot.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from holoviews.element import Bars
+import holoviews as hv
 from holoviews.plotting.plotly.util import PLOTLY_VERSION
 from holoviews.testing import assert_data_equal
 
@@ -11,7 +11,7 @@ from .test_plot import TestPlotlyPlot
 class TestBarsPlot(TestPlotlyPlot):
 
     def test_bars_plot(self):
-        bars = Bars([3, 2, 1])
+        bars = hv.Bars([3, 2, 1])
         state = self._get_plot_state(bars)
         assert state['data'][0]['x'] == [0, 1, 2]
         assert_data_equal(state['data'][0]['y'], np.array([3, 2, 1]))
@@ -22,7 +22,7 @@ class TestBarsPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'y'
 
     def test_bars_plot_inverted(self):
-        bars = Bars([3, 2, 1]).opts(invert_axes=True)
+        bars = hv.Bars([3, 2, 1]).opts(invert_axes=True)
         state = self._get_plot_state(bars)
         assert state['data'][0]['y'] == [0, 1, 2]
         assert_data_equal(state['data'][0]['x'], np.array([3, 2, 1]))
@@ -33,7 +33,7 @@ class TestBarsPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'x'
 
     def test_bars_grouped(self):
-        bars = Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
+        bars = hv.Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
                     kdims=['A', 'B'])
         state = self._get_plot_state(bars)
         assert state['data'][0]['x'] == [['A', 'B', 'C', 'C'], ['1', '2', '2', '1']]
@@ -46,7 +46,7 @@ class TestBarsPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'y'
 
     def test_bars_grouped_inverted(self):
-        bars = Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
+        bars = hv.Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
                     kdims=['A', 'B']).opts(invert_axes=True)
         state = self._get_plot_state(bars)
         assert state['data'][0]['y'] == [['A', 'B', 'C', 'C'], ['1', '2', '2', '1']]
@@ -59,7 +59,7 @@ class TestBarsPlot(TestPlotlyPlot):
         assert state['layout']['xaxis']['title']['text'] == 'y'
 
     def test_bars_stacked(self):
-        bars = Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
+        bars = hv.Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
                     kdims=['A', 'B']).opts(stacked=True)
         state = self._get_plot_state(bars)
         assert state['data'][0]['x'] == ['A', 'B', 'C']
@@ -75,7 +75,7 @@ class TestBarsPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'y'
 
     def test_bars_stacked_inverted(self):
-        bars = Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
+        bars = hv.Bars([('A', 1, 1), ('B', 2, 2), ('C', 2, 3), ('C', 1, 4)],
                     kdims=['A', 'B']).opts(stacked=True, invert_axes=True)
         state = self._get_plot_state(bars)
         assert state['data'][0]['y'] == ['A', 'B', 'C']
@@ -91,32 +91,32 @@ class TestBarsPlot(TestPlotlyPlot):
         assert state['layout']['xaxis']['title']['text'] == 'y'
 
     def test_visible(self):
-        element = Bars([3, 2, 1]).opts(visible=False)
+        element = hv.Bars([3, 2, 1]).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False
 
     def test_bars_continuous_data_list_same_interval(self):
-        bars = Bars(([0, 1, 2], [10, 20, 30]))
+        bars = hv.Bars(([0, 1, 2], [10, 20, 30]))
         plot = self._get_plot_state(bars)
         np.testing.assert_equal(plot['data'][0]['x'], [0, 1, 2])
         np.testing.assert_equal(plot['data'][0]['y'], [10, 20, 30])
 
     def test_bars_continuous_data_list_diff_interval(self):
-        bars = Bars(([0, 3, 10], [10, 20, 30]))
+        bars = hv.Bars(([0, 3, 10], [10, 20, 30]))
         plot = self._get_plot_state(bars)
         np.testing.assert_equal(plot['data'][0]['x'], [0, 3, 10])
         np.testing.assert_equal(plot['data'][0]['y'], [10, 20, 30])
 
     def test_bars_continuous_datetime(self):
         y = np.random.rand(10)
-        bars = Bars((pd.date_range("1/1/2000", periods=10), y))
+        bars = hv.Bars((pd.date_range("1/1/2000", periods=10), y))
         plot = self._get_plot_state(bars)
         dtype = "datetime64[us]" if PLOTLY_VERSION >= (6, 5, 0) else float
         np.testing.assert_equal(plot['data'][0]['x'], pd.date_range("1/1/2000", periods=10).values.astype(dtype))
         np.testing.assert_equal(plot['data'][0]['y'], y)
 
     def test_bars_not_continuous_data_list(self):
-        bars = Bars([("A", 1), ("B", 2), ("C", 3)])
+        bars = hv.Bars([("A", 1), ("B", 2), ("C", 3)])
         plot = self._get_plot_state(bars)
         np.testing.assert_equal(plot['data'][0]['x'], ["A", "B", "C"])
         np.testing.assert_equal(plot['data'][0]['y'], [1, 2, 3])
@@ -131,7 +131,7 @@ class TestBarsPlot(TestPlotlyPlot):
         pets_sample = np.random.choice(pets, samples)
         gender_sample = np.random.choice(genders, samples)
 
-        bars = Bars(
+        bars = hv.Bars(
             (pets_sample, gender_sample, np.ones(samples)), ["Pets", "Gender"]
         ).aggregate(function=np.sum)
         plot = self._get_plot_state(bars)
@@ -151,7 +151,7 @@ class TestBarsPlot(TestPlotlyPlot):
         gender_sample = np.random.choice(genders, samples)
 
         bars = (
-            Bars((pets_sample, gender_sample, np.ones(samples)), ["Pets", "Gender"])
+            hv.Bars((pets_sample, gender_sample, np.ones(samples)), ["Pets", "Gender"])
             .aggregate(function=np.sum)
             .opts(stacked=True)
         )
@@ -161,7 +161,7 @@ class TestBarsPlot(TestPlotlyPlot):
 
     def test_bar_color(self):
         data = pd.DataFrame({"A": range(5)})
-        bars = Bars(data).opts(color="gold")
+        bars = hv.Bars(data).opts(color="gold")
         fig = self._get_plot_state(bars)
         data = fig["data"][0]
         assert data["marker"]["color"] == "gold"

--- a/holoviews/tests/plotting/plotly/test_bivariateplot.py
+++ b/holoviews/tests/plotting/plotly/test_bivariateplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Bivariate
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -9,7 +9,7 @@ from .test_plot import TestPlotlyPlot
 class TestBivariatePlot(TestPlotlyPlot):
 
     def test_bivariate_state(self):
-        bivariate = Bivariate(([3, 2, 1], [0, 1, 2]))
+        bivariate = hv.Bivariate(([3, 2, 1], [0, 1, 2]))
         state = self._get_plot_state(bivariate)
         assert state['data'][0]['type'] == 'histogram2dcontour'
         assert_data_equal(state['data'][0]['x'], np.array([3, 2, 1]))
@@ -19,19 +19,19 @@ class TestBivariatePlot(TestPlotlyPlot):
         assert state['data'][0]['contours']['coloring'] == 'lines'
 
     def test_bivariate_filled(self):
-        bivariate = Bivariate(([3, 2, 1], [0, 1, 2])).opts(
+        bivariate = hv.Bivariate(([3, 2, 1], [0, 1, 2])).opts(
             filled=True)
         state = self._get_plot_state(bivariate)
         assert state['data'][0]['contours']['coloring'] == 'fill'
 
     def test_bivariate_ncontours(self):
-        bivariate = Bivariate(([3, 2, 1], [0, 1, 2])).opts(ncontours=5)
+        bivariate = hv.Bivariate(([3, 2, 1], [0, 1, 2])).opts(ncontours=5)
         state = self._get_plot_state(bivariate)
         assert state['data'][0]['ncontours'] == 5
         assert state['data'][0]['autocontour'] is False
 
     def test_bivariate_colorbar(self):
-        bivariate = Bivariate(([3, 2, 1], [0, 1, 2]))\
+        bivariate = hv.Bivariate(([3, 2, 1], [0, 1, 2]))\
 
         bivariate.opts(colorbar=True)
         state = self._get_plot_state(bivariate)
@@ -44,6 +44,6 @@ class TestBivariatePlot(TestPlotlyPlot):
         assert not trace['showscale']
 
     def test_visible(self):
-        element = Bivariate(([3, 2, 1], [0, 1, 2])).opts(visible=False)
+        element = hv.Bivariate(([3, 2, 1], [0, 1, 2])).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False

--- a/holoviews/tests/plotting/plotly/test_boxwhiskerplot.py
+++ b/holoviews/tests/plotting/plotly/test_boxwhiskerplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import BoxWhisker
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -9,7 +9,7 @@ from .test_plot import TestPlotlyPlot
 class TestBoxWhiskerPlot(TestPlotlyPlot):
 
     def test_boxwhisker_single(self):
-        box = BoxWhisker([1, 1, 2, 3, 3, 4, 5, 5])
+        box = hv.BoxWhisker([1, 1, 2, 3, 3, 4, 5, 5])
         state = self._get_plot_state(box)
         assert len(state['data']) == 1
         assert state['data'][0]['type'] == 'box'
@@ -20,7 +20,7 @@ class TestBoxWhiskerPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'y'
 
     def test_boxwhisker_single_invert_axes(self):
-        box = BoxWhisker([1, 1, 2, 3, 3, 4, 5, 5]).opts(invert_axes=True)
+        box = hv.BoxWhisker([1, 1, 2, 3, 3, 4, 5, 5]).opts(invert_axes=True)
         state = self._get_plot_state(box)
         assert len(state['data']) == 1
         assert state['data'][0]['type'] == 'box'
@@ -31,7 +31,7 @@ class TestBoxWhiskerPlot(TestPlotlyPlot):
         assert state['layout']['xaxis']['title']['text'] == 'y'
 
     def test_boxwhisker_multi(self):
-        box = BoxWhisker((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y')
+        box = hv.BoxWhisker((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y')
         state = self._get_plot_state(box)
         assert len(state['data']) == 2
         assert state['data'][0]['type'] == 'box'
@@ -45,7 +45,7 @@ class TestBoxWhiskerPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'y'
 
     def test_boxwhisker_multi_invert_axes(self):
-        box = BoxWhisker((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y').opts(
+        box = hv.BoxWhisker((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y').opts(
             invert_axes=True)
         state = self._get_plot_state(box)
         assert len(state['data']) == 2
@@ -60,6 +60,6 @@ class TestBoxWhiskerPlot(TestPlotlyPlot):
         assert state['layout']['xaxis']['title']['text'] == 'y'
 
     def test_visible(self):
-        element = BoxWhisker(([3, 2, 1], [0, 1, 2])).opts(visible=False)
+        element = hv.BoxWhisker(([3, 2, 1], [0, 1, 2])).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False

--- a/holoviews/tests/plotting/plotly/test_callbacks.py
+++ b/holoviews/tests/plotting/plotly/test_callbacks.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import plotly.graph_objs as go
 
-from holoviews import Tiles
+import holoviews as hv
 from holoviews.plotting.plotly.callbacks import (
     BoundsXCallback,
     BoundsXYCallback,
@@ -106,7 +106,7 @@ class TestCallbacks:
 
         # Precompute a pair of lat/lon, easting/northing, mapbox coord values
         self.lon_range1, self.lat_range1 = (10, 30), (20, 40)
-        self.easting_range1, self.northing_range1 = Tiles.lon_lat_to_easting_northing(
+        self.easting_range1, self.northing_range1 = hv.Tiles.lon_lat_to_easting_northing(
             self.lon_range1, self.lat_range1
         )
         self.easting_range1 = tuple(self.easting_range1)
@@ -120,7 +120,7 @@ class TestCallbacks:
         ]
 
         self.lon_range2, self.lat_range2 = (-50, -30), (-70, -40)
-        self.easting_range2, self.northing_range2 = Tiles.lon_lat_to_easting_northing(
+        self.easting_range2, self.northing_range2 = hv.Tiles.lon_lat_to_easting_northing(
             self.lon_range2, self.lat_range2
         )
         self.easting_range2 = tuple(self.easting_range2)

--- a/holoviews/tests/plotting/plotly/test_curveplot.py
+++ b/holoviews/tests/plotting/plotly/test_curveplot.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from holoviews.element import Curve, Tiles
+import holoviews as hv
 from holoviews.plotting.plotly.util import PLOTLY_MAP
 from holoviews.testing import assert_data_equal
 
@@ -11,7 +11,7 @@ from .test_plot import TestPlotlyPlot
 class TestCurvePlot(TestPlotlyPlot):
 
     def test_curve_state(self):
-        curve = Curve([1, 2, 3])
+        curve = hv.Curve([1, 2, 3])
         state = self._get_plot_state(curve)
         assert_data_equal(state['data'][0]['x'], np.array([0, 1, 2]))
         assert_data_equal(state['data'][0]['y'], np.array([1, 2, 3]))
@@ -20,7 +20,7 @@ class TestCurvePlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['range'] == [1, 3]
 
     def test_curve_inverted(self):
-        curve = Curve([1, 2, 3]).opts(invert_axes=True)
+        curve = hv.Curve([1, 2, 3]).opts(invert_axes=True)
         state = self._get_plot_state(curve)
         assert_data_equal(state['data'][0]['x'], np.array([1, 2, 3]))
         assert_data_equal(state['data'][0]['y'], np.array([0, 1, 2]))
@@ -31,33 +31,33 @@ class TestCurvePlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'x'
 
     def test_curve_interpolation(self):
-        curve = Curve([1, 2, 3]).opts(interpolation='steps-mid')
+        curve = hv.Curve([1, 2, 3]).opts(interpolation='steps-mid')
         state = self._get_plot_state(curve)
         assert_data_equal(state['data'][0]['x'], np.array([0., 0.5, 0.5, 1.5, 1.5, 2.]))
         assert_data_equal(state['data'][0]['y'], np.array([1, 1, 2, 2, 3, 3]))
 
     def test_curve_color(self):
-        curve = Curve([1, 2, 3]).opts(color='red')
+        curve = hv.Curve([1, 2, 3]).opts(color='red')
         state = self._get_plot_state(curve)
         assert state['data'][0]['line']['color'] == 'red'
 
     def test_curve_color_mapping_error(self):
-        curve = Curve([1, 2, 3]).opts(color='x')
+        curve = hv.Curve([1, 2, 3]).opts(color='x')
         with pytest.raises(ValueError):  # noqa: PT011
             self._get_plot_state(curve)
 
     def test_curve_dash(self):
-        curve = Curve([1, 2, 3]).opts(dash='dash')
+        curve = hv.Curve([1, 2, 3]).opts(dash='dash')
         state = self._get_plot_state(curve)
         assert state['data'][0]['line']['dash'] == 'dash'
 
     def test_curve_line_width(self):
-        curve = Curve([1, 2, 3]).opts(line_width=5)
+        curve = hv.Curve([1, 2, 3]).opts(line_width=5)
         state = self._get_plot_state(curve)
         assert state['data'][0]['line']['width'] == 5
 
     def test_visible(self):
-        element = Curve([1, 2, 3]).opts(visible=False)
+        element = hv.Curve([1, 2, 3]).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False
 
@@ -74,14 +74,14 @@ class TestMapboxCurvePlot(TestPlotlyPlot):
         self.x_center = sum(self.x_range) / 2.0
         self.y_range = (-3000000, 2000000)
         self.y_center = sum(self.y_range) / 2.0
-        self.lon_centers, self.lat_centers = Tiles.easting_northing_to_lon_lat(
+        self.lon_centers, self.lat_centers = hv.Tiles.easting_northing_to_lon_lat(
             [self.x_center], [self.y_center]
         )
         self.lon_center, self.lat_center = self.lon_centers[0], self.lat_centers[0]
-        self.lons, self.lats = Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
+        self.lons, self.lats = hv.Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
 
     def test_curve_state(self):
-        curve = Tiles("") * Curve((self.xs, self.ys)).redim.range(
+        curve = hv.Tiles("") * hv.Curve((self.xs, self.ys)).redim.range(
             x=self.x_range, y=self.y_range
         )
         state = self._get_plot_state(curve)
@@ -93,43 +93,43 @@ class TestMapboxCurvePlot(TestPlotlyPlot):
             }
 
     def test_curve_inverted(self):
-        curve = Tiles("") * Curve([1, 2, 3]).opts(invert_axes=True)
+        curve = hv.Tiles("") * hv.Curve([1, 2, 3]).opts(invert_axes=True)
         with pytest.raises(ValueError, match="invert_axes"):
             self._get_plot_state(curve)
 
     def test_curve_interpolation(self):
         from holoviews.operation import interpolate_curve
         interp_xs = np.array([0., 0.5, 0.5, 1.5, 1.5, 2.])
-        interp_curve = interpolate_curve(Curve(self.ys), interpolation='steps-mid')
+        interp_curve = interpolate_curve(hv.Curve(self.ys), interpolation='steps-mid')
         interp_ys = interp_curve.dimension_values("y")
-        interp_lons, interp_lats = Tiles.easting_northing_to_lon_lat(interp_xs, interp_ys)
+        interp_lons, interp_lats = hv.Tiles.easting_northing_to_lon_lat(interp_xs, interp_ys)
 
-        curve = Tiles("") * Curve(self.ys).opts(interpolation='steps-mid')
+        curve = hv.Tiles("") * hv.Curve(self.ys).opts(interpolation='steps-mid')
         state = self._get_plot_state(curve)
         assert_data_equal(state['data'][1]['lat'], interp_lats)
         assert_data_equal(state['data'][1]['lon'], interp_lons)
 
     def test_curve_color(self):
-        curve = Tiles("") * Curve([1, 2, 3]).opts(color='red')
+        curve = hv.Tiles("") * hv.Curve([1, 2, 3]).opts(color='red')
         state = self._get_plot_state(curve)
         assert state['data'][1]['line']['color'] == 'red'
 
     def test_curve_color_mapping_error(self):
-        curve = Tiles("") * Curve([1, 2, 3]).opts(color='x')
+        curve = hv.Tiles("") * hv.Curve([1, 2, 3]).opts(color='x')
         with pytest.raises(ValueError):  # noqa: PT011
             self._get_plot_state(curve)
 
     def test_curve_dash(self):
-        curve = Tiles("") * Curve([1, 2, 3]).opts(dash='dash')
+        curve = hv.Tiles("") * hv.Curve([1, 2, 3]).opts(dash='dash')
         with pytest.raises(ValueError, match="dash"):
             self._get_plot_state(curve)
 
     def test_curve_line_width(self):
-        curve = Tiles("") * Curve([1, 2, 3]).opts(line_width=5)
+        curve = hv.Tiles("") * hv.Curve([1, 2, 3]).opts(line_width=5)
         state = self._get_plot_state(curve)
         assert state['data'][1]['line']['width'] == 5
 
     def test_visible(self):
-        element = Tiles("") * Curve([1, 2, 3]).opts(visible=False)
+        element = hv.Tiles("") * hv.Curve([1, 2, 3]).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][1]['visible'] is False

--- a/holoviews/tests/plotting/plotly/test_dash.py
+++ b/holoviews/tests/plotting/plotly/test_dash.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import holoviews as hv
+
 try:
     import dash  # noqa: F401
 except ImportError:
@@ -9,7 +11,6 @@ except ImportError:
 
 from dash._callback_context import CallbackContext
 
-from holoviews import Bounds, DynamicMap, Scatter
 from holoviews.plotting.plotly.dash import (
     DashComponents,
     decode_store_data,
@@ -42,7 +43,7 @@ class TestHoloViewsDash(TestPlotlyPlot):
 
     def test_simple_element(self):
         # Build Holoviews Elements
-        scatter = Scatter([0, 0])
+        scatter = hv.Scatter([0, 0])
 
         # Convert to Dash
         components = to_dash(self.app, [scatter])
@@ -61,10 +62,10 @@ class TestHoloViewsDash(TestPlotlyPlot):
 
     def test_boundsxy_dynamic_map(self):
         # Build Holoviews Elements
-        scatter = Scatter([0, 0])
+        scatter = hv.Scatter([0, 0])
         boundsxy = BoundsXY(source=scatter)
-        dmap = DynamicMap(
-            lambda bounds: Bounds(bounds) if bounds is not None else Bounds((0, 0, 0, 0)),
+        dmap = hv.DynamicMap(
+            lambda bounds: hv.Bounds(bounds) if bounds is not None else hv.Bounds((0, 0, 0, 0)),
             streams=[boundsxy]
         )
 
@@ -173,7 +174,7 @@ class TestHoloViewsDash(TestPlotlyPlot):
     def test_rangexy_dynamic_map(self):
 
         # Create dynamic map that inputs rangexy, returns scatter on bounds
-        scatter = Scatter(
+        scatter = hv.Scatter(
             [[0, 1], [0, 1]], kdims=["x"], vdims=["y"]
         )
         rangexy = RangeXY(source=scatter)
@@ -181,12 +182,12 @@ class TestHoloViewsDash(TestPlotlyPlot):
         def dmap_fn(x_range, y_range):
             x_range = (0, 1) if x_range is None else x_range
             y_range = (0, 1) if y_range is None else y_range
-            return Scatter(
+            return hv.Scatter(
                 [[x_range[0], y_range[0]],
                  [x_range[1], y_range[1]]], kdims=["x1"], vdims=["y1"]
             )
 
-        dmap = DynamicMap(dmap_fn, streams=[rangexy])
+        dmap = hv.DynamicMap(dmap_fn, streams=[rangexy])
 
         # Convert to Dash
         components = to_dash(self.app, [scatter, dmap], reset_button=True)
@@ -259,9 +260,9 @@ class TestHoloViewsDash(TestPlotlyPlot):
     def test_selection1d_dynamic_map(self):
         # Create dynamic map that inputs selection1d, returns overlay of scatter on
         # selected points
-        scatter = Scatter([[0, 0], [1, 1], [2, 2]])
+        scatter = hv.Scatter([[0, 0], [1, 1], [2, 2]])
         selection1d = Selection1D(source=scatter)
-        dmap = DynamicMap(
+        dmap = hv.DynamicMap(
             lambda index: scatter.iloc[index].opts(size=len(index) + 1),
             streams=[selection1d]
         )
@@ -381,8 +382,8 @@ class TestHoloViewsDash(TestPlotlyPlot):
 
     def test_kdims_dynamic_map(self):
         # Dynamic map with two key dimensions
-        dmap = DynamicMap(
-            lambda kdim1: Scatter([kdim1, kdim1]),
+        dmap = hv.DynamicMap(
+            lambda kdim1: hv.Scatter([kdim1, kdim1]),
             kdims=["kdim1"]
         ).redim.values(kdim1=[1, 2, 3, 4])
 

--- a/holoviews/tests/plotting/plotly/test_distributionplot.py
+++ b/holoviews/tests/plotting/plotly/test_distributionplot.py
@@ -1,5 +1,6 @@
 
-from holoviews.element import Distribution
+
+import holoviews as hv
 
 from ...utils import optional_dependencies
 from .test_plot import TestPlotlyPlot
@@ -10,20 +11,20 @@ _, scipy_skip = optional_dependencies("scipy")
 class TestDistributionPlot(TestPlotlyPlot):
 
     def test_distribution_filled(self):
-        dist = Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2])
+        dist = hv.Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2])
         state = self._get_plot_state(dist)
         assert state['data'][0]['type'] == 'scatter'
         assert state['data'][0]['mode'] == 'lines'
         assert state['data'][0]['fill'] == 'tozeroy'
 
     def test_distribution_not_filled(self):
-        dist = Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2]).opts(filled=False)
+        dist = hv.Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2]).opts(filled=False)
         state = self._get_plot_state(dist)
         assert state['data'][0]['type'] == 'scatter'
         assert state['data'][0]['mode'] == 'lines'
         assert state['data'][0].get('fill') is None
 
     def test_visible(self):
-        element = Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2]).opts(visible=False)
+        element = hv.Distribution([1, 1.1,  2.1, 3, 2, 1, 2.2]).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False

--- a/holoviews/tests/plotting/plotly/test_distributionplot.py
+++ b/holoviews/tests/plotting/plotly/test_distributionplot.py
@@ -1,5 +1,3 @@
-
-
 import holoviews as hv
 
 from ...utils import optional_dependencies

--- a/holoviews/tests/plotting/plotly/test_elementplot.py
+++ b/holoviews/tests/plotting/plotly/test_elementplot.py
@@ -5,9 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews.core.dimension import Dimension
-from holoviews.core.spaces import DynamicMap
-from holoviews.element import Curve, Path3D, QuadMesh, Scatter, Scatter3D
+import holoviews as hv
 from holoviews.streams import PointerX
 from holoviews.testing import assert_data_equal
 
@@ -20,9 +18,9 @@ class TestElementPlot(TestPlotlyPlot):
         history = deque(maxlen=10)
         def history_callback(x):
             history.append(x)
-            return Curve(list(history))
+            return hv.Curve(list(history))
         stream = PointerX(x=0)
-        dmap = DynamicMap(history_callback, kdims=[], streams=[stream])
+        dmap = hv.DynamicMap(history_callback, kdims=[], streams=[stream])
         plot = plotly_renderer.get_plot(dmap)
         plotly_renderer(dmap)
         for i in range(20):
@@ -34,104 +32,104 @@ class TestElementPlot(TestPlotlyPlot):
     def test_element_hooks(self):
         def hook(plot, element):
             plot.state['layout']['title'] = 'Called'
-        curve = Curve(range(10), label='Not Called').opts(hooks=[hook])
+        curve = hv.Curve(range(10), label='Not Called').opts(hooks=[hook])
         plot = plotly_renderer.get_plot(curve)
         assert plot.state['layout']['title'] == 'Called'
 
     def test_title_fontsize(self):
-        curve = Curve([1, 2, 3]).opts(title='Test',fontsize={'title': 42})
+        curve = hv.Curve([1, 2, 3]).opts(title='Test',fontsize={'title': 42})
         plot = plotly_renderer.get_plot(curve)
         assert plot.state["layout"]["title"]["font"]["size"] == 42
 
     ### Axis labelling ###
 
     def test_element_plot_xlabel(self):
-        curve = Curve([(10, 1), (100, 2), (1000, 3)]).opts(xlabel='X-Axis')
+        curve = hv.Curve([(10, 1), (100, 2), (1000, 3)]).opts(xlabel='X-Axis')
         state = self._get_plot_state(curve)
         assert state['layout']['xaxis']['title']['text'] == 'X-Axis'
 
     def test_element_plot_ylabel(self):
-        curve = Curve([(10, 1), (100, 2), (1000, 3)]).opts(ylabel='Y-Axis')
+        curve = hv.Curve([(10, 1), (100, 2), (1000, 3)]).opts(ylabel='Y-Axis')
         state = self._get_plot_state(curve)
         assert state['layout']['yaxis']['title']['text'] == 'Y-Axis'
 
     def test_element_plot_zlabel(self):
-        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(zlabel='Z-Axis')
+        scatter = hv.Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(zlabel='Z-Axis')
         state = self._get_plot_state(scatter)
         assert state['layout']['scene']['zaxis']['title']['text'] == 'Z-Axis'
 
     ### Axis ranges ###
 
     def test_element_plot_xrange(self):
-        curve = Curve([(10, 1), (100, 2), (1000, 3)])
+        curve = hv.Curve([(10, 1), (100, 2), (1000, 3)])
         state = self._get_plot_state(curve)
         assert state['layout']['xaxis']['range'] == [10, 1000]
 
     def test_element_plot_xlim(self):
-        curve = Curve([(1, 1), (2, 10), (3, 100)]).opts(xlim=(0, 1010))
+        curve = hv.Curve([(1, 1), (2, 10), (3, 100)]).opts(xlim=(0, 1010))
         state = self._get_plot_state(curve)
         assert state['layout']['xaxis']['range'] == [0, 1010]
 
     def test_element_plot_invert_xaxis(self):
-        curve = Curve([(1, 1), (2, 10), (3, 100)]).opts(invert_xaxis=True)
+        curve = hv.Curve([(1, 1), (2, 10), (3, 100)]).opts(invert_xaxis=True)
         state = self._get_plot_state(curve)
         assert state['layout']['xaxis']['range'] == [3, 1]
 
     def test_element_plot_yrange(self):
-        curve = Curve([(10, 1), (100, 2), (1000, 3)])
+        curve = hv.Curve([(10, 1), (100, 2), (1000, 3)])
         state = self._get_plot_state(curve)
         assert state['layout']['yaxis']['range'] == [1, 3]
 
     def test_element_plot_ylim(self):
-        curve = Curve([(1, 1), (2, 10), (3, 100)]).opts(ylim=(0, 8))
+        curve = hv.Curve([(1, 1), (2, 10), (3, 100)]).opts(ylim=(0, 8))
         state = self._get_plot_state(curve)
         assert state['layout']['yaxis']['range'] == [0, 8]
 
     def test_element_plot_invert_yaxis(self):
-        curve = Curve([(1, 1), (2, 10), (3, 100)]).opts(invert_yaxis=True)
+        curve = hv.Curve([(1, 1), (2, 10), (3, 100)]).opts(invert_yaxis=True)
         state = self._get_plot_state(curve)
         assert state['layout']['yaxis']['range'] == [100, 1]
 
     def test_element_plot_zrange(self):
-        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)])
+        scatter = hv.Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)])
         state = self._get_plot_state(scatter)
         assert state['layout']['scene']['zaxis']['range'] == [2, 5]
 
     def test_element_plot_zlim(self):
-        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(zlim=(1, 6))
+        scatter = hv.Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(zlim=(1, 6))
         state = self._get_plot_state(scatter)
         assert state['layout']['scene']['zaxis']['range'] == [1, 6]
 
     def test_element_plot_invert_zaxis(self):
-        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(invert_zaxis=True)
+        scatter = hv.Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(invert_zaxis=True)
         state = self._get_plot_state(scatter)
         assert state['layout']['scene']['zaxis']['range'] == [5, 2]
 
     def test_element_plot_xpadding(self):
-        curve = Curve([(0, 1), (1, 2), (2, 3)]).opts(padding=(0.1, 0))
+        curve = hv.Curve([(0, 1), (1, 2), (2, 3)]).opts(padding=(0.1, 0))
         state = self._get_plot_state(curve)
         assert state['layout']['xaxis']['range'] == [-0.2, 2.2]
         assert state['layout']['yaxis']['range'] == [1, 3]
 
     def test_element_plot_ypadding(self):
-        curve = Curve([(0, 1), (1, 2), (2, 3)]).opts(padding=(0, 0.1))
+        curve = hv.Curve([(0, 1), (1, 2), (2, 3)]).opts(padding=(0, 0.1))
         state = self._get_plot_state(curve)
         assert state['layout']['xaxis']['range'] == [0, 2]
         assert state['layout']['yaxis']['range'] == [0.8, 3.2]
 
     def test_element_plot_zpadding(self):
-        scatter = Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(padding=(0, 0, 0.1))
+        scatter = hv.Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(padding=(0, 0, 0.1))
         state = self._get_plot_state(scatter)
         assert state['layout']['scene']['zaxis']['range'] == [1.7, 5.3]
 
     def test_element_plot_padding(self):
-        curve = Curve([(0, 1), (1, 2), (2, 3)]).opts(padding=0.1)
+        curve = hv.Curve([(0, 1), (1, 2), (2, 3)]).opts(padding=0.1)
         state = self._get_plot_state(curve)
         assert state['layout']['xaxis']['range'] == [-0.2, 2.2]
         assert state['layout']['yaxis']['range'] == [0.8, 3.2]
 
     def test_element_plot3d_padding(self):
-        scatter = Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 5)]).opts(padding=0.1)
+        scatter = hv.Scatter3D([(0, 1, 2), (1, 2, 3), (2, 3, 5)]).opts(padding=0.1)
         state = self._get_plot_state(scatter)
         assert state['layout']['scene']['xaxis']['range'] == [-0.2, 2.2]
         assert state['layout']['scene']['yaxis']['range'] == [0.8, 3.2]
@@ -140,52 +138,52 @@ class TestElementPlot(TestPlotlyPlot):
     ### Axis log ###
 
     def test_element_plot_logx(self):
-        curve = Curve([(10, 1), (100, 2), (1000, 3)]).opts(logx=True)
+        curve = hv.Curve([(10, 1), (100, 2), (1000, 3)]).opts(logx=True)
         state = self._get_plot_state(curve)
         assert state['layout']['xaxis']['type'] == 'log'
 
     def test_element_plot_logy(self):
-        curve = Curve([(1, 1), (2, 10), (3, 100)]).opts(logy=True)
+        curve = hv.Curve([(1, 1), (2, 10), (3, 100)]).opts(logy=True)
         state = self._get_plot_state(curve)
         assert state['layout']['yaxis']['type'] == 'log'
 
     def test_element_plot_logz(self):
-        scatter = Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).opts(logz=True)
+        scatter = hv.Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).opts(logz=True)
         state = self._get_plot_state(scatter)
         assert state['layout']['scene']['zaxis']['type'] == 'log'
 
     ### Axis ticks ###
 
     def test_element_plot_xticks_values(self):
-        curve = Curve([(1, 1), (5, 2), (10, 3)]).opts(xticks=[1, 5, 10])
+        curve = hv.Curve([(1, 1), (5, 2), (10, 3)]).opts(xticks=[1, 5, 10])
         state = self._get_plot_state(curve)
         assert state['layout']['xaxis']['tickvals'] == [1, 5, 10]
 
     def test_element_plot_yticks_values(self):
-        curve = Curve([(1, 1), (5, 2), (10, 3)]).opts(yticks=[1, 1.5, 2.5, 3])
+        curve = hv.Curve([(1, 1), (5, 2), (10, 3)]).opts(yticks=[1, 1.5, 2.5, 3])
         state = self._get_plot_state(curve)
         assert state['layout']['yaxis']['tickvals'] == [1, 1.5, 2.5, 3]
 
     def test_element_plot_zticks_values(self):
-        scatter = Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).opts(zticks=[0, 500, 1000])
+        scatter = hv.Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).opts(zticks=[0, 500, 1000])
         state = self._get_plot_state(scatter)
         assert state['layout']['scene']['zaxis']['tickvals'] == [0, 500, 1000]
 
     def test_element_plot_xticks_items(self):
-        curve = Curve([(1, 1), (5, 2), (10, 3)]).opts(xticks=[(1, 'A'), (5, 'B'), (10, 'C')])
+        curve = hv.Curve([(1, 1), (5, 2), (10, 3)]).opts(xticks=[(1, 'A'), (5, 'B'), (10, 'C')])
         state = self._get_plot_state(curve)
         assert state['layout']['xaxis']['tickvals'] == [1, 5, 10]
         assert state['layout']['xaxis']['ticktext'] == ['A', 'B', 'C']
 
     def test_element_plot_yticks_items(self):
-        curve = Curve([(1, 1), (5, 2), (10, 3)]).opts(
+        curve = hv.Curve([(1, 1), (5, 2), (10, 3)]).opts(
             yticks=[(1, 'A'), (1.5, 'B'), (2.5, 'C'), (3, 'D')])
         state = self._get_plot_state(curve)
         assert state['layout']['yaxis']['tickvals'] == [1, 1.5, 2.5, 3]
         assert state['layout']['yaxis']['ticktext'] == ['A', 'B', 'C', 'D']
 
     def test_element_plot_zticks_items(self):
-        scatter = Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).opts(
+        scatter = hv.Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]).opts(
             zticks=[(0, 'A'), (500, 'B'), (1000, 'C')])
         state = self._get_plot_state(scatter)
         assert state['layout']['scene']['zaxis']['tickvals'] == [0, 500, 1000]
@@ -196,7 +194,7 @@ class TestElementPlot(TestPlotlyPlot):
         X = pd.date_range(start="1/1/2018", end="1/08/2018", periods=100)
         Y = np.linspace(1, 100, 100)
         Z = np.random.randn(100, 100)
-        qm = QuadMesh((X, Y, Z)).opts(aspect='equal')
+        qm = hv.QuadMesh((X, Y, Z)).opts(aspect='equal')
         msg = (
             "The aspect is set to 'equal', but the axes does not have the same type: "
             "x-axis timedelta64 and y-axis float64. "
@@ -210,7 +208,7 @@ class TestElementPlot(TestPlotlyPlot):
 class TestOverlayPlot(TestPlotlyPlot):
 
     def test_overlay_state(self):
-        layout = Curve([1, 2, 3]) * Curve([2, 4, 6])
+        layout = hv.Curve([1, 2, 3]) * hv.Curve([2, 4, 6])
         state = self._get_plot_state(layout)
         assert_data_equal(state['data'][0]['y'], np.array([1, 2, 3]))
         assert_data_equal(state['data'][1]['y'], np.array([2, 4, 6]))
@@ -219,34 +217,34 @@ class TestOverlayPlot(TestPlotlyPlot):
     ### Axis log ###
 
     def test_overlay_plot_logx(self):
-        curve = (Curve([(10, 1), (100, 2), (1000, 3)]) * Curve([])).opts(logx=True)
+        curve = (hv.Curve([(10, 1), (100, 2), (1000, 3)]) * hv.Curve([])).opts(logx=True)
         state = self._get_plot_state(curve)
         assert state['layout']['xaxis']['type'] == 'log'
 
     def test_overlay_plot_logy(self):
-        curve = (Curve([(1, 1), (2, 10), (3, 100)]) * Curve([])).opts(logy=True)
+        curve = (hv.Curve([(1, 1), (2, 10), (3, 100)]) * hv.Curve([])).opts(logy=True)
         state = self._get_plot_state(curve)
         assert state['layout']['yaxis']['type'] == 'log'
 
     def test_overlay_plot_logz(self):
-        scatter = (Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]) * Path3D([])).opts(logz=True)
+        scatter = (hv.Scatter3D([(0, 1, 10), (1, 2, 100), (2, 3, 1000)]) * hv.Path3D([])).opts(logz=True)
         state = self._get_plot_state(scatter)
         assert state['layout']['scene']['zaxis']['type'] == 'log'
 
     ### Axis labelling ###
 
     def test_overlay_plot_xlabel(self):
-        overlay = Curve([]) * Curve([(10, 1), (100, 2), (1000, 3)]).opts(xlabel='X-Axis')
+        overlay = hv.Curve([]) * hv.Curve([(10, 1), (100, 2), (1000, 3)]).opts(xlabel='X-Axis')
         state = self._get_plot_state(overlay)
         assert state['layout']['xaxis']['title']['text'] == 'X-Axis'
 
     def test_overlay_plot_ylabel(self):
-        overlay = Curve([]) * Curve([(10, 1), (100, 2), (1000, 3)]).opts(ylabel='Y-Axis')
+        overlay = hv.Curve([]) * hv.Curve([(10, 1), (100, 2), (1000, 3)]).opts(ylabel='Y-Axis')
         state = self._get_plot_state(overlay)
         assert state['layout']['yaxis']['title']['text'] == 'Y-Axis'
 
     def test_overlay_plot_zlabel(self):
-        scatter = Path3D([]) * Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(zlabel='Z-Axis')
+        scatter = hv.Path3D([]) * hv.Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(zlabel='Z-Axis')
         state = self._get_plot_state(scatter)
         assert state['layout']['scene']['zaxis']['title']['text'] == 'Z-Axis'
 
@@ -254,20 +252,20 @@ class TestColorbarPlot(TestPlotlyPlot):
 
     def test_base(self):
         df = pd.DataFrame(np.random.random((10, 4)), columns=list("XYZT"))
-        scatter = Scatter3D(data=df)
+        scatter = hv.Scatter3D(data=df)
         state = self._get_plot_state(scatter)
         assert "colorbar" not in state["data"][0]["marker"]
 
     def test_colorbar(self):
         df = pd.DataFrame(np.random.random((10, 4)), columns=list("XYZT"))
-        scatter = Scatter3D(data=df).opts(color="T", colorbar=True)
+        scatter = hv.Scatter3D(data=df).opts(color="T", colorbar=True)
         state = self._get_plot_state(scatter)
         assert "colorbar" in state["data"][0]["marker"]
         assert state["data"][0]["marker"]["colorbar"]["title"]["text"] == "T"
 
     def test_colorbar_opts_title(self):
         df = pd.DataFrame(np.random.random((10, 4)), columns=list("XYZT"))
-        scatter = Scatter3D(data=df).opts(
+        scatter = hv.Scatter3D(data=df).opts(
             color="T",
             colorbar=True,
             colorbar_opts={"title": "some-title"}
@@ -277,15 +275,15 @@ class TestColorbarPlot(TestPlotlyPlot):
         assert state["data"][0]["marker"]["colorbar"]["title"]["text"] == "some-title"
 
     def test_style_map_dimension_object(self):
-        x = Dimension("x")
-        y = Dimension("y")
-        scatter = Scatter([1, 2, 3], kdims=[x], vdims=[y]).opts(color=x)
+        x = hv.Dimension("x")
+        y = hv.Dimension("y")
+        scatter = hv.Scatter([1, 2, 3], kdims=[x], vdims=[y]).opts(color=x)
         state = self._get_plot_state(scatter)
         assert state["data"][0]["marker"]["cmin"] == 0
         assert state["data"][0]["marker"]["cmax"] == 2
 
     def test_categorical_colorbar_ticks(self):
-        scatter = Scatter([
+        scatter = hv.Scatter([
             (0, 1, 'Category A'), (1, 2, 'Category B'), (2, 3, 'Category C')
         ], vdims=['y', 'category']).opts(color='category', colorbar=True)
         state = self._get_plot_state(scatter)

--- a/holoviews/tests/plotting/plotly/test_errorbarplot.py
+++ b/holoviews/tests/plotting/plotly/test_errorbarplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import ErrorBars
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -9,7 +9,7 @@ from .test_plot import TestPlotlyPlot
 class TestErrorBarsPlot(TestPlotlyPlot):
 
     def test_errorbars_plot(self):
-        errorbars = ErrorBars([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2'])
+        errorbars = hv.ErrorBars([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2'])
         state = self._get_plot_state(errorbars)
         assert_data_equal(state['data'][0]['x'], np.array([0, 1, 2]))
         assert_data_equal(state['data'][0]['y'], np.array([1, 2, 3]))
@@ -19,7 +19,7 @@ class TestErrorBarsPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['range'] == [0.5, 5.25]
 
     def test_errorbars_plot_inverted(self):
-        errorbars = ErrorBars([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2']).opts(invert_axes=True)
+        errorbars = hv.ErrorBars([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2']).opts(invert_axes=True)
         state = self._get_plot_state(errorbars)
         assert_data_equal(state['data'][0]['x'], np.array([1, 2, 3]))
         assert_data_equal(state['data'][0]['y'], np.array([0, 1, 2]))
@@ -29,7 +29,7 @@ class TestErrorBarsPlot(TestPlotlyPlot):
         assert state['layout']['xaxis']['range'] == [0.5, 5.25]
 
     def test_visible(self):
-        element = ErrorBars(
+        element = hv.ErrorBars(
             [(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)],
             vdims=['y', 'y2']
         ).opts(visible=False)

--- a/holoviews/tests/plotting/plotly/test_figuresize.py
+++ b/holoviews/tests/plotting/plotly/test_figuresize.py
@@ -1,4 +1,3 @@
-
 import holoviews as hv
 
 from .test_plot import TestPlotlyPlot

--- a/holoviews/tests/plotting/plotly/test_figuresize.py
+++ b/holoviews/tests/plotting/plotly/test_figuresize.py
@@ -1,4 +1,5 @@
-from holoviews.element import Points
+
+import holoviews as hv
 
 from .test_plot import TestPlotlyPlot
 
@@ -6,7 +7,7 @@ from .test_plot import TestPlotlyPlot
 class TestImagePlot(TestPlotlyPlot):
 
     def test_image_state(self):
-        img = Points([(0, 0)]).opts(width=345, height=456)
+        img = hv.Points([(0, 0)]).opts(width=345, height=456)
         state = self._get_plot_state(img)
 
         assert state["layout"]["width"] == 345

--- a/holoviews/tests/plotting/plotly/test_gridplot.py
+++ b/holoviews/tests/plotting/plotly/test_gridplot.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from holoviews.core.spaces import GridSpace
-from holoviews.element import Curve, Scatter
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -11,12 +10,12 @@ class TestGridPlot(TestPlotlyPlot):
 
     def test_layout_with_grid(self):
         # Create GridSpace
-        grid = GridSpace({(i, j): Curve([i, j]) for i in [0, 1]
+        grid = hv.GridSpace({(i, j): hv.Curve([i, j]) for i in [0, 1]
                           for j in [0, 1]})
         grid = grid.opts(vspacing=0, hspacing=0)
 
         # Create Scatter
-        scatter = Scatter([-10, 0])
+        scatter = hv.Scatter([-10, 0])
 
         # Create Horizontal Layout
         layout = (scatter + grid).opts(vspacing=0, hspacing=0)
@@ -78,7 +77,7 @@ class TestGridPlot(TestPlotlyPlot):
 
 
     def test_grid_state(self):
-        grid = GridSpace({(i, j): Curve([i, j]) for i in [0, 1]
+        grid = hv.GridSpace({(i, j): hv.Curve([i, j]) for i in [0, 1]
                           for j in [0, 1]})
         state = self._get_plot_state(grid)
         assert_data_equal(state['data'][0]['y'], np.array([0, 0]))

--- a/holoviews/tests/plotting/plotly/test_histogram.py
+++ b/holoviews/tests/plotting/plotly/test_histogram.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Histogram
+import holoviews as hv
 
 from .test_plot import TestPlotlyPlot
 
@@ -13,7 +13,7 @@ class TestHistogramPlot(TestPlotlyPlot):
         self.edges = [-3, -2, -1, 0, 1, 2]
 
     def test_histogram_plot(self):
-        hist = Histogram((self.edges, self.frequencies))
+        hist = hv.Histogram((self.edges, self.frequencies))
         state = self._get_plot_state(hist)
         np.testing.assert_equal(state['data'][0]['x'], self.edges)
         np.testing.assert_equal(state['data'][0]['y'], self.frequencies)
@@ -26,7 +26,7 @@ class TestHistogramPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'Frequency'
 
     def test_histogram_plot_inverted(self):
-        hist = Histogram(
+        hist = hv.Histogram(
             (self.edges, self.frequencies)
         ).opts(invert_axes=True)
 
@@ -47,12 +47,12 @@ class TestHistogramPlot(TestPlotlyPlot):
             'line_width': 7,
             'line_color': 'green',
         }
-        hist = Histogram((self.edges, self.frequencies)).opts(**props)
+        hist = hv.Histogram((self.edges, self.frequencies)).opts(**props)
         state = self._get_plot_state(hist)
         marker = state['data'][0]['marker']
         self.assert_property_values(marker, props)
 
     def test_visible(self):
-        element = Histogram((self.edges, self.frequencies)).opts(visible=False)
+        element = hv.Histogram((self.edges, self.frequencies)).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False

--- a/holoviews/tests/plotting/plotly/test_imageplot.py
+++ b/holoviews/tests/plotting/plotly/test_imageplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Image
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -9,7 +9,7 @@ from .test_plot import TestPlotlyPlot
 class TestImagePlot(TestPlotlyPlot):
 
     def test_image_state(self):
-        img = Image(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]])))
+        img = hv.Image(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]])))
         state = self._get_plot_state(img)
         assert state['data'][0]['type'] == 'heatmap'
         assert state['data'][0]['x0'] == 1
@@ -23,20 +23,20 @@ class TestImagePlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['range'] == [-0.5, 1.5]
 
     def test_image_nodata(self):
-        img = Image(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))).opts(nodata=0)
+        img = hv.Image(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))).opts(nodata=0)
         state = self._get_plot_state(img)
         assert state['data'][0]['type'] == 'heatmap'
         assert_data_equal(state['data'][0]['z'], np.array([[np.nan, 1, 2], [2, 3, 4]]))
 
     def test_image_nodata_unint(self):
-        img = Image(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]],
+        img = hv.Image(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]],
                                                  dtype='uint32'))).opts(nodata=0)
         state = self._get_plot_state(img)
         assert state['data'][0]['type'] == 'heatmap'
         assert_data_equal(state['data'][0]['z'], np.array([[np.nan, 1, 2], [2, 3, 4]]))
 
     def test_image_state_inverted(self):
-        img = Image(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))).opts(
+        img = hv.Image(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))).opts(
             invert_axes=True)
         state = self._get_plot_state(img)
         assert state['data'][0]['y0'] == 1
@@ -50,7 +50,7 @@ class TestImagePlot(TestPlotlyPlot):
         assert state['layout']['xaxis']['range'] == [-0.5, 1.5]
 
     def test_visible(self):
-        element = Image(
+        element = hv.Image(
             ([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))
         ).opts(visible=False)
         state = self._get_plot_state(element)

--- a/holoviews/tests/plotting/plotly/test_imagestack.py
+++ b/holoviews/tests/plotting/plotly/test_imagestack.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import ImageStack
+import holoviews as hv
 from holoviews.plotting.plotly import RGBPlot
 
 from ...utils import optional_dependencies
@@ -17,7 +17,7 @@ class TestImageStackPlot(TestPlotlyPlot):
         a = np.array([[np.nan, np.nan, 1], [np.nan] * 3, [np.nan] * 3])
         b = np.array([[np.nan] * 3, [1, 1, np.nan], [np.nan] * 3])
         c = np.array([[np.nan] * 3, [np.nan] * 3, [1, 1, 1]])
-        image_stack = ImageStack(
+        image_stack = hv.ImageStack(
             (x, y, a, b, c), kdims=["x", "y"], vdims=["a", "b", "c"]
         )
         assert isinstance(plotly_renderer.get_plot(image_stack), RGBPlot)

--- a/holoviews/tests/plotting/plotly/test_labelplot.py
+++ b/holoviews/tests/plotting/plotly/test_labelplot.py
@@ -1,9 +1,7 @@
 import numpy as np
 import pytest
 
-from holoviews.core.options import Cycle
-from holoviews.core.spaces import HoloMap
-from holoviews.element import Labels, Tiles
+import holoviews as hv
 from holoviews.plotting.plotly.util import PLOTLY_MAP
 from holoviews.testing import assert_data_equal
 
@@ -13,7 +11,7 @@ from .test_plot import TestPlotlyPlot
 class TestLabelsPlot(TestPlotlyPlot):
 
     def test_labels_state(self):
-        labels = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)])
+        labels = hv.Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)])
         state = self._get_plot_state(labels)
         assert_data_equal(state['data'][0]['x'], np.array([0, 1, 2]))
         assert_data_equal(state['data'][0]['y'], np.array([3, 2, 1]))
@@ -25,7 +23,7 @@ class TestLabelsPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'y'
 
     def test_labels_inverted(self):
-        labels = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(invert_axes=True)
+        labels = hv.Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(invert_axes=True)
         state = self._get_plot_state(labels)
         assert_data_equal(state['data'][0]['x'], np.array([3, 2, 1]))
         assert_data_equal(state['data'][0]['y'], np.array([0, 1, 2]))
@@ -37,22 +35,22 @@ class TestLabelsPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'x'
 
     def test_labels_size(self):
-        labels = Labels([(0, 3, 0), (0, 2, 1), (0, 1, 1)]).opts(size='y')
+        labels = hv.Labels([(0, 3, 0), (0, 2, 1), (0, 1, 1)]).opts(size='y')
         state = self._get_plot_state(labels)
         assert_data_equal(state['data'][0]['textfont']['size'], np.array([3, 2, 1]))
 
     def test_labels_xoffset(self):
-        labels = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(xoffset=0.5)
+        labels = hv.Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(xoffset=0.5)
         state = self._get_plot_state(labels)
         assert_data_equal(state['data'][0]['x'], np.array([0.5, 1.5, 2.5]))
 
     def test_labels_yoffset(self):
-        labels = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(yoffset=0.5)
+        labels = hv.Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(yoffset=0.5)
         state = self._get_plot_state(labels)
         assert_data_equal(state['data'][0]['y'], np.array([3.5, 2.5, 1.5]))
 
     def test_visible(self):
-        element = Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(visible=False)
+        element = hv.Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False
 
@@ -69,14 +67,14 @@ class TestMapboxLabelsPlot(TestPlotlyPlot):
         self.x_center = sum(self.x_range) / 2.0
         self.y_range = (-3000000, 2000000)
         self.y_center = sum(self.y_range) / 2.0
-        self.lon_centers, self.lat_centers = Tiles.easting_northing_to_lon_lat(
+        self.lon_centers, self.lat_centers = hv.Tiles.easting_northing_to_lon_lat(
             [self.x_center], [self.y_center]
         )
         self.lon_center, self.lat_center = self.lon_centers[0], self.lat_centers[0]
-        self.lons, self.lats = Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
+        self.lons, self.lats = hv.Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
 
     def test_labels_state(self):
-        labels = Tiles("") * Labels([
+        labels = hv.Tiles("") * hv.Labels([
             (self.xs[0], self.ys[0], 'A'),
             (self.xs[1], self.ys[1], 'B'),
             (self.xs[2], self.ys[2], 'C')
@@ -93,52 +91,52 @@ class TestMapboxLabelsPlot(TestPlotlyPlot):
             }
 
     def test_labels_inverted(self):
-        labels = Tiles("") * Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(
+        labels = hv.Tiles("") * hv.Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(
             invert_axes=True
         )
         with pytest.raises(ValueError, match="invert_axes"):
             self._get_plot_state(labels)
 
     def test_labels_size(self):
-        labels = Tiles("") * Labels([(0, 3, 0), (0, 2, 1), (0, 1, 1)]).opts(size=23)
+        labels = hv.Tiles("") * hv.Labels([(0, 3, 0), (0, 2, 1), (0, 1, 1)]).opts(size=23)
         state = self._get_plot_state(labels)
         assert state['data'][1]['textfont']['size'] == 23
 
     def test_labels_xoffset(self):
         offset = 10000
-        labels = Tiles("") * Labels([
+        labels = hv.Tiles("") * hv.Labels([
             (self.xs[0], self.ys[0], 'A'),
             (self.xs[1], self.ys[1], 'B'),
             (self.xs[2], self.ys[2], 'C')
         ]).opts(xoffset=offset)
 
         state = self._get_plot_state(labels)
-        lons, lats = Tiles.easting_northing_to_lon_lat(np.array(self.xs) + offset, self.ys)
+        lons, lats = hv.Tiles.easting_northing_to_lon_lat(np.array(self.xs) + offset, self.ys)
         assert_data_equal(state['data'][1]['lon'], lons)
         assert_data_equal(state['data'][1]['lat'], lats)
 
     def test_labels_yoffset(self):
         offset = 20000
-        labels = Tiles("") * Labels([
+        labels = hv.Tiles("") * hv.Labels([
             (self.xs[0], self.ys[0], 'A'),
             (self.xs[1], self.ys[1], 'B'),
             (self.xs[2], self.ys[2], 'C')
         ]).opts(yoffset=offset)
         state = self._get_plot_state(labels)
-        lons, lats = Tiles.easting_northing_to_lon_lat(self.xs, np.array(self.ys) + offset)
+        lons, lats = hv.Tiles.easting_northing_to_lon_lat(self.xs, np.array(self.ys) + offset)
         assert_data_equal(state['data'][1]['lon'], lons)
         assert_data_equal(state['data'][1]['lat'], lats)
 
     def test_visible(self):
-        element = Tiles("") * Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(visible=False)
+        element = hv.Tiles("") * hv.Labels([(0, 3, 0), (1, 2, 1), (2, 1, 1)]).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][1]['visible'] is False
 
     def test_labels_text_color_cycle(self):
-        hm = HoloMap(
-            {i: Labels([
+        hm = hv.HoloMap(
+            {i: hv.Labels([
                 (0, 0 + i, "Label 1"),
                 (1, 1 + i, "Label 2")
             ]) for i in range(3)}
         ).overlay()
-        assert isinstance(hm[0].opts["color"], Cycle)
+        assert isinstance(hm[0].opts["color"], hv.Cycle)

--- a/holoviews/tests/plotting/plotly/test_layoutplot.py
+++ b/holoviews/tests/plotting/plotly/test_layoutplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Curve, Image
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot, plotly_renderer
@@ -9,21 +9,21 @@ from .test_plot import TestPlotlyPlot, plotly_renderer
 class TestLayoutPlot(TestPlotlyPlot):
 
     def test_layout_instantiate_subplots(self):
-        layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
-                  Curve(range(10)) + Curve(range(10)))
+        layout = (hv.Curve(range(10)) + hv.Curve(range(10)) + hv.Image(np.random.rand(10,10)) +
+                  hv.Curve(range(10)) + hv.Curve(range(10)))
         plot = plotly_renderer.get_plot(layout)
         positions = [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
         assert sorted(plot.subplots.keys()) == positions
 
     def test_layout_instantiate_subplots_transposed(self):
-        layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
-                  Curve(range(10)) + Curve(range(10)))
+        layout = (hv.Curve(range(10)) + hv.Curve(range(10)) + hv.Image(np.random.rand(10,10)) +
+                  hv.Curve(range(10)) + hv.Curve(range(10)))
         plot = plotly_renderer.get_plot(layout.opts(transpose=True))
         positions = [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (3, 0), (3, 1)]
         assert sorted(plot.subplots.keys()) == positions
 
     def test_layout_state(self):
-        layout = Curve([1, 2, 3]) + Curve([2, 4, 6])
+        layout = hv.Curve([1, 2, 3]) + hv.Curve([2, 4, 6])
         state = self._get_plot_state(layout)
         assert_data_equal(state['data'][0]['y'], np.array([1, 2, 3]))
         assert state['data'][0]['yaxis'] == 'y'

--- a/holoviews/tests/plotting/plotly/test_path3d.py
+++ b/holoviews/tests/plotting/plotly/test_path3d.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Path3D
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -9,7 +9,7 @@ from .test_plot import TestPlotlyPlot
 class TestPath3DPlot(TestPlotlyPlot):
 
     def test_path3D_state(self):
-        path3D = Path3D([(0, 1, 0), (1, 2, 1), (2, 3, 2)])
+        path3D = hv.Path3D([(0, 1, 0), (1, 2, 1), (2, 3, 2)])
         state = self._get_plot_state(path3D)
         assert_data_equal(state['data'][0]['x'], np.array([0, 1, 2]))
         assert_data_equal(state['data'][0]['y'], np.array([1, 2, 3]))
@@ -20,7 +20,7 @@ class TestPath3DPlot(TestPlotlyPlot):
         assert state['layout']['scene']['zaxis']['range'] == [0, 2]
 
     def test_path3D_multi(self):
-        path3D = Path3D([[(0, 1, 0), (1, 2, 1), (2, 3, 2)], [(-1, 1, 3), (-2, 2, 4), (-3, 3, 5)]])
+        path3D = hv.Path3D([[(0, 1, 0), (1, 2, 1), (2, 3, 2)], [(-1, 1, 3), (-2, 2, 4), (-3, 3, 5)]])
         state = self._get_plot_state(path3D)
         assert_data_equal(state['data'][0]['x'], np.array([0, 1, 2]))
         assert_data_equal(state['data'][0]['y'], np.array([1, 2, 3]))
@@ -37,7 +37,7 @@ class TestPath3DPlot(TestPlotlyPlot):
         assert state['layout']['scene']['zaxis']['range'] == [0, 5]
 
     def test_path3D_multi_colors(self):
-        path3D = Path3D([[(0, 1, 0, 'red'), (1, 2, 1, 'red'), (2, 3, 2, 'red')],
+        path3D = hv.Path3D([[(0, 1, 0, 'red'), (1, 2, 1, 'red'), (2, 3, 2, 'red')],
                          [(-1, 1, 3, 'blue'), (-2, 2, 4, 'blue'), (-3, 3, 5, 'blue')]],
                         vdims='color').opts(color='color')
         state = self._get_plot_state(path3D)
@@ -45,6 +45,6 @@ class TestPath3DPlot(TestPlotlyPlot):
         assert state['data'][1]['line']['color'] == 'blue'
 
     def test_visible(self):
-        element = Path3D([(0, 1, 0), (1, 2, 1), (2, 3, 2)]).opts(visible=False)
+        element = hv.Path3D([(0, 1, 0), (1, 2, 1), (2, 3, 2)]).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False

--- a/holoviews/tests/plotting/plotly/test_plot.py
+++ b/holoviews/tests/plotting/plotly/test_plot.py
@@ -2,21 +2,20 @@ import plotly.graph_objs as go
 import pyviz_comms as comms
 from param import concrete_descendents
 
-from holoviews.core import DynamicMap, Store
-from holoviews.element import Curve
+import holoviews as hv
 from holoviews.plotting.plotly.element import ElementPlot
 from holoviews.plotting.plotly.util import figure_grid
 from holoviews.streams import Pipe
 
 from .. import option_intersections
 
-plotly_renderer = Store.renderers['plotly']
+plotly_renderer = hv.Store.renderers['plotly']
 
 
 def test_element_plot_stream_cleanup():
     stream = Pipe()
 
-    dmap = DynamicMap(Curve, streams=[stream])
+    dmap = hv.DynamicMap(hv.Curve, streams=[stream])
 
     plot = plotly_renderer.get_plot(dmap)
 
@@ -31,8 +30,8 @@ def test_overlay_plot_stream_cleanup():
     stream1 = Pipe()
     stream2 = Pipe()
 
-    dmap1 = DynamicMap(Curve, streams=[stream1])
-    dmap2 = DynamicMap(Curve, streams=[stream2])
+    dmap1 = hv.DynamicMap(hv.Curve, streams=[stream1])
+    dmap2 = hv.DynamicMap(hv.Curve, streams=[stream2])
 
     plot = plotly_renderer.get_plot(dmap1 * dmap2)
 
@@ -49,8 +48,8 @@ def test_layout_plot_stream_cleanup():
     stream1 = Pipe()
     stream2 = Pipe()
 
-    dmap1 = DynamicMap(Curve, streams=[stream1])
-    dmap2 = DynamicMap(Curve, streams=[stream2])
+    dmap1 = hv.DynamicMap(hv.Curve, streams=[stream1])
+    dmap2 = hv.DynamicMap(hv.Curve, streams=[stream2])
 
     plot = plotly_renderer.get_plot(dmap1 + dmap2)
 
@@ -66,8 +65,8 @@ def test_layout_plot_stream_cleanup():
 class TestPlotlyPlot:
 
     def setup_method(self):
-        self.previous_backend = Store.current_backend
-        Store.set_current_backend('plotly')
+        self.previous_backend = hv.Store.current_backend
+        hv.Store.set_current_backend('plotly')
         self.comm_manager = plotly_renderer.comm_manager
         plotly_renderer.comm_manager = comms.CommManager
         self._padding = {}
@@ -76,7 +75,7 @@ class TestPlotlyPlot:
             plot.padding = 0
 
     def teardown_method(self):
-        Store.current_backend = self.previous_backend
+        hv.Store.current_backend = self.previous_backend
         plotly_renderer.comm_manager = self.comm_manager
         for plot, padding in self._padding.items():
             plot.padding = padding

--- a/holoviews/tests/plotting/plotly/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/plotly/test_quadmeshplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import QuadMesh
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -9,7 +9,7 @@ from .test_plot import TestPlotlyPlot
 class TestQuadMeshPlot(TestPlotlyPlot):
 
     def test_quadmesh_state(self):
-        img = QuadMesh(([1, 2, 4], [0, 1], np.array([[0, 1, 2], [2, 3, 4]])))
+        img = hv.QuadMesh(([1, 2, 4], [0, 1], np.array([[0, 1, 2], [2, 3, 4]])))
         state = self._get_plot_state(img)
         assert state['data'][0]['type'] == 'heatmap'
         assert_data_equal(state['data'][0]['x'], np.array([0.5, 1.5, 3., 5.]))
@@ -21,21 +21,21 @@ class TestQuadMeshPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['range'] == [-0.5, 1.5]
 
     def test_quadmesh_nodata(self):
-        img = QuadMesh(([1, 2, 4], [0, 1],
+        img = hv.QuadMesh(([1, 2, 4], [0, 1],
                         np.array([[0, 1, 2], [2, 3, 4]]))).opts(nodata=0)
         state = self._get_plot_state(img)
         assert state['data'][0]['type'] == 'heatmap'
         assert_data_equal(state['data'][0]['z'], np.array([[np.nan, 1, 2], [2, 3, 4]]))
 
     def test_quadmesh_nodata_uint(self):
-        img = QuadMesh(([1, 2, 4], [0, 1],
+        img = hv.QuadMesh(([1, 2, 4], [0, 1],
                         np.array([[0, 1, 2], [2, 3, 4]], dtype='uint32'))).opts(nodata=0)
         state = self._get_plot_state(img)
         assert state['data'][0]['type'] == 'heatmap'
         assert_data_equal(state['data'][0]['z'], np.array([[np.nan, 1, 2], [2, 3, 4]]))
 
     def test_quadmesh_state_inverted(self):
-        img = QuadMesh(([1, 2, 4], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))).opts(
+        img = hv.QuadMesh(([1, 2, 4], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))).opts(
             invert_axes=True)
         state = self._get_plot_state(img)
         assert_data_equal(state['data'][0]['x'], np.array([-0.5, .5, 1.5]))
@@ -47,7 +47,7 @@ class TestQuadMeshPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['range'] == [0.5, 5]
 
     def test_visible(self):
-        element = QuadMesh(
+        element = hv.QuadMesh(
             ([1, 2, 4], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))
         ).opts(visible=False)
         state = self._get_plot_state(element)

--- a/holoviews/tests/plotting/plotly/test_renderer.py
+++ b/holoviews/tests/plotting/plotly/test_renderer.py
@@ -7,7 +7,7 @@ import pytest
 from panel.widgets import DiscreteSlider, FloatSlider, Player
 from pyviz_comms import CommManager
 
-from holoviews import Curve, DynamicMap, HoloMap, Store
+import holoviews as hv
 from holoviews.plotting.plotly import PlotlyRenderer
 from holoviews.plotting.renderer import Renderer
 from holoviews.streams import Stream
@@ -16,8 +16,8 @@ from holoviews.streams import Stream
 class PlotlyRendererTest:
 
     def setup_method(self):
-        self.previous_backend = Store.current_backend
-        Store.current_backend = 'plotly'
+        self.previous_backend = hv.Store.current_backend
+        hv.Store.current_backend = 'plotly'
         self.renderer = PlotlyRenderer.instance()
         self.nbcontext = Renderer.notebook_context
         self.comm_manager = Renderer.comm_manager
@@ -29,10 +29,10 @@ class PlotlyRendererTest:
         with param.logging_level('ERROR'):
             Renderer.notebook_context = self.nbcontext
             Renderer.comm_manager = self.comm_manager
-        Store.current_backend = self.previous_backend
+        hv.Store.current_backend = self.previous_backend
 
     def test_render_static(self):
-        curve = Curve([])
+        curve = hv.Curve([])
         obj, _ = self.renderer._validate(curve, None)
         assert isinstance(obj, pn.pane.HoloViews)
         assert obj.center is True
@@ -40,7 +40,7 @@ class PlotlyRendererTest:
         assert obj.backend == 'plotly'
 
     def test_render_holomap_individual(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer._validate(hmap, None)
         assert isinstance(obj, pn.pane.HoloViews)
         assert obj.center is True
@@ -52,7 +52,7 @@ class PlotlyRendererTest:
         assert slider.options == dict([(str(i), i) for i in range(5)])
 
     def test_render_holomap_embedded(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         data, _ = self.renderer.components(hmap)
         assert 'State"' in data['text/html']
 
@@ -62,7 +62,7 @@ class PlotlyRendererTest:
     #     self.assertNotIn('State"', data['text/html'])
 
     def test_render_holomap_scrubber(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer._validate(hmap, 'scrubber')
         assert isinstance(obj, pn.pane.HoloViews)
         assert obj.center is True
@@ -75,7 +75,7 @@ class PlotlyRendererTest:
         assert player.end == 4
 
     def test_render_holomap_scrubber_fps(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer.instance(fps=2)._validate(hmap, 'scrubber')
         assert isinstance(obj, pn.pane.HoloViews)
         widgets = obj.layout.select(Player)
@@ -84,7 +84,7 @@ class PlotlyRendererTest:
         assert player.interval == 500
 
     def test_render_holomap_individual_widget_position(self):
-        hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
         obj, _ = self.renderer.instance(widget_location='top')._validate(hmap, None)
         assert isinstance(obj, pn.pane.HoloViews)
         assert obj.center is True
@@ -93,7 +93,7 @@ class PlotlyRendererTest:
 
     @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_dims(self):
-        dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
+        dmap = hv.DynamicMap(lambda y: hv.Curve([1, 2, y]), kdims=['y']).redim.range(y=(0.1, 5))
         obj, _ = self.renderer._validate(dmap, None)
         self.renderer.components(obj)
         [(plot, _pane)] = obj._plots.values()
@@ -108,7 +108,7 @@ class PlotlyRendererTest:
     @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_stream(self):
         stream = Stream.define('Custom', y=2)()
-        dmap = DynamicMap(lambda y: Curve([1, 2, y]), kdims=['y'], streams=[stream])
+        dmap = hv.DynamicMap(lambda y: hv.Curve([1, 2, y]), kdims=['y'], streams=[stream])
         obj, _ = self.renderer._validate(dmap, None)
         self.renderer.components(obj)
         [(plot, _pane)] = obj._plots.values()
@@ -122,7 +122,7 @@ class PlotlyRendererTest:
     @pytest.mark.filterwarnings('ignore:Attempted to send message over Jupyter Comm:UserWarning')
     def test_render_dynamicmap_with_stream_dims(self):
         stream = Stream.define('Custom', y=2)()
-        dmap = DynamicMap(lambda x, y: Curve([x, 1, y]), kdims=['x', 'y'],
+        dmap = hv.DynamicMap(lambda x, y: hv.Curve([x, 1, y]), kdims=['x', 'y'],
                           streams=[stream]).redim.values(x=[1, 2, 3])
         obj, _ = self.renderer._validate(dmap, None)
         self.renderer.components(obj)

--- a/holoviews/tests/plotting/plotly/test_rgb.py
+++ b/holoviews/tests/plotting/plotly/test_rgb.py
@@ -2,11 +2,8 @@ import numpy as np
 import PIL.Image
 import plotly.graph_objs as go
 
-from holoviews.element import RGB, Tiles
-from holoviews.plotting.plotly.util import (
-    PLOTLY_MAP,
-    PLOTLY_SCATTERMAP,
-)
+import holoviews as hv
+from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP
 
 from .test_plot import TestPlotlyPlot, plotly_renderer
 
@@ -30,7 +27,7 @@ class TestRGBPlot(TestPlotlyPlot):
 
     def test_rgb(self):
         rgb_data = np.random.rand(10, 10, 3)
-        rgb = RGB(rgb_data)
+        rgb = hv.RGB(rgb_data)
         fig_dict = plotly_renderer.get_plot_state(rgb)
         x_range = fig_dict['layout']['xaxis']['range']
         assert x_range[0] == -0.5
@@ -64,7 +61,7 @@ class TestRGBPlot(TestPlotlyPlot):
 
     def test_rgb_invert_xaxis(self):
         rgb_data = np.random.rand(10, 10, 3)
-        rgb = RGB(rgb_data).opts(invert_xaxis=True)
+        rgb = hv.RGB(rgb_data).opts(invert_xaxis=True)
 
         fig_dict = plotly_renderer.get_plot_state(rgb)
         x_range = fig_dict['layout']['xaxis']['range']
@@ -104,7 +101,7 @@ class TestRGBPlot(TestPlotlyPlot):
 
     def test_rgb_invert_xaxis_and_yaxis(self):
         rgb_data = np.random.rand(10, 10, 3)
-        rgb = RGB(rgb_data).opts(invert_xaxis=True, invert_yaxis=True)
+        rgb = hv.RGB(rgb_data).opts(invert_xaxis=True, invert_yaxis=True)
 
         fig_dict = plotly_renderer.get_plot_state(rgb)
         x_range = fig_dict['layout']['xaxis']['range']
@@ -144,7 +141,7 @@ class TestRGBPlot(TestPlotlyPlot):
 
     def test_rgb_invert_axes(self):
         rgb_data = np.random.rand(10, 10, 3)
-        rgb = RGB(rgb_data).opts(invert_axes=True)
+        rgb = hv.RGB(rgb_data).opts(invert_axes=True)
 
         fig_dict = plotly_renderer.get_plot_state(rgb)
         x_range = fig_dict['layout']['xaxis']['range']
@@ -184,7 +181,7 @@ class TestRGBPlot(TestPlotlyPlot):
 
     def test_rgb_invert_xaxis_and_yaxis_and_axes(self):
         rgb_data = np.random.rand(10, 10, 3)
-        rgb = RGB(rgb_data).opts(invert_xaxis=True, invert_yaxis=True, invert_axes=True)
+        rgb = hv.RGB(rgb_data).opts(invert_xaxis=True, invert_yaxis=True, invert_axes=True)
 
         fig_dict = plotly_renderer.get_plot_state(rgb)
         x_range = fig_dict['layout']['xaxis']['range']
@@ -224,7 +221,7 @@ class TestRGBPlot(TestPlotlyPlot):
 
     def test_rgb_opacity(self):
         rgb_data = np.random.rand(10, 10, 3)
-        rgb = RGB(rgb_data).opts(opacity=0.5)
+        rgb = hv.RGB(rgb_data).opts(opacity=0.5)
         fig_dict = plotly_renderer.get_plot_state(rgb)
 
         # Check layout.image object
@@ -262,16 +259,16 @@ class TestMapboxRGBPlot(TestPlotlyPlot):
         self.x_center = sum(self.x_range) / 2.0
         self.y_range = (-3000000, 2000000)
         self.y_center = sum(self.y_range) / 2.0
-        self.lon_range, self.lat_range = Tiles.easting_northing_to_lon_lat(self.x_range, self.y_range)
-        self.lon_centers, self.lat_centers = Tiles.easting_northing_to_lon_lat(
+        self.lon_range, self.lat_range = hv.Tiles.easting_northing_to_lon_lat(self.x_range, self.y_range)
+        self.lon_centers, self.lat_centers = hv.Tiles.easting_northing_to_lon_lat(
             [self.x_center], [self.y_center]
         )
         self.lon_center, self.lat_center = self.lon_centers[0], self.lat_centers[0]
-        self.lons, self.lats = Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
+        self.lons, self.lats = hv.Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
 
     def test_rgb(self):
         rgb_data = np.random.rand(10, 10, 3)
-        rgb = Tiles("") * RGB(
+        rgb = hv.Tiles("") * hv.RGB(
             rgb_data,
             bounds=(self.x_range[0], self.y_range[0], self.x_range[1], self.y_range[1])
         ).opts(

--- a/holoviews/tests/plotting/plotly/test_scatter3dplot.py
+++ b/holoviews/tests/plotting/plotly/test_scatter3dplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Scatter3D
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -9,7 +9,7 @@ from .test_plot import TestPlotlyPlot
 class TestScatter3DPlot(TestPlotlyPlot):
 
     def test_scatter3d_state(self):
-        scatter = Scatter3D(([0,1], [2,3], [4,5]))
+        scatter = hv.Scatter3D(([0,1], [2,3], [4,5]))
         state = self._get_plot_state(scatter)
         assert_data_equal(state['data'][0]['x'], np.array([0, 1]))
         assert_data_equal(state['data'][0]['y'], np.array([2, 3]))
@@ -19,18 +19,18 @@ class TestScatter3DPlot(TestPlotlyPlot):
         assert state['layout']['scene']['zaxis']['range'] == [4, 5]
 
     def test_scatter3d_color_mapped(self):
-        scatter = Scatter3D(([0,1], [2,3], [4,5])).opts(color='y')
+        scatter = hv.Scatter3D(([0,1], [2,3], [4,5])).opts(color='y')
         state = self._get_plot_state(scatter)
         assert_data_equal(state['data'][0]['marker']['color'], np.array([2, 3]))
         assert state['data'][0]['marker']['cmin'] == 2
         assert state['data'][0]['marker']['cmax'] == 3
 
     def test_scatter3d_size(self):
-        scatter = Scatter3D(([0,1], [2,3], [4,5])).opts(size='y')
+        scatter = hv.Scatter3D(([0,1], [2,3], [4,5])).opts(size='y')
         state = self._get_plot_state(scatter)
         assert_data_equal(state['data'][0]['marker']['size'], np.array([2, 3]))
 
     def test_visible(self):
-        element = Scatter3D(([0, 1], [2, 3], [4, 5])).opts(visible=False)
+        element = hv.Scatter3D(([0, 1], [2, 3], [4, 5])).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False

--- a/holoviews/tests/plotting/plotly/test_scatterplot.py
+++ b/holoviews/tests/plotting/plotly/test_scatterplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Scatter, Tiles
+import holoviews as hv
 from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP
 from holoviews.testing import assert_data_equal
 
@@ -10,7 +10,7 @@ from .test_plot import TestPlotlyPlot
 class TestScatterPlot(TestPlotlyPlot):
 
     def test_scatter_state(self):
-        scatter = Scatter([3, 2, 1])
+        scatter = hv.Scatter([3, 2, 1])
         state = self._get_plot_state(scatter)
         assert state['data'][0]['type'] == 'scatter'
         assert_data_equal(state['data'][0]['y'], np.array([3, 2, 1]))
@@ -18,7 +18,7 @@ class TestScatterPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['range'] == [1, 3]
 
     def test_scatter_inverted(self):
-        scatter = Scatter([1, 2, 3]).opts(invert_axes=True)
+        scatter = hv.Scatter([1, 2, 3]).opts(invert_axes=True)
         state = self._get_plot_state(scatter)
         assert_data_equal(state['data'][0]['x'], np.array([1, 2, 3]))
         assert_data_equal(state['data'][0]['y'], np.array([0, 1, 2]))
@@ -29,19 +29,19 @@ class TestScatterPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'x'
 
     def test_scatter_color_mapped(self):
-        scatter = Scatter([3, 2, 1]).opts(color='x')
+        scatter = hv.Scatter([3, 2, 1]).opts(color='x')
         state = self._get_plot_state(scatter)
         assert_data_equal(state['data'][0]['marker']['color'], np.array([0, 1, 2]))
         assert state['data'][0]['marker']['cmin'] == 0
         assert state['data'][0]['marker']['cmax'] == 2
 
     def test_scatter_size(self):
-        scatter = Scatter([3, 2, 1]).opts(size='y')
+        scatter = hv.Scatter([3, 2, 1]).opts(size='y')
         state = self._get_plot_state(scatter)
         assert_data_equal(state['data'][0]['marker']['size'], np.array([3, 2, 1]))
 
     def test_scatter_colors(self):
-        scatter = Scatter([
+        scatter = hv.Scatter([
             (0, 1, 'red'), (1, 2, 'green'), (2, 3, 'blue')
         ], vdims=['y', 'color']).opts(color='color')
         state = self._get_plot_state(scatter)
@@ -49,7 +49,7 @@ class TestScatterPlot(TestPlotlyPlot):
                                         np.array(['red', 'green', 'blue'])) is True
 
     def test_scatter_categorical_color(self):
-        scatter = Scatter([
+        scatter = hv.Scatter([
             (0, 1, 'A'), (1, 2, 'B'), (2, 3, 'C')
         ], vdims=['y', 'category']).opts(color='category')
         state = self._get_plot_state(scatter)
@@ -60,7 +60,7 @@ class TestScatterPlot(TestPlotlyPlot):
         assert state['data'][0]['marker']['cmax'] == 2
 
     def test_scatter_markers(self):
-        scatter = Scatter([
+        scatter = hv.Scatter([
             (0, 1, 'square'), (1, 2, 'circle'), (2, 3, 'triangle-up')
         ], vdims=['y', 'marker']).opts(marker='marker')
         state = self._get_plot_state(scatter)
@@ -68,14 +68,14 @@ class TestScatterPlot(TestPlotlyPlot):
                                         np.array(['square', 'circle', 'triangle-up'])) is True
 
     def test_scatter_selectedpoints(self):
-        scatter = Scatter([
+        scatter = hv.Scatter([
             (0, 1,), (1, 2), (2, 3)
         ]).opts(selectedpoints=[1, 2])
         state = self._get_plot_state(scatter)
         assert state['data'][0]['selectedpoints'] == [1, 2]
 
     def test_visible(self):
-        element = Scatter([3, 2, 1]).opts(visible=False)
+        element = hv.Scatter([3, 2, 1]).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False
 
@@ -89,11 +89,11 @@ class TestMapboxScatterPlot(TestPlotlyPlot):
         x_center = sum(x_range) / 2.0
         y_range = (-3000000, 2000000)
         y_center = sum(y_range) / 2.0
-        lon_centers, lat_centers = Tiles.easting_northing_to_lon_lat([x_center], [y_center])
+        lon_centers, lat_centers = hv.Tiles.easting_northing_to_lon_lat([x_center], [y_center])
         lon_center, lat_center = lon_centers[0], lat_centers[0]
-        lons, lats = Tiles.easting_northing_to_lon_lat(xs, ys)
+        lons, lats = hv.Tiles.easting_northing_to_lon_lat(xs, ys)
 
-        scatter = Tiles('') * Scatter((xs, ys)).redim.range(x=x_range, y=y_range)
+        scatter = hv.Tiles('') * hv.Scatter((xs, ys)).redim.range(x=x_range, y=y_range)
         state = self._get_plot_state(scatter)
         assert state['data'][1]['type'] == PLOTLY_SCATTERMAP
         assert_data_equal(state['data'][1]['lon'], lons)
@@ -106,7 +106,7 @@ class TestMapboxScatterPlot(TestPlotlyPlot):
         assert 'yaxis' not in state['layout']
 
     def test_scatter_color_mapped(self):
-        scatter = Tiles('') * Scatter([3, 2, 1]).opts(color='x')
+        scatter = hv.Tiles('') * hv.Scatter([3, 2, 1]).opts(color='x')
         state = self._get_plot_state(scatter)
         assert_data_equal(state['data'][1]['marker']['color'], np.array([0, 1, 2]))
         assert state['data'][1]['marker']['cmin'] == 0
@@ -114,12 +114,12 @@ class TestMapboxScatterPlot(TestPlotlyPlot):
 
     def test_scatter_size(self):
         # size values should not go through meters-to-lnglat conversion
-        scatter = Tiles('') * Scatter([3, 2, 1]).opts(size='y')
+        scatter = hv.Tiles('') * hv.Scatter([3, 2, 1]).opts(size='y')
         state = self._get_plot_state(scatter)
         assert_data_equal(state['data'][1]['marker']['size'], np.array([3, 2, 1]))
 
     def test_scatter_colors(self):
-        scatter = Tiles('') * Scatter([
+        scatter = hv.Tiles('') * hv.Scatter([
             (0, 1, 'red'), (1, 2, 'green'), (2, 3, 'blue')
         ], vdims=['y', 'color']).opts(color='color')
         state = self._get_plot_state(scatter)
@@ -127,7 +127,7 @@ class TestMapboxScatterPlot(TestPlotlyPlot):
                                         np.array(['red', 'green', 'blue'])) is True
 
     def test_scatter_categorical_color(self):
-        scatter = Tiles('') * Scatter([
+        scatter = hv.Tiles('') * hv.Scatter([
             (0, 1, 'A'), (1, 2, 'B'), (2, 3, 'C')
         ], vdims=['y', 'category']).opts(color='category')
         state = self._get_plot_state(scatter)
@@ -139,7 +139,7 @@ class TestMapboxScatterPlot(TestPlotlyPlot):
 
 
     def test_scatter_markers(self):
-        scatter = Tiles('') * Scatter([
+        scatter = hv.Tiles('') * hv.Scatter([
             (0, 1, 'square'), (1, 2, 'circle'), (2, 3, 'triangle-up')
         ], vdims=['y', 'marker']).opts(marker='marker')
         state = self._get_plot_state(scatter)
@@ -148,13 +148,13 @@ class TestMapboxScatterPlot(TestPlotlyPlot):
                 np.array(['square', 'circle', 'triangle-up'])) is True
 
     def test_scatter_selectedpoints(self):
-        scatter = Tiles('') * Scatter([
+        scatter = hv.Tiles('') * hv.Scatter([
             (0, 1,), (1, 2), (2, 3)
         ]).opts(selectedpoints=[1, 2])
         state = self._get_plot_state(scatter)
         assert state['data'][1]['selectedpoints'] == [1, 2]
 
     def test_visible(self):
-        element = Tiles('') * Scatter([3, 2, 1]).opts(visible=False)
+        element = hv.Tiles('') * hv.Scatter([3, 2, 1]).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][1]['visible'] is False

--- a/holoviews/tests/plotting/plotly/test_shapeplots.py
+++ b/holoviews/tests/plotting/plotly/test_shapeplots.py
@@ -1,15 +1,6 @@
 import numpy as np
 
-from holoviews.element import (
-    Bounds,
-    Box,
-    HLine,
-    Path,
-    Rectangles,
-    Segments,
-    Tiles,
-    VLine,
-)
+import holoviews as hv
 from holoviews.plotting.plotly.util import PLOTLY_MAP, PLOTLY_SCATTERMAP
 from holoviews.testing import assert_data_equal
 
@@ -44,12 +35,12 @@ class TestMapboxShape(TestPlotlyPlot):
         self.x_center = sum(self.x_range) / 2.0
         self.y_range = (-3000000, 2000000)
         self.y_center = sum(self.y_range) / 2.0
-        self.lon_range, self.lat_range = Tiles.easting_northing_to_lon_lat(self.x_range, self.y_range)
-        self.lon_centers, self.lat_centers = Tiles.easting_northing_to_lon_lat(
+        self.lon_range, self.lat_range = hv.Tiles.easting_northing_to_lon_lat(self.x_range, self.y_range)
+        self.lon_centers, self.lat_centers = hv.Tiles.easting_northing_to_lon_lat(
             [self.x_center], [self.y_center]
         )
         self.lon_center, self.lat_center = self.lon_centers[0], self.lat_centers[0]
-        self.lons, self.lats = Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
+        self.lons, self.lats = hv.Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
 
 
 class TestVLineHLine(TestShape):
@@ -75,7 +66,7 @@ class TestVLineHLine(TestShape):
         assert shape['xref'] == 'paper'
 
     def test_single_vline(self):
-        vline = VLine(3)
+        vline = hv.VLine(3)
         state = self._get_plot_state(vline)
 
         shapes = state['layout']['shapes']
@@ -83,7 +74,7 @@ class TestVLineHLine(TestShape):
         self.assert_vline(shapes[0], 3)
 
     def test_single_hline(self):
-        hline = HLine(3)
+        hline = hv.HLine(3)
         state = self._get_plot_state(hline)
 
         shapes = state['layout']['shapes']
@@ -91,8 +82,8 @@ class TestVLineHLine(TestShape):
         self.assert_hline(shapes[0], 3)
 
     def test_vline_layout(self):
-        layout = (VLine(1) + VLine(2) +
-                  VLine(3) + VLine(4)).cols(2).opts(vspacing=0, hspacing=0)
+        layout = (hv.VLine(1) + hv.VLine(2) +
+                  hv.VLine(3) + hv.VLine(4)).cols(2).opts(vspacing=0, hspacing=0)
         state = self._get_plot_state(layout)
 
         shapes = state['layout']['shapes']
@@ -105,8 +96,8 @@ class TestVLineHLine(TestShape):
         self.assert_vline(shapes[3], 2, xref='x4', ydomain=[0.5, 1.0])
 
     def test_hline_layout(self):
-        layout = (HLine(1) + HLine(2) +
-                  HLine(3) + HLine(4)).cols(2).opts(vspacing=0, hspacing=0)
+        layout = (hv.HLine(1) + hv.HLine(2) +
+                  hv.HLine(3) + hv.HLine(4)).cols(2).opts(vspacing=0, hspacing=0)
         state = self._get_plot_state(layout)
 
         shapes = state['layout']['shapes']
@@ -119,10 +110,10 @@ class TestVLineHLine(TestShape):
         self.assert_hline(shapes[3], 2, yref='y4', xdomain=[0.5, 1.0])
 
     def test_vline_styling(self):
-        self.assert_shape_element_styling(VLine(3))
+        self.assert_shape_element_styling(hv.VLine(3))
 
     def test_hline_styling(self):
-        self.assert_shape_element_styling(HLine(3))
+        self.assert_shape_element_styling(hv.HLine(3))
 
 
 class TestPathShape(TestShape):
@@ -146,7 +137,7 @@ class TestPathShape(TestShape):
         assert shape['yref'] == yref
 
     def test_simple_path(self):
-        path = Path([(0, 0), (1, 1), (0, 1), (0, 0)])
+        path = hv.Path([(0, 0), (1, 1), (0, 1), (0, 0)])
         state = self._get_plot_state(path)
         shapes = state['layout']['shapes']
         assert len(shapes) == 1
@@ -156,7 +147,7 @@ class TestPathShape(TestShape):
 
 class TestMapboxPathShape(TestMapboxShape):
     def test_simple_path(self):
-        path = Tiles("") * Path([
+        path = hv.Tiles("") * hv.Path([
             (self.x_range[0], self.y_range[0]),
             (self.x_range[1], self.y_range[1]),
             (self.x_range[0], self.y_range[1]),
@@ -184,7 +175,7 @@ class TestMapboxPathShape(TestMapboxShape):
 class TestBounds(TestPathShape):
 
     def test_single_bounds(self):
-        bounds = Bounds((1, 2, 3, 4))
+        bounds = hv.Bounds((1, 2, 3, 4))
 
         state = self._get_plot_state(bounds)
 
@@ -193,10 +184,10 @@ class TestBounds(TestPathShape):
         self.assert_path_shape_element(shapes[0], bounds)
 
     def test_bounds_layout(self):
-        bounds1 = Bounds((0, 0, 1, 1))
-        bounds2 = Bounds((0, 0, 2, 2))
-        bounds3 = Bounds((0, 0, 3, 3))
-        bounds4 = Bounds((0, 0, 4, 4))
+        bounds1 = hv.Bounds((0, 0, 1, 1))
+        bounds2 = hv.Bounds((0, 0, 2, 2))
+        bounds3 = hv.Bounds((0, 0, 3, 3))
+        bounds4 = hv.Bounds((0, 0, 4, 4))
 
         layout = (bounds1 + bounds2 +
                   bounds3 + bounds4).cols(2)
@@ -213,12 +204,12 @@ class TestBounds(TestPathShape):
         self.assert_path_shape_element(shapes[3], bounds2, xref='x4', yref='y4')
 
     def test_bounds_styling(self):
-        self.assert_shape_element_styling(Bounds((1, 2, 3, 4)))
+        self.assert_shape_element_styling(hv.Bounds((1, 2, 3, 4)))
 
 
 class TestMapboxBounds(TestMapboxShape):
     def test_single_bounds(self):
-        bounds = Tiles("") * Bounds(
+        bounds = hv.Tiles("") * hv.Bounds(
             (self.x_range[0], self.y_range[0], self.x_range[1], self.y_range[1])
         ).redim.range(
             x=self.x_range, y=self.y_range
@@ -240,13 +231,13 @@ class TestMapboxBounds(TestMapboxShape):
             }
 
     def test_bounds_layout(self):
-        bounds1 = Bounds((0, 0, 1, 1))
-        bounds2 = Bounds((0, 0, 2, 2))
-        bounds3 = Bounds((0, 0, 3, 3))
-        bounds4 = Bounds((0, 0, 4, 4))
+        bounds1 = hv.Bounds((0, 0, 1, 1))
+        bounds2 = hv.Bounds((0, 0, 2, 2))
+        bounds3 = hv.Bounds((0, 0, 3, 3))
+        bounds4 = hv.Bounds((0, 0, 4, 4))
 
-        layout = (Tiles("") * bounds1 + Tiles("") * bounds2 +
-                  Tiles("") * bounds3 + Tiles("") * bounds4).cols(2)
+        layout = (hv.Tiles("") * bounds1 + hv.Tiles("") * bounds2 +
+                  hv.Tiles("") * bounds3 + hv.Tiles("") * bounds4).cols(2)
 
         state = self._get_plot_state(layout)
         assert state['data'][1]["subplot"] == PLOTLY_MAP
@@ -260,17 +251,17 @@ class TestMapboxBounds(TestMapboxShape):
 class TestBox(TestPathShape):
 
     def test_single_box(self):
-        box = Box(0, 0, (1, 2), orientation=1)
+        box = hv.Box(0, 0, (1, 2), orientation=1)
         state = self._get_plot_state(box)
         shapes = state['layout']['shapes']
         assert len(shapes) == 1
         self.assert_path_shape_element(shapes[0], box)
 
     def test_bounds_layout(self):
-        box1 = Box(0, 0, (1, 1), orientation=0)
-        box2 = Box(0, 0, (2, 2), orientation=0.5)
-        box3 = Box(0, 0, (3, 3), orientation=1.0)
-        box4 = Box(0, 0, (4, 4), orientation=1.5)
+        box1 = hv.Box(0, 0, (1, 1), orientation=0)
+        box2 = hv.Box(0, 0, (2, 2), orientation=0.5)
+        box3 = hv.Box(0, 0, (3, 3), orientation=1.0)
+        box4 = hv.Box(0, 0, (4, 4), orientation=1.5)
 
         layout = (box1 + box2 +
                   box3 + box4).cols(2)
@@ -287,18 +278,18 @@ class TestBox(TestPathShape):
         self.assert_path_shape_element(shapes[3], box2, xref='x4', yref='y4')
 
     def test_box_styling(self):
-        self.assert_shape_element_styling(Box(0, 0, (1, 1)))
+        self.assert_shape_element_styling(hv.Box(0, 0, (1, 1)))
 
 
 class TestMapboxBox(TestMapboxShape):
     def test_single_box(self):
-        box = Tiles("") * Box(0, 0, (1000000, 2000000)).redim.range(
+        box = hv.Tiles("") * hv.Box(0, 0, (1000000, 2000000)).redim.range(
             x=self.x_range, y=self.y_range
         )
 
         x_box_range = [-500000, 500000]
         y_box_range = [-1000000, 1000000]
-        lon_box_range, lat_box_range = Tiles.easting_northing_to_lon_lat(x_box_range, y_box_range)
+        lon_box_range, lat_box_range = hv.Tiles.easting_northing_to_lon_lat(x_box_range, y_box_range)
 
         state = self._get_plot_state(box)
         assert state["data"][1]["type"] == PLOTLY_SCATTERMAP
@@ -320,7 +311,7 @@ class TestMapboxBox(TestMapboxShape):
 class TestRectangles(TestPathShape):
 
     def test_boxes_simple(self):
-        boxes = Rectangles([(0, 0, 1, 1), (2, 2, 4, 3)])
+        boxes = hv.Rectangles([(0, 0, 1, 1), (2, 2, 4, 3)])
         state = self._get_plot_state(boxes)
         shapes = state['layout']['shapes']
         assert len(shapes) == 2
@@ -336,7 +327,7 @@ class TestRectangles(TestPathShape):
 
 class TestMapboxRectangles(TestMapboxShape):
     def test_rectangles_simple(self):
-        rectangles = Tiles("") * Rectangles([
+        rectangles = hv.Tiles("") * hv.Rectangles([
             (0, 0, self.x_range[1], self.y_range[1]),
             (self.x_range[0], self.y_range[0], 0, 0),
         ]).redim.range(
@@ -365,7 +356,7 @@ class TestMapboxRectangles(TestMapboxShape):
 class TestSegments(TestPathShape):
 
     def test_segments_simple(self):
-        boxes = Segments([(0, 0, 1, 1), (2, 2, 4, 3)])
+        boxes = hv.Segments([(0, 0, 1, 1), (2, 2, 4, 3)])
         state = self._get_plot_state(boxes)
         shapes = state['layout']['shapes']
         assert len(shapes) == 2
@@ -381,7 +372,7 @@ class TestSegments(TestPathShape):
 
 class TestMapboxSegments(TestMapboxShape):
     def test_segments_simple(self):
-        rectangles = Tiles("") * Segments([
+        rectangles = hv.Tiles("") * hv.Segments([
             (0, 0, self.x_range[1], self.y_range[1]),
             (self.x_range[0], self.y_range[0], 0, 0),
         ]).redim.range(

--- a/holoviews/tests/plotting/plotly/test_spreadplot.py
+++ b/holoviews/tests/plotting/plotly/test_spreadplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Spread
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -9,7 +9,7 @@ from .test_plot import TestPlotlyPlot
 class TestSpreadPlot(TestPlotlyPlot):
 
     def test_spread_fill_between_ys(self):
-        spread = Spread([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2'])
+        spread = hv.Spread([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2'])
         state = self._get_plot_state(spread)
         assert_data_equal(state['data'][0]['y'], np.array([0.5, 1, 0.75]))
         assert state['data'][0]['mode'] == 'lines'
@@ -20,7 +20,7 @@ class TestSpreadPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['range'] == [0.5, 5.25]
 
     def test_spread_fill_between_xs(self):
-        spread = Spread([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2']).options(invert_axes=True)
+        spread = hv.Spread([(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)], vdims=['y', 'y2']).options(invert_axes=True)
         state = self._get_plot_state(spread)
         assert_data_equal(state['data'][0]['x'], np.array([0.5, 1, 0.75]))
         assert state['data'][0]['mode'] == 'lines'
@@ -32,7 +32,7 @@ class TestSpreadPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['range'] == [0, 2]
 
     def test_visible(self):
-        element = Spread(
+        element = hv.Spread(
             [(0, 1, 0.5), (1, 2, 1), (2, 3, 2.25)],
             vdims=['y', 'y2']
         ).opts(visible=False)

--- a/holoviews/tests/plotting/plotly/test_surfaceplot.py
+++ b/holoviews/tests/plotting/plotly/test_surfaceplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Surface
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -9,7 +9,7 @@ from .test_plot import TestPlotlyPlot
 class TestSurfacePlot(TestPlotlyPlot):
 
     def test_surface_state(self):
-        img = Surface(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]])))
+        img = hv.Surface(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]])))
         state = self._get_plot_state(img)
         assert state['data'][0]['type'] == 'surface'
         assert_data_equal(state['data'][0]['x'], np.array([1, 2, 3]))
@@ -22,7 +22,7 @@ class TestSurfacePlot(TestPlotlyPlot):
         assert state['layout']['scene']['zaxis']['range'] == [0, 4]
 
     def test_surface_colorbar(self):
-        img = Surface(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]])))
+        img = hv.Surface(([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]])))
         img.opts(colorbar=True)
         state = self._get_plot_state(img)
         trace = state['data'][0]
@@ -34,7 +34,7 @@ class TestSurfacePlot(TestPlotlyPlot):
         assert not trace['showscale']
 
     def test_visible(self):
-        element = Surface(
+        element = hv.Surface(
             ([1, 2, 3], [0, 1], np.array([[0, 1, 2], [2, 3, 4]]))
         ).opts(visible=False)
         state = self._get_plot_state(element)

--- a/holoviews/tests/plotting/plotly/test_tableplot.py
+++ b/holoviews/tests/plotting/plotly/test_tableplot.py
@@ -1,4 +1,5 @@
-from holoviews.element import Table
+
+import holoviews as hv
 
 from .test_plot import TestPlotlyPlot
 
@@ -6,13 +7,13 @@ from .test_plot import TestPlotlyPlot
 class TestTablePlot(TestPlotlyPlot):
 
     def test_table_state(self):
-        table = Table([(0, 1), (1, 2), (2, 3)], 'x', 'y')
+        table = hv.Table([(0, 1), (1, 2), (2, 3)], 'x', 'y')
         state = self._get_plot_state(table)
         assert state['data'][0]['type'] == 'table'
         assert state['data'][0]['header']['values'] == ['x', 'y']
         assert state['data'][0]['cells']['values'] == [['0', '1', '2'], ['1', '2', '3']]
 
     def test_visible(self):
-        element = Table([(0, 1), (1, 2), (2, 3)], 'x', 'y').options(visible=False)
+        element = hv.Table([(0, 1), (1, 2), (2, 3)], 'x', 'y').options(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False

--- a/holoviews/tests/plotting/plotly/test_tableplot.py
+++ b/holoviews/tests/plotting/plotly/test_tableplot.py
@@ -1,4 +1,3 @@
-
 import holoviews as hv
 
 from .test_plot import TestPlotlyPlot

--- a/holoviews/tests/plotting/plotly/test_tiles.py
+++ b/holoviews/tests/plotting/plotly/test_tiles.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from holoviews.element import RGB, Bounds, Points, Tiles
+import holoviews as hv
 from holoviews.element.tiles import _ATTRIBUTIONS, StamenTerrain
 from holoviews.plotting.plotly.util import (
     PLOTLY_GE_6_0_0,
@@ -24,15 +24,15 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         self.x_center = sum(self.x_range) / 2.0
         self.y_range = (-3000000, 2000000)
         self.y_center = sum(self.y_range) / 2.0
-        self.lon_range, self.lat_range = Tiles.easting_northing_to_lon_lat(self.x_range, self.y_range)
-        self.lon_centers, self.lat_centers = Tiles.easting_northing_to_lon_lat(
+        self.lon_range, self.lat_range = hv.Tiles.easting_northing_to_lon_lat(self.x_range, self.y_range)
+        self.lon_centers, self.lat_centers = hv.Tiles.easting_northing_to_lon_lat(
             [self.x_center], [self.y_center]
         )
         self.lon_center, self.lat_center = self.lon_centers[0], self.lat_centers[0]
-        self.lons, self.lats = Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
+        self.lons, self.lats = hv.Tiles.easting_northing_to_lon_lat(self.xs, self.ys)
 
     def test_mapbox_tiles_defaults(self):
-        tiles = Tiles("").redim.range(
+        tiles = hv.Tiles("").redim.range(
             x=self.x_range, y=self.y_range
         )
 
@@ -62,7 +62,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
 
     def test_styled_mapbox_tiles(self):
         opts = dict(mapstyle="dark") if PLOTLY_GE_6_0_0 else dict(mapboxstyle="dark", accesstoken="token-str")
-        tiles = Tiles().opts(**opts).redim.range(x=self.x_range, y=self.y_range)
+        tiles = hv.Tiles().opts(**opts).redim.range(x=self.x_range, y=self.y_range)
 
         fig_dict = plotly_renderer.get_plot_state(tiles)
 
@@ -108,7 +108,7 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
     def test_xyzservices_tileprovider(self):
         xyzservices = pytest.importorskip("xyzservices")
         osm = xyzservices.providers.OpenStreetMap.Mapnik
-        tiles = Tiles(osm, name="xyzservices").redim.range(
+        tiles = hv.Tiles(osm, name="xyzservices").redim.range(
             x=self.x_range, y=self.y_range
         )
 
@@ -124,14 +124,14 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
     def test_overlay(self):
         # Base layer is mapbox vector layer
         opts = dict(mapstyle="dark") if PLOTLY_GE_6_0_0 else dict(mapboxstyle="dark", accesstoken="token-str")
-        tiles = Tiles("").opts(**opts)
+        tiles = hv.Tiles("").opts(**opts)
 
         # Raster tile layer
         stamen_raster = StamenTerrain().opts(alpha=0.7)
 
         # RGB layer
         rgb_data = np.random.rand(10, 10, 3)
-        rgb = RGB(
+        rgb = hv.RGB(
             rgb_data,
             bounds=(self.x_range[0], self.y_range[0], self.x_range[1], self.y_range[1])
         ).opts(
@@ -139,12 +139,12 @@ class TestMapboxTilesPlot(TestPlotlyPlot):
         )
 
         # Points layer
-        points = Points([(0, 0), (self.x_range[1], self.y_range[1])]).opts(
+        points = hv.Points([(0, 0), (self.x_range[1], self.y_range[1])]).opts(
             show_legend=True
         )
 
         # Bounds
-        bounds = Bounds((self.x_range[0], self.y_range[0], 0, 0))
+        bounds = hv.Bounds((self.x_range[0], self.y_range[0], 0, 0))
 
         # Overlay
         overlay = (tiles * stamen_raster * rgb * points * bounds).redim.range(

--- a/holoviews/tests/plotting/plotly/test_violinplot.py
+++ b/holoviews/tests/plotting/plotly/test_violinplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from holoviews.element import Violin
+import holoviews as hv
 from holoviews.testing import assert_data_equal
 
 from .test_plot import TestPlotlyPlot
@@ -9,7 +9,7 @@ from .test_plot import TestPlotlyPlot
 class TestViolinPlot(TestPlotlyPlot):
 
     def test_violin_single(self):
-        violin = Violin([1, 1, 2, 3, 3, 4, 5, 5])
+        violin = hv.Violin([1, 1, 2, 3, 3, 4, 5, 5])
         state = self._get_plot_state(violin)
         assert len(state['data']) == 1
         assert state['data'][0]['type'] == 'violin'
@@ -20,7 +20,7 @@ class TestViolinPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'y'
 
     def test_violin_single_invert_axes(self):
-        violin = Violin([1, 1, 2, 3, 3, 4, 5, 5]).opts(invert_axes=True)
+        violin = hv.Violin([1, 1, 2, 3, 3, 4, 5, 5]).opts(invert_axes=True)
         state = self._get_plot_state(violin)
         assert len(state['data']) == 1
         assert state['data'][0]['type'] == 'violin'
@@ -31,7 +31,7 @@ class TestViolinPlot(TestPlotlyPlot):
         assert state['layout']['xaxis']['title']['text'] == 'y'
 
     def test_violin_multi(self):
-        violin = Violin((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y')
+        violin = hv.Violin((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y')
         state = self._get_plot_state(violin)
         assert len(state['data']) == 2
         assert state['data'][0]['type'] == 'violin'
@@ -45,7 +45,7 @@ class TestViolinPlot(TestPlotlyPlot):
         assert state['layout']['yaxis']['title']['text'] == 'y'
 
     def test_violin_multi_invert_axes(self):
-        violin = Violin((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y').opts(
+        violin = hv.Violin((['A']*8+['B']*8, [1, 1, 2, 3, 3, 4, 5, 5]*2), 'x', 'y').opts(
             invert_axes=True)
         state = self._get_plot_state(violin)
         assert len(state['data']) == 2
@@ -60,6 +60,6 @@ class TestViolinPlot(TestPlotlyPlot):
         assert state['layout']['xaxis']['title']['text'] == 'y'
 
     def test_visible(self):
-        element = Violin([1, 1, 2, 3, 3, 4, 5, 5]).opts(visible=False)
+        element = hv.Violin([1, 1, 2, 3, 3, 4, 5, 5]).opts(visible=False)
         state = self._get_plot_state(element)
         assert state['data'][0]['visible'] is False

--- a/holoviews/tests/plotting/test_plotutils.py
+++ b/holoviews/tests/plotting/test_plotutils.py
@@ -1,19 +1,7 @@
 import numpy as np
 import pytest
 
-from holoviews import Dimension, NdOverlay, Overlay
-from holoviews.core.options import Cycle
-from holoviews.core.spaces import DynamicMap, HoloMap
-from holoviews.element import (
-    Area,
-    Curve,
-    HLine,
-    Image,
-    Path,
-    Points,
-    Scatter,
-    VectorField,
-)
+import holoviews as hv
 from holoviews.operation import operation
 from holoviews.plotting.util import (
     _get_min_distance_numpy,
@@ -34,21 +22,21 @@ from holoviews.streams import PointerX
 class TestOverlayableZorders:
 
     def test_compute_overlayable_zorders_holomap(self):
-        hmap = HoloMap({0: Points([])})
+        hmap = hv.HoloMap({0: hv.Points([])})
         sources = compute_overlayable_zorders(hmap)
         assert sources[0] == [hmap, hmap.last]
 
     def test_compute_overlayable_zorders_with_overlaid_holomap(self):
-        points = Points([])
-        hmap = HoloMap({0: points})
-        curve = Curve([])
+        points = hv.Points([])
+        hmap = hv.HoloMap({0: points})
+        curve = hv.Curve([])
         combined = hmap*curve
         sources = compute_overlayable_zorders(combined)
         assert sources[0] == [points, combined.last, combined]
 
     def test_dynamic_compute_overlayable_zorders_two_mixed_layers(self):
-        area = Area(range(10))
-        dmap = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area = hv.Area(range(10))
+        dmap = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         combined = area*dmap
         combined[()]
         sources = compute_overlayable_zorders(combined)
@@ -56,8 +44,8 @@ class TestOverlayableZorders:
         assert sources[1] == [dmap]
 
     def test_dynamic_compute_overlayable_zorders_two_mixed_layers_reverse(self):
-        area = Area(range(10))
-        dmap = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area = hv.Area(range(10))
+        dmap = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         combined = dmap*area
         combined[()]
         sources = compute_overlayable_zorders(combined)
@@ -65,8 +53,8 @@ class TestOverlayableZorders:
         assert sources[1] == [area]
 
     def test_dynamic_compute_overlayable_zorders_two_dynamic_layers(self):
-        area = DynamicMap(lambda: Area(range(10)), kdims=[])
-        dmap = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area = hv.DynamicMap(lambda: hv.Area(range(10)), kdims=[])
+        dmap = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         combined = area*dmap
         combined[()]
         sources = compute_overlayable_zorders(combined)
@@ -74,8 +62,8 @@ class TestOverlayableZorders:
         assert sources[1] == [dmap]
 
     def test_dynamic_compute_overlayable_zorders_two_deep_dynamic_layers(self):
-        area = DynamicMap(lambda: Area(range(10)), kdims=[])
-        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area = hv.DynamicMap(lambda: hv.Area(range(10)), kdims=[])
+        curve = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         area_redim = area.redim(x='x2')
         curve_redim = curve.redim(x='x2')
         combined = area_redim*curve_redim
@@ -91,9 +79,9 @@ class TestOverlayableZorders:
         assert area not in sources[1]
 
     def test_dynamic_compute_overlayable_zorders_three_deep_dynamic_layers(self):
-        area = DynamicMap(lambda: Area(range(10)), kdims=[])
-        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
-        curve2 = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area = hv.DynamicMap(lambda: hv.Area(range(10)), kdims=[])
+        curve = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
+        curve2 = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         area_redim = area.redim(x='x2')
         curve_redim = curve.redim(x='x2')
         curve2_redim = curve2.redim(x='x3')
@@ -123,9 +111,9 @@ class TestOverlayableZorders:
         assert curve not in sources[2]
 
     def test_dynamic_compute_overlayable_zorders_three_deep_dynamic_layers_cloned(self):
-        area = DynamicMap(lambda: Area(range(10)), kdims=[])
-        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
-        curve2 = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area = hv.DynamicMap(lambda: hv.Area(range(10)), kdims=[])
+        curve = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
+        curve2 = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         area_redim = area.redim(x='x2')
         curve_redim = curve.redim(x='x2')
         curve2_redim = curve2.redim(x='x3')
@@ -156,10 +144,10 @@ class TestOverlayableZorders:
         assert curve not in sources[2]
 
     def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_non_dynamic_overlays_reverse(self):
-        area1 = Area(range(10))
-        area2 = Area(range(10))
+        area1 = hv.Area(range(10))
+        area2 = hv.Area(range(10))
         overlay = area1 * area2
-        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        curve = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         curve_redim = curve.redim(x='x2')
         combined = curve_redim*overlay
         combined[()]
@@ -180,8 +168,8 @@ class TestOverlayableZorders:
         assert curve not in sources[2]
 
     def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_non_dynamic_ndoverlays(self):
-        ndoverlay = NdOverlay({i: Area(range(10+i)) for i in range(2)})
-        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        ndoverlay = hv.NdOverlay({i: hv.Area(range(10+i)) for i in range(2)})
+        curve = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         curve_redim = curve.redim(x='x2')
         combined = ndoverlay*curve_redim
         combined[()]
@@ -202,17 +190,17 @@ class TestOverlayableZorders:
         assert ndoverlay not in sources[2]
 
     def test_dynamic_compute_overlayable_zorders_ndoverlays_as_input(self):
-        ndoverlay1 = NdOverlay({i: Area(range(10+i)) for i in range(2)}).apply(lambda el: el.get(0), dynamic=True)
-        ndoverlay2 = NdOverlay({i: Area((range(15, 25+i), range(10+i))) for i in range(2)}).apply(lambda el: el.get(0), dynamic=True)
+        ndoverlay1 = hv.NdOverlay({i: hv.Area(range(10+i)) for i in range(2)}).apply(lambda el: el.get(0), dynamic=True)
+        ndoverlay2 = hv.NdOverlay({i: hv.Area((range(15, 25+i), range(10+i))) for i in range(2)}).apply(lambda el: el.get(0), dynamic=True)
         combined = ndoverlay1*ndoverlay2
         combined[()]
         sources = compute_overlayable_zorders(combined)
         assert len(sources) == 2
 
     def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_dynamic_ndoverlay_with_streams(self):
-        ndoverlay = DynamicMap(lambda x: NdOverlay({i: Area(range(10+i)) for i in range(2)}),
+        ndoverlay = hv.DynamicMap(lambda x: hv.NdOverlay({i: hv.Area(range(10+i)) for i in range(2)}),
                                kdims=[], streams=[PointerX()])
-        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        curve = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         curve_redim = curve.redim(x='x2')
         combined = ndoverlay*curve_redim
         combined[()]
@@ -231,9 +219,9 @@ class TestOverlayableZorders:
         assert ndoverlay not in sources[2]
 
     def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_dynamic_ndoverlay_with_streams_cloned(self):
-        ndoverlay = DynamicMap(lambda x: NdOverlay({i: Area(range(10+i)) for i in range(2)}),
+        ndoverlay = hv.DynamicMap(lambda x: hv.NdOverlay({i: hv.Area(range(10+i)) for i in range(2)}),
                                kdims=[], streams=[PointerX()])
-        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        curve = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         curve_redim = curve.redim(x='x2')
         combined = ndoverlay*curve_redim
         combined[()]
@@ -252,8 +240,8 @@ class TestOverlayableZorders:
         assert ndoverlay not in sources[2]
 
     def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_non_dynamic_ndoverlays_reverse(self):
-        ndoverlay = NdOverlay({i: Area(range(10+i)) for i in range(2)})
-        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        ndoverlay = hv.NdOverlay({i: hv.Area(range(10+i)) for i in range(2)})
+        curve = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         curve_redim = curve.redim(x='x2')
         combined = curve_redim*ndoverlay
         combined[()]
@@ -274,13 +262,13 @@ class TestOverlayableZorders:
         assert curve not in sources[2]
 
     def test_dynamic_compute_overlayable_zorders_three_deep_dynamic_layers_reduced(self):
-        area = DynamicMap(lambda: Area(range(10)), kdims=[])
-        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
-        curve2 = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area = hv.DynamicMap(lambda: hv.Area(range(10)), kdims=[])
+        curve = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
+        curve2 = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         area_redim = area.redim(x='x2')
         curve_redim = curve.redim(x='x2')
         curve2_redim = curve2.redim(x='x3')
-        combined = (area_redim*curve_redim).map(lambda x: x.get(0), Overlay)
+        combined = (area_redim*curve_redim).map(lambda x: x.get(0), hv.Overlay)
         combined1 = combined*curve2_redim
         combined1[()]
         sources = compute_overlayable_zorders(combined1)
@@ -301,14 +289,14 @@ class TestOverlayableZorders:
 
 
     def test_dynamic_compute_overlayable_zorders_three_deep_dynamic_layers_reduced_layers_by_one(self):
-        area = DynamicMap(lambda: Area(range(10)), kdims=[])
-        area2 = DynamicMap(lambda: Area(range(10)), kdims=[])
-        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
-        curve2 = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area = hv.DynamicMap(lambda: hv.Area(range(10)), kdims=[])
+        area2 = hv.DynamicMap(lambda: hv.Area(range(10)), kdims=[])
+        curve = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
+        curve2 = hv.DynamicMap(lambda: hv.Curve(range(10)), kdims=[])
         area_redim = area.redim(x='x2')
         curve_redim = curve.redim(x='x2')
         curve2_redim = curve2.redim(x='x3')
-        combined = (area_redim*curve_redim*area2).map(lambda x: x.clone(x.items()[:2]), Overlay)
+        combined = (area_redim*curve_redim*area2).map(lambda x: x.clone(x.items()[:2]), hv.Overlay)
         combined1 = combined*curve2_redim
         combined1[()]
         sources = compute_overlayable_zorders(combined1)
@@ -339,14 +327,14 @@ class TestOverlayableZorders:
 class TestInitializeDynamic:
 
     def test_dynamicmap_default_initializes(self):
-        dims = [Dimension('N', default=5, range=(0, 10))]
-        dmap = DynamicMap(lambda N: Curve([1, N, 5]), kdims=dims)
+        dims = [hv.Dimension('N', default=5, range=(0, 10))]
+        dmap = hv.DynamicMap(lambda N: hv.Curve([1, N, 5]), kdims=dims)
         initialize_dynamic(dmap)
         assert dmap.keys() == [5]
 
     def test_dynamicmap_numeric_values_initializes(self):
-        dims = [Dimension('N', values=[10, 5, 0])]
-        dmap = DynamicMap(lambda N: Curve([1, N, 5]), kdims=dims)
+        dims = [hv.Dimension('N', values=[10, 5, 0])]
+        dmap = hv.DynamicMap(lambda N: hv.Curve([1, N, 5]), kdims=dims)
         initialize_dynamic(dmap)
         assert dmap.keys() == [0]
 
@@ -358,13 +346,13 @@ class TestSplitDynamicMapOverlay:
     """
 
     def setup_method(self):
-        self.dmap_element = DynamicMap(lambda: Image([]))
-        self.dmap_overlay = DynamicMap(lambda: Overlay([Curve([]), Points([])]))
-        self.dmap_ndoverlay = DynamicMap(lambda: NdOverlay({0: Curve([]), 1: Curve([])}))
-        self.element = Scatter([])
-        self.el1, self.el2 = Path([]), HLine(0)
-        self.overlay = Overlay([self.el1, self.el2])
-        self.ndoverlay = NdOverlay({0: VectorField([]), 1: VectorField([])})
+        self.dmap_element = hv.DynamicMap(lambda: hv.Image([]))
+        self.dmap_overlay = hv.DynamicMap(lambda: hv.Overlay([hv.Curve([]), hv.Points([])]))
+        self.dmap_ndoverlay = hv.DynamicMap(lambda: hv.NdOverlay({0: hv.Curve([]), 1: hv.Curve([])}))
+        self.element = hv.Scatter([])
+        self.el1, self.el2 = hv.Path([]), hv.HLine(0)
+        self.overlay = hv.Overlay([self.el1, self.el2])
+        self.ndoverlay = hv.NdOverlay({0: hv.VectorField([]), 1: hv.VectorField([])})
 
     def test_dmap_ndoverlay(self):
         test = self.dmap_ndoverlay
@@ -450,7 +438,7 @@ class TestSplitDynamicMapOverlay:
         assert split_dmap_overlay(test)[0] == layers
 
     def test_dmap_overlay_linked_operation_mul_dmap_element_ndoverlay(self):
-        mapped = self.dmap_overlay.map(lambda x: x.get(0), Overlay)
+        mapped = self.dmap_overlay.map(lambda x: x.get(0), hv.Overlay)
         test = mapped * self.element * self.dmap_ndoverlay
         initialize_dynamic(test)
         layers = [mapped, self.element, self.dmap_ndoverlay]
@@ -464,7 +452,7 @@ class TestPlotColorUtils:
         assert colors == ['#ffffff', '#959595', '#000000', '#ffffff']
 
     def test_process_cmap_cycle(self):
-        colors = process_cmap(Cycle(values=['#ffffff', '#959595', '#000000']), 4)
+        colors = process_cmap(hv.Cycle(values=['#ffffff', '#959595', '#000000']), 4)
         assert colors == ['#ffffff', '#959595', '#000000', '#ffffff']
 
     def test_process_cmap_invalid_str(self):
@@ -614,28 +602,28 @@ class TestPlotUtils:
         xs, ys = (np.arange(0, 2., .2, dtype='float32'),
                   np.arange(0, 2., .2, dtype='float32'))
         X, Y = np.meshgrid(xs, ys)
-        dist = get_min_distance(Points((X.flatten(), Y.flatten())))
+        dist = get_min_distance(hv.Points((X.flatten(), Y.flatten())))
         assert np.isclose(dist, 0.2)
 
     def test_get_min_distance_int32_type(self):
         xs, ys = (np.arange(0, 10, dtype='int32'),
                   np.arange(0, 10, dtype='int32'))
         X, Y = np.meshgrid(xs, ys)
-        dist = get_min_distance(Points((X.flatten(), Y.flatten())))
+        dist = get_min_distance(hv.Points((X.flatten(), Y.flatten())))
         assert dist == 1.0
 
     def test_get_min_distance_float32_type_no_scipy(self):
         xs, ys = (np.arange(0, 2., .2, dtype='float32'),
                   np.arange(0, 2., .2, dtype='float32'))
         X, Y = np.meshgrid(xs, ys)
-        dist = _get_min_distance_numpy(Points((X.flatten(), Y.flatten())))
+        dist = _get_min_distance_numpy(hv.Points((X.flatten(), Y.flatten())))
         assert np.isclose(dist,np.float32(0.2))
 
     def test_get_min_distance_int32_type_no_scipy(self):
         xs, ys = (np.arange(0, 10, dtype='int32'),
                   np.arange(0, 10, dtype='int32'))
         X, Y = np.meshgrid(xs, ys)
-        dist = _get_min_distance_numpy(Points((X.flatten(), Y.flatten())))
+        dist = _get_min_distance_numpy(hv.Points((X.flatten(), Y.flatten())))
         assert dist == 1.0
 
 
@@ -654,16 +642,16 @@ class TestRangeUtilities:
         assert padding == (0.1, 0.2, 0.3)
 
     def test_get_range_from_element(self):
-        dim = Dimension('y', soft_range=(0, 3), range=(0, 2))
-        element = Scatter([1, 2, 3], vdims=dim)
+        dim = hv.Dimension('y', soft_range=(0, 3), range=(0, 2))
+        element = hv.Scatter([1, 2, 3], vdims=dim)
         drange, srange, hrange = get_range(element, {}, dim)
         assert drange == (1, 3)
         assert srange == (0, 3)
         assert hrange == (0, 2)
 
     def test_get_range_from_ranges(self):
-        dim = Dimension('y', soft_range=(0, 3), range=(0, 2))
-        element = Scatter([1, 2, 3], vdims=dim)
+        dim = hv.Dimension('y', soft_range=(0, 3), range=(0, 2))
+        element = hv.Scatter([1, 2, 3], vdims=dim)
         ranges = {'y': {'soft': (-1, 4), 'hard': (-1, 3), 'data': (-0.5, 2.5)}}
         drange, srange, hrange = get_range(element, ranges, dim)
         assert drange == (-0.5, 2.5)

--- a/holoviews/tests/test_annotators.py
+++ b/holoviews/tests/test_annotators.py
@@ -1,7 +1,6 @@
-from holoviews import Overlay
-from holoviews.annotators import PathAnnotator, PointAnnotator, annotate
-from holoviews.element import Path, Points, Table
-from holoviews.element.tiles import EsriStreet, Tiles
+import holoviews as hv
+from holoviews.annotators import PathAnnotator, PointAnnotator
+from holoviews.element.tiles import EsriStreet
 from holoviews.testing import assert_element_equal
 from holoviews.tests.plotting.bokeh.test_plot import TestBokehPlot
 
@@ -9,51 +8,51 @@ from holoviews.tests.plotting.bokeh.test_plot import TestBokehPlot
 class Test_annotate(TestBokehPlot):
 
     def test_compose_annotators(self):
-        layout1 = annotate(Points([]), annotations=['Label'])
-        layout2 = annotate(Path([]), annotations=['Name'])
+        layout1 = hv.annotate(hv.Points([]), annotations=['Label'])
+        layout2 = hv.annotate(hv.Path([]), annotations=['Name'])
 
-        combined = annotate.compose(layout1, layout2)
+        combined = hv.annotate.compose(layout1, layout2)
         overlay = combined.DynamicMap.I[()]
         tables = combined.Annotator.I[()]
 
-        assert isinstance(overlay, Overlay)
+        assert isinstance(overlay, hv.Overlay)
         assert len(overlay) == 2
-        assert_element_equal(overlay.get(0), Points([], vdims='Label'))
-        assert_element_equal(overlay.get(1), Path([], vdims='Name'))
+        assert_element_equal(overlay.get(0), hv.Points([], vdims='Label'))
+        assert_element_equal(overlay.get(1), hv.Path([], vdims='Name'))
 
-        assert isinstance(tables, Overlay)
+        assert isinstance(tables, hv.Overlay)
         assert len(tables) == 3
 
     def test_annotate_overlay(self):
-        layout = annotate(EsriStreet() * Points([]), annotations=['Label'])
+        layout = hv.annotate(EsriStreet() * hv.Points([]), annotations=['Label'])
 
         overlay = layout.DynamicMap.I[()]
         tables = layout.Annotator.PointAnnotator[()]
 
-        assert isinstance(overlay, Overlay)
+        assert isinstance(overlay, hv.Overlay)
         assert len(overlay) == 2
-        assert isinstance(overlay.get(0), Tiles)
-        assert_element_equal(overlay.get(1), Points([], vdims='Label'))
+        assert isinstance(overlay.get(0), hv.Tiles)
+        assert_element_equal(overlay.get(1), hv.Points([], vdims='Label'))
 
-        assert isinstance(tables, Overlay)
+        assert isinstance(tables, hv.Overlay)
         assert len(tables) == 1
 
     def test_annotated_property(self):
-        annotator = annotate.instance()
-        annotator(Points([]), annotations=['Label'])
+        annotator = hv.annotate.instance()
+        annotator(hv.Points([]), annotations=['Label'])
         assert 'Label' in annotator.annotated
 
     def test_selected_property(self):
-        annotator = annotate.instance()
-        annotator(Points([(1, 2), (2, 3)]), annotations=['Label'])
+        annotator = hv.annotate.instance()
+        annotator(hv.Points([(1, 2), (2, 3)]), annotations=['Label'])
         annotator.annotator._selection.update(index=[1])
-        assert_element_equal(annotator.selected, Points([(2, 3, '')], vdims='Label'))
+        assert_element_equal(annotator.selected, hv.Points([(2, 3, '')], vdims='Label'))
 
 
 class TestPointAnnotator(TestBokehPlot):
 
     def test_add_annotations(self):
-        annotator = PointAnnotator(Points([]), annotations=['Label'])
+        annotator = PointAnnotator(hv.Points([]), annotations=['Label'])
         assert 'Label' in annotator.object
 
     def test_add_name(self):
@@ -63,29 +62,29 @@ class TestPointAnnotator(TestBokehPlot):
         assert annotator.editor._names == ["Test Annotator"]
 
     def test_annotation_type(self):
-        annotator = PointAnnotator(Points([(1, 2)]), annotations={'Int': int})
-        expected = Table([(1, 2, 0)], ['x', 'y'], vdims=['Int'], label='PointAnnotator')
+        annotator = PointAnnotator(hv.Points([(1, 2)]), annotations={'Int': int})
+        expected = hv.Table([(1, 2, 0)], ['x', 'y'], vdims=['Int'], label='PointAnnotator')
         assert_element_equal(annotator._table, expected)
 
     def test_replace_object(self):
-        annotator = PointAnnotator(Points([]), annotations=['Label'])
-        annotator.object = Points([(1, 2)])
+        annotator = PointAnnotator(hv.Points([]), annotations=['Label'])
+        annotator.object = hv.Points([(1, 2)])
         assert 'Label' in annotator.object
-        expected = Table([(1, 2, '')], ['x', 'y'], vdims=['Label'], label='PointAnnotator')
+        expected = hv.Table([(1, 2, '')], ['x', 'y'], vdims=['Label'], label='PointAnnotator')
         assert_element_equal(annotator._table, expected)
         assert annotator._link.target is annotator._table
 
     def test_stream_update(self):
-        annotator = PointAnnotator(Points([(1, 2)]), annotations=['Label'])
+        annotator = PointAnnotator(hv.Points([(1, 2)]), annotations=['Label'])
         annotator._stream.event(data={'x': [1], 'y': [2], 'Label': ['A']})
-        assert_element_equal(annotator.object, Points([(1, 2, 'A')], vdims=['Label']))
+        assert_element_equal(annotator.object, hv.Points([(1, 2, 'A')], vdims=['Label']))
 
 
 
 class TestPathAnnotator(TestBokehPlot):
 
     def test_add_annotations(self):
-        annotator = PathAnnotator(Path([]), annotations=['Label'])
+        annotator = PathAnnotator(hv.Path([]), annotations=['Label'])
         assert 'Label' in annotator.object
 
     def test_add_name(self):
@@ -97,16 +96,16 @@ class TestPathAnnotator(TestBokehPlot):
         assert annotator.editor._names == ["Test Annotator", "Test Annotator Vertices"]
 
     def test_add_vertex_annotations(self):
-        annotator = PathAnnotator(Path([]), vertex_annotations=['Label'])
+        annotator = PathAnnotator(hv.Path([]), vertex_annotations=['Label'])
         assert 'Label' in annotator.object
 
     def test_replace_object(self):
-        annotator = PathAnnotator(Path([]), annotations=['Label'], vertex_annotations=['Value'])
-        annotator.object = Path([(1, 2), (2, 3), (0, 0)])
+        annotator = PathAnnotator(hv.Path([]), annotations=['Label'], vertex_annotations=['Value'])
+        annotator.object = hv.Path([(1, 2), (2, 3), (0, 0)])
         assert 'Label' in annotator.object
-        expected = Table([('')], kdims=['Label'], label='PathAnnotator')
+        expected = hv.Table([('')], kdims=['Label'], label='PathAnnotator')
         assert_element_equal(annotator._table, expected)
-        expected = Table([], ['x', 'y'], 'Value', label='PathAnnotator Vertices')
+        expected = hv.Table([], ['x', 'y'], 'Value', label='PathAnnotator Vertices')
         assert_element_equal(annotator._vertex_table, expected)
         assert annotator._link.target is annotator._table
         assert annotator._vertex_link.target is annotator._vertex_table

--- a/holoviews/tests/test_selection.py
+++ b/holoviews/tests/test_selection.py
@@ -3,10 +3,7 @@ import panel as pn
 import pytest
 
 import holoviews as hv
-from holoviews.core.options import Cycle, Store
-from holoviews.element import ErrorBars, Points, Rectangles, Table, VSpan
 from holoviews.plotting.util import linear_gradient
-from holoviews.selection import link_selections
 from holoviews.streams import SelectionXY
 from holoviews.testing import assert_data_equal, assert_dict_equal, assert_element_equal
 
@@ -69,12 +66,12 @@ class TestLinkSelections:
     @pytest.mark.parametrize("dynamic", [True, False])
     @pytest.mark.parametrize("show_regions", [True, False])
     def test_points_selection(self, dynamic, show_regions):
-        points = Points(self.data)
+        points = hv.Points(self.data)
         if dynamic:
             # Convert points to DynamicMap that returns the element
             points = hv.util.Dynamic(points)
 
-        lnk_sel = link_selections.instance(show_regions=show_regions,
+        lnk_sel = hv.link_selections.instance(show_regions=show_regions,
                                            unselected_color='#ff0000')
         linked = lnk_sel(points)
         current_obj = linked[()]
@@ -105,14 +102,14 @@ class TestLinkSelections:
         self.check_overlay_points_like(selected, lnk_sel, self.data.iloc[1:])
 
         if show_regions:
-            assert_element_equal(region, Rectangles([(0, 1, 5, 5)]))
+            assert_element_equal(region, hv.Rectangles([(0, 1, 5, 5)]))
         else:
-            assert_element_equal(region, Rectangles([]))
+            assert_element_equal(region, hv.Rectangles([]))
 
     def test_layout_selection_points_table(self):
-        points = Points(self.data)
-        table = Table(self.data)
-        lnk_sel = link_selections.instance(
+        points = hv.Points(self.data)
+        table = hv.Table(self.data)
+        lnk_sel = hv.link_selections.instance(
             selected_color="#aa0000", unselected_color='#ff0000'
         )
         linked = lnk_sel(points + table)
@@ -158,7 +155,7 @@ class TestLinkSelections:
             ]
 
     def test_select_expr_show_regions(self):
-        lnk_sel = link_selections.instance()
+        lnk_sel = hv.link_selections.instance()
         assert lnk_sel.show_regions
         se = (
             (hv.dim('x') >= 0) & (hv.dim('x') <= 1) &
@@ -173,9 +170,9 @@ class TestLinkSelections:
 
     @pytest.mark.parametrize("dynamic", [True, False])
     def test_overlay_points_errorbars(self, dynamic):
-        points = Points(self.data)
-        error = ErrorBars(self.data, kdims='x', vdims=['y', 'e'])
-        lnk_sel = link_selections.instance(unselected_color='#ff0000')
+        points = hv.Points(self.data)
+        error = hv.ErrorBars(self.data, kdims='x', vdims=['y', 'e'])
+        lnk_sel = hv.link_selections.instance(unselected_color='#ff0000')
         overlay = points * error
 
         if dynamic:
@@ -212,10 +209,10 @@ class TestLinkSelections:
 
     @ds_skip
     def test_datashade_selection(self):
-        points = Points(self.data)
+        points = hv.Points(self.data)
         layout = points + dynspread(datashade(points))
 
-        lnk_sel = link_selections.instance(unselected_color='#ff0000')
+        lnk_sel = hv.link_selections.instance(unselected_color='#ff0000')
         linked = lnk_sel(layout)
         current_obj = linked[()]
 
@@ -277,10 +274,10 @@ class TestLinkSelections:
 
     @ds_skip
     def test_datashade_in_overlay_selection(self):
-        points = Points(self.data)
+        points = hv.Points(self.data)
         layout = points * dynspread(datashade(points))
 
-        lnk_sel = link_selections.instance(unselected_color='#ff0000')
+        lnk_sel = hv.link_selections.instance(unselected_color='#ff0000')
         linked = lnk_sel(layout)
         current_obj = linked[()]
 
@@ -342,8 +339,8 @@ class TestLinkSelections:
 
     def test_points_selection_streaming(self):
         buffer = hv.streams.Buffer(self.data.iloc[:2], index=False)
-        points = hv.DynamicMap(Points, streams=[buffer])
-        lnk_sel = link_selections.instance(unselected_color='#ff0000')
+        points = hv.DynamicMap(hv.Points, streams=[buffer])
+        lnk_sel = hv.link_selections.instance(unselected_color='#ff0000')
         linked = lnk_sel(points)
 
         # Perform selection of first and (future) third point
@@ -381,7 +378,7 @@ class TestLinkSelections:
             selected3, selected4, points_region1, points_region2,
             points_region3, points_region4, hist_region2, hist_region3,
             hist_region4, show_regions=True, dynamic=False):
-        points = Points(self.data)
+        points = hv.Points(self.data)
         hist = points.hist('x', adjoin=False, normed=False, num_bins=5)
 
         if dynamic:
@@ -391,7 +388,7 @@ class TestLinkSelections:
         else:
             hist_orig = hist
 
-        lnk_sel = link_selections.instance(
+        lnk_sel = hv.link_selections.instance(
             selection_mode=selection_mode,
             cross_filter_mode=cross_filter_mode,
             show_regions=show_regions,
@@ -450,7 +447,7 @@ class TestLinkSelections:
 
         # Check points region bounds
         region_bounds = current_obj[0][()].Rectangles.I
-        assert_element_equal(region_bounds, Rectangles(points_region1))
+        assert_element_equal(region_bounds, hv.Rectangles(points_region1))
 
         if show_regions:
             assert self.element_color(region_bounds) == box_region_color
@@ -468,7 +465,7 @@ class TestLinkSelections:
         # Check points selection overlay
         self.check_overlay_points_like(points_sel, lnk_sel, self.data.iloc[selected2])
 
-        assert_element_equal(points_region, Rectangles(points_region2))
+        assert_element_equal(points_region, hv.Rectangles(points_region2))
 
         # Check base histogram unchanged
         base_hist, region_hist, sel_hist = current_obj[1][()].values()
@@ -503,7 +500,7 @@ class TestLinkSelections:
 
         # Check points region bounds
         region_bounds = current_obj[0][()].Rectangles.I
-        assert_element_equal(region_bounds, Rectangles(points_region3))
+        assert_element_equal(region_bounds, hv.Rectangles(points_region3))
 
         # Check second and third histogram bars selected
         selection_hist = current_obj[1][()].Histogram.II
@@ -532,7 +529,7 @@ class TestLinkSelections:
 
         # Check points region bounds
         region_bounds = current_obj[0][()].Rectangles.I
-        assert_element_equal(region_bounds, Rectangles(points_region4))
+        assert_element_equal(region_bounds, hv.Rectangles(points_region4))
 
         # Check bar selection region
         region_hist = current_obj[1][()].NdOverlay.I.last
@@ -658,8 +655,8 @@ class TestLinkSelections:
         )
 
     def test_unlink_points(self):
-        points = Points(self.data)
-        lnk_sel = link_selections.instance(unselected_color='#ff0000')
+        points = hv.Points(self.data)
+        lnk_sel = hv.link_selections.instance(unselected_color='#ff0000')
         linked = lnk_sel(points)
 
         current_obj = linked[()]
@@ -688,9 +685,9 @@ class TestLinkSelections:
         assert len(lnk_sel._cross_filter_stream.input_streams[0].history_stream.values) == 0
 
     def test_unlink_layout_one_object(self):
-        points = Points(self.data)
-        table = Table(self.data)
-        lnk_sel = link_selections.instance(
+        points = hv.Points(self.data)
+        table = hv.Table(self.data)
+        lnk_sel = hv.link_selections.instance(
             selected_color="#aa0000", unselected_color='#ff0000'
         )
         layout = points + table
@@ -716,10 +713,10 @@ class TestLinkSelections:
         assert len(lnk_sel._plot_reset_streams) == 1
 
     def test_unlink_dynamic(self):
-        points = Points(self.data)
+        points = hv.Points(self.data)
         points_dynamic = hv.util.Dynamic(points)
 
-        lnk_sel = link_selections.instance(unselected_color='#ff0000')
+        lnk_sel = hv.link_selections.instance(unselected_color='#ff0000')
         linked = lnk_sel(points_dynamic)
 
         current_obj = linked[()]
@@ -740,10 +737,10 @@ class TestLinkSelections:
         assert len(lnk_sel._plot_reset_streams) == 0
 
     def test_unlink_multiple_objects(self):
-        points1 = Points(self.data)
-        points2 = Points(self.data)
+        points1 = hv.Points(self.data)
+        points2 = hv.Points(self.data)
 
-        lnk_sel = link_selections.instance(unselected_color='#ff0000')
+        lnk_sel = hv.link_selections.instance(unselected_color='#ff0000')
         lnk_sel(points1)
         lnk_sel(points2)
 
@@ -767,10 +764,10 @@ class TestLinkSelections:
         assert len(lnk_sel._plot_reset_streams) == 0
 
     def test_unlink_nonexistent_object_no_error(self):
-        points1 = Points(self.data)
-        points2 = Points(self.data)
+        points1 = hv.Points(self.data)
+        points2 = hv.Points(self.data)
 
-        lnk_sel = link_selections.instance(unselected_color='#ff0000')
+        lnk_sel = hv.link_selections.instance(unselected_color='#ff0000')
         lnk_sel(points1)
 
         lnk_sel.unlink(points2)
@@ -786,22 +783,22 @@ class TestLinkSelectionsPlotly(TestLinkSelections):
 
     def setup_method(self):
         super().setup_method()
-        self._backend = Store.current_backend
-        Store.set_current_backend('plotly')
+        self._backend = hv.Store.current_backend
+        hv.Store.set_current_backend('plotly')
 
     def teardown_method(self):
-        Store.current_backend = self._backend
+        hv.Store.current_backend = self._backend
 
     def element_color(self, element, color_prop=None):
 
-        if isinstance(element, Table):
+        if isinstance(element, hv.Table):
             color = element.opts.get('style').kwargs['fill']
-        elif isinstance(element, (Rectangles, VSpan)):
+        elif isinstance(element, (hv.Rectangles, hv.VSpan)):
             color = element.opts.get('style').kwargs['line_color']
         else:
             color = element.opts.get('style').kwargs['color']
 
-        if isinstance(color, (Cycle, str)):
+        if isinstance(color, (hv.Cycle, str)):
             return color
         else:
             return list(color)
@@ -814,11 +811,11 @@ class TestLinkSelectionsBokeh(TestLinkSelections):
     def setup_method(self):
         import holoviews.plotting.bokeh # noqa
         super().setup_method()
-        self._backend = Store.current_backend
-        Store.set_current_backend('bokeh')
+        self._backend = hv.Store.current_backend
+        hv.Store.set_current_backend('bokeh')
 
     def teardown_method(self):
-        Store.current_backend = self._backend
+        hv.Store.current_backend = self._backend
 
     def element_color(self, element):
         color = element.opts.get('style').kwargs['color']

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -10,9 +10,7 @@ import pytest
 from panel.widgets import IntSlider
 
 import holoviews as hv
-from holoviews.core.spaces import DynamicMap
 from holoviews.core.util import NUMPY_GE_2_0_0, PARAM_VERSION
-from holoviews.element import Curve, Histogram, Points, Polygons, Scatter
 from holoviews.streams import (
     Buffer,
     Derived,
@@ -35,8 +33,7 @@ from holoviews.streams import (
     Tap,
 )
 from holoviews.testing import assert_data_equal, assert_dict_equal, assert_element_equal
-from holoviews.util import Dynamic, extension
-from holoviews.util.transform import dim
+from holoviews.util import Dynamic
 
 from .utils import LoggingComparison, optional_dependencies
 
@@ -440,7 +437,7 @@ class TestParamMethodStream:
             @param.depends('x')
             def method(self):
                 self.count += 1
-                return Points([])
+                return hv.Points([])
 
             @param.depends('action')
             def action_method(self):
@@ -449,7 +446,7 @@ class TestParamMethodStream:
             @param.depends('action', 'x')
             def action_number_method(self):
                 self.count += 1
-                return Points([])
+                return hv.Points([])
 
             @param.depends('y')
             def op_method(self, obj):
@@ -489,48 +486,48 @@ class TestParamMethodStream:
 
         @param.depends(inner.param.x)
         def test(x):
-            return Points([x])
+            return hv.Points([x])
 
-        dmap = DynamicMap(test)
+        dmap = hv.DynamicMap(test)
 
         inner.x = 10
-        assert_element_equal(dmap[()], Points([10]))
+        assert_element_equal(dmap[()], hv.Points([10]))
 
 
     def test_param_instance_steams_dict(self):
         inner = self.inner()
 
         def test(x):
-            return Points([x])
+            return hv.Points([x])
 
-        dmap = DynamicMap(test, streams=dict(x=inner.param.x))
+        dmap = hv.DynamicMap(test, streams=dict(x=inner.param.x))
 
         inner.x = 10
-        assert_element_equal(dmap[()], Points([10]))
+        assert_element_equal(dmap[()], hv.Points([10]))
 
     def test_param_class_steams_dict(self):
         class ClassParamExample(param.Parameterized):
             x = param.Number(default=1)
 
         def test(x):
-            return Points([x])
+            return hv.Points([x])
 
-        dmap = DynamicMap(test, streams=dict(x=ClassParamExample.param.x))
+        dmap = hv.DynamicMap(test, streams=dict(x=ClassParamExample.param.x))
 
         ClassParamExample.x = 10
-        assert_element_equal(dmap[()], Points([10]))
+        assert_element_equal(dmap[()], hv.Points([10]))
 
     def test_panel_param_steams_dict(self):
         import panel as pn
         widget = pn.widgets.FloatSlider(value=1)
 
         def test(x):
-            return Points([x])
+            return hv.Points([x])
 
-        dmap = DynamicMap(test, streams=dict(x=widget))
+        dmap = hv.DynamicMap(test, streams=dict(x=widget))
 
         widget.value = 10
-        assert_element_equal(dmap[()], Points([10]))
+        assert_element_equal(dmap[()], hv.Points([10]))
 
 
     def test_param_method_depends_no_deps(self):
@@ -566,7 +563,7 @@ class TestParamMethodStream:
 
     def test_dynamicmap_param_method_deps(self):
         inner = self.inner()
-        dmap = DynamicMap(inner.method)
+        dmap = hv.DynamicMap(inner.method)
         assert len(dmap.streams) == 1
         stream = dmap.streams[0]
         assert isinstance(stream, ParamMethod)
@@ -598,7 +595,7 @@ class TestParamMethodStream:
 
     def test_dynamicmap_param_method_deps_memoization(self):
         inner = self.inner()
-        dmap = DynamicMap(inner.method)
+        dmap = hv.DynamicMap(inner.method)
         stream = dmap.streams[0]
         assert set(stream.parameters) == {inner.param.x}
         assert stream.contents == {}
@@ -609,12 +606,12 @@ class TestParamMethodStream:
 
     def test_dynamicmap_param_method_no_deps(self):
         inner = self.inner()
-        dmap = DynamicMap(inner.method_no_deps)
+        dmap = hv.DynamicMap(inner.method_no_deps)
         assert dmap.streams == []
 
     def test_dynamicmap_param_method_action_param(self):
         inner = self.inner()
-        dmap = DynamicMap(inner.action_method)
+        dmap = hv.DynamicMap(inner.action_method)
         assert len(dmap.streams) == 1
         stream = dmap.streams[0]
         assert set(stream.parameters) == {inner.param.action}
@@ -632,7 +629,7 @@ class TestParamMethodStream:
 
     def test_dynamicmap_param_action_number_method_memoizes(self):
         inner = self.inner()
-        dmap = DynamicMap(inner.action_number_method)
+        dmap = hv.DynamicMap(inner.action_number_method)
         assert len(dmap.streams) == 1
         stream = dmap.streams[0]
         assert set(stream.parameters) == {inner.param.action, inner.param.x}
@@ -655,7 +652,7 @@ class TestParamMethodStream:
 
     def test_dynamicmap_param_method_dynamic_operation(self):
         inner = self.inner()
-        dmap = DynamicMap(inner.method)
+        dmap = hv.DynamicMap(inner.method)
         inner_stream = dmap.streams[0]
         op_dmap = Dynamic(dmap, operation=inner.op_method)
         assert len(op_dmap.streams) == 1
@@ -683,12 +680,12 @@ def test_dynamicmap_partial_bind_and_streams():
     # Ref: https://github.com/holoviz/holoviews/issues/6008
 
     def make_plot(z, x_range, y_range):
-        return Curve([1, 2, 3, 4, z])
+        return hv.Curve([1, 2, 3, 4, z])
 
     slider = IntSlider(name='Slider', start=0, end=10)
     range_xy = RangeXY()
 
-    dmap = DynamicMap(param.bind(make_plot, z=slider), streams=[range_xy])
+    dmap = hv.DynamicMap(param.bind(make_plot, z=slider), streams=[range_xy])
 
     bk_figure = hv.render(dmap)
 
@@ -756,10 +753,10 @@ class TestSubscribers:
     def test_pipe_memoization(self):
         def points(data):
             subscriber.call_count += 1
-            return Points([(0, data)])
+            return hv.Points([(0, data)])
 
         stream = Pipe(data=0)
-        dmap = DynamicMap(points, streams=[stream])
+        dmap = hv.DynamicMap(points, streams=[stream])
         def cb():
             dmap[()]
         subscriber = _Subscriber(cb)
@@ -780,31 +777,31 @@ class TestStreamSource:
             Stream.registry = defaultdict(list)
 
     def test_source_empty_element(self):
-        points = Points([])
+        points = hv.Points([])
         stream = PointerX(source=points)
         assert stream.source is points
 
     def test_source_empty_element_remap(self):
-        points = Points([])
+        points = hv.Points([])
         stream = PointerX(source=points)
         assert stream.source is points
-        curve = Curve([])
+        curve = hv.Curve([])
         stream.source = curve
         assert points not in Stream.registry
         assert curve in Stream.registry
 
     def test_source_empty_dmap(self):
-        points_dmap = DynamicMap(lambda x: Points([]), kdims=['X'])
+        points_dmap = hv.DynamicMap(lambda x: hv.Points([]), kdims=['X'])
         stream = PointerX(source=points_dmap)
         assert stream.source is points_dmap
 
     def test_source_registry(self):
-        points = Points([(0, 0)])
+        points = hv.Points([(0, 0)])
         PointerX(source=points)
         assert points in Stream.registry
 
     def test_source_registry_empty_element(self):
-        points = Points([])
+        points = hv.Points([])
         PointerX(source=points)
         assert points in Stream.registry
 
@@ -1216,10 +1213,10 @@ class TestHistoryStream:
 class TestExprSelectionStream:
 
     def setup_method(self):
-        extension("bokeh")
+        hv.extension("bokeh")
 
     def test_selection_expr_stream_2D_elements(self):
-        element_type_2D = [Points]
+        element_type_2D = [hv.Points]
         for element_type in element_type_2D:
             # Create SelectionExpr on element
             element = element_type(([1, 2, 3], [1, 5, 10]))
@@ -1237,11 +1234,11 @@ class TestExprSelectionStream:
             expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
 
             # Check SelectionExpr values
-            assert repr(expr_stream.selection_expr) == repr(((dim('x')>=1)&(dim('x')<=3))&((dim('y')>=1)&(dim('y')<=4)))
+            assert repr(expr_stream.selection_expr) == repr(((hv.dim('x')>=1)&(hv.dim('x')<=3))&((hv.dim('y')>=1)&(hv.dim('y')<=4)))
             assert expr_stream.bbox == {'x': (1, 3), 'y': (1, 4)}
 
     def test_selection_expr_stream_1D_elements(self):
-        element_type_1D = [Scatter]
+        element_type_1D = [hv.Scatter]
         for element_type in element_type_1D:
             # Create SelectionExpr on element
             element = element_type(([1, 2, 3], [1, 5, 10]))
@@ -1257,12 +1254,12 @@ class TestExprSelectionStream:
             expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
 
             # Check SelectionExpr values
-            assert repr(expr_stream.selection_expr) == repr((dim('x')>=1)&(dim('x')<=3))
+            assert repr(expr_stream.selection_expr) == repr((hv.dim('x')>=1)&(hv.dim('x')<=3))
             assert expr_stream.bbox == {'x': (1, 3)}
 
 
     def test_selection_expr_stream_invert_axes_2D_elements(self):
-        element_type_2D = [Points]
+        element_type_2D = [hv.Points]
         for element_type in element_type_2D:
             # Create SelectionExpr on element
             element = element_type(([1, 2, 3], [1, 5, 10])).opts(invert_axes=True)
@@ -1280,11 +1277,11 @@ class TestExprSelectionStream:
             expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
 
             # Check SelectionExpr values
-            assert repr(expr_stream.selection_expr) == repr(((dim('y')>=1)&(dim('y')<=3))&((dim('x')>=1)&(dim('x')<=4)))
+            assert repr(expr_stream.selection_expr) == repr(((hv.dim('y')>=1)&(hv.dim('y')<=3))&((hv.dim('x')>=1)&(hv.dim('x')<=4)))
             assert expr_stream.bbox == {'y': (1, 3), 'x': (1, 4)}
 
     def test_selection_expr_stream_invert_axes_1D_elements(self):
-        element_type_1D = [Scatter]
+        element_type_1D = [hv.Scatter]
         for element_type in element_type_1D:
             # Create SelectionExpr on element
             element = element_type(([1, 2, 3], [1, 5, 10])).opts(invert_axes=True)
@@ -1300,11 +1297,11 @@ class TestExprSelectionStream:
             expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
 
             # Check SelectionExpr values
-            assert repr(expr_stream.selection_expr) == repr((dim('x')>=1)&(dim('x')<=4))
+            assert repr(expr_stream.selection_expr) == repr((hv.dim('x')>=1)&(hv.dim('x')<=4))
             assert expr_stream.bbox == {'x': (1, 4)}
 
     def test_selection_expr_stream_invert_xaxis_yaxis_2D_elements(self):
-        element_type_2D = [Points]
+        element_type_2D = [hv.Points]
         for element_type in element_type_2D:
 
             # Create SelectionExpr on element
@@ -1326,11 +1323,11 @@ class TestExprSelectionStream:
             expr_stream.input_streams[0].event(bounds=(3, 4, 1, 1))
 
             # Check SelectionExpr values
-            assert repr(expr_stream.selection_expr) == repr(((dim('x')>=1)&(dim('x')<=3))&((dim('y')>=1)&(dim('y')<=4)))
+            assert repr(expr_stream.selection_expr) == repr(((hv.dim('x')>=1)&(hv.dim('x')<=3))&((hv.dim('y')>=1)&(hv.dim('y')<=4)))
             assert expr_stream.bbox == {'x': (1, 3), 'y': (1, 4)}
 
     def test_selection_expr_stream_invert_xaxis_yaxis_1D_elements(self):
-        element_type_1D = [Scatter]
+        element_type_1D = [hv.Scatter]
         for element_type in element_type_1D:
 
             # Create SelectionExpr on element
@@ -1350,12 +1347,12 @@ class TestExprSelectionStream:
             expr_stream.input_streams[0].event(bounds=(3, 4, 1, 1))
 
             # Check SelectionExpr values
-            assert repr(expr_stream.selection_expr) == repr((dim('x')>=1)&(dim('x')<=3))
+            assert repr(expr_stream.selection_expr) == repr((hv.dim('x')>=1)&(hv.dim('x')<=3))
             assert expr_stream.bbox == {'x': (1, 3)}
 
     def test_selection_expr_stream_hist(self):
         # Create SelectionExpr on element
-        hist = Histogram(([1, 2, 3, 4, 5], [1, 5, 2, 3, 7]))
+        hist = hv.Histogram(([1, 2, 3, 4, 5], [1, 5, 2, 3, 7]))
         expr_stream = SelectionExpr(hist)
 
         # Check stream properties
@@ -1367,19 +1364,19 @@ class TestExprSelectionStream:
         # Simulate interactive update by triggering source stream.
         # Select second and forth bar.
         expr_stream.input_streams[0].event(bounds=(1.5, 2.5, 4.6, 6))
-        assert repr(expr_stream.selection_expr) == repr((dim('x')>=1.5)&(dim('x')<=4.6))
+        assert repr(expr_stream.selection_expr) == repr((hv.dim('x')>=1.5)&(hv.dim('x')<=4.6))
         assert expr_stream.bbox == {'x': (1.5, 4.6)}
 
         # Select third, forth, and fifth bar.  Make sure there is special
         # handling when last bar is selected to include values exactly on the
         # upper edge in the selection
         expr_stream.input_streams[0].event(bounds=(2.5, -10, 8, 10))
-        assert repr(expr_stream.selection_expr) == repr((dim('x')>=2.5)&(dim('x')<=8))
+        assert repr(expr_stream.selection_expr) == repr((hv.dim('x')>=2.5)&(hv.dim('x')<=8))
         assert expr_stream.bbox == {'x': (2.5, 8)}
 
     def test_selection_expr_stream_hist_invert_axes(self):
         # Create SelectionExpr on element
-        hist = Histogram(([1, 2, 3, 4, 5], [1, 5, 2, 3, 7])).opts(
+        hist = hv.Histogram(([1, 2, 3, 4, 5], [1, 5, 2, 3, 7])).opts(
             invert_axes=True
         )
         expr_stream = SelectionExpr(hist)
@@ -1393,19 +1390,19 @@ class TestExprSelectionStream:
         # Simulate interactive update by triggering source stream.
         # Select second and forth bar.
         expr_stream.input_streams[0].event(bounds=(2.5, 1.5, 6, 4.6))
-        assert repr(expr_stream.selection_expr) == repr((dim('x')>=1.5)&(dim('x')<=4.6))
+        assert repr(expr_stream.selection_expr) == repr((hv.dim('x')>=1.5)&(hv.dim('x')<=4.6))
         assert expr_stream.bbox == {'x': (1.5, 4.6)}
 
         # Select third, forth, and fifth bar.  Make sure there is special
         # handling when last bar is selected to include values exactly on the
         # upper edge in the selection
         expr_stream.input_streams[0].event(bounds=(-10, 2.5, 10, 8))
-        assert repr(expr_stream.selection_expr) == repr((dim('x')>=2.5)&(dim('x')<=8))
+        assert repr(expr_stream.selection_expr) == repr((hv.dim('x')>=2.5)&(hv.dim('x')<=8))
         assert expr_stream.bbox == {'x': (2.5, 8)}
 
     def test_selection_expr_stream_hist_invert_xaxis_yaxis(self):
         # Create SelectionExpr on element
-        hist = Histogram(([1, 2, 3, 4, 5], [1, 5, 2, 3, 7])).opts(
+        hist = hv.Histogram(([1, 2, 3, 4, 5], [1, 5, 2, 3, 7])).opts(
                 invert_xaxis=True,
                 invert_yaxis=True,
         )
@@ -1420,20 +1417,20 @@ class TestExprSelectionStream:
         # Simulate interactive update by triggering source stream.
         # Select second and forth bar.
         expr_stream.input_streams[0].event(bounds=(4.6, 6, 1.5, 2.5))
-        assert repr(expr_stream.selection_expr) == repr((dim('x')>=1.5)&(dim('x')<=4.6))
+        assert repr(expr_stream.selection_expr) == repr((hv.dim('x')>=1.5)&(hv.dim('x')<=4.6))
         assert expr_stream.bbox == {'x': (1.5, 4.6)}
 
         # Select third, forth, and fifth bar.  Make sure there is special
         # handling when last bar is selected to include values exactly on the
         # upper edge in the selection
         expr_stream.input_streams[0].event(bounds=(8, 10, 2.5, -10))
-        assert repr(expr_stream.selection_expr) == repr((dim('x')>=2.5)&(dim('x')<=8))
+        assert repr(expr_stream.selection_expr) == repr((hv.dim('x')>=2.5)&(hv.dim('x')<=8))
         assert expr_stream.bbox == {'x': (2.5, 8)}
 
 
     @shapely_skip
     def test_selection_expr_stream_polygon_index_cols(self):
-        poly = Polygons([
+        poly = hv.Polygons([
             [(0, 0, 'a'), (2, 0, 'a'), (1, 1, 'a')],
             [(2, 0, 'b'), (4, 0, 'b'), (3, 1, 'b')],
             [(1, 1, 'c'), (3, 1, 'c'), (2, 2, 'c')]
@@ -1454,28 +1451,28 @@ class TestExprSelectionStream:
         fmt = lambda x: list(map(np.str_, x)) if NUMPY_GE_2_0_0 else x
 
         expr_stream.input_streams[2].event(index=[0, 1])
-        assert repr(expr_stream.selection_expr) == repr(dim('cat').isin(fmt(['a', 'b'])))
+        assert repr(expr_stream.selection_expr) == repr(hv.dim('cat').isin(fmt(['a', 'b'])))
         assert expr_stream.bbox is None
         assert len(events) == 1
 
         # Ensure bounds event does not trigger another update
         expr_stream.input_streams[0].event(bounds=(0, 0, 4, 1))
-        assert repr(expr_stream.selection_expr) == repr(dim('cat').isin(fmt(['a', 'b'])))
+        assert repr(expr_stream.selection_expr) == repr(hv.dim('cat').isin(fmt(['a', 'b'])))
         assert len(events) == 1
 
         # Ensure geometry event does trigger another update
         expr_stream.input_streams[1].event(geometry=np.array([(0, 0), (4, 0), (4, 2), (0, 2)]))
-        assert repr(expr_stream.selection_expr) == repr(dim('cat').isin(fmt(['a', 'b', 'c'])))
+        assert repr(expr_stream.selection_expr) == repr(hv.dim('cat').isin(fmt(['a', 'b', 'c'])))
         assert len(events) == 2
 
         # Ensure index event does trigger another update
         expr_stream.input_streams[2].event(index=[1, 2])
-        assert repr(expr_stream.selection_expr) == repr(dim('cat').isin(fmt(['b', 'c'])))
+        assert repr(expr_stream.selection_expr) == repr(hv.dim('cat').isin(fmt(['b', 'c'])))
         assert expr_stream.bbox is None
         assert len(events) == 3
 
     def test_selection_expr_stream_dynamic_map_2D_elements(self):
-        element_type_2D = [Points]
+        element_type_2D = [hv.Points]
         for element_type in element_type_2D: # Scatter,
             # Create SelectionExpr on element
             dmap = Dynamic(element_type(([1, 2, 3], [1, 5, 10])))
@@ -1491,11 +1488,11 @@ class TestExprSelectionStream:
             expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
 
             # Check SelectionExpr values
-            assert repr(expr_stream.selection_expr) == repr(((dim('x')>=1)&(dim('x')<=3))&((dim('y')>=1)&(dim('y')<=4)))
+            assert repr(expr_stream.selection_expr) == repr(((hv.dim('x')>=1)&(hv.dim('x')<=3))&((hv.dim('y')>=1)&(hv.dim('y')<=4)))
             assert expr_stream.bbox == {'x': (1, 3), 'y': (1, 4)}
 
     def test_selection_expr_stream_dynamic_map_1D_elements(self):
-        element_type_1D = [Scatter]
+        element_type_1D = [hv.Scatter]
         for element_type in element_type_1D:
             # Create SelectionExpr on element
             dmap = Dynamic(element_type(([1, 2, 3], [1, 5, 10])))
@@ -1511,5 +1508,5 @@ class TestExprSelectionStream:
             expr_stream.input_streams[0].event(bounds=(1, 1, 3, 4))
 
             # Check SelectionExpr values
-            assert repr(expr_stream.selection_expr) == repr((dim('x')>=1)&(dim('x')<=3))
+            assert repr(expr_stream.selection_expr) == repr((hv.dim('x')>=1)&(hv.dim('x')<=3))
             assert expr_stream.bbox == {'x': (1, 3)}

--- a/holoviews/tests/testing/test_chart.py
+++ b/holoviews/tests/testing/test_chart.py
@@ -5,7 +5,7 @@ Test cases for the Comparisons class over the Chart elements
 import numpy as np
 import pytest
 
-from holoviews import Bars, Curve, Dimension, Histogram, Points, Scatter, VectorField
+import holoviews as hv
 from holoviews.testing import assert_element_equal
 
 
@@ -14,8 +14,8 @@ class CurveComparisonTest:
     def setup_method(self):
         "Variations on the constructors in the Elements notebook"
 
-        self.curve1 = Curve([(0.1*i, np.sin(0.1*i)) for i in range(100)])
-        self.curve2 = Curve([(0.1*i, np.sin(0.1*i)) for i in range(101)])
+        self.curve1 = hv.Curve([(0.1*i, np.sin(0.1*i)) for i in range(100)])
+        self.curve2 = hv.Curve([(0.1*i, np.sin(0.1*i)) for i in range(101)])
 
     def test_curves_equal(self):
         assert_element_equal(self.curve1, self.curve1)
@@ -31,14 +31,14 @@ class BarsComparisonTest:
     def setup_method(self):
         "Variations on the constructors in the Elements notebook"
 
-        key_dims1=[Dimension('Car occupants')]
-        key_dims2=[Dimension('Cyclists')]
+        key_dims1=[hv.Dimension('Car occupants')]
+        key_dims2=[hv.Dimension('Cyclists')]
         value_dims1=['Count']
-        self.bars1 = Bars([('one',8),('two', 10), ('three', 16)],
+        self.bars1 = hv.Bars([('one',8),('two', 10), ('three', 16)],
                           kdims=key_dims1, vdims=value_dims1)
-        self.bars2 = Bars([('one',8),('two', 10), ('three', 17)],
+        self.bars2 = hv.Bars([('one',8),('two', 10), ('three', 17)],
                           kdims=key_dims1, vdims=value_dims1)
-        self.bars3 = Bars([('one',8),('two', 10), ('three', 16)],
+        self.bars3 = hv.Bars([('one',8),('two', 10), ('three', 16)],
                           kdims=key_dims2, vdims=value_dims1)
 
     def test_bars_equal_1(self):
@@ -70,12 +70,12 @@ class HistogramComparisonTest:
 
         np.random.seed(1)
         frequencies1, edges1 = np.histogram([np.random.normal() for i in range(1000)], 20)
-        self.hist1 = Histogram((edges1, frequencies1))
+        self.hist1 = hv.Histogram((edges1, frequencies1))
         np.random.seed(2)
         frequencies2, edges2 =  np.histogram([np.random.normal() for i in range(1000)], 20)
-        self.hist2 = Histogram((edges2, frequencies2))
-        self.hist3 = Histogram((edges2, frequencies1))
-        self.hist4 = Histogram((edges1, frequencies2))
+        self.hist2 = hv.Histogram((edges2, frequencies2))
+        self.hist3 = hv.Histogram((edges2, frequencies1))
+        self.hist4 = hv.Histogram((edges1, frequencies2))
 
     def test_histograms_equal_1(self):
         assert_element_equal(self.hist1, self.hist1)
@@ -102,9 +102,9 @@ class ScatterComparisonTest:
     def setup_method(self):
         "Variations on the constructors in the Elements notebook"
 
-        self.scatter1 = Scatter([(1, i) for i in range(20)])
-        self.scatter2 = Scatter([(1, i) for i in range(21)])
-        self.scatter3 = Scatter([(1, i*2) for i in range(20)])
+        self.scatter1 = hv.Scatter([(1, i) for i in range(20)])
+        self.scatter2 = hv.Scatter([(1, i) for i in range(21)])
+        self.scatter3 = hv.Scatter([(1, i*2) for i in range(20)])
 
 
     def test_scatter_equal_1(self):
@@ -132,9 +132,9 @@ class PointsComparisonTest:
     def setup_method(self):
         "Variations on the constructors in the Elements notebook"
 
-        self.points1 = Points([(1, i) for i in range(20)])
-        self.points2 = Points([(1, i) for i in range(21)])
-        self.points3 = Points([(1, i*2) for i in range(20)])
+        self.points1 = hv.Points([(1, i) for i in range(20)])
+        self.points2 = hv.Points([(1, i) for i in range(21)])
+        self.points3 = hv.Points([(1, i*2) for i in range(20)])
 
 
     def test_points_equal_1(self):
@@ -167,8 +167,8 @@ class VectorFieldComparisonTest:
         exp_falloff1 = 1/np.exp((x**2+y**2)/8)
         exp_falloff2 = 1/np.exp((x**2+y**2)/9)
 
-        self.vfield1 = VectorField([x,y,sine_rings, exp_falloff1])
-        self.vfield2 = VectorField([x,y,sine_rings, exp_falloff2])
+        self.vfield1 = hv.VectorField([x,y,sine_rings, exp_falloff1])
+        self.vfield2 = hv.VectorField([x,y,sine_rings, exp_falloff2])
 
 
     def test_vfield_equal_1(self):

--- a/holoviews/tests/testing/test_composite.py
+++ b/holoviews/tests/testing/test_composite.py
@@ -9,18 +9,18 @@ HoloMaps are not tested in this file.
 
 import pytest
 
-from holoviews import Element
+import holoviews as hv
 from holoviews.testing import assert_element_equal
 
 
 class CompositeComparisonTestCase:
 
     def setup_method(self):
-        self.el1 = Element('data1')
-        self.el2 = Element('data2')
-        self.el3 = Element('data3')
-        self.el4 = Element('data5', group='ValB')
-        self.el5 = Element('data6', label='LabelA')
+        self.el1 = hv.Element('data1')
+        self.el2 = hv.Element('data2')
+        self.el3 = hv.Element('data3')
+        self.el4 = hv.Element('data5', group='ValB')
+        self.el5 = hv.Element('data6', label='LabelA')
 
     #========================#
     # Tests for layout trees #

--- a/holoviews/tests/testing/test_dimension.py
+++ b/holoviews/tests/testing/test_dimension.py
@@ -3,37 +3,38 @@ Test cases for Dimension and Dimensioned object comparison.
 """
 import pytest
 
-from holoviews.core import Dimension, Dimensioned
+import holoviews as hv
+from holoviews.core import Dimensioned
 from holoviews.testing import assert_element_equal
 
 
 class DimensionsComparisonTestCase:
 
     def setup_method(self):
-        self.dimension1 = Dimension('dim1', range=(0,1))
-        self.dimension2 = Dimension('dim2', range=(0,1))
-        self.dimension3 = Dimension('dim1', range=(0,2))
-        self.dimension4 = Dimension('dim1')
-        self.dimension5 = Dimension('dim1', cyclic=True)
-        self.dimension6 = Dimension('dim1', cyclic=True, range=(0,1))
-        self.dimension7 = Dimension('dim1', cyclic=True, range=(0,1), unit='ms')
-        self.dimension8 = Dimension('dim1', values=['a', 'b'])
-        self.dimension9 = Dimension('dim1', type=int)
-        self.dimension10 = Dimension('dim1', type=float)
-        self.dimension11 = Dimension(('dim1','Test Dimension'), range=(0,1))
-        self.dimension12 = Dimension('dim1', value_format=lambda x: x)
-        self.dimension13 = Dimension('dim1', value_format=lambda x: x)
+        self.dimension1 = hv.Dimension('dim1', range=(0,1))
+        self.dimension2 = hv.Dimension('dim2', range=(0,1))
+        self.dimension3 = hv.Dimension('dim1', range=(0,2))
+        self.dimension4 = hv.Dimension('dim1')
+        self.dimension5 = hv.Dimension('dim1', cyclic=True)
+        self.dimension6 = hv.Dimension('dim1', cyclic=True, range=(0,1))
+        self.dimension7 = hv.Dimension('dim1', cyclic=True, range=(0,1), unit='ms')
+        self.dimension8 = hv.Dimension('dim1', values=['a', 'b'])
+        self.dimension9 = hv.Dimension('dim1', type=int)
+        self.dimension10 = hv.Dimension('dim1', type=float)
+        self.dimension11 = hv.Dimension(('dim1','Test Dimension'), range=(0,1))
+        self.dimension12 = hv.Dimension('dim1', value_format=lambda x: x)
+        self.dimension13 = hv.Dimension('dim1', value_format=lambda x: x)
 
     def test_dimension_comparison_equal1(self):
         assert_element_equal(self.dimension1, self.dimension1)
 
     def test_dimension_comparison_equal2(self):
         assert_element_equal(self.dimension1,
-                         Dimension('dim1', range=(0,1)))
+                         hv.Dimension('dim1', range=(0,1)))
 
     def test_dimension_comparison_equal3(self):
         assert_element_equal(self.dimension7,
-                         Dimension('dim1', cyclic=True, range=(0,1), unit='ms'))
+                         hv.Dimension('dim1', cyclic=True, range=(0,1), unit='ms'))
 
     def test_dimension_comparison_names_unequal(self):
         msg = "'dim1' == 'dim2'"
@@ -85,11 +86,11 @@ class DimensionedComparisonTestCase:
 
     def setup_method(self):
         # Value dimension lists
-        self.value_list1 = [Dimension('val1')]
-        self.value_list2 = [Dimension('val2')]
+        self.value_list1 = [hv.Dimension('val1')]
+        self.value_list2 = [hv.Dimension('val2')]
         # Key dimension lists
-        self.key_list1 = [Dimension('key1')]
-        self.key_list2 = [Dimension('key2')]
+        self.key_list1 = [hv.Dimension('key1')]
+        self.key_list2 = [hv.Dimension('key2')]
         # Dimensioned instances
         self.dimensioned1 = Dimensioned('data1', vdims=self.value_list1,
                                         kdims=self.key_list1)

--- a/holoviews/tests/testing/test_path.py
+++ b/holoviews/tests/testing/test_path.py
@@ -4,36 +4,36 @@ Test cases for the Comparisons class over the Path elements
 
 import pytest
 
-from holoviews import Bounds, Box, Contours, Ellipse, Path
+import holoviews as hv
 from holoviews.testing import assert_element_equal
 
 
 class PathComparisonTest:
 
     def setup_method(self):
-        self.path1 = Path([(-0.3, 0.4), (-0.3, 0.3), (-0.2, 0.3),
+        self.path1 = hv.Path([(-0.3, 0.4), (-0.3, 0.3), (-0.2, 0.3),
                            (-0.2, 0.4),(-0.3, 0.4)])
 
-        self.path2 = Path([(-0.3, 0.4), (-0.3, 0.3), (-0.2, 0.3),
+        self.path2 = hv.Path([(-0.3, 0.4), (-0.3, 0.3), (-0.2, 0.3),
                            (-0.2, 0.4),(-3, 4)])
 
-        self.contours1 = Contours([(-0.3, 0.4, 1), (-0.3, 0.3, 1), (-0.2, 0.3, 1),
+        self.contours1 = hv.Contours([(-0.3, 0.4, 1), (-0.3, 0.3, 1), (-0.2, 0.3, 1),
                                    (-0.2, 0.4, 1),(-0.3, 0.4, 1)], vdims='Level')
 
-        self.contours2 = Contours([(-0.3, 0.4, 1), (-0.3, 0.3, 1), (-0.2, 0.3, 1),
+        self.contours2 = hv.Contours([(-0.3, 0.4, 1), (-0.3, 0.3, 1), (-0.2, 0.3, 1),
                                    (-0.2, 0.4, 1), (-3, 4, 1)], vdims='Level')
 
-        self.contours3 = Contours([(-0.3, 0.4, 2), (-0.3, 0.3, 2), (-0.2, 0.3, 2),
+        self.contours3 = hv.Contours([(-0.3, 0.4, 2), (-0.3, 0.3, 2), (-0.2, 0.3, 2),
                                    (-0.2, 0.4, 2), (-0.3, 0.4, 2)], vdims='Level')
 
-        self.bounds1 = Bounds(0.3)
-        self.bounds2 = Bounds(0.4)
+        self.bounds1 = hv.Bounds(0.3)
+        self.bounds2 = hv.Bounds(0.4)
 
-        self.box1 = Box(-0.25, 0.3, 0.3)
-        self.box2 = Box(-0.25, 0.3, 0.4)
+        self.box1 = hv.Box(-0.25, 0.3, 0.3)
+        self.box2 = hv.Box(-0.25, 0.3, 0.4)
 
-        self.ellipse1 = Ellipse(-0.25, 0.3, 0.3)
-        self.ellipse2 = Ellipse(-0.25, 0.3, 0.4)
+        self.ellipse1 = hv.Ellipse(-0.25, 0.3, 0.3)
+        self.ellipse2 = hv.Ellipse(-0.25, 0.3, 0.4)
 
     def test_paths_equal(self):
         assert_element_equal(self.path1, self.path1)

--- a/holoviews/tests/testing/test_raster.py
+++ b/holoviews/tests/testing/test_raster.py
@@ -6,9 +6,7 @@ import re
 import numpy as np
 import pytest
 
-from holoviews import Image
-from holoviews.core import BoundingBox, Dimension
-from holoviews.core.element import HoloMap
+import holoviews as hv
 from holoviews.testing import assert_element_equal
 
 
@@ -19,12 +17,12 @@ class RasterTestCase:
         self.arr2 = np.array([[10,2], [3,4]])
         self.arr3 = np.array([[10,2], [3,40]])
         # Varying arrays, default bounds
-        self.mat1 = Image(self.arr1, bounds=BoundingBox())
-        self.mat2 = Image(self.arr2, bounds=BoundingBox())
-        self.mat3 = Image(self.arr3, bounds=BoundingBox())
+        self.mat1 = hv.Image(self.arr1, bounds=hv.BoundingBox())
+        self.mat2 = hv.Image(self.arr2, bounds=hv.BoundingBox())
+        self.mat3 = hv.Image(self.arr3, bounds=hv.BoundingBox())
         # Varying arrays, different bounds
-        self.mat4 = Image(self.arr1, bounds=BoundingBox(radius=0.3))
-        self.mat5 = Image(self.arr2, bounds=BoundingBox(radius=0.3))
+        self.mat4 = hv.Image(self.arr1, bounds=hv.BoundingBox(radius=0.3))
+        self.mat5 = hv.Image(self.arr2, bounds=hv.BoundingBox(radius=0.3))
 
 
 class RasterOverlayTestCase(RasterTestCase):
@@ -45,45 +43,45 @@ class RasterMapTestCase(RasterOverlayTestCase):
     def setup_method(self):
         super().setup_method()
         # Example 1D map
-        self.map1_1D = HoloMap(kdims=['int'])
+        self.map1_1D = hv.HoloMap(kdims=['int'])
         self.map1_1D[0] = self.mat1
         self.map1_1D[1] = self.mat2
         # Changed keys...
-        self.map2_1D = HoloMap(kdims=['int'])
+        self.map2_1D = hv.HoloMap(kdims=['int'])
         self.map2_1D[1] = self.mat1
         self.map2_1D[2] = self.mat2
         # Changed number of keys...
-        self.map3_1D = HoloMap(kdims=['int'])
+        self.map3_1D = hv.HoloMap(kdims=['int'])
         self.map3_1D[1] = self.mat1
         self.map3_1D[2] = self.mat2
         self.map3_1D[3] = self.mat3
         # Changed values...
-        self.map4_1D = HoloMap(kdims=['int'])
+        self.map4_1D = hv.HoloMap(kdims=['int'])
         self.map4_1D[0] = self.mat1
         self.map4_1D[1] = self.mat3
         # Changed bounds...
-        self.map5_1D = HoloMap(kdims=['int'])
+        self.map5_1D = hv.HoloMap(kdims=['int'])
         self.map5_1D[0] = self.mat4
         self.map5_1D[1] = self.mat5
         # Example dimension label
-        self.map6_1D = HoloMap(kdims=['int_v2'])
+        self.map6_1D = hv.HoloMap(kdims=['int_v2'])
         self.map6_1D[0] = self.mat1
         self.map6_1D[1] = self.mat2
         # A HoloMap of Overlays
-        self.map7_1D = HoloMap(kdims=['int'])
+        self.map7_1D = hv.HoloMap(kdims=['int'])
         self.map7_1D[0] =  self.overlay1_depth2
         self.map7_1D[1] =  self.overlay2_depth2
         # A different HoloMap of Overlays
-        self.map8_1D = HoloMap(kdims=['int'])
+        self.map8_1D = hv.HoloMap(kdims=['int'])
         self.map8_1D[0] =  self.overlay2_depth2
         self.map8_1D[1] =  self.overlay1_depth2
 
         # Example 2D map
-        self.map1_2D = HoloMap(kdims=['int', Dimension('float')])
+        self.map1_2D = hv.HoloMap(kdims=['int', hv.Dimension('float')])
         self.map1_2D[0, 0.5] = self.mat1
         self.map1_2D[1, 1.0] = self.mat2
         # Changed 2D keys...
-        self.map2_2D = HoloMap(kdims=['int', Dimension('float')])
+        self.map2_2D = hv.HoloMap(kdims=['int', hv.Dimension('float')])
         self.map2_2D[0, 1.0] = self.mat1
         self.map2_2D[1, 1.5] = self.mat2
 

--- a/holoviews/tests/testing/test_simple.py
+++ b/holoviews/tests/testing/test_simple.py
@@ -8,7 +8,7 @@ import re
 import numpy as np
 import pytest
 
-from holoviews.core import BoundingBox
+import holoviews as hv
 from holoviews.testing import assert_data_equal, assert_element_equal
 
 
@@ -34,22 +34,22 @@ class SimpleComparisonTest:
                              np.array([[1,2],[3,5]], dtype=np.float32))
 
     def test_bounds_equal(self):
-        assert_element_equal(BoundingBox(radius=0.5), BoundingBox(radius=0.5))
+        assert_element_equal(hv.BoundingBox(radius=0.5), hv.BoundingBox(radius=0.5))
 
     def test_bounds_unequal(self):
         msg = "BoundingBox(radius=0.5) == BoundingBox(radius=0.7)"
         with pytest.raises(AssertionError, match=re.escape(msg)):
-            assert_element_equal(BoundingBox(radius=0.5), BoundingBox(radius=0.7))
+            assert_element_equal(hv.BoundingBox(radius=0.5), hv.BoundingBox(radius=0.7))
 
 
     def test_bounds_equal_lbrt(self):
-        assert_element_equal(BoundingBox(points=((-1,-1),(3,4.5))),
-                         BoundingBox(points=((-1,-1),(3,4.5))))
+        assert_element_equal(hv.BoundingBox(points=((-1,-1),(3,4.5))),
+                         hv.BoundingBox(points=((-1,-1),(3,4.5))))
 
     def test_bounds_unequal_lbrt(self):
         msg = 'BoundingBox(points=((-1,-1),(3,4.5))) == BoundingBox(points=((-1,-1),(3,5.0)))'
         with pytest.raises(AssertionError, match=re.escape(msg)):
             assert_element_equal(
-                BoundingBox(points=((-1, -1,), (3, 4.5,),)),
-                BoundingBox(points=((-1, -1,), (3, 5.0,),))
+                hv.BoundingBox(points=((-1, -1,), (3, 4.5,),)),
+                hv.BoundingBox(points=((-1, -1,), (3, 5.0,),))
             )

--- a/holoviews/tests/ui/bokeh/test_autorange.py
+++ b/holoviews/tests/ui/bokeh/test_autorange.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from holoviews.element import Curve
+import holoviews as hv
 from holoviews.plotting.bokeh.renderer import BokehRenderer
 
 from .. import expect, wait_until
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.ui
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_autorange_single(serve_hv):
-    curve = Curve(np.arange(1000)).opts(autorange='y', active_tools=['box_zoom'])
+    curve = hv.Curve(np.arange(1000)).opts(autorange='y', active_tools=['box_zoom'])
 
     plot = BokehRenderer.get_plot(curve)
 
@@ -35,8 +35,8 @@ def test_autorange_single(serve_hv):
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_autorange_single_in_overlay(serve_hv):
-    c1 = Curve(np.arange(1000))
-    c2 = Curve(-np.arange(1000)).opts(autorange='y')
+    c1 = hv.Curve(np.arange(1000))
+    c2 = hv.Curve(-np.arange(1000)).opts(autorange='y')
 
     overlay = (c1*c2).opts(active_tools=['box_zoom'])
 
@@ -61,8 +61,8 @@ def test_autorange_single_in_overlay(serve_hv):
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_autorange_overlay(serve_hv):
-    c1 = Curve(np.arange(1000))
-    c2 = Curve(-np.arange(1000))
+    c1 = hv.Curve(np.arange(1000))
+    c2 = hv.Curve(-np.arange(1000))
 
     overlay = (c1*c2).opts(active_tools=['box_zoom'], autorange='y')
 

--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -5,7 +5,6 @@ import pytest
 from bokeh.models import PolyDrawTool
 
 import holoviews as hv
-from holoviews import Curve, DynamicMap, Scatter
 from holoviews.plotting.bokeh.util import BOKEH_GE_3_4_0, BOKEH_GE_3_7_0
 from holoviews.streams import (
     BoundsX,
@@ -41,7 +40,7 @@ def points():
     ],
 )
 def test_box_select(serve_hv, BoundsTool, bound_slice, bound_attr):
-    hv_scatter = Scatter([1, 2, 3]).opts(
+    hv_scatter = hv.Scatter([1, 2, 3]).opts(
         tools=['box_select'], active_tools=['box_select']
     )
 
@@ -66,7 +65,7 @@ def test_box_select(serve_hv, BoundsTool, bound_slice, bound_attr):
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_lasso_select(serve_hv):
-    hv_scatter = Scatter([1, 2, 3]).opts(
+    hv_scatter = hv.Scatter([1, 2, 3]).opts(
         tools=['lasso_select'], active_tools=['lasso_select']
     )
 
@@ -124,7 +123,7 @@ def test_lasso_select(serve_hv):
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_rangexy(serve_hv):
-    hv_scatter = Scatter([1, 2, 3]).opts(active_tools=['box_zoom'])
+    hv_scatter = hv.Scatter([1, 2, 3]).opts(active_tools=['box_zoom'])
 
     rangexy = RangeXY(source=hv_scatter)
 
@@ -147,8 +146,8 @@ def test_rangexy(serve_hv):
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_multi_axis_rangexy(serve_hv):
-    c1 = Curve(np.arange(100).cumsum(), vdims='y')
-    c2 = Curve(-np.arange(100).cumsum(), vdims='y2')
+    c1 = hv.Curve(np.arange(100).cumsum(), vdims='y')
+    c2 = hv.Curve(-np.arange(100).cumsum(), vdims='y2')
     s1 = RangeXY(source=c1)
     s2 = RangeXY(source=c2)
 
@@ -179,8 +178,8 @@ def test_multi_axis_rangexy(serve_hv):
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_multi_axis_tap(serve_hv):
-    c1 = Curve(np.arange(10).cumsum(), vdims='y1')
-    c2 = Curve(np.arange(20).cumsum(), vdims='y2')
+    c1 = hv.Curve(np.arange(10).cumsum(), vdims='y1')
+    c2 = hv.Curve(np.arange(20).cumsum(), vdims='y2')
 
     overlay = (c1 * c2).opts(multi_y=True)
 
@@ -205,8 +204,8 @@ def test_multi_axis_tap(serve_hv):
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_multi_axis_tap_datetime(serve_hv):
-    c1 = Curve((pd.date_range('2024-01-01', '2024-01-10'), np.arange(10).cumsum()), vdims='y1')
-    c2 = Curve((pd.date_range('2024-01-01', '2024-01-20'), np.arange(20).cumsum()), vdims='y2')
+    c1 = hv.Curve((pd.date_range('2024-01-01', '2024-01-10'), np.arange(10).cumsum()), vdims='y1')
+    c2 = hv.Curve((pd.date_range('2024-01-01', '2024-01-20'), np.arange(20).cumsum()), vdims='y2')
 
     overlay = (c1 * c2).opts(multi_y=True)
 
@@ -242,15 +241,15 @@ def test_bind_trigger(serve_hv):
 
     def bound_function():
         BOUND_COUNT[0] += 1
-        return Curve([])
+        return hv.Curve([])
 
 
     def range_function(x_range, y_range):
         RANGE_COUNT[0] += 1
-        return Curve([])
+        return hv.Curve([])
 
-    range_dmap = DynamicMap(range_function, streams=[hv.streams.RangeXY()])
-    bind_dmap = DynamicMap(pn.bind(bound_function))
+    range_dmap = hv.DynamicMap(range_function, streams=[hv.streams.RangeXY()])
+    bind_dmap = hv.DynamicMap(pn.bind(bound_function))
 
     page = serve_hv(bind_dmap * range_dmap)
     hv_plot = page.locator('.bk-events')
@@ -273,12 +272,12 @@ def test_bind_trigger(serve_hv):
 def test_stream_subcoordinate_y_range(serve_hv, points):
     def cb(x_range, y_range):
         return (
-            Curve(np.arange(100).cumsum(), vdims='y', label='A').opts(subcoordinate_y=True) *
-            Curve(-np.arange(100).cumsum(), vdims='y2', label='B').opts(subcoordinate_y=True)
+            hv.Curve(np.arange(100).cumsum(), vdims='y', label='A').opts(subcoordinate_y=True) *
+            hv.Curve(-np.arange(100).cumsum(), vdims='y2', label='B').opts(subcoordinate_y=True)
         )
 
     stream = RangeXY()
-    dmap = DynamicMap(cb, streams=[stream]).opts(active_tools=['box_zoom'])
+    dmap = hv.DynamicMap(cb, streams=[stream]).opts(active_tools=['box_zoom'])
 
     page = serve_hv(dmap)
 
@@ -556,8 +555,8 @@ def test_poly_point_visible(serve_panel, start_value):
     def polygons_layer(value):
         return hv.Polygons([[(0.6, 0.1), (0.9, 0.1), (0.9, 0.9), (0.6, 0.9)]]).opts(visible=value == "Polygons")
 
-    dm_points = DynamicMap(points_layer)
-    dm_polys = DynamicMap(polygons_layer)
+    dm_points = hv.DynamicMap(points_layer)
+    dm_polys = hv.DynamicMap(polygons_layer)
 
     PointDraw(source=dm_points)
     PolyDraw(source=dm_polys, show_vertices=True)

--- a/holoviews/tests/ui/bokeh/test_histogram.py
+++ b/holoviews/tests/ui/bokeh/test_histogram.py
@@ -1,7 +1,7 @@
 import pytest
 from bokeh.models import CustomJS
 
-from holoviews.element import Histogram
+import holoviews as hv
 
 from .. import expect, wait_until
 
@@ -34,7 +34,7 @@ def watch_hook(dim, pos):
     ids=["logy", "logx", "logy-invert", "logx-invert"],
 )
 def test_histogram_log_scaling(serve_hv, opts_kwargs, hook, drag_direction):
-    hist = Histogram(([1, 3, 6, 9], [1, 10, 0, 100])).opts(hooks=[hook], **opts_kwargs)
+    hist = hv.Histogram(([1, 3, 6, 9], [1, 10, 0, 100])).opts(hooks=[hook], **opts_kwargs)
 
     page = serve_hv(hist)
     hv_plot = page.locator(".bk-events")

--- a/holoviews/tests/ui/bokeh/test_link_selections.py
+++ b/holoviews/tests/ui/bokeh/test_link_selections.py
@@ -3,7 +3,6 @@ import pytest
 
 import holoviews as hv
 from holoviews.plotting.bokeh.renderer import BokehRenderer
-from holoviews.selection import link_selections
 
 from .. import expect
 
@@ -24,7 +23,7 @@ def test_link_selections_programmatic_clear_removes_region(serve_hv):
                 continue
         return cnt
 
-    ls = link_selections.instance()
+    ls = hv.link_selections.instance()
     linked = ls(points).opts(active_tools=["box_select"])
 
     page = serve_hv(linked)

--- a/holoviews/tests/util/test_help.py
+++ b/holoviews/tests/util/test_help.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 import pytest
 
 import holoviews as hv
-from holoviews.core.options import Store
 
 
 @contextmanager
@@ -19,7 +18,7 @@ def _set_store(store):
 @pytest.mark.usefixtures("bokeh_backend")
 def test_help_pattern(capsys):
     pytest.importorskip("IPython")
-    with _set_store(Store):
+    with _set_store(hv.Store):
         hv.help(hv.Curve, pattern='border')
         captured = capsys.readouterr()
         assert '\x1b[43;1;30mborder\x1b[0m' in captured.out

--- a/holoviews/tests/util/test_transform.py
+++ b/holoviews/tests/util/test_transform.py
@@ -10,9 +10,7 @@ import param
 import pytest
 
 import holoviews as hv
-from holoviews.core.data import Dataset
 from holoviews.testing import assert_element_equal
-from holoviews.util.transform import dim
 
 from ..utils import optional_dependencies
 
@@ -43,7 +41,7 @@ class TestDimTransforms:
             ['A', 'B', 'C', 'A', 'B', 'C', 'A', 'B', 'C', 'A']
         )
         self.booleans = self.repeating == 'A'
-        self.dataset = Dataset(
+        self.dataset = hv.Dataset(
             (self.linear_ints, self.linear_floats,
              self.negative, self.repeating, self.booleans),
             ['int', 'float', 'negative', 'categories', 'booleans']
@@ -64,7 +62,7 @@ class TestDimTransforms:
             coords=dict([('x', x), ('y', y)]),
             dims=['y','x']
         )
-        self.dataset_xarray = Dataset(darray, vdims=['z'])
+        self.dataset_xarray = hv.Dataset(darray, vdims=['z'])
         if dask is not None:
             dask_array = da.from_array(array)
             dask_da = xr.DataArray(
@@ -72,7 +70,7 @@ class TestDimTransforms:
                 coords=dict([('x', x), ('y', y)]),
                 dims=['y','x']
             )
-            self.dataset_xarray_dask = Dataset(dask_da, vdims=['z'])
+            self.dataset_xarray_dask = hv.Dataset(dask_da, vdims=['z'])
 
     # Assertion helpers
 
@@ -203,143 +201,143 @@ class TestDimTransforms:
     # Unary operators
 
     def test_abs_transform(self):
-        expr = abs(dim('negative'))
+        expr = abs(hv.dim('negative'))
         self.assert_apply(expr, self.linear_floats)
 
     def test_neg_transform(self):
-        expr = -dim('negative')
+        expr = -hv.dim('negative')
         self.assert_apply(expr, self.linear_floats)
 
     def test_inv_transform(self):
-        expr = ~dim('booleans')
+        expr = ~hv.dim('booleans')
         self.assert_apply(expr, ~self.booleans)
 
     # Binary operators
 
     def test_add_transform(self):
-        expr = dim('float') + 1
+        expr = hv.dim('float') + 1
         self.assert_apply(expr, self.linear_floats+1)
 
     def test_div_transform(self):
-        expr = dim('int') / 10.
+        expr = hv.dim('int') / 10.
         self.assert_apply(expr, self.linear_floats)
 
     def test_floor_div_transform(self):
-        expr = dim('int') // 2
+        expr = hv.dim('int') // 2
         self.assert_apply(expr, self.linear_ints//2)
 
     def test_mod_transform(self):
-        expr = dim('int') % 2
+        expr = hv.dim('int') % 2
         self.assert_apply(expr, self.linear_ints % 2)
 
     def test_mul_transform(self):
-        expr = dim('float') * 10.
+        expr = hv.dim('float') * 10.
         self.assert_apply(expr, self.linear_ints.astype('float64'))
 
     def test_pow_transform(self):
-        expr = dim('int') ** 2
+        expr = hv.dim('int') ** 2
         self.assert_apply(expr, self.linear_ints ** 2)
 
     def test_sub_transform(self):
-        expr = dim('int') - 10
+        expr = hv.dim('int') - 10
         self.assert_apply(expr, self.linear_ints - 10)
 
     # Reverse binary operators
 
     def test_radd_transform(self):
-        expr = 1 + dim('float')
+        expr = 1 + hv.dim('float')
         self.assert_apply(expr, 1 + self.linear_floats)
 
     def test_rdiv_transform(self):
-        expr = 10. / dim('int')
+        expr = 10. / hv.dim('int')
         self.assert_apply(expr, 10. / self.linear_ints)
 
     def test_rfloor_div_transform(self):
-        expr = 2 // dim('int')
+        expr = 2 // hv.dim('int')
         self.assert_apply(expr, 2 // self.linear_ints)
 
     def test_rmod_transform(self):
-        expr = 2 % dim('int')
+        expr = 2 % hv.dim('int')
         self.assert_apply(expr, 2 % self.linear_ints)
 
     def test_rmul_transform(self):
-        expr = 10. * dim('float')
+        expr = 10. * hv.dim('float')
         self.assert_apply(expr, self.linear_ints.astype('float64'))
 
     def test_rsub_transform(self):
-        expr = 10 - dim('int')
+        expr = 10 - hv.dim('int')
         self.assert_apply(expr, 10 - self.linear_ints)
 
     # NumPy operations
 
     def test_ufunc_transform(self):
-        expr = np.sin(dim('float'))
+        expr = np.sin(hv.dim('float'))
         self.assert_apply(expr, np.sin(self.linear_floats))
 
     def test_astype_transform(self):
-        expr = dim('int').astype('float64')
+        expr = hv.dim('int').astype('float64')
         self.assert_apply(expr, self.linear_ints.astype('float64'))
 
     def test_cumsum_transform(self):
-        expr = dim('float').cumsum()
+        expr = hv.dim('float').cumsum()
         self.assert_apply(expr, self.linear_floats.cumsum())
 
     def test_max_transform(self):
-        expr = dim('float').max()
+        expr = hv.dim('float').max()
         self.assert_apply(expr, self.linear_floats.max())
 
     def test_min_transform(self):
-        expr = dim('float').min()
+        expr = hv.dim('float').min()
         self.assert_apply(expr, self.linear_floats.min())
 
     def test_round_transform(self):
-        expr = dim('float').round()
+        expr = hv.dim('float').round()
         self.assert_apply(expr, self.linear_floats.round())
 
     def test_sum_transform(self):
-        expr = dim('float').sum()
+        expr = hv.dim('float').sum()
         self.assert_apply(expr, self.linear_floats.sum())
 
     def test_std_transform(self):
-        expr = dim('float').std(ddof=0)
+        expr = hv.dim('float').std(ddof=0)
         self.assert_apply(expr, self.linear_floats.std(ddof=0))
 
     def test_var_transform(self):
-        expr = dim('float').var(ddof=0)
+        expr = hv.dim('float').var(ddof=0)
         self.assert_apply(expr, self.linear_floats.var(ddof=0))
 
     def test_log_transform(self):
-        expr = dim('float').log()
+        expr = hv.dim('float').log()
         self.assert_apply(expr, np.log(self.linear_floats))
 
     def test_log10_transform(self):
-        expr = dim('float').log10()
+        expr = hv.dim('float').log10()
         self.assert_apply(expr, np.log10(self.linear_floats))
 
     # Custom functions
 
     def test_str_astype(self):
-        expr = dim('int').str()
+        expr = hv.dim('int').str()
         self.assert_apply(expr, self.linear_ints.astype(str), skip_dask=True)
 
     def test_norm_transform(self):
-        expr = dim('int').norm()
+        expr = hv.dim('int').norm()
         self.assert_apply(expr, (self.linear_ints-1)/9.)
 
     def test_iloc_transform_int(self):
-        expr = dim('int').iloc[1]
+        expr = hv.dim('int').iloc[1]
         self.assert_apply(expr, self.linear_ints[1])
 
     def test_iloc_transform_slice(self):
-        expr = dim('int').iloc[1:3]
+        expr = hv.dim('int').iloc[1:3]
         self.assert_apply(expr, self.linear_ints[1:3], skip_dask=True)
 
     def test_iloc_transform_list(self):
-        expr = dim('int').iloc[[1, 3, 5]]
+        expr = hv.dim('int').iloc[[1, 3, 5]]
         self.assert_apply(expr, self.linear_ints[[1, 3, 5]], skip_dask=True)
 
     def test_bin_transform(self):
-        expr = dim('int').bin([0, 5, 10])
+        expr = hv.dim('int').bin([0, 5, 10])
         expected = pd.Series(
             [2.5, 2.5, 2.5, 2.5, 2.5, 7.5, 7.5, 7.5, 7.5, 7.5]
         )
@@ -347,7 +345,7 @@ class TestDimTransforms:
 
     @dask_conversion_warning
     def test_bin_transform_with_labels(self):
-        expr = dim('int').bin([0, 5, 10], ['A', 'B'])
+        expr = hv.dim('int').bin([0, 5, 10], ['A', 'B'])
         expected = pd.Series(
             ['A', 'A', 'A', 'A', 'A', 'B', 'B', 'B', 'B', 'B']
         )
@@ -355,7 +353,7 @@ class TestDimTransforms:
         self.assert_apply(expr, expected, dask_convert_string=False)
 
     def test_categorize_transform_list(self):
-        expr = dim('categories').categorize(['circle', 'square', 'triangle'])
+        expr = hv.dim('categories').categorize(['circle', 'square', 'triangle'])
         expected = pd.Series(
             (['circle', 'square', 'triangle']*3)+['circle']
         )
@@ -364,7 +362,7 @@ class TestDimTransforms:
 
     @dask_conversion_warning
     def test_categorize_transform_dict(self):
-        expr = dim('categories').categorize(
+        expr = hv.dim('categories').categorize(
             {'A': 'circle', 'B': 'square', 'C': 'triangle'}
         )
         expected = pd.Series(
@@ -376,7 +374,7 @@ class TestDimTransforms:
 
     @dask_conversion_warning
     def test_categorize_transform_dict_with_default(self):
-        expr = dim('categories').categorize(
+        expr = hv.dim('categories').categorize(
             {'A': 'circle', 'B': 'square'}, default='triangle'
         )
         expected = pd.Series(
@@ -389,12 +387,12 @@ class TestDimTransforms:
     # Numpy functions
 
     def test_digitize(self):
-        expr = dim('int').digitize([1, 5, 10])
+        expr = hv.dim('int').digitize([1, 5, 10])
         expected = pd.Series(np.array([1, 1, 1, 1, 2, 2, 2, 2, 2, 3])).astype('int64')
         self.assert_apply(expr, expected)
 
     def test_isin(self):
-        expr = dim('int').digitize([1, 5, 10]).isin([1, 3])
+        expr = hv.dim('int').digitize([1, 5, 10]).isin([1, 3])
         expected = pd.Series(
             np.array([1, 1, 1, 1, 0, 0, 0, 0, 0, 1], dtype='bool')
         )
@@ -403,60 +401,60 @@ class TestDimTransforms:
     # Complex expressions
 
     def test_multi_operator_expression(self):
-        expr = (((dim('float')-2)*3)**2)
+        expr = (((hv.dim('float')-2)*3)**2)
         self.assert_apply(expr, ((self.linear_floats-2)*3)**2)
 
     def test_multi_dim_expression(self):
-        expr = dim('int')-dim('float')
+        expr = hv.dim('int')-hv.dim('float')
         self.assert_apply(expr, self.linear_ints-self.linear_floats)
 
     # Repr method
 
     def test_dim_repr(self):
-        assert repr(dim('float')) == "dim('float')"
+        assert repr(hv.dim('float')) == "dim('float')"
 
     def test_unary_op_repr(self):
-        assert repr(-dim('float')) == "-dim('float')"
+        assert repr(-hv.dim('float')) == "-dim('float')"
 
     def test_binary_op_repr(self):
-        assert repr(dim('float')*2) == "dim('float')*2"
+        assert repr(hv.dim('float')*2) == "dim('float')*2"
 
     def test_reverse_binary_op_repr(self):
-        assert repr(1+dim('float')) == "1+dim('float')"
+        assert repr(1+hv.dim('float')) == "1+dim('float')"
 
     def test_ufunc_expression_repr(self):
-        assert repr(np.log(dim('float'))) == "dim('float').log()"
+        assert repr(np.log(hv.dim('float'))) == "dim('float').log()"
 
     def test_custom_func_repr(self):
-        assert repr(dim('float').norm()) == "dim('float').norm()"
+        assert repr(hv.dim('float').norm()) == "dim('float').norm()"
 
     def test_multi_operator_expression_repr(self):
-        assert repr(((dim('float')-2)*3)**2) == "((dim('float')-2)*3)**2"
+        assert repr(((hv.dim('float')-2)*3)**2) == "((dim('float')-2)*3)**2"
 
     # Applies method
 
     def test_multi_dim_expression_applies(self):
-        assert (dim('int')-dim('float')).applies(self.dataset) is True
+        assert (hv.dim('int')-hv.dim('float')).applies(self.dataset) is True
 
     def test_multi_dim_expression_not_applies(self):
-        assert (dim('foo')-dim('bar')).applies(self.dataset) is False
+        assert (hv.dim('foo')-hv.dim('bar')).applies(self.dataset) is False
 
     def test_multi_dim_expression_partial_applies(self):
-        assert (dim('int')-dim('bar')).applies(self.dataset) is False
+        assert (hv.dim('int')-hv.dim('bar')).applies(self.dataset) is False
 
     # Check namespaced expressions
 
     def test_pandas_namespace_accessor_repr(self):
-        assert repr(dim('date').df.dt.year) == "dim('date').pd.dt.year"
+        assert repr(hv.dim('date').df.dt.year) == "dim('date').pd.dt.year"
 
     @dask_conversion_warning
     def test_pandas_str_accessor(self):
-        expr = dim('categories').df.str.lower()
+        expr = hv.dim('categories').df.str.lower()
         # Use dask convert-string as we use the setup data
         self.assert_apply(expr, self.repeating.str.lower(), dask_convert_string=True)
 
     def test_pandas_chained_methods(self):
-        expr = dim('int').df.rolling(1).mean()
+        expr = hv.dim('int').df.rolling(1).mean()
 
         with warnings.catch_warnings():
             # The kwargs is {'axis': None} and is already handled by the code.
@@ -467,28 +465,28 @@ class TestDimTransforms:
 
     @xr_skip
     def test_xarray_namespace_method_repr(self):
-        assert repr(dim('date').xr.quantile(0.95)) == "dim('date').xr.quantile(0.95)"
+        assert repr(hv.dim('date').xr.quantile(0.95)) == "dim('date').xr.quantile(0.95)"
 
     @xr_skip
     def test_xarray_quantile_method(self):
-        expr = dim('z').xr.quantile(0.95)
+        expr = hv.dim('z').xr.quantile(0.95)
         self.assert_apply_xarray(expr, self.dataset_xarray.data.z.quantile(0.95), skip_dask=True)
 
     @xr_skip
     def test_xarray_roll_method(self):
-        expr = dim('z').xr.roll({'x': 1}, roll_coords=False)
+        expr = hv.dim('z').xr.roll({'x': 1}, roll_coords=False)
         self.assert_apply_xarray(expr, self.dataset_xarray.data.z.roll({'x': 1}, roll_coords=False))
 
     @xr_skip
     def test_xarray_coarsen_method(self):
-        expr = dim('z').xr.coarsen({'x': 4}).mean()
+        expr = hv.dim('z').xr.coarsen({'x': 4}).mean()
         self.assert_apply_xarray(expr, self.dataset_xarray.data.z.coarsen({'x': 4}).mean())
 
     # Dynamic arguments
 
     def test_dynamic_mul(self):
         p = Params(a=1)
-        expr = dim('float') * p.param.a
+        expr = hv.dim('float') * p.param.a
         assert list(expr.params.values()) == [p.param.a]
         self.assert_apply(expr, self.linear_floats)
         p.a = 2
@@ -496,7 +494,7 @@ class TestDimTransforms:
 
     def test_dynamic_arg(self):
         p = Params(a=1)
-        expr = dim('float').round(p.param.a)
+        expr = hv.dim('float').round(p.param.a)
         assert list(expr.params.values()) == [p.param.a]
         self.assert_apply(expr, np.round(self.linear_floats, 1))
         p.a = 2
@@ -504,14 +502,14 @@ class TestDimTransforms:
 
     def test_dynamic_kwarg(self):
         p = Params(a=1)
-        expr = dim('float').round(decimals=p.param.a)
+        expr = hv.dim('float').round(decimals=p.param.a)
         assert list(expr.params.values()) == [p.param.a]
         self.assert_apply(expr, np.round(self.linear_floats, 1))
         p.a = 2
         self.assert_apply(expr, np.round(self.linear_floats, 2))
 
     def test_pickle(self):
-        expr = (((dim('float')-2)*3)**2)
+        expr = (((hv.dim('float')-2)*3)**2)
         expr2 = pickle.loads(pickle.dumps(expr))
         assert repr(expr) == repr(expr2)
 

--- a/holoviews/tests/util/test_utils.py
+++ b/holoviews/tests/util/test_utils.py
@@ -3,10 +3,10 @@ Unit tests of the helper functions in utils
 """
 from pyviz_comms import CommManager
 
-from holoviews import Store
+import holoviews as hv
 from holoviews.core.options import OptionTree
 from holoviews.plotting import bokeh
-from holoviews.util import Options, OutputSettings, opts, output
+from holoviews.util import OutputSettings
 
 from ..utils import LoggingComparison, optional_dependencies
 
@@ -25,42 +25,42 @@ class TestOutputUtil:
         from holoviews.plotting import mpl
 
         notebook_extension(*BACKENDS)
-        Store.current_backend = 'matplotlib'
-        Store.renderers['matplotlib'] = mpl.MPLRenderer.instance()
-        Store.renderers['bokeh'] = bokeh.BokehRenderer.instance()
+        hv.Store.current_backend = 'matplotlib'
+        hv.Store.renderers['matplotlib'] = mpl.MPLRenderer.instance()
+        hv.Store.renderers['bokeh'] = bokeh.BokehRenderer.instance()
         OutputSettings.options =  dict(OutputSettings.defaults.items())
 
     def teardown_method(self):
         from holoviews.plotting import mpl
 
-        Store.renderers['matplotlib'] = mpl.MPLRenderer.instance()
-        Store.renderers['bokeh'] = bokeh.BokehRenderer.instance()
+        hv.Store.renderers['matplotlib'] = mpl.MPLRenderer.instance()
+        hv.Store.renderers['bokeh'] = bokeh.BokehRenderer.instance()
         OutputSettings.options =  dict(OutputSettings.defaults.items())
-        for renderer in Store.renderers.values():
+        for renderer in hv.Store.renderers.values():
             renderer.comm_manager = CommManager
 
     def test_output_util_svg_string(self):
         assert OutputSettings.options.get('fig', None) is None
-        output("fig='svg'")
+        hv.output("fig='svg'")
         assert OutputSettings.options.get('fig', None) == 'svg'
 
     def test_output_util_png_kwargs(self):
         assert OutputSettings.options.get('fig', None) is None
-        output(fig='png')
+        hv.output(fig='png')
         assert OutputSettings.options.get('fig', None) == 'png'
 
     def test_output_util_backend_string(self):
         assert OutputSettings.options.get('backend', None) is None
-        output("backend='bokeh'")
+        hv.output("backend='bokeh'")
         assert OutputSettings.options.get('backend', None) == 'bokeh'
 
     def test_output_util_backend_kwargs(self):
         assert OutputSettings.options.get('backend', None) is None
-        output(backend='bokeh')
+        hv.output(backend='bokeh')
         assert OutputSettings.options.get('backend', None) == 'bokeh'
 
     def test_output_util_object_noop(self):
-        assert output("fig='svg'",3) == 3
+        assert hv.output("fig='svg'",3) == 3
 
 
 @mpl_skip
@@ -71,19 +71,19 @@ class TestOptsUtil(LoggingComparison):
 
     def setup_method(self):
         from holoviews.plotting import mpl  # noqa: F401
-        self.backend = Store.current_backend
-        Store.current_backend = 'matplotlib'
-        self.store_copy = OptionTree(sorted(Store.options().items()),
-                                     groups=Options._option_groups)
+        self.backend = hv.Store.current_backend
+        hv.Store.current_backend = 'matplotlib'
+        self.store_copy = OptionTree(sorted(hv.Store.options().items()),
+                                     groups=hv.Options._option_groups)
 
     def teardown_method(self):
-        Store.current_backend = self.backend
-        Store.options(val=self.store_copy)
+        hv.Store.current_backend = self.backend
+        hv.Store.options(val=self.store_copy)
 
     def test_opts_builder_repr_options_dotted(self):
-        options = [Options('Bivariate.Test.Example', bandwidth=0.5, cmap='Blues'),
-                   Options('Points', size=2, logx=True)]
+        options = [hv.Options('Bivariate.Test.Example', bandwidth=0.5, cmap='Blues'),
+                   hv.Options('Points', size=2, logx=True)]
         expected= ["opts.Bivariate('Test.Example', bandwidth=0.5, cmap='Blues')",
                    "opts.Points(logx=True, size=2)"]
-        reprs = opts._builder_reprs(options)
+        reprs = hv.opts._builder_reprs(options)
         assert reprs == expected


### PR DESCRIPTION
## Description

<!-- Please describe your changes here and if it fixes an issue-->

This is a small pet-peeve of mine. I like the tests to mimic imports on how code is actually written in whether it is notebook or scripts. Here we refactor so imports in the tests will use the top-level import like `hv.Curve`. 

This will make it easier to pull code out of test and run it in a notebook. 

Built on top of https://github.com/holoviz/holoviews/pull/6802   

I have used claude code to generate the following script to do the conversion:

<details><summary>Details</summary>
<p>

``` python
"""
Refactor test imports to use `import holoviews as hv`.

Names in hv.__all__ are accessed as hv.<name>.
Names NOT in hv.__all__ keep their full submodule import path.

Usage:
    python refactor_imports.py holoviews/tests/           # dry-run (show diffs)
    python refactor_imports.py --apply holoviews/tests/   # apply changes
"""
import ast
import io
import re
import sys
import difflib
import tokenize
from pathlib import Path

import types

import holoviews as hv

HV_ALL = set(hv.__all__)

# Submodule names in __all__ - these should only be replaced when imported
# directly from 'holoviews' (not from 'holoviews.core', 'holoviews.element', etc.)
# because 'from holoviews.core import util' gives holoviews.core.util (different from hv.util)
HV_SUBMODULES = {
    name for name in HV_ALL
    if isinstance(getattr(hv, name, None), types.ModuleType)
}

# Pattern to match `from holoviews` or `from holoviews.something` imports
# Handles both single-line and multi-line (parenthesized) forms
IMPORT_RE = re.compile(
    r'^(from\s+holoviews(?:\.\w+)*\s+import\s*)'  # group 1: "from holoviews[.x] import "
    r'(\([^)]*\)|[^\\\n]+(?:\\\n[^\\\n]+)*)'      # group 2: names (parens or backslash-continued)
    r'(\n?)',                                       # group 3: trailing newline (consumed when line is removed)
    re.MULTILINE,
)


def parse_names(names_str: str) -> list[tuple[str, str | None]]:
    """Parse a comma-separated import name string into (name, alias) tuples."""
    s = names_str.strip()
    if s.startswith("(") and s.endswith(")"):
        s = s[1:-1]
    s = s.replace("\\\n", " ").replace("\n", " ")
    result = []
    for part in s.split(","):
        part = part.strip()
        if not part:
            continue
        if " as " in part:
            name, alias = [x.strip() for x in part.split(" as ", 1)]
            result.append((name, alias))
        else:
            result.append((part, None))
    return result


def build_import_line(module: str, names: list[tuple[str, str | None]]) -> str:
    """Build an import statement from module and (name, alias) pairs."""
    parts = []
    for name, alias in names:
        if alias:
            parts.append(f"{name} as {alias}")
        else:
            parts.append(name)
    return f"from {module} import {', '.join(parts)}"


class ScopeAwareNameFinder(ast.NodeVisitor):
    """
    Finds all Name nodes in Load context that refer to the imported names
    (not locally-shadowed by assignments in the same function scope).
    """

    def __init__(self, names: set[str], source: str):
        self.names = names
        self.source = source
        lines = source.splitlines(keepends=True)
        self.line_starts = [0]
        for line in lines:
            self.line_starts.append(self.line_starts[-1] + len(line))
        # Stack of sets of locally-assigned names (one set per scope)
        # Module level is scope[0]; don't treat module-level as "local"
        self.scope_stack: list[set[str]] = []
        self.load_positions: list[tuple[int, int, str]] = []

    def _offset(self, node: ast.AST) -> int:
        return self.line_starts[node.lineno - 1] + node.col_offset  # type: ignore[attr-defined]

    def _is_locally_shadowed(self, name: str) -> bool:
        """True if any function scope (not class/module) on the stack assigns this name."""
        return any(name in scope for scope in self.scope_stack)

    def _get_local_names(self, node: ast.AST) -> set[str]:
        """Collect names directly assigned in this node's body (not nested funcs)."""
        assigned: set[str] = set()
        for child in ast.walk(node):
            if child is node:
                continue
            # Don't descend into nested function/class scopes
            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
                if child is not node:
                    continue  # skip nested scopes
            if isinstance(child, ast.Name) and isinstance(child.ctx, (ast.Store, ast.Del)):
                assigned.add(child.id)
            elif isinstance(child, ast.arg):
                assigned.add(child.arg)
        return assigned

    def _collect_local_names_direct(self, stmts: list[ast.stmt]) -> set[str]:
        """Collect names assigned at the top level of a list of statements (non-nested)."""
        assigned: set[str] = set()
        for stmt in stmts:
            for node in ast.walk(stmt):
                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
                    if node is not stmt:
                        # Don't descend into nested function bodies
                        # (only look at the stmt itself)
                        continue
                if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
                    assigned.add(node.id)
                elif isinstance(node, ast.arg):
                    assigned.add(node.arg)
        return assigned

    def _visit_scope(self, node: ast.AST, body: list[ast.stmt]) -> None:
        """Visit a new scope (function/lambda) with its own locals."""
        local_names: set[str] = set()
        # Collect parameters
        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
            args = node.args
            for a in args.args + args.posonlyargs + args.kwonlyargs:
                local_names.add(a.arg)
            if args.vararg:
                local_names.add(args.vararg.arg)
            if args.kwarg:
                local_names.add(args.kwarg.arg)
        # Collect all names assigned in this scope's body
        for stmt in body:
            for n in ast.walk(stmt):
                # Don't descend into nested function/class defs
                if n is not stmt and isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
                    break
                if isinstance(n, ast.Name) and isinstance(n.ctx, (ast.Store, ast.Del)):
                    local_names.add(n.id)

        self.scope_stack.append(local_names)
        for stmt in body:
            self.visit(stmt)
        self.scope_stack.pop()

    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
        # Decorators and default arg values are evaluated in the ENCLOSING scope
        for decorator in node.decorator_list:
            self.visit(decorator)
        args = node.args
        for default in args.defaults:
            self.visit(default)
        for default in args.kw_defaults:
            if default is not None:
                self.visit(default)
        if args.vararg and args.vararg.annotation:
            self.visit(args.vararg.annotation)
        if args.kwarg and args.kwarg.annotation:
            self.visit(args.kwarg.annotation)
        for arg in args.args + args.posonlyargs + args.kwonlyargs:
            if arg.annotation:
                self.visit(arg.annotation)
        if node.returns:
            self.visit(node.returns)
        # Body is evaluated in the function scope
        self._visit_scope(node, node.body)

    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
        self._visit_function(node)

    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
        self._visit_function(node)

    def visit_ClassDef(self, node: ast.ClassDef) -> None:
        # Classes don't create a scope that shadows imports for methods
        # (in Python, class body is a separate scope but methods create their own)
        # We just visit the body without pushing a scope
        self.generic_visit(node)

    def visit_Name(self, node: ast.Name) -> None:
        if node.id in self.names and isinstance(node.ctx, ast.Load):
            if not self._is_locally_shadowed(node.id):
                start = self._offset(node)
                end = start + len(node.id)
                self.load_positions.append((start, end, node.id))
        self.generic_visit(node)


def find_replacement_positions(source: str, local_to_hv: dict[str, str]) -> list[tuple[int, int, str]]:
    """
    Use AST to find all Name load positions for names in local_to_hv
    that are not shadowed by local assignments.
    Returns list of (start, end, hv_replacement_name) sorted by start offset.
    """
    try:
        tree = ast.parse(source)
    except SyntaxError:
        return []

    finder = ScopeAwareNameFinder(set(local_to_hv.keys()), source)
    finder.visit(tree)

    result = []
    for start, end, local_name in finder.load_positions:
        result.append((start, end, local_to_hv[local_name]))

    return sorted(result, key=lambda x: x[0])


def apply_replacements(source: str, replacements: list[tuple[int, int, str]]) -> str:
    """Apply (start, end, replacement) tuples to source (in order)."""
    result = []
    last = 0
    for start, end, repl in sorted(replacements, key=lambda x: x[0]):
        result.append(source[last:start])
        result.append(repl)
        last = end
    result.append(source[last:])
    return "".join(result)


def process_imports(text: str) -> tuple[str, list[tuple[str, str | None]]]:
    """
    Process holoviews imports: remove hv-all names, return modified text
    and list of (local_name, hv_name) replacements needed.
    """
    names_to_replace: list[tuple[str, str | None]] = []

    def process_match(m: re.Match) -> str:
        prefix = m.group(1)
        names_str = m.group(2)
        trailing_newline = m.group(3)  # preserve or drop the line's newline

        module_match = re.match(r'from\s+(holoviews(?:\.\w+)*)\s+import', prefix)
        module = module_match.group(1) if module_match else "holoviews"

        pairs = parse_names(names_str)

        # Submodule names (like 'util', 'core') should only be replaced when
        # imported directly from 'holoviews' (not from 'holoviews.core', etc.)
        # because they refer to different objects in sub-packages.
        hv_pairs = [
            (n, a) for n, a in pairs
            if n in HV_ALL and (n not in HV_SUBMODULES or module == 'holoviews')
        ]
        keep_pairs = [(n, a) for n, a in pairs if (n, a) not in [(x, y) for x, y in hv_pairs]]

        for name, alias in hv_pairs:
            names_to_replace.append((name, alias))

        if not keep_pairs:
            # Consume the trailing newline so no empty line is left behind
            return ""
        else:
            return build_import_line(module, keep_pairs) + trailing_newline

    new_text = IMPORT_RE.sub(process_match, text)
    return new_text, names_to_replace


def refactor_file(path: Path, apply: bool) -> bool:
    """Refactor a single file. Returns True if changes were made (or would be made)."""
    original = path.read_text(encoding="utf-8")
    text = original

    already_has_hv_import = bool(re.search(r'^\s*import\s+holoviews\s+as\s+hv\b', text, re.MULTILINE))

    # Step 1: Process import statements
    new_text, names_to_replace = process_imports(text)

    if not names_to_replace:
        return False

    # Build local_name → hv.Name mapping
    local_to_hv: dict[str, str] = {}
    for name, alias in names_to_replace:
        local_name = alias if alias else name
        local_to_hv[local_name] = f"hv.{name}"

    # Step 2: Find replacement positions using AST (scope-aware)
    replacements = find_replacement_positions(new_text, local_to_hv)

    # Step 3: Apply replacements
    new_text = apply_replacements(new_text, replacements)

    # Step 4: Add `import holoviews as hv` if not already present
    if not already_has_hv_import:
        lines = new_text.split("\n")
        insert_idx = _find_import_insert_idx(lines)
        lines.insert(insert_idx, "import holoviews as hv")
        new_text = "\n".join(lines)

    if new_text == original:
        return False

    if apply:
        path.write_text(new_text, encoding="utf-8")
        print(f"Applied: {path}")
    else:
        diff = difflib.unified_diff(
            original.splitlines(keepends=True),
            new_text.splitlines(keepends=True),
            fromfile=str(path),
            tofile=str(path),
        )
        diff_text = "".join(diff)
        if diff_text:
            print(diff_text)

    return True


def _find_import_insert_idx(lines: list[str]) -> int:
    """Find the line index where `import holoviews as hv` should be inserted."""
    in_docstring = False
    docstring_char = None
    insert_idx = 0

    for i, line in enumerate(lines):
        stripped = line.strip()
        if not in_docstring:
            if stripped.startswith('"""') or stripped.startswith("'''"):
                docstring_char = stripped[:3]
                if stripped.count(docstring_char) >= 2 and len(stripped) > 3:
                    insert_idx = i + 1
                    continue
                else:
                    in_docstring = True
                    continue
            if stripped.startswith("#") or stripped == "" or stripped.startswith("__future__"):
                insert_idx = i + 1
                continue
            if stripped.startswith("from __future__"):
                insert_idx = i + 1
                continue
            if stripped.startswith("import ") or stripped.startswith("from "):
                insert_idx = i
                break
            break
        else:
            if docstring_char and docstring_char in stripped:
                in_docstring = False
                insert_idx = i + 1

    return insert_idx


def main():
    apply = "--apply" in sys.argv
    args = [a for a in sys.argv[1:] if not a.startswith("--")]

    if not args:
        print("Usage: refactor_imports.py [--apply] <test_dir>")
        sys.exit(1)

    test_dir = Path(args[0])
    files = sorted(test_dir.rglob("*.py"))

    changed = 0
    for f in files:
        if refactor_file(f, apply=apply):
            changed += 1

    print(f"\n{'Applied' if apply else 'Would change'} {changed} / {len(files)} files.")


if __name__ == "__main__":
    main()

```

</p>
</details> 


## Checklist

- [x] Pull request title follows the conventional format
- [x] Tests added and is passing

<!--
Conventional format: <Type>(<Scope>): <Subject>
Valid Types: `build`, `chore`, `ci`, `compat`, `docs`, `enh`, `feat`, `fix`, `perf`, `refactor`, `test`, and `type`
Valid Scopes (optional): `dev`, `data`, `plotting`, `bokeh`, `matplotlib`, `plotly`, and `notebook`

For more information on how to contribute to this repository, see the [developer guide](https://www.holoviews.org/developer_guide/index.html)
-->
