### PR TITLE
perf: Skip param.update when plot options unchanged

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -2647,7 +2647,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             ranges = self.compute_ranges(self.hmap, key, ranges)
         else:
             self.ranges.update(ranges)
-        self.param.update(**self.lookup_options(style_element, "plot").options)
+        self._apply_plot_opts(self.lookup_options(style_element, "plot").options)
         ranges = util.match_spec(style_element, ranges)
         self.current_ranges = ranges
         plot = self.handles["plot"]
@@ -4000,7 +4000,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                 element, "plot", self._propagate_options, defaults=False
             )
             plot_opts.update(**{k: v[0] for k, v in inherited.items() if k not in plot_opts})
-            self.param.update(**plot_opts)
+            self._apply_plot_opts(plot_opts)
 
             if not self.overlaid and not self.tabs and not self.batched:
                 self._update_ranges(element, ranges)

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -148,7 +148,7 @@ class TablePlot(BokehPlot, GenericElementPlot):
 
         """
         element = self._get_frame(key)
-        self.param.update(**self.lookup_options(element, "plot").options)
+        self._apply_plot_opts(self.lookup_options(element, "plot").options)
         self._get_title_div(key, "12pt")
 
         # Cache frame object id to skip updating data if unchanged

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -611,7 +611,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             self.current_frame = element
 
         if element is not None:
-            self.param.update(**self.lookup_options(element, "plot").options)
+            self._apply_plot_opts(self.lookup_options(element, "plot").options)
         axis = self.handles["axis"]
 
         axes_visible = element is not None or self.overlaid
@@ -1469,7 +1469,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             element, "plot", self._propagate_options, defaults=False
         )
         plot_opts.update(**{k: v[0] for k, v in inherited.items() if k not in plot_opts})
-        self.param.update(**plot_opts)
+        self._apply_plot_opts(plot_opts)
 
         if self.show_legend and not empty:
             self._adjust_legend(element, axis)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1384,7 +1384,7 @@ class GenericElementPlot(DimensionedPlot):
     def _apply_plot_opts(self, plot_opts: dict) -> None:
         """Apply plot options, skipping if unchanged from the previous frame."""
         try:
-            unchanged = plot_opts == self._prev_plot_opts
+            unchanged = bool(plot_opts == self._prev_plot_opts)
         except (ValueError, TypeError):
             # Options may contain numpy arrays where == is element-wise
             unchanged = False

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1379,6 +1379,14 @@ class GenericElementPlot(DimensionedPlot):
 
     _multi_y_propagation = False
 
+    _prev_plot_opts = None
+
+    def _apply_plot_opts(self, plot_opts: dict) -> None:
+        """Apply plot options, skipping if unchanged from the previous frame."""
+        if plot_opts != self._prev_plot_opts:
+            self._prev_plot_opts = plot_opts
+            self.param.update(**plot_opts)
+
     def __init__(
         self,
         element,

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1381,17 +1381,6 @@ class GenericElementPlot(DimensionedPlot):
 
     _prev_plot_opts = None
 
-    def _apply_plot_opts(self, plot_opts: dict) -> None:
-        """Apply plot options, skipping if unchanged from the previous frame."""
-        try:
-            unchanged = bool(plot_opts == self._prev_plot_opts)
-        except (ValueError, TypeError):
-            # Options may contain numpy arrays where == is element-wise
-            unchanged = False
-        if not unchanged:
-            self._prev_plot_opts = plot_opts
-            self.param.update(**plot_opts)
-
     def __init__(
         self,
         element,
@@ -1925,6 +1914,20 @@ class GenericElementPlot(DimensionedPlot):
 
         attr_accessor = accessors[-1]
         return model, attr_accessor
+
+    def _apply_plot_opts(self, plot_opts: dict) -> None:
+        """Apply plot options, skipping if unchanged from the previous frame.
+
+        This is a performance optimization to avoid unnecessary updates when
+        options have not changed.
+        """
+        try:
+            changed = bool(plot_opts != self._prev_plot_opts)
+        except (ValueError, TypeError):
+            changed = True
+        if changed:
+            self._prev_plot_opts = plot_opts
+            self.param.update(**plot_opts)
 
     def update_frame(self, key, ranges=None):
         """Set the plot(s) to the given frame number.  Operates by

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1383,7 +1383,12 @@ class GenericElementPlot(DimensionedPlot):
 
     def _apply_plot_opts(self, plot_opts: dict) -> None:
         """Apply plot options, skipping if unchanged from the previous frame."""
