### PR TITLE
fix: Raise error if RGB getitem uses Ellipsis with bad name

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -790,6 +790,16 @@ class RGB(Image):
 
         return False
 
+    def __getitem__(self, slices):
+        wrapped = util.wrap_tuple(slices)
+        if Ellipsis in wrapped:
+            index = wrapped.index(Ellipsis)
+            head = wrapped[:index]
+            tail = wrapped[index + 1 :]
+            padlen = (self.ndims + 1) - (len(head) + len(tail))
+            slices = head + (slice(None),) * max(padlen, 0) + tail
+        return super().__getitem__(slices)
+
 
 class HSV(RGB):
     """HSV represents a regularly spaced 2D grid of an underlying

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -793,11 +793,14 @@ class RGB(Image):
     def __getitem__(self, slices):
         wrapped = util.wrap_tuple(slices)
         if Ellipsis in wrapped:
+            if wrapped.count(Ellipsis) > 1:
+                msg = "Only a single ellipsis is allowed"
+                raise ValueError(msg)
             index = wrapped.index(Ellipsis)
             head = wrapped[:index]
             tail = wrapped[index + 1 :]
-            padlen = (self.ndims + 1) - (len(head) + len(tail))
-            slices = head + (slice(None),) * max(padlen, 0) + tail
+            padlen = max(self.ndims + 1 - len(head) - len(tail), 0)
+            slices = head + (slice(None),) * padlen + tail
         return super().__getitem__(slices)
 
 

--- a/holoviews/tests/element/test_ellipsis.py
+++ b/holoviews/tests/element/test_ellipsis.py
@@ -100,12 +100,22 @@ class TestEllipsisRaster:
         sliced = hv.RGB(data)[:, :, "R"]
         assert_data_equal(sliced.data, data[:, :, 0])
 
-    @pytest.mark.xfail(reason="Should raise IndexError like Image")
     def test_rgb_ellipsis_slice_value_missing(self):
         rgb = hv.RGB(np.random.rand(10, 10, 3))
         msg = "'Non-existent' is not an available value dimension"
         with pytest.raises(IndexError, match=msg):
             rgb[..., "Non-existent"]
+
+    def test_rgb_ellipsis_slice_alpha_channel(self):
+        rgba = np.random.rand(10, 10, 4)
+        sliced = hv.RGB(rgba)[..., "A"]
+        assert_data_equal(sliced.data, rgba[:, :, 3])
+
+    def test_rgb_ellipsis_slice_alpha_channel_missing(self):
+        rgba = hv.RGB(np.random.rand(10, 10, 4))
+        msg = "'Non-existent' is not an available value dimension"
+        with pytest.raises(IndexError, match=msg):
+            rgba[..., "Non-existent"]
 
 
 class TestEllipsisDeepIndexing:

--- a/holoviews/tests/element/test_ellipsis.py
+++ b/holoviews/tests/element/test_ellipsis.py
@@ -26,11 +26,9 @@ class TestEllipsisCharts:
         hv.Scatter(range(10))[..., "y"]
 
     def test_scatter_ellipsis_value_missing(self):
-        try:
+        msg = "'Non-existent' is not an available value dimension"
+        with pytest.raises(IndexError, match=msg):
             hv.Scatter(range(10))[..., "Non-existent"]
-        except Exception as e:
-            if str(e) != "'Non-existent' is not an available value dimension":
-                raise AssertionError("Incorrect exception raised.")
 
     def test_points_ellipsis_slice_y(self):
         sliced = hv.Points([(i, 2 * i) for i in range(10)])[..., 3:9]
@@ -82,11 +80,9 @@ class TestEllipsisRaster:
 
     def test_raster_ellipsis_slice_value_missing(self):
         data = np.random.rand(10, 10)
-        try:
+        msg = r"'z' is the only selectable value dimension"
+        with pytest.raises(KeyError, match=msg):
             hv.Raster(data)[..., "Non-existent"]
-        except Exception as e:
-            if "'z' is the only selectable value dimension" not in str(e):
-                raise AssertionError("Unexpected exception.")
 
     def test_image_ellipsis_slice_value(self):
         data = np.random.rand(10, 10)
@@ -95,24 +91,21 @@ class TestEllipsisRaster:
 
     def test_image_ellipsis_slice_value_missing(self):
         data = np.random.rand(10, 10)
-        try:
+        msg = "'Non-existent' is not an available value dimension"
+        with pytest.raises(IndexError, match=msg):
             hv.Image(data)[..., "Non-existent"]
-        except Exception as e:
-            if str(e) != "'Non-existent' is not an available value dimension":
-                raise AssertionError("Unexpected exception.")
 
     def test_rgb_ellipsis_slice_value(self):
         data = np.random.rand(10, 10, 3)
         sliced = hv.RGB(data)[:, :, "R"]
         assert_data_equal(sliced.data, data[:, :, 0])
 
+    @pytest.mark.xfail(reason="Should raise IndexError like Image")
     def test_rgb_ellipsis_slice_value_missing(self):
         rgb = hv.RGB(np.random.rand(10, 10, 3))
-        try:
+        msg = "'Non-existent' is not an available value dimension"
+        with pytest.raises(IndexError, match=msg):
             rgb[..., "Non-existent"]
-        except Exception as e:
-            if str(e) != repr("'Non-existent' is not an available value dimension"):
-                raise AssertionError("Incorrect exception raised.")
 
 
 class TestEllipsisDeepIndexing:

--- a/holoviews/tests/element/test_ellipsis.py
+++ b/holoviews/tests/element/test_ellipsis.py
@@ -106,6 +106,12 @@ class TestEllipsisRaster:
         with pytest.raises(IndexError, match=msg):
             rgb[..., "Non-existent"]
 
+    def test_rgb_ellipsis_slice_multiple_ellipsis(self):
+        rgb = hv.RGB(np.random.rand(10, 10, 3))
+        msg = "Only a single ellipsis is allowed"
+        with pytest.raises(ValueError, match=msg):
+            rgb[..., ..., "R"]
+
     def test_rgb_ellipsis_slice_alpha_channel(self):
         rgba = np.random.rand(10, 10, 4)
         sliced = hv.RGB(rgba)[..., "A"]

--- a/holoviews/tests/testing/test_chart.py
+++ b/holoviews/tests/testing/test_chart.py
@@ -52,11 +52,9 @@ class BarsComparisonTest:
         assert_element_equal(self.bars3, self.bars3)
 
     def test_bars_unequal_1(self):
-        try:
+        msg = "Arrays are not almost equal"
+        with pytest.raises(AssertionError, match=msg):
             assert_element_equal(self.bars1, self.bars2)
-        except AssertionError as e:
-            if "not almost equal" not in str(e):
-                raise Exception(f"Bars mismatched data error not raised. {e}")
 
     def test_bars_unequal_keydims(self):
         msg = "assert 'Car occupants' == 'Cyclists'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,17 +208,15 @@ extend-unsafe-fixes = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F403"]
 "holoviews/tests/*" = [
     "RUF001", # Ambiguous unicode character
     "RUF002", # Ambiguous unicode character
     "RUF003", # Ambiguous unicode character
     "NPY002", # Replace legacy `np.random.rand` call with Generator
-    "B904", # Within an `except` clause, raise exceptions with from err or None
     "D", # pydocstyle
 ]
 "examples/*" = [
-    "B905", # zip zip-without-explicit-strict
+    "B905", # zip-without-explicit-strict
     "NPY002", # Replace legacy `np.random.rand` call with Generator
     "PLW0603", # Using global statement
     "RUF001", # Ambiguous unicode character
@@ -226,7 +224,7 @@ extend-unsafe-fixes = [
     "RUF003", # Ambiguous unicode character
 ]
 "holoviews/element/comparison.py" = ["PT009"]
-"holoviews/tests/element/test_comparison*.py" = ["PT009", "PT027"]
+"holoviews/tests/element/test_comparison*.py" = ["B904", "PT009", "PT027"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["holoviews"]


### PR DESCRIPTION
## Description

<!--
- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Update ruff rules and found an error in a test case for RGB.

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so it can be reproduced while reviewing your changes. -->

CI

## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and how you have used it. -->

Tools: Claude + Sonnet 4.6, used to iterate over the fix for RGB.

## Checklist

<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and is passing


<!--
Conventional format: <Type>(<Scope>): <Subject>
Valid Types: `build`, `chore`, `ci`, `compat`, `docs`, `enh`, `feat`, `fix`, `perf`, `refactor`, `test`, and `type`
Valid Scopes (optional): `dev`, `data`, `plotting`, `bokeh`, `matplotlib`, `plotly`, and `notebook`

For more information on how to contribute to this repository, see the [developer guide](https://www.holoviews.org/developer_guide/index.html)
-->
