### PR TITLE
fix: hv.help not showing style/plot options outside Jupyter

### DIFF
--- a/holoviews/tests/util/test_help.py
+++ b/holoviews/tests/util/test_help.py
@@ -31,3 +31,14 @@ def test_help_pattern_no_ipython(capsys):
         hv.help(hv.Curve)
         captured = capsys.readouterr()
         assert captured.out.startswith('Help on class Curve')
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_help_after_extension_sets_store(capsys):
+    """hv.extension() should set InfoPrinter.store so hv.help works outside Jupyter."""
+    from holoviews.core.pprint import InfoPrinter
+    assert InfoPrinter.store is Store
+    hv.help(hv.Curve)
+    captured = capsys.readouterr()
+    assert 'Style Options' in captured.out
+    assert 'Plot Options' in captured.out

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -744,6 +744,9 @@ class extension(_pyviz_extension):
             raise ImportError('None of the backends could be imported')
         Store.set_current_backend(selected_backend)
 
+        from ..core.pprint import InfoPrinter
+        InfoPrinter.store = Store
+
         import panel as pn
 
         if params.get("enable_mathjax", False) and selected_backend == "bokeh":


### PR DESCRIPTION
## Summary

`hv.help()` was not displaying style and plot options when called outside of Jupyter/IPython (e.g., in plain Python scripts or MCP servers). This is because `InfoPrinter.store` was only set in `holoviews/ipython/__init__.py`, which is only loaded inside IPython.

Closes #6775

## Fix

Set `InfoPrinter.store = Store` in the base `extension.__call__()` method (`holoviews/util/__init__.py`) so it works in all environments.

**Before (outside Jupyter):**
```
>>> hv.help(hv.Curve)
Help on class Curve in module holoviews.element.chart:
...
# No style options, no plot options shown
```

**After (outside Jupyter):**
```
>>> hv.help(hv.Curve)
Curve
Online example: https://holoviews.org/reference/elements/bokeh/Curve.html

Style Options
-------------
alpha, color, hover_alpha, ...

Plot Options
------------
Parameters of 'CurvePlot'
...
```

## Changes

- `holoviews/util/__init__.py`: Added `InfoPrinter.store = Store` after `Store.set_current_backend()` in `extension.__call__()`
- `holoviews/tests/util/test_help.py`: Added test verifying `hv.help()` shows full output after `hv.extension()`

## Tests

All 3 tests in `test_help.py` pass (including the new one).