### PR TITLE
test: Wait for networkidle before interacting in popup UI tests

### DIFF
--- a/holoviews/tests/ui/bokeh/test_callback.py
+++ b/holoviews/tests/ui/bokeh/test_callback.py
@@ -339,7 +339,6 @@ class TestPopup:
             page.mouse.up()
         elif tool == "tap":
             plot.click()
-            page.wait_for_timeout(200)
 
     def _get_popup_distances_relative_to_bbox(self, popup_box, plot_box):
         return {
@@ -368,6 +367,7 @@ class TestPopup:
         page = serve_hv(plot)
         hv_plot = page.locator(".bk-events")
         expect(hv_plot).to_have_count(1)
+        page.wait_for_load_state("networkidle")
         return page, hv_plot
 
     def _locate_popup(self, page, count=1):

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -11,17 +11,17 @@ def retry(func, *args, **kwargs):
         try:
             return func(*args, **kwargs)
         except Exception as e:
-            if i == 4:
-                raise
             wait = 10 * 2**i
             print(f"Attempt {i + 1} failed: {e}. Retrying in {wait}s...", file=sys.stderr)
             time.sleep(wait)
+    func(*args, **kwargs)
 
 
 if Version(bokeh.__version__).release < (3, 5, 0):
     import bokeh.sampledata
 
     retry(bokeh.sampledata.download)
+    print("Downloaded bokeh sampledata")
 
 with suppress(ImportError):
     import pooch  # noqa: F401
@@ -30,3 +30,10 @@ with suppress(ImportError):
 
     retry(xr.tutorial.open_dataset, "air_temperature")
     retry(xr.tutorial.open_dataset, "rasm", decode_times=False)
+    print("Downloaded xarray tutorial datasets")
+
+with suppress(ImportError):
+    from scipy.datasets import ascent
+
+    retry(ascent)
+    print("Downloaded scipy dataset")


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Hopeful this will fix the flaky UI test `holoviews/tests/ui/bokeh/test_callback.py::TestPopup::test_position_selection1d[chromium-bottom-tap]`

Written by Claude:

The tap tool tests were flaky on CI because the click occurred ~31ms after `.bk-events` entered the DOM — before Bokeh had finished building its hit-testing index for 1000 points. `box_select` and `lasso_select` were unaffected since their multi-step mouse drags gave Bokeh enough extra time to finish initializing.

Waiting for `networkidle` in `_serve_plot` ensures Bokeh's JavaScript has fully executed before any mouse interaction.



## How Has This Been Tested?

CI

## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: Cursor + Sonnet 4.6, used it to take a look at the tracing generated on failure.

## Checklist

<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and is passing

<!--
Conventional format: <Type>(<Scope>): <Subject>
Valid Types: `build`, `chore`, `ci`, `compat`, `docs`, `enh`, `feat`, `fix`, `perf`, `refactor`, `test`, and `type`
Valid Scopes (optional): `dev`, `data`, `plotting`, `bokeh`, `matplotlib`, `plotly`, and `notebook`

For more information on how to contribute to this repository, see the [developer guide](https://www.holoviews.org/developer_guide/index.html)
-->
