### PR TITLE
fix(matplotlib): Don't clip animation

### DIFF
--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -16,16 +16,14 @@ from ...core.options import Store
 from ..renderer import HTML_TAGS, MIME_TYPES, Renderer
 from .util import get_old_rcparams, get_tight_bbox
 
-
-class OutputWarning(param.Parameterized):
-    pass
-
-
-outputwarning = OutputWarning(name="Warning")
-
 # <format name> : (animation writer, format,  anim_kwargs, extra_args)
 ANIMATION_OPTS = {
-    "webm": ("ffmpeg", "webm", {}, ["-vcodec", "libvpx-vp9", "-b", "1000k"]),
+    "webm": (
+        "ffmpeg",
+        "webm",
+        {},
+        ["-vcodec", "libvpx-vp9", "-b", "1000k", "-pix_fmt", "yuv420p"],
+    ),
     "mp4": ("ffmpeg", "mp4", {"codec": "libx264"}, ["-pix_fmt", "yuv420p"]),
     "gif": ("pillow", "gif", {"fps": 10}, []),
     "scrubber": ("html", None, {"fps": 5}, None),
@@ -152,6 +150,8 @@ class MPLRenderer(Renderer):
         """
         if fmt in ["gif", "mp4", "webm"]:
             with mpl.rc_context(rc=plot.fig_rcparams):
+                if bbox_inches == "tight":
+                    self._adjust_figure_for_anim(plot, fmt)
                 anim = plot.anim(fps=self.fps)
             data = self._anim_data(anim, fmt)
         else:
@@ -234,6 +234,78 @@ class MPLRenderer(Renderer):
             else:
                 kw["bbox_inches"] = MPLRenderer.drawn[fig_id]
         return kw
+
+    def _adjust_figure_for_anim(self, plot, fmt):
+        """Adjust figure size and subplot positions to tightly fit all content.
+
+        Matplotlib's animation writers do not support bbox_inches='tight',
+        so animations can have clipped labels and titles. This method
+        computes the tight bounding box of the rendered figure and adjusts
+        the figure dimensions and axes positions so that all content fits
+        within the figure bounds without clipping.
+        """
+        from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+        fig = plot.state
+
+        traverse_fn = lambda x: x.handles.get("bbox_extra_artists", None)
+        extra_artists = list(
+            chain.from_iterable(
+                artists for artists in plot.traverse(traverse_fn) if artists is not None
+            )
+        )
+
+        pad = mpl.rcParams["savefig.pad_inches"]
+
+        # Ensure we have a non-interactive canvas for rendering, since
+        # the figure may have been closed (plt.close) but still retain
+        # a Tk/Qt canvas that errors on resize operations.
+        if type(fig.canvas) is not FigureCanvasAgg:
+            fig.canvas.manager = None
+            FigureCanvasAgg(fig)
+
+        dpi = self.dpi or fig.dpi
+        fig.set_dpi(dpi)
+        fig.canvas.draw()
+        bbox_inches = get_tight_bbox(fig, extra_artists, pad=pad)
+
+        orig_w, orig_h = fig.get_size_inches()
+        new_w = bbox_inches.width
+        new_h = bbox_inches.height
+
+        # Video codecs like libx264 require even pixel dimensions.
+        # Round up to the nearest even number of pixels for video formats.
+        if fmt in ("mp4", "webm"):
+            pw, ph = int(new_w * dpi), int(new_h * dpi)
+            new_w = (pw + pw % 2) / dpi
+            new_h = (ph + ph % 2) / dpi
+
+        # Compute how to transform positions from old figure coordinates
+        # to new figure coordinates. The tight bbox defines the visible
+        # region in the old coordinate system; we need to map that region
+        # to fill the new (resized) figure.
+        x_shift = -bbox_inches.x0 / orig_w
+        y_shift = -bbox_inches.y0 / orig_h
+        x_scale = orig_w / new_w
+        y_scale = orig_h / new_h
+
+        for ax in fig.axes:
+            pos = ax.get_position()
+            new_pos = [
+                (pos.x0 + x_shift) * x_scale,
+                (pos.y0 + y_shift) * y_scale,
+                pos.width * x_scale,
+                pos.height * y_scale,
+            ]
+            ax.set_position(new_pos)
+
+        # Reposition figure-level texts (e.g. suptitle) which use
+        # figure-fraction coordinates and are not moved by axes adjustment.
+        for text in fig.texts:
+            x, y = text.get_position()
+            text.set_position(((x + x_shift) * x_scale, (y + y_shift) * y_scale))
+
+        fig.set_size_inches(new_w, new_h)
 
     @classmethod
     @contextmanager

--- a/holoviews/tests/plotting/bokeh/test_renderer.py
+++ b/holoviews/tests/plotting/bokeh/test_renderer.py
@@ -118,10 +118,10 @@ class BokehRendererTest:
         data, _ = self.renderer.components(hmap)
         assert 'State"' in data["text/html"]
 
-    # def test_render_holomap_not_embedded(self):
-    #     hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
-    #     data, _ = self.renderer.instance(widget_mode='live').components(hmap)
-    #     self.assertNotIn('State"', data['text/html'])
+    def test_render_holomap_not_embedded(self):
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
+        data, _ = self.renderer.instance(widget_mode="live").components(hmap)
+        assert 'State"' not in data["text/html"]
 
     def test_render_holomap_scrubber(self):
         hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -5,6 +5,7 @@ Test cases for rendering exporters
 import base64
 import re
 import shutil
+import sys
 from io import BytesIO
 
 import numpy as np
@@ -88,6 +89,8 @@ class MPLRendererTest:
     @pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not available")
     @pytest.mark.parametrize("fmt", ["mp4", "webm"])
     def test_render_video(self, fmt):
+        if fmt == "webm" and sys.platform == "win32":
+            pytest.skip("webm format not supported on Windows")
         data, _metadata = self.renderer.components(self.map1, fmt)
         assert f"<source src='data:video/{fmt}" in data["text/html"]
 

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -3,9 +3,8 @@ Test cases for rendering exporters
 """
 
 import base64
-import os
 import re
-import subprocess
+import shutil
 import sys
 from io import BytesIO
 
@@ -87,15 +86,9 @@ class MPLRendererTest:
         data, _metadata = self.renderer.components(self.map1, "gif")
         assert "<img src='data:image/gif" in data["text/html"]
 
-    @pytest.mark.skipif(
-        sys.platform == "win32" and os.environ.get("GITHUB_RUN_ID"), reason="Skip on Windows CI"
-    )
+    @pytest.mark.skipif(sys.platform == "win32", reason="Skip on Windows")
+    @pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not available")
     def test_render_mp4(self):
-        devnull = subprocess.DEVNULL
-        try:
-            subprocess.call(["ffmpeg", "-h"], stdout=devnull, stderr=devnull)
-        except Exception:
-            pytest.skip("ffmpeg not available, skipping mp4 export test")
         data, _metadata = self.renderer.components(self.map1, "mp4")
         assert "<source src='data:video/mp4" in data["text/html"]
 
@@ -121,10 +114,10 @@ class MPLRendererTest:
         data, _ = self.renderer.components(hmap)
         assert 'State"' in data["text/html"]
 
-    # def test_render_holomap_not_embedded(self):
-    #     hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
-    #     data, _ = self.renderer.instance(widget_mode='live').components(hmap)
-    #     self.assertNotIn('State"', data['text/html'])
+    def test_render_holomap_not_embedded(self):
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
+        data, _ = self.renderer.instance(widget_mode="live").components(hmap)
+        assert 'State"' not in data["text/html"]
 
     def test_render_holomap_scrubber(self):
         hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
@@ -212,11 +205,7 @@ class MPLRendererTest:
 
 
 class TestAnimationBbox:
-    """Test that matplotlib animations are not clipped (GH#4975).
-
-    Matplotlib's animation writers do not support bbox_inches='tight',
-    so _adjust_figure_for_anim pre-adjusts the figure to prevent clipping.
-    """
+    """Test that matplotlib animations are not clipped"""
 
     def setup_method(self):
         self.renderer = MPLRenderer.instance()
@@ -266,6 +255,8 @@ class TestAnimationBbox:
         )
         assert self._all_labels_visible(hmap)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Skip on Windows")