-        if plot_opts != self._prev_plot_opts:
+        try:
+            unchanged = plot_opts == self._prev_plot_opts
+        except (ValueError, TypeError):
+            # Options may contain numpy arrays where == is element-wise
+            unchanged = False
+        if not unchanged:
             self._prev_plot_opts = plot_opts
             self.param.update(**plot_opts)
 

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -817,7 +817,7 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
             element, "plot", self._propagate_options, defaults=False
         )
         plot_opts.update(**{k: v[0] for k, v in inherited.items() if k not in plot_opts})
-        self.param.update(**plot_opts)
+        self._apply_plot_opts(plot_opts)
 
         ranges = self.compute_ranges(self.hmap, key, ranges)
         figure = None
@@ -841,7 +841,7 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
                 el = None
 
             # propagate plot options to subplots
-            subplot.param.update(**plot_opts)
+            subplot._apply_plot_opts(plot_opts)
 
             fig = subplot.generate_plot(key, ranges, el, is_geo=is_geo)
             if figure is None:

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -318,6 +318,18 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.xaxis.ticker.ticks == [dt_to_int(tick, "ms")]
         assert plot.state.xaxis.major_label_overrides == {dt_to_int(tick, "ms"): "A"}
 
+    def test_update_frame_with_numpy_xticks(self):
+        # Apply opts inside the callback so each frame produces a fresh
+        # numpy array, exercising the plot-options cache comparison.
+        pipe = Pipe(data=[1, 2, 3])
+        dmap = hv.DynamicMap(
+            lambda data: hv.Curve(data).opts(xticks=np.array([1.0, 2.0, 3.0])),
+            streams=[pipe],
+        )
+        bokeh_renderer.get_plot(dmap)
+        pipe.send([4, 5, 6])
+        pipe.send([7, 8, 9])
+
     def test_element_grid_custom_xticker(self):
         curve = hv.Curve([1, 2, 3]).opts(xticks=[0.5, 1.5], show_grid=True)
         plot = bokeh_renderer.get_plot(curve)

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -319,8 +319,9 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         assert plot.state.xaxis.major_label_overrides == {dt_to_int(tick, "ms"): "A"}
 
     def test_update_frame_with_numpy_xticks(self):
-        # Apply opts inside the callback so each frame produces a fresh
-        # numpy array, exercising the plot-options cache comparison.
+        # Apply opts inside the callback so each frame produces a fresh numpy
+        # array, checking that _apply_plot_opts function does not raise an
+        # exception.
         pipe = Pipe(data=[1, 2, 3])
         dmap = hv.DynamicMap(
             lambda data: hv.Curve(data).opts(xticks=np.array([1.0, 2.0, 3.0])),


### PR DESCRIPTION
## Description

Cache the plot options dict returned by `lookup_options` and skip the `param.update()` call when the dict matches the previous frame. Applied in `ElementPlot.update_frame` and `OverlayPlot.update_frame` across all backends (bokeh, matplotlib, plotly) via `_prev_plot_opts` on`GenericElementPlot`.

`param.update` iterates all parameters to build a restore dict, sets attributes, and checks watchers. In streaming scenarios where plot options are static between frames, this is pure overhead.

End-to-end improvement measured with the Bokeh-backend
[streaming app](https://gist.github.com/SimonHeybrock/880de22fd75dfa56d0299c9f4fe5773f)
(4 plots × 4 curves × 1000 points, `panel serve`, Chrome):

| | main | this PR |
|---|---|---|
| median | 98 ms | 92 ms |

This is part of a series of independent performance improvements to the
streaming/DynamicMap update path.
See also https://discourse.holoviz.org/t/optimizing-holoviews-and-param-for-faster-streaming-dynamicmap/9121.
See the [streaming app](https://gist.github.com/SimonHeybrock/880de22fd75dfa56d0299c9f4fe5773f),
[streaming benchmark](https://gist.github.com/SimonHeybrock/5ffe34160f661f618f2d66e925e1ab1a), and
[profiling suite](https://gist.github.com/SimonHeybrock/4d9654473549b22c138c09b9250ddd15)
gists to reproduce.

## How Has This Been Tested?

Existing plotting test suites pass across all backends (bokeh: 1193, matplotlib: 368). No dedicated test added — the change guards an existing call with a cache check and introduces no new behavior.

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

Tools: Claude Code (Opus)

## Checklist

- [x] Pull request title follows the conventional format
