### PR TITLE
ci: Add retry option to download test data

### DIFF
--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -1,17 +1,32 @@
+import sys
+import time
 from contextlib import suppress
 
 import bokeh
 from packaging.version import Version
 
+
+def retry(func, *args, **kwargs):
+    for i in range(5):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            if i == 4:
+                raise
+            wait = 10 * 2**i
+            print(f"Attempt {i + 1} failed: {e}. Retrying in {wait}s...", file=sys.stderr)
+            time.sleep(wait)
+
+
 if Version(bokeh.__version__).release < (3, 5, 0):
     import bokeh.sampledata
 
-    bokeh.sampledata.download()
+    retry(bokeh.sampledata.download)
 
 with suppress(ImportError):
     import pooch  # noqa: F401
     import scipy  # noqa: F401
     import xarray as xr
 
-    xr.tutorial.open_dataset("air_temperature")
-    xr.tutorial.open_dataset("rasm")
+    retry(xr.tutorial.open_dataset, "air_temperature")
+    retry(xr.tutorial.open_dataset, "rasm", decode_times=False)


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Github (used to download data) seems more and more flaky when downloading data. This adds a simple retry step, so we don't have to wait for CI to finish to rerun. 

## How Has This Been Tested?

CI
