### PR TITLE
perf: Disable pipeline bookkeeping during plot refresh

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -188,7 +188,7 @@ def disable_pipeline():
 
 @contextmanager
 def enable_pipeline():
-    """Re-enable PipelineMeta class for storing pipelines."""
+    """Enable PipelineMeta class for storing pipelines."""
     prev = PipelineMeta.disable
     PipelineMeta.disable = False
     try:

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -178,11 +178,23 @@ class DataConversion:
 @contextmanager
 def disable_pipeline():
     """Disable PipelineMeta class from storing pipelines."""
+    prev = PipelineMeta.disable
     PipelineMeta.disable = True
     try:
         yield
     finally:
-        PipelineMeta.disable = False
+        PipelineMeta.disable = prev
+
+
+@contextmanager
+def enable_pipeline():
+    """Re-enable PipelineMeta class for storing pipelines."""
+    prev = PipelineMeta.disable
+    PipelineMeta.disable = False
+    try:
+        yield
+    finally:
+        PipelineMeta.disable = prev
 
 
 class PipelineMeta(ParameterizedMetaclass):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -207,6 +207,9 @@ class PipelineMeta(ParameterizedMetaclass):
     def pipelined(method_fn, method_name):
         @wraps(method_fn)
         def pipelined_fn(*args, **kwargs):
+            if PipelineMeta.disable:
+                return method_fn(*args, **kwargs)
+
             from ...operation.element import method as method_op
 
             inst = args[0]
@@ -217,8 +220,6 @@ class PipelineMeta(ParameterizedMetaclass):
 
             try:
                 result = method_fn(*args, **kwargs)
-                if PipelineMeta.disable:
-                    return result
 
                 op = method_op.instance(
                     input_type=type(inst),

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -243,7 +243,8 @@ class Plot(param.Parameterized):
             )
             stream_key = util.wrap_tuple_streams(key, self.dimensions, self.streams)
 
-            self._trigger_refresh(stream_key)
+            with disable_pipeline():
+                self._trigger_refresh(stream_key)
             if self.top_level:
                 self.push()
         except Exception as e:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -20,7 +20,7 @@ from panel.io.state import state
 from pyviz_comms import JupyterComm
 
 from ..core import traversal, util
-from ..core.data import Dataset, PipelineMeta, disable_pipeline
+from ..core.data import Dataset, disable_pipeline, enable_pipeline
 from ..core.element import Element, Element3D
 from ..core.layout import Empty, Layout, NdLayout
 from ..core.options import Compositor, SkipRendering, Store, lookup_options
@@ -1506,12 +1506,8 @@ class GenericElementPlot(DimensionedPlot):
         # the disable_pipeline() call there), but user callbacks may call
         # Dataset methods (e.g. select) whose results should retain pipeline
         # provenance.
-        prev_disable = PipelineMeta.disable
-        PipelineMeta.disable = False
-        try:
+        with enable_pipeline():
             frame = get_plot_frame(self.hmap, key_map, cached)
-        finally:
-            PipelineMeta.disable = prev_disable
         traverse_setter(self, "_force", False)
 
         if key not in self.keys and len(key) == self.hmap.ndims and self.dynamic:
@@ -2369,15 +2365,11 @@ class GenericCompositePlot(DimensionedPlot):
         key_map = dict(zip([d.name for d in self.dimensions], key, strict=None))
         # Re-enable pipeline tracking for the DynamicMap callback evaluation.
         # See GenericElementPlot._get_frame for rationale.
-        prev_disable = PipelineMeta.disable
-        PipelineMeta.disable = False
-        try:
+        with enable_pipeline():
             for path, item in self.layout.items():
                 frame = get_nested_plot_frame(item, key_map, cached)
                 if frame is not None:
                     layout_frame[path] = frame
-        finally:
-            PipelineMeta.disable = prev_disable
         traverse_setter(self, "_force", False)
 
         self.current_frame = layout_frame

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -20,7 +20,7 @@ from panel.io.state import state
 from pyviz_comms import JupyterComm
 
 from ..core import traversal, util
-from ..core.data import Dataset, disable_pipeline
+from ..core.data import Dataset, PipelineMeta, disable_pipeline
 from ..core.element import Element, Element3D
 from ..core.layout import Empty, Layout, NdLayout
 from ..core.options import Compositor, SkipRendering, Store, lookup_options
@@ -1501,7 +1501,17 @@ class GenericElementPlot(DimensionedPlot):
 
         cached = self.current_key is None and not any(s._triggering for s in self.streams)
         key_map = dict(zip([d.name for d in self.dimensions], key, strict=None))
