### PR TITLE
fix(plotting): Fix Bars crash with datetime x-axis for single or duplicate values

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -1154,7 +1154,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
                 xdiff = np.abs(np.diff(xvals[xslice]))
                 diff_size = len(np.unique(xdiff))
                 if diff_size == 0 or (diff_size == 1 and xdiff[0] == 0):
-                    xdiff = 1
+                    xdiff = np.array([np.timedelta64(1, "D")]) if is_dt else np.array([1])
                 if is_dt:
                     width *= xdiff.astype("timedelta64[ms]").astype(np.int64)
                 else:

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -1154,7 +1154,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
                 xdiff = np.abs(np.diff(xvals[xslice]))
                 diff_size = len(np.unique(xdiff))
                 if diff_size == 0 or (diff_size == 1 and xdiff[0] == 0):
-                    xdiff = np.array([np.timedelta64(1, "D")]) if is_dt else np.array([1])
+                    xdiff = np.array([np.timedelta64(1, "D")]) if is_dt else 1
                 if is_dt:
                     width *= xdiff.astype("timedelta64[ms]").astype(np.int64)
                 else:

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -1101,7 +1101,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
             xdiff = np.abs(np.diff(xvals))
             diff_size = len(np.unique(xdiff))
             if diff_size == 0 or (diff_size == 1 and xdiff[0] == 0):
-                xdiff = 1
+                xdiff = np.timedelta64(1, "D") if is_dt else 1
             else:
                 xdiff = np.min(xdiff)
             width = (1 - self.bar_padding) * (

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -349,13 +349,11 @@ class TestBarPlot(TestBokehPlot):
         np.testing.assert_almost_equal(plot.handles["glyph"].width, 69120000.0)
 
     def test_bars_continuous_datetime_single(self):
-        # See: https://github.com/holoviz/holoviews/issues/6813
         bars = hv.Bars([(pd.Timestamp("2024-01-01"), 5)])
         plot = bokeh_renderer.get_plot(bars)
         np.testing.assert_almost_equal(plot.handles["glyph"].width, 69120000.0)
 
     def test_bars_continuous_datetime_duplicates(self):
-        # See: https://github.com/holoviz/holoviews/issues/6813
         bars = hv.Bars([(pd.Timestamp("2024-01-01"), 5), (pd.Timestamp("2024-01-01"), 3)])
         plot = bokeh_renderer.get_plot(bars)
         np.testing.assert_almost_equal(plot.handles["glyph"].width, 69120000.0)

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -348,6 +348,18 @@ class TestBarPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(bars)
         np.testing.assert_almost_equal(plot.handles["glyph"].width, 69120000.0)
 
+    def test_bars_continuous_datetime_single(self):
+        # See: https://github.com/holoviz/holoviews/issues/6813
+        bars = hv.Bars([(pd.Timestamp("2024-01-01"), 5)])
+        plot = bokeh_renderer.get_plot(bars)
+        np.testing.assert_almost_equal(plot.handles["glyph"].width, 69120000.0)
+
+    def test_bars_continuous_datetime_duplicates(self):
+        # See: https://github.com/holoviz/holoviews/issues/6813
+        bars = hv.Bars([(pd.Timestamp("2024-01-01"), 5), (pd.Timestamp("2024-01-01"), 3)])
+        plot = bokeh_renderer.get_plot(bars)
+        np.testing.assert_almost_equal(plot.handles["glyph"].width, 69120000.0)
+
     def test_bars_continuous_datetime_timezone_in_overlay(self):
         # See: https://github.com/holoviz/holoviews/issues/6364
         bars = hv.Bars((pd.date_range("1/1/2000", periods=10, tz="UTC"), np.random.rand(10)))

--- a/holoviews/tests/plotting/matplotlib/test_barplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_barplot.py
@@ -40,6 +40,18 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         assert ax.get_xticklabels()[0].get_text() == "01"
         assert ax.get_xticklabels()[-1].get_text() == "10"
 
+    def test_bars_continuous_datetime_single(self):
+        bars = hv.Bars([(pd.Timestamp("2024-01-01"), 5)])
+        plot = mpl_renderer.get_plot(bars)
+        ax = plot.handles["axis"]
+        assert ax.patches[0].get_width() == 0.8
+
+    def test_bars_continuous_datetime_duplicates(self):
+        bars = hv.Bars([(pd.Timestamp("2024-01-01"), 5), (pd.Timestamp("2024-01-01"), 3)])
+        plot = mpl_renderer.get_plot(bars)
+        ax = plot.handles["axis"]
+        assert ax.patches[0].get_width() == 0.8
+
     def test_bars_not_continuous_data_list(self):
         bars = hv.Bars([("A", 1), ("B", 2), ("C", 3)])
         plot = mpl_renderer.get_plot(bars)


### PR DESCRIPTION
## Description

Fixes `AttributeError: 'int' object has no attribute 'astype'` when rendering `hv.Bars` with a datetime x-axis that has either a single data point or all identical x-values.

In `BarPlot.get_data()`, when `np.diff()` returns an empty or all-zero array, `xdiff` gets reassigned to the plain Python int `1`. The subsequent `.astype('timedelta64[ms]')` call then fails because `int` doesn't have `.astype()`.

Fixed by wrapping the fallback as `np.array([1])` so `.astype()` and `np.min()` continue to work. Applied to both the Bokeh and Matplotlib backends.

Fixes #6813

## How Has This Been Tested?

Added two regression tests in `test_barplot.py`:
- `test_bars_continuous_datetime_single` - single datetime bar
- `test_bars_continuous_datetime_duplicates` - duplicate datetime x-values

Full barplot test suite passes (48/48).

## Checklist

- [x] Pull request title follows the conventional format
- [x] Tests added and is passing