### PR TITLE
perf(bokeh): Remove dead hasattr check triggering difflib

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2618,12 +2618,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self.current_frame = element
 
         renderer = self.handles.get("glyph_renderer", None)
-        glyph = self.handles.get("glyph", None)
         visible = element is not None
         if hasattr(renderer, "visible"):
             renderer.visible = visible
-        if hasattr(glyph, "visible"):
-            glyph.visible = visible
 
         if (
             (self.batched and not element)


### PR DESCRIPTION
## Description

This removes the dead `hasattr` check and the unused `glyph` variable lookup. Visibility is already correctly controlled via the `GlyphRenderer`, which has a `visible` property and is handled on the line above.

Microbenchmark: each `hasattr(glyph, 'visible')` call takes ~26 µs because Bokeh's `__getattr__` runs `difflib.get_close_matches()` before raising `AttributeError` (vs ~0.25 µs for an attribute that exists). For a 6-curve overlay this adds ~0.16 ms per update (~0.8% of the ~20 ms baseline).

`ElementPlot.update_frame` called `hasattr(glyph, 'visible')` on every update. No Bokeh glyph type has a `visible` property — only renderers do — so `hasattr` always returned `False`. `visible` is defined on `Renderer`, not on the `Glyph → Model` branch, and Bokeh's `HasProps.__setattr__` prevents dynamic property addition, so this cannot change at runtime. However, Bokeh's `__getattr__` runs `difflib.get_close_matches()` before raising `AttributeError`, adding unnecessary overhead on every frame. The `glyph.visible = visible` assignment was never reached.

<details>
<summary>Verification: no Bokeh glyph type has <code>visible</code></summary>

```python
from bokeh.models.glyphs import (Line, Circle, MultiLine, Patch, Patches, Rect, Quad,
                                  Image, ImageRGBA, Step, Scatter, VBar, HBar, Wedge,
                                  AnnularWedge, Text, HArea, VArea)
from bokeh.models.renderers import GlyphRenderer

for cls in [Line, Circle, MultiLine, Patch, Patches, Rect, Quad, Image, ImageRGBA,
            Step, Scatter, VBar, HBar, Wedge, AnnularWedge, Text, HArea, VArea]:
    print(f"{cls.__name__:20s} visible={hasattr(cls, 'visible')}")
# All print False

print(f"{'GlyphRenderer':20s} visible={hasattr(GlyphRenderer, 'visible')}")
# Prints True — visibility is a renderer property, not a glyph property
```

</details>

This is part of a series of independent performance improvements to the streaming/DynamicMap update path. See also https://discourse.holoviz.org/t/optimizing-holoviews-and-param-for-faster-streaming-dynamicmap/9121.

## How Has This Been Tested?

Existing Bokeh plotting test suite passes (1180 tests). No new tests added — this is dead code removal.

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

Tools: Claude Code (Opus)

## Checklist

- [x] Pull request title follows the conventional format
