### PR TITLE
enh: Ensure we allow all narwhals versions

### DIFF
--- a/holoviews/core/data/narwhals.py
+++ b/holoviews/core/data/narwhals.py
@@ -44,14 +44,6 @@ _EAGER_TYPE = {
 _NO_DROP_NULL = [nw.Implementation.DUCKDB, nw.Implementation.IBIS]
 
 
-def _get_obj_info(obj) -> tuple[str, str]:
-    try:
-        obj_type = type(obj)
-        return obj_type.__module__.lower(), obj_type.__name__.lower()
-    except Exception:
-        return "", ""
-
-
 class NarwhalsDtype:
     __slots__ = ("dtype",)
 
@@ -76,7 +68,9 @@ class NarwhalsInterface(Interface):
 
     @classmethod
     def applies(cls, obj):
-        module, name = _get_obj_info(obj)
+        obj_type = type(obj)
+        module = getattr(obj_type, "__module__", "").lower()
+        name = getattr(obj_type, "__name__", "").lower()
         return (
             (module.startswith("narwhals.") and name in ("series", "dataframe", "lazyframe"))
             or nw.dependencies.is_into_dataframe(obj)

--- a/holoviews/core/data/narwhals.py
+++ b/holoviews/core/data/narwhals.py
@@ -44,12 +44,12 @@ _EAGER_TYPE = {
 _NO_DROP_NULL = [nw.Implementation.DUCKDB, nw.Implementation.IBIS]
 
 
-def _is_geodataframe(obj) -> True:
-    # Do not use for GeoPandas and SpatialPandas
+def _get_obj_info(obj) -> tuple[str, str]:
     try:
-        return "geo" in type(obj).__name__.lower()
+        obj_type = type(obj)
+        return obj_type.__module__.lower(), obj_type.__name__.lower()
     except Exception:
-        return False
+        return "", ""
 
 
 class NarwhalsDtype:
@@ -76,13 +76,14 @@ class NarwhalsInterface(Interface):
 
     @classmethod
     def applies(cls, obj):
+        module, name = _get_obj_info(obj)
         return (
-            isinstance(obj, (nw.Series, nw.DataFrame, nw.LazyFrame))
+            (module.startswith("narwhals.") and name in ("series", "dataframe", "lazyframe"))
             or nw.dependencies.is_into_dataframe(obj)
             or nw.dependencies.is_into_series(obj)
             or nw.dependencies.is_ibis_table(obj)
             or bool(cls.narwhals_backend and isinstance(obj, (dict, tuple, np.ndarray)))
-        ) and not _is_geodataframe(obj)
+        ) and "geo" not in name  # Do not use for GeoPandas and SpatialPandas
 
     @classmethod
     def dimension_type(cls, dataset, dim):

--- a/holoviews/core/util/types.py
+++ b/holoviews/core/util/types.py
@@ -4,18 +4,16 @@ import sys
 from types import GeneratorType
 from typing import TYPE_CHECKING
 
-import narwhals
 import narwhals.stable.v2 as nw
+import numpy as np
 
 from .dependencies import _LazyModule
 
 if TYPE_CHECKING:
     import cftime
-    import numpy as np
     import pandas as pd
 else:
     cftime = _LazyModule("cftime", bool_use_sys_modules=True)
-    np = _LazyModule("numpy", bool_use_sys_modules=True)
     pd = _LazyModule("pandas", bool_use_sys_modules=True)
 
 
@@ -93,37 +91,29 @@ def cftime_types():
 
 @gen_types
 def datetime_types():
-    yield from (dt.datetime, dt.date, dt.time)
-    if np:
-        yield np.datetime64
+    yield from (dt.datetime, dt.date, dt.time, np.datetime64)
     yield from pandas_datetime_types
     yield from cftime_types
 
 
 @gen_types
 def timedelta_types():
-    yield dt.timedelta
-    if np:
-        yield np.timedelta64
+    yield from (dt.timedelta, np.timedelta64)
     yield from pandas_timedelta_types
 
 
 @gen_types
 def arraylike_types():
-    if np:
-        yield np.ndarray
+    yield from (np.ndarray, nw.Series)
     if pd:
         from pandas.core.dtypes.generic import ABCExtensionArray, ABCIndex, ABCSeries
 
         yield from (ABCIndex, ABCSeries, ABCExtensionArray)
 
-    yield from (nw.Series, narwhals.Series)
-
 
 @gen_types
 def masked_types():
-    if np:
-        yield np.ma.core.MaskedArray
+    yield np.ma.core.MaskedArray
 
     if pd:
         from pandas.core.arrays.masked import BaseMaskedArray

--- a/holoviews/tests/core/data/test_narwhalsinterface.py
+++ b/holoviews/tests/core/data/test_narwhalsinterface.py
@@ -9,7 +9,10 @@ import holoviews as hv
 from holoviews.core.data import NarwhalsInterface
 from holoviews.testing import assert_data_equal
 
+from ...utils import optional_dependencies
 from .base import HeterogeneousColumnTests, InterfaceTests
+
+_, pl_skip = optional_dependencies("polars")
 
 
 class BaseNarwhalsInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
@@ -350,3 +353,21 @@ class CudfNarwhalsInterfaceTests(BaseNarwhalsInterfaceTests):
         samples = self.dataset_ht.sample([0, 5, 10]).dimension_values("y")
         assert samples.implementation == nw.Implementation.CUDF
         assert_data_equal(np.array([0, 0.5, 1]), samples.to_numpy())
+
+
+@pl_skip
+def test_applies_for_all_versions():
+    import narwhals as nwm
+    import narwhals.stable.v1 as nw1
+    import narwhals.stable.v2 as nw2
+    import polars as pl
+
+    from holoviews.core.data.narwhals import NarwhalsInterface
+
+    df = pl.DataFrame({"A": [1, 2, 3]})
+    converters = [nwm.from_native, nw1.from_native, nw2.from_native]
+    for c in converters:
+        cdf = c(df)
+        assert NarwhalsInterface.applies(cdf)
+        assert NarwhalsInterface.applies(cdf.lazy())
+        assert NarwhalsInterface.applies(cdf["A"])

--- a/holoviews/tests/core/data/test_narwhalsinterface.py
+++ b/holoviews/tests/core/data/test_narwhalsinterface.py
@@ -7,6 +7,7 @@ import pytest
 
 import holoviews as hv
 from holoviews.core.data import NarwhalsInterface
+from holoviews.core.util.dependencies import _no_import_version
 from holoviews.testing import assert_data_equal
 
 from ...utils import optional_dependencies
@@ -371,3 +372,27 @@ def test_applies_for_all_versions():
         assert NarwhalsInterface.applies(cdf)
         assert NarwhalsInterface.applies(cdf.lazy())
         assert NarwhalsInterface.applies(cdf["A"])
+
+
+@pl_skip
+@pytest.mark.skipif(
+    _no_import_version("narwhals") < (2, 19, 0),
+    reason="Version 2.19.0 or higher of narwhals is required",
+)
+def test_init_for_all_versions():
+    import narwhals as nwm
+    import narwhals.stable.v1 as nw1
+    import narwhals.stable.v2 as nw2
+    import polars as pl
+
+    from holoviews.core.data.narwhals import NarwhalsInterface
+
+    df = pl.DataFrame({"A": [1, 2, 3]})
+    converters = [nwm.from_native, nw1.from_native, nw2.from_native]
+    get_init_type = lambda x: type(NarwhalsInterface.init(hv.Dataset, x, ["A"], None)[0])
+
+    for c in converters:
+        cdf = c(df)
+        assert get_init_type(cdf) is nw2.DataFrame
+        assert get_init_type(cdf.lazy()) is nw2.LazyFrame
+        assert get_init_type(cdf["A"]) is nw2.DataFrame


### PR DESCRIPTION
## Description

Previously we did not support all narwhals versions `Series`/`Frames`. This will make sure it so:    

``` python
import narwhals as nw
import narwhals.stable.v1 as nw1
import narwhals.stable.v2 as nw2
import polars as pl
from holoviews.core.data.narwhals import NarwhalsInterface

df = pl.DataFrame({"A": [1, 2, 3]})
converters = [nw.from_native, nw1.from_native, nw2.from_native]
for c in converters:
    cdf = c(df)

    print(type(cdf), NarwhalsInterface.applies(cdf))
    print(type(cdf.lazy()), NarwhalsInterface.applies(cdf.lazy()))
    print(type(cdf["A"]), NarwhalsInterface.applies(cdf["A"]))
```

Before:
``` 
<class 'narwhals.dataframe.DataFrame'> True
<class 'narwhals.dataframe.LazyFrame'> False
<class 'narwhals.series.Series'> True
<class 'narwhals.stable.v1.DataFrame'> True
<class 'narwhals.stable.v1.LazyFrame'> False
<class 'narwhals.stable.v1.Series'> True
<class 'narwhals.stable.v2.DataFrame'> True
<class 'narwhals.stable.v2.LazyFrame'> True
<class 'narwhals.stable.v2.Series'> True
```

After:
``` 
<class 'narwhals.dataframe.DataFrame'> True
<class 'narwhals.dataframe.LazyFrame'> True
<class 'narwhals.series.Series'> True
<class 'narwhals.stable.v1.DataFrame'> True
<class 'narwhals.stable.v1.LazyFrame'> True
<class 'narwhals.stable.v1.Series'> True
<class 'narwhals.stable.v2.DataFrame'> True
<class 'narwhals.stable.v2.LazyFrame'> True
<class 'narwhals.stable.v2.Series'> True
```

Also cleaning up `types.py`, the removal of `narwhals.Series` should be handled by a new release of narwhals, so we internally always see it as `v2`.

## How Has This Been Tested?

CI

## Checklist

<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and is passing
- [ ] Added documentation

<!--
Conventional format: <Type>(<Scope>): <Subject>
Valid Types: `build`, `chore`, `ci`, `compat`, `docs`, `enh`, `feat`, `fix`, `perf`, `refactor`, `test`, and `type`
Valid Scopes (optional): `dev`, `data`, `plotting`, `bokeh`, `matplotlib`, `plotly`, and `notebook`

For more information on how to contribute to this repository, see the [developer guide](https://www.holoviews.org/developer_guide/index.html)
-->
