### PR TITLE
perf: Add numeric fast path to max_range and dimension_range

### DIFF
--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -981,18 +981,25 @@ _numeric_fast_types = (int, float, np.integer, np.floating)
 
 
 def _minmax_finite(values):
-    """Return (min, max) of finite floats, or (np.nan, np.nan) if none found."""
-    lo = math.inf
-    hi = -math.inf
-    found = False
+    """Return (min, max) of finite values, or (np.nan, np.nan) if none found.
+
+    Uses float conversion for NaN checks and comparison, but preserves the
+    original types in the returned values.
+    """
+    lo_f = math.inf
+    hi_f = -math.inf
+    lo_val = hi_val = None
     for v in values:
         if v is not None:
             fv = float(v)
             if not math.isnan(fv):
-                found = True
-                lo = min(lo, fv)
-                hi = max(hi, fv)
-    return (lo, hi) if found else (np.nan, np.nan)
+                if fv <= lo_f:
+                    lo_f = fv
+                    lo_val = v
+                if fv >= hi_f:
+                    hi_f = fv
+                    hi_val = v
+    return (lo_val, hi_val) if lo_val is not None else (np.nan, np.nan)
 
 
 def _max_range_numeric(ranges, combined):

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -4,6 +4,7 @@ import hashlib
 import inspect
 import itertools
 import json
+import math
 import numbers
 import operator
 import pickle
@@ -976,6 +977,33 @@ def find_range(values, soft_range=None):
             return (None, None)
 
 
+_numeric_fast_types = (int, float, np.integer, np.floating)
+
+
+def _minmax_finite(values):
+    """Return (min, max) of finite floats, or (np.nan, np.nan) if none found."""
+    lo = math.inf
+    hi = -math.inf
+    found = False
+    for v in values:
+        if v is not None:
+            fv = float(v)
+            if not math.isnan(fv):
+                found = True
+                lo = min(lo, fv)
+                hi = max(hi, fv)
+    return (lo, hi) if found else (np.nan, np.nan)
+
+
+def _max_range_numeric(ranges, combined):
+    """Pure-Python fast path for max_range when all values are numeric or None."""
+    if combined:
+        return _minmax_finite(v for r in ranges for v in r)
+    lo, _ = _minmax_finite(r[0] for r in ranges)
+    _, hi = _minmax_finite(r[1] for r in ranges)
+    return lo, hi
+
+
 def max_range(ranges, combined=True):
     """Computes the maximal lower and upper bounds from a list bounds.
 
@@ -992,6 +1020,13 @@ def max_range(ranges, combined=True):
     -------
     The maximum range as a single tuple
     """
+    if not ranges:
+        return (np.nan, np.nan)
+
+    # Fast path: all values are plain numerics or None.
+    if all(v is None or isinstance(v, _numeric_fast_types) for r in ranges for v in r):
+        return _max_range_numeric(ranges, combined)
+
     try:
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
@@ -1022,10 +1057,7 @@ def max_range(ranges, combined=True):
                           (arr[:, 0].min(), arr[:, 1].max()))
                 return drange
 
-            if combined:
-                return (np.nanmin(arr), np.nanmax(arr))
-            else:
-                return (np.nanmin(arr[:, 0]), np.nanmax(arr[:, 1]))
+            return _max_range_numeric(ranges, combined)
     except Exception:
         return (np.nan, np.nan)
 