+    @pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not available")
     def test_video_has_even_dimensions(self):
         hmap = hv.HoloMap({i: hv.Curve(np.random.rand(10)) for i in range(3)})
         plot = self.renderer.get_plot(hmap)

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -85,7 +85,6 @@ class MPLRendererTest:
         data, _metadata = self.renderer.components(self.map1, "gif")
         assert "<img src='data:image/gif" in data["text/html"]
 
-    # @pytest.mark.skipif(sys.platform == "win32", reason="Skip on Windows")
     @pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not available")
     def test_render_mp4(self):
         data, _metadata = self.renderer.components(self.map1, "mp4")
@@ -254,8 +253,6 @@ class TestAnimationBbox:
         )
         assert self._all_labels_visible(hmap)
 
-    # @pytest.mark.skipif(sys.platform == "win32", reason="Skip on Windows")
-    @pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not available")
     def test_video_has_even_dimensions(self):
         hmap = hv.HoloMap({i: hv.Curve(np.random.rand(10)) for i in range(3)})
         plot = self.renderer.get_plot(hmap)

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -2,9 +2,12 @@
 Test cases for rendering exporters
 """
 
+import base64
 import os
+import re
 import subprocess
 import sys
+from io import BytesIO
 
 import numpy as np
 import panel as pn
@@ -12,6 +15,7 @@ import param
 import pytest
 from matplotlib import style
 from panel.widgets import DiscreteSlider, FloatSlider, Player
+from PIL import Image
 from pyviz_comms import CommManager
 
 import holoviews as hv
@@ -205,3 +209,70 @@ class MPLRendererTest:
         slider.value = 3
         (_, y) = artist.get_data()
         assert y[0] == 3
+
+
+class TestAnimationBbox:
+    """Test that matplotlib animations are not clipped (GH#4975).
+
+    Matplotlib's animation writers do not support bbox_inches='tight',
+    so _adjust_figure_for_anim pre-adjusts the figure to prevent clipping.
+    """
+
+    def setup_method(self):
+        self.renderer = MPLRenderer.instance()
+
+    def _gif_frame_size(self, obj):
+        """Render obj as GIF and return the (width, height) of the first frame."""
+        data, _ = self.renderer.components(obj, "gif")
+        # Extract the base64 data from the img tag
+        match = re.search(r"base64,([^'\"]+)", data["text/html"])
+        raw = base64.b64decode(match.group(1))
+        img = Image.open(BytesIO(raw))
+        return img.size
+
+    def _png_size(self, obj):
+        """Render obj as PNG and return the (width, height)."""
+        data = self.renderer(self.renderer.get_plot(obj), "png")[0]
+
+        img = Image.open(BytesIO(data))
+        return img.size
+
+    def _all_labels_visible(self, obj):
+        """Check that the GIF frame is at least as large as the PNG.
+
+        The PNG uses bbox_inches='tight' which tightly crops to content.
+        If the GIF is smaller in either dimension, content is clipped.
+        """
+        gif_w, gif_h = self._gif_frame_size(obj)
+        png_w, png_h = self._png_size(obj)
+        return gif_w >= png_w and gif_h >= png_h
+
+    def test_gif_single_plot_not_clipped(self):
+        hmap = hv.HoloMap({i: hv.Curve(np.random.rand(10)) for i in range(3)})
+        assert self._all_labels_visible(hmap)
+
+    def test_gif_layout_not_clipped(self):
+        hmap = hv.HoloMap({i: hv.Curve(np.random.rand(10)) for i in range(3)})
+        layout = hmap + hmap
+        assert self._all_labels_visible(layout)
+
+    def test_gif_with_long_labels_not_clipped(self):
+        hmap = hv.HoloMap(
+            {
+                i: hv.Curve(np.random.rand(10), "long x-axis label", "long y-axis label")
+                for i in range(3)
+            },
+            kdims=["parameter with a very long name"],
+        )
+        assert self._all_labels_visible(hmap)
+
+    def test_video_has_even_dimensions(self):
+        hmap = hv.HoloMap({i: hv.Curve(np.random.rand(10)) for i in range(3)})
+        plot = self.renderer.get_plot(hmap)
+        self.renderer._adjust_figure_for_anim(plot, "mp4")
+        fig = plot.state
+        dpi = self.renderer.dpi or fig.dpi
+        w_px = int(fig.get_size_inches()[0] * dpi)
+        h_px = int(fig.get_size_inches()[1] * dpi)
+        assert w_px % 2 == 0
+        assert h_px % 2 == 0

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -5,7 +5,6 @@ Test cases for rendering exporters
 import base64
 import re
 import shutil
-import sys
 from io import BytesIO
 
 import numpy as np
@@ -86,7 +85,7 @@ class MPLRendererTest:
         data, _metadata = self.renderer.components(self.map1, "gif")
         assert "<img src='data:image/gif" in data["text/html"]
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Skip on Windows")
+    # @pytest.mark.skipif(sys.platform == "win32", reason="Skip on Windows")
     @pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not available")
     def test_render_mp4(self):
         data, _metadata = self.renderer.components(self.map1, "mp4")
@@ -255,7 +254,7 @@ class TestAnimationBbox:
         )
         assert self._all_labels_visible(hmap)
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Skip on Windows")
+    # @pytest.mark.skipif(sys.platform == "win32", reason="Skip on Windows")
     @pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not available")
     def test_video_has_even_dimensions(self):
         hmap = hv.HoloMap({i: hv.Curve(np.random.rand(10)) for i in range(3)})

--- a/holoviews/tests/plotting/matplotlib/test_renderer.py
+++ b/holoviews/tests/plotting/matplotlib/test_renderer.py
@@ -86,9 +86,10 @@ class MPLRendererTest:
         assert "<img src='data:image/gif" in data["text/html"]
 
     @pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not available")
-    def test_render_mp4(self):
-        data, _metadata = self.renderer.components(self.map1, "mp4")
-        assert "<source src='data:video/mp4" in data["text/html"]
+    @pytest.mark.parametrize("fmt", ["mp4", "webm"])
+    def test_render_video(self, fmt):
+        data, _metadata = self.renderer.components(self.map1, fmt)
+        assert f"<source src='data:video/{fmt}" in data["text/html"]
 
     def test_render_static(self):
         curve = hv.Curve([])

--- a/holoviews/tests/plotting/plotly/test_renderer.py
+++ b/holoviews/tests/plotting/plotly/test_renderer.py
@@ -56,10 +56,10 @@ class PlotlyRendererTest:
         data, _ = self.renderer.components(hmap)
         assert 'State"' in data["text/html"]
 
-    # def test_render_holomap_not_embedded(self):
-    #     hmap = HoloMap({i: Curve([1, 2, i]) for i in range(5)})
-    #     data, _ = self.renderer.instance(widget_mode='live').components(hmap)
-    #     self.assertNotIn('State"', data['text/html'])
+    def test_render_holomap_not_embedded(self):
+        hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})
+        data, _ = self.renderer.instance(widget_mode="live").components(hmap)
+        assert 'State"' not in data["text/html"]
 
     def test_render_holomap_scrubber(self):
         hmap = hv.HoloMap({i: hv.Curve([1, 2, i]) for i in range(5)})


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Fixes #4975

Matplotlib's animation writers do not support `bbox_inches='tight'`, so animations can have clipped labels and titles.

Also fixes an error when trying to make `.webm` animation.

## How Has This Been Tested?

CI + Checking original reported issue:

``` python
import numpy as np

import holoviews as hv

hv.extension("matplotlib")

frequencies = np.linspace(0.5, 0.6, 5)


def sine_curve(phase, freq):
    xvals = [0.1 * i for i in range(100)]
    return hv.Curve((xvals, [np.sin(phase + freq * x) for x in xvals]))


curve_dict = {f: sine_curve(0, f) for f in frequencies}
hmap = hv.HoloMap(curve_dict, kdims="frequency")

path = "after/" 
hv.save(hmap, path + "sines.webm", fmt="webm")
hv.save(hmap, path + "sines.webm", fmt="mp4")
hv.save(hmap, path + "sines.gif", fmt="gif", fps=5)
hv.save(hmap, path + "sines.png", fmt="png")

layout = hmap + hmap
hv.save(layout, path + "sines_layout.webm", fmt="webm")
hv.save(layout, path + "sines_layout.mp4", fmt="mp4")
hv.save(layout, path + "sines_layout.gif", fmt="gif", fps=5)
hv.save(layout, path + "sines_layout.png", fmt="png")
```

| Type | Before | After |
| -- | -- | -- |
| `.png` | <img width="261" height="262" alt="sines" src="https://github.com/user-attachments/assets/d128d3fb-c31f-4e65-90db-e85afe9427ab" /> |  <img width="261" height="262" alt="sines" src="https://github.com/user-attachments/assets/1418aefe-cb77-4262-983c-d0940fe107b9" /> | 
| `.gif` | ![sines](https://github.com/user-attachments/assets/0e7a0950-7f86-419d-b973-2c5bf263cbcf) | ![sines](https://github.com/user-attachments/assets/35d3fb99-9a02-4b91-a6a8-e3feb2d7b0ce) | 
| `.mp4` | <video src="https://github.com/user-attachments/assets/44e303f6-4986-45d0-9cb7-02aee600f26c"> | <video src="https://github.com/user-attachments/assets/cfc6f6d6-15a5-44fb-9deb-b29ab4f46c98"> |

| Type | Before | After |
| -- | -- | -- |
| `.png` | <img width="596" height="295" alt="sines_layout" src="https://github.com/user-attachments/assets/d0273f0c-2e47-459b-9f07-852b88a45aba" /> | <img width="596" height="295" alt="sines_layout" src="https://github.com/user-attachments/assets/cb1630b6-e37c-40d4-81da-499d2e098ed2" /> |
| `.gif` | ![sines_layout](https://github.com/user-attachments/assets/4eb2777b-0a5d-4f21-8a25-044c49cb72fa) | ![sines_layout](https://github.com/user-attachments/assets/785ee4c6-935f-43f2-a865-d986c9a34cd1) |
| `.mp4` |  <video src="https://github.com/user-attachments/assets/a14a003f-9f04-45ee-b84d-b353f1d3ff82"> | <video src="https://github.com/user-attachments/assets/281c7a37-a39a-47dc-9970-0e2fa6e90c0f"> | 


*) `.mp4` failed on main for layout, used this diff on main:
``` diff
diff --git a/holoviews/plotting/mpl/renderer.py b/holoviews/plotting/mpl/renderer.py
index d6c7fc674..2bff41a0e 100644
--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -26,7 +26,7 @@ outputwarning = OutputWarning(name="Warning")
 # <format name> : (animation writer, format,  anim_kwargs, extra_args)
 ANIMATION_OPTS = {
     "webm": ("ffmpeg", "webm", {}, ["-vcodec", "libvpx-vp9", "-b", "1000k"]),
-    "mp4": ("ffmpeg", "mp4", {"codec": "libx264"}, ["-pix_fmt", "yuv420p"]),
+    "mp4": ("ffmpeg", "mp4", {"codec": "libx264"}, ["-pix_fmt", "yuv420p", "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2"]),
     "gif": ("pillow", "gif", {"fps": 10}, []),
     "scrubber": ("html", None, {"fps": 5}, None),
 }
```



## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: Opencode + Claude Opus 4.6. Used for the implementation of `_adjust_figure_for_anim` and also writing simple tests.

## Checklist

<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and is passing