-        frame = get_plot_frame(self.hmap, key_map, cached)
+        # Re-enable pipeline tracking for the DynamicMap callback evaluation.
+        # Plot.refresh() disables pipeline for the entire update path (see
+        # the disable_pipeline() call there), but user callbacks may call
+        # Dataset methods (e.g. select) whose results should retain pipeline
+        # provenance.
+        prev_disable = PipelineMeta.disable
+        PipelineMeta.disable = False
+        try:
+            frame = get_plot_frame(self.hmap, key_map, cached)
+        finally:
+            PipelineMeta.disable = prev_disable
         traverse_setter(self, "_force", False)
 
         if key not in self.keys and len(key) == self.hmap.ndims and self.dynamic:
@@ -2357,10 +2367,17 @@ class GenericCompositePlot(DimensionedPlot):
             self.current_key = key
 
         key_map = dict(zip([d.name for d in self.dimensions], key, strict=None))
-        for path, item in self.layout.items():
-            frame = get_nested_plot_frame(item, key_map, cached)
-            if frame is not None:
-                layout_frame[path] = frame
+        # Re-enable pipeline tracking for the DynamicMap callback evaluation.
+        # See GenericElementPlot._get_frame for rationale.
+        prev_disable = PipelineMeta.disable
+        PipelineMeta.disable = False
+        try:
+            for path, item in self.layout.items():
+                frame = get_nested_plot_frame(item, key_map, cached)
+                if frame is not None:
+                    layout_frame[path] = frame
+        finally:
+            PipelineMeta.disable = prev_disable
         traverse_setter(self, "_force", False)
 
         self.current_frame = layout_frame


### PR DESCRIPTION
## Description

Every public `Dataset` method call (`range`, `dimension_values`, `sort`, etc.) is wrapped by `PipelineMeta.pipelined`, which records operations into a pipeline object for reproducibility. This wrapper performs an import, `copy.copy` of the pipeline, `_in_method` flag tracking, and `method_op.instance(...)` creation on every call — even when pipeline recording is disabled via the existing `disable_pipeline()` context manager.

Two changes:

- Move the `PipelineMeta.disable` check to the top of `pipelined_fn`, before any bookkeeping. Previously the check happened after the method call, so all overhead was still incurred. Now disabled calls go straight to the wrapped method with zero overhead.
- Wrap `Plot.refresh()` → `_trigger_refresh()` in `disable_pipeline()`. During plot refresh, all Dataset method calls are read-only queries — no new Datasets are created that need pipeline tracking. The `disable_pipeline` context manager already existed and was used in two other places (renderer, compositor) but not in the update path that dominates streaming performance. **Note: This is a part I was not certain about, so in the end we added [f242880](https://github.com/holoviz/holoviews/pull/6832/commits/f242880a7a35acf7c41bd5a6f03ba4445df4652c) (second commit) - is this actually necessary, or is the first commit correct on its own?**

End-to-end with the [streaming app](https://gist.github.com/SimonHeybrock/880de22fd75dfa56d0299c9f4fe5773f) (4 plots x 6 curves, 20 ms interval, hold=True, freeze=True):
- 115 ms -> 101 ms median per update.
- 115 ms -> 96 ms median per update when combined with #6831.

Headless benchmark (Curve x6 overlay, 1000 pts/curve, 60 updates, median of 5 runs):

| Scenario | Before | After | Change |
|---|---|---|---|
| With Bokeh validation | 23.2 ms | 21.7 ms | -6.6% |
| Without Bokeh validation | 18.6 ms | 16.1 ms | -13.0% |

This is part of a series of independent performance improvements to the streaming/DynamicMap update path.
See also https://discourse.holoviz.org/t/optimizing-holoviews-and-param-for-faster-streaming-dynamicmap/9121.
See the [streaming app](https://gist.github.com/SimonHeybrock/880de22fd75dfa56d0299c9f4fe5773f), [streaming benchmark](https://gist.github.com/SimonHeybrock/5ffe34160f661f618f2d66e925e1ab1a), and [profiling suite](https://gist.github.com/SimonHeybrock/4d9654473549b22c138c09b9250ddd15) gists to reproduce.

## How Has This Been Tested?

Existing Bokeh plotting tests (1180 passed) and core tests (719 passed) cover correctness. The pipeline mechanism is exercised throughout the test suite via normal Dataset operations.

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

Tools: Claude Code (Opus)

## Checklist

- [x] Pull request title follows the conventional format