@@ -1065,6 +1097,10 @@ def dimension_range(lower, upper, hard_range, soft_range, padding=None, log=Fals
     with the Dimension soft_range and range.
 
     """
+    dmin, dmax = hard_range
+    if (dmin is not None and isfinite(dmin)
+            and dmax is not None and isfinite(dmax)):
+        return dmin, dmax
     plower, pupper = range_pad(lower, upper, padding, log)
     if isfinite(soft_range[0]) and soft_range[0] <= lower:
         lower = soft_range[0]
@@ -1074,7 +1110,6 @@ def dimension_range(lower, upper, hard_range, soft_range, padding=None, log=Fals
         upper = soft_range[1]
     else:
         upper = max_range([(None, pupper), (None, soft_range[1])])[1]
-    dmin, dmax = hard_range
     lower = lower if dmin is None or not isfinite(dmin) else dmin
     upper = upper if dmax is None or not isfinite(dmax) else dmax
     return lower, upper

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -992,6 +992,12 @@ def _minmax_finite(values):
     lo_val = hi_val = None
     for v in values:
         if v is not None:
+            # We benchmarked dropping float() entirely -- the min()/max() vs <=/>=
+            # difference is negligible in the big picture (the real win is avoiding the
+            # numpy array path). But float() conversion does help noticeably for mixed
+            # numpy scalar types (e.g., np.int64 vs np.float64), where without it the
+            # comparisons go through numpy's dispatch and are ~5x slower. Still fast
+            # compared to the old path, but a modest benefit for one line of code.
             fv = float(v)
             if fv <= lo_f:
                 lo_f = fv

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -983,8 +983,9 @@ _numeric_fast_types = (int, float, np.integer, np.floating)
 def _minmax_finite(values):
     """Return (min, max) of finite values, or (np.nan, np.nan) if none found.
 
-    Uses float conversion for NaN checks and comparison, but preserves the
-    original types in the returned values.
+    Converts to Python float for fast comparison while preserving original
+    types in the return values.  NaN values are implicitly excluded because
+    IEEE 754 comparisons with NaN always return False.
     """
     lo_f = math.inf
     hi_f = -math.inf
@@ -992,13 +993,12 @@ def _minmax_finite(values):
     for v in values:
         if v is not None:
             fv = float(v)
-            if not math.isnan(fv):
-                if fv <= lo_f:
-                    lo_f = fv
-                    lo_val = v
-                if fv >= hi_f:
-                    hi_f = fv
-                    hi_val = v
+            if fv <= lo_f:
+                lo_f = fv
+                lo_val = v
+            if fv >= hi_f:
+                hi_f = fv
+                hi_val = v
     return (lo_val, hi_val) if lo_val is not None else (np.nan, np.nan)
 
 

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -983,21 +983,17 @@ _numeric_fast_types = (int, float, np.integer, np.floating)
 def _minmax_finite(values):
     """Return (min, max) of finite values, or (np.nan, np.nan) if none found.
 
-    Converts to Python float for fast comparison while preserving original
-    types in the return values.  NaN values are implicitly excluded because
-    IEEE 754 comparisons with NaN always return False.
+    Converts to Python float for better performance for numpy scalar type while
+    preserving original types in the return values.
+
+    NaN values are implicitly excluded because IEEE 754 comparisons with NaN
+    always return False.
     """
     lo_f = math.inf
     hi_f = -math.inf
     lo_val = hi_val = None
     for v in values:
         if v is not None:
-            # We benchmarked dropping float() entirely -- the min()/max() vs <=/>=
-            # difference is negligible in the big picture (the real win is avoiding the
-            # numpy array path). But float() conversion does help noticeably for mixed
-            # numpy scalar types (e.g., np.int64 vs np.float64), where without it the
-            # comparisons go through numpy's dispatch and are ~5x slower. Still fast
-            # compared to the old path, but a modest benefit for one line of code.
             fv = float(v)
             if fv <= lo_f:
                 lo_f = fv

--- a/holoviews/tests/core/test_utils.py
+++ b/holoviews/tests/core/test_utils.py
@@ -359,6 +359,44 @@ class TestDimensionRange:
                                  (None, None), self.date_range2)
         assert drange == self.date_range2
 
+    def test_both_hard_finite_short_circuits(self):
+        result = dimension_range(0.0, 100.0, (10.0, 90.0), (None, None))
+        assert result == (10.0, 90.0)
+
+    def test_both_hard_finite_np_scalars(self):
+        """hard_range from max_range output contains numpy scalars."""
+        result = dimension_range(
+            np.float64(0.0), np.float64(100.0),
+            (np.float64(10.0), np.float64(90.0)), (None, None),
+        )
+        assert result == (np.float64(10.0), np.float64(90.0))
+
+    def test_both_hard_finite_ignores_soft_range(self):
+        result = dimension_range(0.0, 100.0, (10.0, 90.0), (0.0, 200.0))
+        assert result == (10.0, 90.0)
+
+    def test_both_hard_finite_ignores_padding(self):
+        result = dimension_range(0.0, 100.0, (10.0, 90.0), (None, None),
+                                 padding=(0.1, 0.1))
+        assert result == (10.0, 90.0)
+
+    def test_one_hard_bound_does_not_short_circuit(self):
+        result = dimension_range(0.0, 100.0, (10.0, None), (None, None))
+        assert result[0] == 10.0
+        assert result[1] == 100.0
+
+    def test_nan_hard_range_does_not_short_circuit(self):
+        result = dimension_range(0.0, 100.0, (np.nan, np.nan), (None, None))
+        assert result == (0.0, 100.0)
+
+    def test_soft_range_extends_data(self):
+        result = dimension_range(5.0, 95.0, (None, None), (0.0, 100.0))
+        assert result == (0.0, 100.0)
+
+    def test_soft_range_within_data(self):
+        result = dimension_range(0.0, 100.0, (None, None), (20.0, 80.0))
+        assert result == (0.0, 100.0)
+
 
 class TestMaxRange:
     """
@@ -381,6 +419,102 @@ class TestMaxRange:
         periods = [(pd.Period("1990", freq="M"), pd.Period("1991", freq="M"))]
         expected = (np.datetime64("1990", 'ns'), np.datetime64("1991", 'ns'))
         assert max_range(periods) == expected
+
+    # ── Numeric fast path ─────────────────────────────────────────
+
+    def test_empty(self):
+        lo, hi = max_range([])
+        assert math.isnan(lo)
+        assert math.isnan(hi)
+
+    def test_single_float_tuple(self):
+        assert max_range([(1.0, 5.0)]) == (1.0, 5.0)
+
+    def test_single_float_tuple_uncombined(self):
+        assert max_range([(1.0, 5.0)], combined=False) == (1.0, 5.0)
+
+    def test_multiple_float_tuples_combined(self):
+        assert max_range([(1.0, 5.0), (2.0, 3.0)]) == (1.0, 5.0)
+
+    def test_multiple_float_tuples_uncombined(self):
+        assert max_range([(1.0, 5.0), (2.0, 3.0)], combined=False) == (1.0, 5.0)
+
+    def test_all_none_combined(self):
+        lo, hi = max_range([(None, None)])
+        assert math.isnan(lo)
+        assert math.isnan(hi)
+
+    def test_all_none_uncombined(self):
+        lo, hi = max_range([(None, None)], combined=False)
+        assert math.isnan(lo)
+        assert math.isnan(hi)
+
+    def test_none_mixed_with_float_combined(self):
+        assert max_range([(None, 5.0), (2.0, None)]) == (2.0, 5.0)
+
+    def test_none_mixed_with_float_uncombined(self):
+        lo, hi = max_range([(None, 5.0), (2.0, None)], combined=False)
+        assert lo == 2.0
+        assert hi == 5.0
+
+    def test_nan_mixed_with_float(self):
+        assert max_range([(np.nan, np.nan), (1.0, 2.0)]) == (1.0, 2.0)
+
+    def test_all_nan(self):
+        lo, hi = max_range([(np.nan, np.nan)])
+        assert math.isnan(lo)
+        assert math.isnan(hi)
+
+    def test_inf(self):
+        assert max_range([(float("inf"), float("inf"))]) == (float("inf"), float("inf"))
+
+    def test_neg_inf(self):
+        assert max_range([(float("-inf"), float("inf"))], combined=False) == (float("-inf"), float("inf"))
+
+    def test_np_int64(self):
+        assert max_range([(np.int64(1), np.int64(5))]) == (1.0, 5.0)
+
+    def test_np_int64_uncombined(self):
+        result = max_range([(np.int64(1), np.int64(10)), (np.int64(3), np.int64(7))], combined=False)
+        assert result == (1.0, 10.0)
+
+    def test_np_float64(self):
+        assert max_range([(np.float64(1.0), np.float64(5.0))]) == (1.0, 5.0)
+
+    def test_np_scalars_mixed_with_none(self):
+        """Realistic case: find_range returns numpy scalars, Dimension defaults are None."""
+        result = max_range([(np.float64(0.3), np.float64(9.7)), (None, None)])
+        assert result == (0.3, 9.7)
+
+    def test_np_scalars_mixed_with_none_uncombined(self):
+        result = max_range(
+            [(np.float64(0.3), np.float64(9.7)), (None, None)], combined=False
+        )
+        assert result == (0.3, 9.7)
+
+    def test_mixed_np_scalar_and_python_float(self):
+        assert max_range([(np.float64(1.0), 5.0), (2.0, np.float64(10.0))]) == (1.0, 10.0)
+
+    def test_negative_floats_combined(self):
+        assert max_range([(-10.0, -1.0), (-5.0, -2.0)]) == (-10.0, -1.0)
+
+    def test_negative_floats_uncombined(self):
+        assert max_range([(-10.0, -1.0), (-5.0, -2.0)], combined=False) == (-10.0, -1.0)
+
+    def test_identical_ranges(self):
+        assert max_range([(5.0, 5.0), (5.0, 5.0)]) == (5.0, 5.0)
+
+    def test_large_values(self):
+        assert max_range([(1e15, 1e16), (1e14, 1e17)]) == (1e14, 1e17)
+
+    # ── Fallback path (non-numeric types) ─────────────────────────
+
+    def test_datetime64(self):
+        result = max_range([(np.datetime64("2021-01-01"), np.datetime64("2021-12-31"))])
+        assert result[0] <= result[1]
+
+    def test_string_ranges(self):
+        assert max_range([("a", "z"), ("b", "y")]) == ("a", "z")
 
 
 class TestWrapTupleStreams:

--- a/holoviews/tests/core/test_utils.py
+++ b/holoviews/tests/core/test_utils.py
@@ -16,6 +16,7 @@ import pytest
 from holoviews import Dimension, Element
 from holoviews.core import util
 from holoviews.core.util import (
+    _minmax_finite,
     closest_match,
     compute_density,
     compute_edges,
@@ -398,6 +399,54 @@ class TestDimensionRange:
         assert result == (0.0, 100.0)
 
 
+class TestMinmaxFinite:
+    """Tests for _minmax_finite helper."""
+
+    def test_basic(self):
+        assert _minmax_finite([1.0, 3.0, 2.0]) == (1.0, 3.0)
+
+    def test_skips_none(self):
+        assert _minmax_finite([None, 2.0, None, 1.0]) == (1.0, 2.0)
+
+    def test_skips_nan(self):
+        assert _minmax_finite([float("nan"), 2.0, float("nan"), 1.0]) == (1.0, 2.0)
+
+    def test_all_none(self):
+        lo, hi = _minmax_finite([None, None])
+        assert math.isnan(lo)
+        assert math.isnan(hi)
+
+    def test_all_nan(self):
+        lo, hi = _minmax_finite([float("nan"), float("nan")])
+        assert math.isnan(lo)
+        assert math.isnan(hi)
+
+    def test_empty(self):
+        lo, hi = _minmax_finite([])
+        assert math.isnan(lo)
+        assert math.isnan(hi)
+
+    def test_preserves_numpy_scalar_type(self):
+        lo, hi = _minmax_finite([np.float64(3.0), np.int64(1)])
+        assert type(lo) is np.int64
+        assert type(hi) is np.float64
+
+    def test_preserves_python_types(self):
+        lo, hi = _minmax_finite([3.0, 1, 2.5])
+        assert type(lo) is int
+        assert type(hi) is float
+
+    def test_single_value(self):
+        lo, hi = _minmax_finite([42.0])
+        assert lo == hi == 42.0
+
+    def test_inf(self):
+        assert _minmax_finite([float("inf"), 1.0]) == (1.0, float("inf"))
+
+    def test_neg_inf(self):
+        assert _minmax_finite([float("-inf"), 1.0]) == (float("-inf"), 1.0)
+
+
 class TestMaxRange:
     """
     Tests for max_range function.
@@ -427,35 +476,23 @@ class TestMaxRange:
         assert math.isnan(lo)
         assert math.isnan(hi)
 
-    def test_single_float_tuple(self):
-        assert max_range([(1.0, 5.0)]) == (1.0, 5.0)
+    @pytest.mark.parametrize("combined", [True, False])
+    def test_single_float_tuple(self, combined):
+        assert max_range([(1.0, 5.0)], combined=combined) == (1.0, 5.0)
 
-    def test_single_float_tuple_uncombined(self):
-        assert max_range([(1.0, 5.0)], combined=False) == (1.0, 5.0)
+    @pytest.mark.parametrize("combined", [True, False])
+    def test_multiple_float_tuples(self, combined):
+        assert max_range([(1.0, 5.0), (2.0, 3.0)], combined=combined) == (1.0, 5.0)
 
-    def test_multiple_float_tuples_combined(self):
-        assert max_range([(1.0, 5.0), (2.0, 3.0)]) == (1.0, 5.0)
-
-    def test_multiple_float_tuples_uncombined(self):
-        assert max_range([(1.0, 5.0), (2.0, 3.0)], combined=False) == (1.0, 5.0)
-
-    def test_all_none_combined(self):
-        lo, hi = max_range([(None, None)])
+    @pytest.mark.parametrize("combined", [True, False])
+    def test_all_none(self, combined):
+        lo, hi = max_range([(None, None)], combined=combined)
         assert math.isnan(lo)
         assert math.isnan(hi)
 
-    def test_all_none_uncombined(self):
-        lo, hi = max_range([(None, None)], combined=False)
-        assert math.isnan(lo)
-        assert math.isnan(hi)
-
-    def test_none_mixed_with_float_combined(self):
-        assert max_range([(None, 5.0), (2.0, None)]) == (2.0, 5.0)
-
-    def test_none_mixed_with_float_uncombined(self):
-        lo, hi = max_range([(None, 5.0), (2.0, None)], combined=False)
-        assert lo == 2.0
-        assert hi == 5.0
+    @pytest.mark.parametrize("combined", [True, False])
+    def test_none_mixed_with_float(self, combined):
+        assert max_range([(None, 5.0), (2.0, None)], combined=combined) == (2.0, 5.0)
 
     def test_nan_mixed_with_float(self):
         assert max_range([(np.nan, np.nan), (1.0, 2.0)]) == (1.0, 2.0)
@@ -481,31 +518,50 @@ class TestMaxRange:
     def test_np_float64(self):
         assert max_range([(np.float64(1.0), np.float64(5.0))]) == (1.0, 5.0)
 
-    def test_np_scalars_mixed_with_none(self):
+    @pytest.mark.parametrize("combined", [True, False])
+    def test_np_scalars_mixed_with_none(self, combined):
         """Realistic case: find_range returns numpy scalars, Dimension defaults are None."""
-        result = max_range([(np.float64(0.3), np.float64(9.7)), (None, None)])
-        assert result == (0.3, 9.7)
-
-    def test_np_scalars_mixed_with_none_uncombined(self):
-        result = max_range(
-            [(np.float64(0.3), np.float64(9.7)), (None, None)], combined=False
-        )
+        result = max_range([(np.float64(0.3), np.float64(9.7)), (None, None)], combined=combined)
         assert result == (0.3, 9.7)
 
     def test_mixed_np_scalar_and_python_float(self):
         assert max_range([(np.float64(1.0), 5.0), (2.0, np.float64(10.0))]) == (1.0, 10.0)
 
-    def test_negative_floats_combined(self):
-        assert max_range([(-10.0, -1.0), (-5.0, -2.0)]) == (-10.0, -1.0)
-
-    def test_negative_floats_uncombined(self):
-        assert max_range([(-10.0, -1.0), (-5.0, -2.0)], combined=False) == (-10.0, -1.0)
+    @pytest.mark.parametrize("combined", [True, False])
+    def test_negative_floats(self, combined):
+        assert max_range([(-10.0, -1.0), (-5.0, -2.0)], combined=combined) == (-10.0, -1.0)
 
     def test_identical_ranges(self):
         assert max_range([(5.0, 5.0), (5.0, 5.0)]) == (5.0, 5.0)
 
     def test_large_values(self):
         assert max_range([(1e15, 1e16), (1e14, 1e17)]) == (1e14, 1e17)
+
+    def test_mixed_int_float_np_types(self):
+        result = max_range([(1, np.float64(10.0)), (np.int64(2), 8.0)])
+        assert result == (1, np.float64(10.0))
+
+    # ── Fast-path type preservation ───────────────────────────────
+
+    def test_fast_path_preserves_python_int(self):
+        lo, hi = max_range([(1, 5)])
+        assert type(lo) is int
+        assert type(hi) is int
+
+    def test_fast_path_preserves_python_float(self):
+        lo, hi = max_range([(1.0, 5.0)])
+        assert type(lo) is float
+        assert type(hi) is float
+
+    def test_fast_path_preserves_np_float64(self):
+        lo, hi = max_range([(np.float64(1.0), np.float64(5.0))])
+        assert type(lo) is np.float64
+        assert type(hi) is np.float64
+
+    def test_fast_path_preserves_np_int64(self):
+        lo, hi = max_range([(np.int64(1), np.int64(5))])
+        assert type(lo) is np.int64
+        assert type(hi) is np.int64
 
     # ── Fallback path (non-numeric types) ─────────────────────────
 


### PR DESCRIPTION
## Description

Profiling streaming dashboards points to frequent and suprisingly costly calls to `max_range` and `dimension_range`, accounting for nearly 10% of the server-side update time in our examples.

The vast majority of these calls receive a handful of numeric `(float, float)` tuples (often with `None` sentinels), but the implementation always allocates a NumPy array and runs `np.nanmin`/`np.nanmax`, which costs around 40–80 µs per call for this common case.

This PR adds a pure-Python fast path that handles numeric inputs using `math` operations, and an early return in `dimension_range` when both hard-range bounds are finite (since the rest of the computation would be overridden).

Non-numeric inputs (datetime, string, etc.) fall through to the existing implementation unchanged. Both paths share the same `_max_range_numeric` helper for numeric types, so there is only one implementation of the numeric min/max logic.

### Micro-benchmark

```python
import time, numpy as np
from holoviews.core.util import max_range

# Typical call pattern: 6 numeric range tuples from a 6-curve overlay
ranges = [(0.0, 100.0)] * 6

N = 100_000
t0 = time.perf_counter()
for _ in range(N):
    max_range(ranges)
us = (time.perf_counter() - t0) / N * 1e6
print(f"{us:.1f} µs/call")
# Before: ~78 µs   After: ~1.8 µs
```

A [streaming Panel dashboard](https://gist.github.com/SimonHeybrock/3e7109f958d839687303f769ae660ab0) was used to verify the improvement translates to reduced per-update latency in-browser (4 plots x 4 curves: ~120 ms → ~112 ms per update).

### Note on return types

The fast path returns Python `float` where the original `np.nanmin`/`np.nanmax` returned `np.float64`. I think it is unlikely to affect downstream code, but worth noting as a subtle behavioral change.

## Checklist

- [x] Pull request title follows the conventional format
- [x] Tests added and is passing