### PR TITLE
fix: Check `narwhals.Series` is also `arraylike`

### DIFF
--- a/holoviews/core/util/types.py
+++ b/holoviews/core/util/types.py
@@ -3,6 +3,7 @@ import inspect
 from types import GeneratorType
 from typing import TYPE_CHECKING
 
+import narwhals
 import narwhals.stable.v2 as nw
 
 from .dependencies import _LazyModule
@@ -97,7 +98,7 @@ def arraylike_types():
 
         yield from (ABCIndex, ABCSeries, ABCExtensionArray)
 
-    yield nw.Series
+    yield from (nw.Series, narwhals.Series)
 
 
 @gen_types


### PR DESCRIPTION
## Description

<!--
- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Fixes part of #6828

The user uses the top level Narwhals import, which causes checks to go down wrong code paths. 

## How Has This Been Tested?

CI


## Checklist

<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and is passing
