### PR TITLE
type:  Add type checking on isolated and utility files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -216,7 +216,7 @@ jobs:
       - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
           environments: ${{ matrix.environment }}
-      - name: Test Unit
+      - name: Type TY
         run: |
           pixi run -e ${{ matrix.environment }} type-ty
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -201,9 +201,28 @@ jobs:
         run: |
           pixi run -e ${{ matrix.environment }} test-unit
 
+  type_suite:
+    name: type:${{ matrix.environment }}:${{ matrix.os }}
+    needs: [pre_commit, setup, pixi_lock]
+    runs-on: ${{ matrix.os }}
+    if: needs.setup.outputs.code_change == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        environment: ["type"]
+    timeout-minutes: 5
+    steps:
+      - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
+        with:
+          environments: ${{ matrix.environment }}
+      - name: Test Unit
+        run: |
+          pixi run -e ${{ matrix.environment }} type-ty
+
   result_test_suite:
     name: result:test
-    needs: [unit_test_suite, ui_test_suite, core_test_suite]
+    needs: [unit_test_suite, ui_test_suite, core_test_suite, type_suite]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -182,6 +182,8 @@ from .util.warnings import (
 )
 
 TYPE_CHECKING = False
+extension: type[extension]
+
 
 if hasattr(builtins, "__IPYTHON__"):
     from .ipython import notebook_extension
@@ -199,9 +201,7 @@ if "_pyodide" in sys.modules:
 
     # The notebook_extension is needed inside jupyterlite,
     # so the override is only done if we are not inside jupyterlite.
-    if in_jupyterlite():
-        extension.inline = False
-    else:
+    if not in_jupyterlite():
         extension = pyodide_extension
     del pyodide_extension, in_jupyterlite
 

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -182,7 +182,8 @@ from .util.warnings import (
 )
 
 TYPE_CHECKING = False
-extension: type[extension]
+if TYPE_CHECKING:
+    extension: type[extension]
 
 
 if hasattr(builtins, "__IPYTHON__"):
@@ -207,7 +208,7 @@ if "_pyodide" in sys.modules:
 
 if TYPE_CHECKING:
     # Adding this here to have better docstring in LSP
-    from .util import extension  # noqa: TC004
+    from .util import extension
 
 _load_rc_file()
 

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import typing as t
 from inspect import getmro
 
 import param
@@ -8,7 +8,7 @@ from panel.layout import Row, Tabs
 from panel.pane import PaneBase
 from panel.util import param_name
 
-from .core import DynamicMap, Element, HoloMap, Layout, Overlay, Store, ViewableElement
+from .core import Dataset, DynamicMap, Element, HoloMap, Layout, Overlay, Store, ViewableElement
 from .core.util import isscalar
 from .element import Curve, Path, Points, Polygons, Rectangles, Table
 from .plotting.links import (
@@ -17,10 +17,15 @@ from .plotting.links import (
     SelectionLink,
     VertexTableLink,
 )
-from .streams import BoxEdit, CurveEdit, PointDraw, PolyDraw, PolyEdit, Selection1D
+from .streams import BoxEdit, CDSStream, CurveEdit, PointDraw, PolyDraw, PolyEdit, Selection1D
+
+if t.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    _T = t.TypeVar("_T")
 
 
-def preprocess(function, current=None):
+def preprocess(function):
     """Turns a param.depends watch call into a preprocessor method, i.e.
     skips all downstream events triggered by it.
 
@@ -32,8 +37,6 @@ def preprocess(function, current=None):
     See https://github.com/holoviz/param/issues/332
 
     """
-    if current is None:
-        current = []
 
     def inner(*args, **kwargs):
         self = args[0]
@@ -225,7 +228,7 @@ class Annotator(PaneBase):
     )
 
     object = param.ClassSelector(
-        class_=Element,
+        class_=Dataset,
         doc="The Element to edit and annotate.",
     )
 
@@ -264,10 +267,14 @@ class Annotator(PaneBase):
 
     priority = 0.7
 
+    _init_stream: Callable[[], None]
+    _process_element: Callable[[t.Any], Dataset]
+    _stream: CDSStream
+    _selection: Selection1D
+    name: str
+
     @classmethod
     def applies(cls, obj):
-        if "holoviews" not in sys.modules:
-            return False
         return isinstance(obj, cls.param.object.class_)
 
     @property
@@ -363,7 +370,7 @@ class Annotator(PaneBase):
 
     @property
     def tables(self):
-        return list(zip(self.editor._names, self.editor, strict=None))
+        return list(zip(self.editor._names, self.editor, strict=True))
 
     @property
     def selected(self):
@@ -405,6 +412,8 @@ class PathAnnotator(Annotator):
     _vertex_table_link = VertexTableLink
 
     _triggers = ["annotations", "edit_vertices", "object", "table_opts", "vertex_annotations"]
+
+    _stream: PolyDraw
 
     def __init__(self, object=None, **params):
         self._vertex_table_row = Row()
@@ -533,9 +542,9 @@ class _GeomAnnotator(Annotator):
         doc="Opts to apply to the element.",
     )
 
-    _stream_type = None
-
     __abstract = True
+
+    _stream_type: t.ClassVar[type[CDSStream]]
 
     def _init_stream(self):
         name = param_name(self.name)

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -19,8 +19,11 @@ from .plotting.links import (
 )
 from .streams import BoxEdit, CDSStream, CurveEdit, PointDraw, PolyDraw, PolyEdit, Selection1D
 
+NoNone = False
 if t.TYPE_CHECKING:
     from collections.abc import Callable
+
+    from param.parameters import NoNone  # noqa: TC004, move up when 2.4 is lower pin
 
     _T = t.TypeVar("_T")
 
@@ -229,6 +232,7 @@ class Annotator(PaneBase):
 
     object = param.ClassSelector(
         class_=Dataset,
+        allow_None=NoNone,
         doc="The Element to edit and annotate.",
     )
 
@@ -299,7 +303,7 @@ class Annotator(PaneBase):
         self._update_table()
         self._update_links()
         self.param.watch(self._update, self._triggers)
-        self.layout[:] = [self.plot, self.editor]
+        self.layout[:] = [self.plot, self.editor]  # ty:ignore[invalid-assignment], fix in panel
 
     @param.depends("annotations", "object", "default_opts")
     def _get_plot(self):
@@ -390,6 +394,7 @@ class PathAnnotator(Annotator):
 
     object = param.ClassSelector(
         class_=Path,
+        allow_None=NoNone,
         doc="Path object to edit and annotate.",
     )
 

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -544,7 +544,7 @@ class _GeomAnnotator(Annotator):
 
     __abstract = True
 
-    _stream_type: t.ClassVar[type[CDSStream]]
+    _stream_type: type[CDSStream]
 
     def _init_stream(self):
         name = param_name(self.name)

--- a/holoviews/annotators.py
+++ b/holoviews/annotators.py
@@ -538,7 +538,7 @@ class PolyAnnotator(PathAnnotator):
     object = param.ClassSelector(
         class_=Polygons,
         doc="Polygon element to edit and annotate.",
-    )
+    )  # ty:ignore[no-matching-overload], https://github.com/astral-sh/ruff/pull/24698
 
 
 class _GeomAnnotator(Annotator):
@@ -601,7 +601,7 @@ class PointAnnotator(_GeomAnnotator):
     object = param.ClassSelector(
         class_=Points,
         doc="Points element to edit and annotate.",
-    )
+    )  # ty:ignore[no-matching-overload], https://github.com/astral-sh/ruff/pull/24698
 
     _stream_type = PointDraw
 
@@ -620,7 +620,7 @@ class CurveAnnotator(_GeomAnnotator):
     object = param.ClassSelector(
         class_=Curve,
         doc="Points element to edit and annotate.",
-    )
+    )  # ty:ignore[no-matching-overload], https://github.com/astral-sh/ruff/pull/24698
 
     vertex_style = param.Dict(
         default={"size": 10},
@@ -645,7 +645,7 @@ class RectangleAnnotator(_GeomAnnotator):
     object = param.ClassSelector(
         class_=Rectangles,
         doc="Points element to edit and annotate.",
-    )
+    )  # ty:ignore[no-matching-overload], https://github.com/astral-sh/ruff/pull/24698
 
     _stream_type = BoxEdit
 

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -409,7 +409,9 @@ class Redim(metaclass=AccessorPipelineMeta):
         """
         filtered = []
         for key, value in dmap.data.items():
-            if not any(kd.values and v not in kd.values for kd, v in zip(kdims, key, strict=None)):
+            if not any(
+                kd.values and v not in kd.values for kd, v in zip(kdims, key, strict=False)
+            ):
                 filtered.append((key, value))
         return filtered
 
@@ -480,7 +482,7 @@ class Redim(metaclass=AccessorPipelineMeta):
 
         kdims = self.replace_dimensions(obj.kdims, dimensions)
         vdims = self.replace_dimensions(obj.vdims, dimensions)
-        zipped_dims = zip(obj.kdims + obj.vdims, kdims + vdims, strict=None)
+        zipped_dims = zip(obj.kdims + obj.vdims, kdims + vdims, strict=False)
         renames = {pk.name: nk for pk, nk in zipped_dims if pk.name != nk.name}
 
         if self.mode == "dataset":

--- a/holoviews/core/accessors.py
+++ b/holoviews/core/accessors.py
@@ -10,6 +10,7 @@ import param
 
 from . import util
 from .pprint import PrettyPrinter
+from .util import _is_deep_indexable
 
 
 class AccessorPipelineMeta(type):
@@ -233,7 +234,7 @@ class Apply(metaclass=AccessorPipelineMeta):
             ):
                 new_obj._dataset = self._obj.dataset
             return new_obj
-        elif self._obj._deep_indexable:
+        elif _is_deep_indexable(self._obj):
             mapped = []
             for k, v in self._obj.data.items():
                 new_val = v.apply(
@@ -469,7 +470,7 @@ class Redim(metaclass=AccessorPipelineMeta):
         """
         obj = self._obj
         redimmed = obj
-        if obj._deep_indexable and self.mode != "dataset":
+        if _is_deep_indexable(obj) and self.mode != "dataset":
             deep_mapped = [(k, v.redim(specs, **dimensions)) for k, v in obj.items()]
             redimmed = obj.clone(deep_mapped)
 

--- a/holoviews/core/boundingregion.py
+++ b/holoviews/core/boundingregion.py
@@ -29,8 +29,8 @@ class BoundingRegion:
     def contains(self, x, y):
         raise NotImplementedError
 
-    def __contains__(self, point):
-        (x, y) = point
+    def __contains__(self, other):
+        (x, y) = other
         return self.contains(x, y)
 
     def scale(self, xs, ys):
@@ -303,7 +303,7 @@ class AARectangle:
         r = min(r1, r2)
         t = min(t1, t2)
 
-        return AARectangle(points=((l, b), (r, t)))
+        return AARectangle((l, b), (r, t))
 
     def width(self):
         return self._right - self._left

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -6,7 +6,8 @@ from .. import util
 from ..dimension import Dimension
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
-from ..util import dd, dtype_kind, pd
+from ..util import dtype_kind
+from ..util.dependencies import dd, pd
 from .interface import Interface
 from .pandas import PandasInterface
 

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import sys
-
 import numpy as np
 
 from .. import util
 from ..dimension import Dimension
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
-from ..util import dtype_kind
+from ..util import dd, dtype_kind, pd
 from .interface import Interface
 from .pandas import PandasInterface
 
@@ -41,20 +39,16 @@ class DaskInterface(PandasInterface):
 
     @classmethod
     def loaded(cls):
-        return "dask.dataframe" in sys.modules and "pandas" in sys.modules
+        return bool(dd and pd)
 
     @classmethod
     def applies(cls, obj):
         if not cls.loaded():
             return False
-        import dask.dataframe as dd
-
         return isinstance(obj, (dd.DataFrame, dd.Series))
 
     @classmethod
     def init(cls, eltype, data, kdims, vdims):
-        import dask.dataframe as dd
-
         data, dims, extra = PandasInterface.init(eltype, data, kdims, vdims)
         if not isinstance(data, dd.DataFrame):
             npartitions = min(cls.default_partitions, max(1, len(data)))
@@ -83,8 +77,6 @@ class DaskInterface(PandasInterface):
 
     @classmethod
     def range(cls, dataset, dimension):
-        import dask.dataframe as dd
-
         dimension = dataset.get_dimension(dimension, strict=True)
         column = dataset.data[dimension.name]
         if dtype_kind(column) == "O":
@@ -282,8 +274,6 @@ class DaskInterface(PandasInterface):
         the interface, return a simple scalar.
 
         """
-        import dask.dataframe as dd
-
         if len(data.columns) > 1 or len(data) != 1:
             return data
         if isinstance(data, dd.DataFrame):
@@ -322,8 +312,6 @@ class DaskInterface(PandasInterface):
 
     @classmethod
     def concat_fn(cls, dataframes, **kwargs):
-        import dask.dataframe as dd
-
         return dd.concat(dataframes, **kwargs)
 
     @classmethod

--- a/holoviews/core/data/ibis.py
+++ b/holoviews/core/data/ibis.py
@@ -9,11 +9,9 @@ from .. import util
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
 from ..util import dtype_kind
-from ..util.dependencies import _LazyModule, _no_import_version
+from ..util.dependencies import _no_import_version, ibis
 from .interface import DataError, Interface
 from .util import cached
-
-ibis = _LazyModule("ibis", "ibis-framework", bool_use_sys_modules=True)
 
 IBIS_VERSION = _no_import_version("ibis-framework")
 IBIS_GE_4_0_0 = IBIS_VERSION >= (4, 0, 0)

--- a/holoviews/core/data/ibis.py
+++ b/holoviews/core/data/ibis.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -14,10 +13,7 @@ from ..util.dependencies import _LazyModule, _no_import_version
 from .interface import DataError, Interface
 from .util import cached
 
-if TYPE_CHECKING:
-    import ibis
-else:
-    ibis = _LazyModule("ibis", "ibis-framework", bool_use_sys_modules=True)
+ibis = _LazyModule("ibis", "ibis-framework", bool_use_sys_modules=True)
 
 IBIS_VERSION = _no_import_version("ibis-framework")
 IBIS_GE_4_0_0 = IBIS_VERSION >= (4, 0, 0)

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -9,7 +9,7 @@ import param
 from .. import util
 from ..element import Element
 from ..ndmapping import NdMapping
-from ..util import dtype_kind
+from ..util import cp, da, dtype_kind
 from .util import finite_range
 
 
@@ -765,19 +765,15 @@ class Interface(param.Parameterized):
             Tuple of (histogram values, bin edges)
         """
         if util.is_dask_array(array):
-            import dask.array as da
-
             histogram = da.histogram
         elif util.is_cupy_array(array):
-            import cupy
-
-            histogram = cupy.histogram
+            histogram = cp.histogram
         else:
             histogram = np.histogram
         hist, edges = histogram(array, bins=bins, density=density, weights=weights)
         if util.is_cupy_array(hist):
-            edges = cupy.asnumpy(edges)
-            hist = cupy.asnumpy(hist)
+            edges = cp.asnumpy(edges)
+            hist = cp.asnumpy(hist)
         return hist, edges
 
     @classmethod

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -130,7 +130,7 @@ class ndloc(Accessor):
 
 
 class Interface(param.Parameterized):
-    interfaces = {}
+    interfaces: dict[str, Interface] = {}
 
     datatype = None
 

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import typing as t
 import warnings
 
 import numpy as np
@@ -131,7 +132,7 @@ class ndloc(Accessor):
 
 
 class Interface(param.Parameterized):
-    interfaces: dict[str, Interface] = {}
+    interfaces: t.ClassVar[dict[str, Interface]] = {}
 
     datatype = None
 

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -9,7 +9,8 @@ import param
 from .. import util
 from ..element import Element
 from ..ndmapping import NdMapping
-from ..util import cp, da, dtype_kind
+from ..util import dtype_kind
+from ..util.dependencies import cp, da
 from .util import finite_range
 
 

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 
 from .. import util
@@ -13,10 +11,7 @@ from ..util.dependencies import PANDAS_GE_2_1_0, _LazyModule
 from .interface import DataError, Interface
 from .util import finite_range
 
-if TYPE_CHECKING:
-    import pandas as pd
-else:
-    pd = _LazyModule("pandas")
+pd = _LazyModule("pandas")
 
 
 class PandasAPI:

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -7,11 +7,9 @@ from ..dimension import Dimension, dimension_name
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
 from ..util import dtype_kind
-from ..util.dependencies import PANDAS_GE_2_1_0, _LazyModule
+from ..util.dependencies import PANDAS_GE_2_1_0, pd
 from .interface import DataError, Interface
 from .util import finite_range
-
-pd = _LazyModule("pandas")
 
 
 class PandasAPI:
@@ -34,7 +32,7 @@ class PandasInterface(Interface, PandasAPI):
     def loaded(cls):
         # 2025-02: As long as it is a required dependency and to not break
         # existing behavior we will for now always return True
-        return bool(pd)
+        return True
 
     @classmethod
     def applies(cls, obj):

--- a/holoviews/core/data/spatialpandas_dask.py
+++ b/holoviews/core/data/spatialpandas_dask.py
@@ -4,7 +4,8 @@ import sys
 
 import numpy as np
 
-from ...core.util import dd, dtype_kind
+from ...core.util import dtype_kind
+from ...core.util.dependencies import dd
 from .dask import DaskInterface
 from .interface import Interface
 from .spatialpandas import SpatialPandasInterface

--- a/holoviews/core/data/spatialpandas_dask.py
+++ b/holoviews/core/data/spatialpandas_dask.py
@@ -4,7 +4,7 @@ import sys
 
 import numpy as np
 
-from ...core.util import dtype_kind
+from ...core.util import dd, dtype_kind
 from .dask import DaskInterface
 from .interface import Interface
 from .spatialpandas import SpatialPandasInterface
@@ -40,7 +40,6 @@ class DaskSpatialPandasInterface(SpatialPandasInterface):
     @classmethod
     def init(cls, eltype, data, kdims, vdims):
         import dask
-        import dask.dataframe as dd
 
         data, dims, params = super().init(eltype, data, kdims, vdims)
         if not isinstance(data, cls.frame_type()):

--- a/holoviews/core/data/util.py
+++ b/holoviews/core/data/util.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 
 from .. import util
 
-if TYPE_CHECKING:
-    import dask.array as da
-else:
-    da = util._LazyModule("dask.array", bool_use_sys_modules=True)
+da = util._LazyModule("dask.array", bool_use_sys_modules=True)
 
 
 def finite_range(column, cmin, cmax):

--- a/holoviews/core/data/util.py
+++ b/holoviews/core/data/util.py
@@ -21,8 +21,6 @@ def finite_range(column, cmin, cmax):
             cmin = np.nanmin(column) if min_inf else cmin
             cmax = np.nanmax(column) if max_inf else cmax
             if is_dask(column):
-                import dask.array as da
-
                 if min_inf and max_inf:
                     cmin, cmax = da.compute(cmin, cmax)
                 elif min_inf:

--- a/holoviews/core/data/util.py
+++ b/holoviews/core/data/util.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 
-from .. import util
-
-da = util._LazyModule("dask.array", bool_use_sys_modules=True)
+from ..util.dependencies import da
+from ..util.types import datetime_types
 
 
 def finite_range(column, cmin, cmax):
@@ -36,8 +35,8 @@ def finite_range(column, cmin, cmax):
         cmin = cmin[()]
     if isinstance(cmax, np.ndarray) and cmax.shape == ():
         cmax = cmax[()]
-    cmin = cmin if np.isscalar(cmin) or isinstance(cmin, util.datetime_types) else cmin.item()
-    cmax = cmax if np.isscalar(cmax) or isinstance(cmax, util.datetime_types) else cmax.item()
+    cmin = cmin if np.isscalar(cmin) or isinstance(cmin, datetime_types) else cmin.item()
+    cmax = cmax if np.isscalar(cmax) or isinstance(cmax, datetime_types) else cmax.item()
     return cmin, cmax
 
 

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 import types
-from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -18,10 +17,7 @@ from .util import dask_array_module, finite_range
 
 XARRAY_VERSION = _no_import_version("xarray")
 
-if TYPE_CHECKING:
-    import cupy as cp
-else:
-    cp = _LazyModule("cupy", bool_use_sys_modules=True)
+cp = _LazyModule("cupy", bool_use_sys_modules=True)
 
 
 def is_cupy(array):

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -10,14 +10,12 @@ from ..dimension import Dimension, asdim, dimension_name
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
 from ..util import dtype_kind
-from ..util.dependencies import _LazyModule, _no_import_version
+from ..util.dependencies import _no_import_version, cp
 from .grid import GridInterface
 from .interface import DataError, Interface
 from .util import dask_array_module, finite_range
 
 XARRAY_VERSION = _no_import_version("xarray")
-
-cp = _LazyModule("cupy", bool_use_sys_modules=True)
 
 
 def is_cupy(array):

--- a/holoviews/core/decollate.py
+++ b/holoviews/core/decollate.py
@@ -13,9 +13,9 @@ from .operation import OperationCallable
 from .overlay import NdOverlay, Overlay
 from .spaces import Callable, DynamicMap, GridSpace, HoloMap
 
-Expr = namedtuple("HoloviewsExpr", ["fn", "args", "kwargs"])
+Expr = namedtuple("Expr", ["fn", "args", "kwargs"])
 StreamIndex = namedtuple("StreamIndex", ["index"])
-KDimIndex = namedtuple("KDim", ["index"])
+KDimIndex = namedtuple("KDimIndex", ["index"])
 
 
 def to_expr_extract_streams(

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -606,17 +606,23 @@ class LabelledData(param.Parameterized):
     @t.overload
     def clone(
         self,
-        data=None,
-        shared_data=True,
-        *,
-        new_type: type[_LabelledDataT],
-        link=True,
+        data: t.Any = ...,
+        shared_data: bool = ...,
+        new_type: None = None,
+        link: bool = ...,
+        *args,
         **overrides,
-    ) -> _LabelledDataT: ...
+    ) -> Self: ...
     @t.overload
     def clone(
-        self, data=None, shared_data=True, new_type: None = None, link=True, *args, **overrides
-    ) -> Self: ...
+        self,
+        data: t.Any = ...,
+        shared_data: bool = ...,
+        new_type: type[_LabelledDataT] = ...,
+        link: bool = ...,
+        *args,
+        **overrides,
+    ) -> _LabelledDataT: ...
     def clone(
         self,
         data=None,

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -25,7 +25,7 @@ from .accessors import Apply, Opts, Redim
 from .options import Options, Store, cleanup_custom_options
 from .pprint import PrettyPrinter
 from .tree import AttrTree
-from .util import bytes_to_unicode
+from .util import _is_deep_indexable, bytes_to_unicode
 
 # Alias parameter support for pickle loading
 
@@ -34,6 +34,11 @@ ALIASES = {"key_dimensions": "kdims", "value_dimensions": "vdims", "constant_dim
 title_format = "{name}: {val}{unit}"
 
 redim = Redim  # pickle compatibility - remove in 2.0
+
+if t.TYPE_CHECKING:
+    from typing_extensions import Self
+
+    _LabelledDataT = t.TypeVar("_LabelledDataT", bound="LabelledData")
 
 
 def param_aliases(d):
@@ -388,10 +393,10 @@ class Dimension(param.Parameterized):
         """Hashes object on Dimension spec, i.e. (name, label)."""
         return hash(self.spec)
 
-    def __setstate__(self, d):
+    def __setstate__(self, state):
         """Compatibility for pickles before alias attribute was introduced."""
-        super().__setstate__(d)
-        if "_label_param_value" not in d:
+        super().__setstate__(state)
+        if "_label_param_value" not in state:
             self.label = self.name
 
     def __eq__(self, other):
@@ -431,8 +436,8 @@ class Dimension(param.Parameterized):
 
         params = self.param.objects("existing")
         ordering = sorted(
-            sorted(changed.keys()),
-            key=lambda k: -float("inf") if params[k].precedence is None else params[k].precedence,
+            changed,
+            key=lambda k: -float("inf") if (p := params[k].precedence) is None else p,
         )
         kws = ", ".join(f"{k}={changed[k]!r}" for k in ordering if k != "name")
         return f"Dimension({self.name!r}, {kws})"
@@ -598,7 +603,29 @@ class LabelledData(param.Parameterized):
             ref = weakref.ref(self, partial(cleanup_custom_options, opts_id))
             Store._weakrefs[opts_id].append(ref)
 
-    def clone(self, data=None, shared_data=True, new_type=None, link=True, *args, **overrides):
+    @t.overload
+    def clone(
+        self,
+        data=None,
+        shared_data=True,
+        *,
+        new_type: type[_LabelledDataT],
+        link=True,
+        **overrides,
+    ) -> _LabelledDataT: ...
+    @t.overload
+    def clone(
+        self, data=None, shared_data=True, new_type: None = None, link=True, *args, **overrides
+    ) -> Self: ...
+    def clone(
+        self,
+        data=None,
+        shared_data=True,
+        new_type: type[LabelledData] | None = None,
+        link=True,
+        *args,
+        **overrides,
+    ) -> LabelledData | Self:
         """Clones the object, overriding data and parameters.
 
         Parameters
@@ -665,7 +692,7 @@ class LabelledData(param.Parameterized):
         Returns relabelled object
         """
         new_data = self.data
-        if (depth > 0) and getattr(self, "_deep_indexable", False):
+        if (depth > 0) and _is_deep_indexable(self):
             new_data = []
             for k, v in self.data.items():
                 relabelled = v.relabel(group=group, label=label, depth=depth - 1)
@@ -700,7 +727,7 @@ class LabelledData(param.Parameterized):
         split_spec = tuple(spec.split(".")) if not isinstance(spec, tuple) else spec
         split_spec, nocompare = zip(
             *((None, True) if s == "*" or s is None else (s, False) for s in split_spec),
-            strict=None,
+            strict=True,
         )
         if all(nocompare):
             return True
@@ -709,9 +736,9 @@ class LabelledData(param.Parameterized):
         unescaped_match = match_fn(specification[: len(split_spec)]) == self_spec
         if unescaped_match:
             return True
-        sanitizers = [util.sanitize_identifier, util.group_sanitizer, util.label_sanitizer]
+        sanitizers = (util.sanitize_identifier, util.group_sanitizer, util.label_sanitizer)
         identifier_specification = tuple(
-            fn(ident, escape=False) for ident, fn in zip(specification, sanitizers, strict=None)
+            fn(ident, escape=False) for ident, fn in zip(specification, sanitizers, strict=True)
         )
         identifier_match = match_fn(identifier_specification[: len(split_spec)]) == self_spec
         return identifier_match
@@ -745,7 +772,7 @@ class LabelledData(param.Parameterized):
             specs = [specs]
         accumulator = []
         matches = specs is None
-        if not matches:
+        if specs is not None:
             for spec in specs:
                 matches = self.matches(spec)
                 if matches:
@@ -754,7 +781,7 @@ class LabelledData(param.Parameterized):
             accumulator.append(fn(self))
 
         # Assumes composite objects are iterables
-        if self._deep_indexable:
+        if _is_deep_indexable(self):
             for el in self:
                 if el is None:
                     continue
@@ -791,7 +818,7 @@ class LabelledData(param.Parameterized):
             specs = [specs]
         applies = specs is None or any(self.matches(spec) for spec in specs)
 
-        if self._deep_indexable:
+        if _is_deep_indexable(self):
             deep_mapped = self.clone(shared_data=False) if clone else self
             for k, v in self.items():
                 new_val = v.map(map_fn, specs, clone)
@@ -821,31 +848,30 @@ class LabelledData(param.Parameterized):
             self.param.warning("Could not pickle custom style information.")
         return obj_dict
 
-    def __setstate__(self, d):
+    def __setstate__(self, state):
         """Restores options applied to this object."""
-        d = param_aliases(d)
+        state = param_aliases(state)
 
-        load_options = Store.load_counter_offset is not None
-        if load_options:
-            matches = [k for k in d if k.startswith("_custom_option")]
+        if Store.load_counter_offset is not None:
+            matches = [k for k in state if k.startswith("_custom_option")]
             for match in matches:
                 custom_id = int(match.split("_")[-1]) + Store.load_counter_offset
-                for backend, info in d[match].items():
+                for backend, info in state[match].items():
                     if backend not in Store._custom_options:
                         Store._custom_options[backend] = {}
                     Store._custom_options[backend][custom_id] = info
-                if d[match]:
+                if state[match]:
                     if custom_id not in Store._weakrefs:
                         Store._weakrefs[custom_id] = []
                     ref = weakref.ref(self, partial(cleanup_custom_options, custom_id))
-                    Store._weakrefs[d["_id"]].append(ref)
-                d.pop(match)
+                    Store._weakrefs[state["_id"]].append(ref)
+                state.pop(match)
 
-            if d["_id"] is not None:
-                d["_id"] += Store.load_counter_offset
+            if state["_id"] is not None:
+                state["_id"] += Store.load_counter_offset
 
-        self.__dict__.update(d)
-        super().__setstate__(d)
+        self.__dict__.update(state)
+        super().__setstate__(state)
 
 
 class Dimensioned(LabelledData):
@@ -1000,7 +1026,7 @@ class Dimensioned(LabelledData):
     @property
     def ddims(self):
         """The list of deep dimensions"""
-        if self._deep_indexable and self:
+        if _is_deep_indexable(self) and self:
             return self.values()[0].dimensions()
         else:
             return []
@@ -1060,7 +1086,9 @@ class Dimensioned(LabelledData):
 
     @t.overload
     def get_dimension(self, dimension, default=None, strict=True) -> Dimension: ...
-    def get_dimension(self, dimension, default=None, strict=False) -> Dimension | None:
+    @t.overload
+    def get_dimension(self, dimension, default=None, strict: bool = False) -> Dimension | None: ...
+    def get_dimension(self, dimension, default=None, strict=False):
         """Get a Dimension object by name or index.
 
         Parameters
@@ -1239,7 +1267,7 @@ class Dimensioned(LabelledData):
                     if isinstance(val, tuple):
                         val = slice(*val)
                     select[self.get_dimension_index(dim)] = val
-            if self._deep_indexable:
+            if _is_deep_indexable(self):
                 selection = self.get(tuple(select), None)
                 if selection is None:
                     selection = self.clone(shared_data=False)
@@ -1255,7 +1283,7 @@ class Dimensioned(LabelledData):
             dimensions = [*selection.dimensions(), "value"]
             if any(kw in dimensions for kw in kwargs):
                 selection = selection.select(selection_specs=selection_specs, **kwargs)
-        elif isinstance(selection, Dimensioned) and selection._deep_indexable:
+        elif isinstance(selection, Dimensioned) and _is_deep_indexable(selection):
             # Apply the deep selection on each item in local selection
             items = []
             for k, v in selection.items():
@@ -1497,13 +1525,13 @@ class ViewableTree(AttrTree, Dimensioned):
         items = cls._deduplicate_items(items)
         return items
 
-    def __setstate__(self, d):
+    def __setstate__(self, state):
         """Ensure that object does not try to reference its parent during
         unpickling.
         """
-        parent = d.pop("parent", None)
-        d["parent"] = None
-        super(AttrTree, self).__setstate__(d)
+        parent = state.pop("parent", None)
+        state["parent"] = None
+        super(AttrTree, self).__setstate__(state)
         self.__dict__["parent"] = parent
 
     @classmethod
@@ -1564,6 +1592,3 @@ class ViewableTree(AttrTree, Dimensioned):
             return vals if expanded else util.unique_array(vals)
         else:
             return super().dimension_values(dimension, expanded, flat)
-
-    def __len__(self):
-        return len(self.data)

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import builtins
 import datetime as dt
 import re
+import typing as t
 import weakref
 from collections import Counter, defaultdict
 from collections.abc import Iterable
@@ -1057,6 +1058,8 @@ class Dimensioned(LabelledData):
             )
         return [(dim.label if label == "long" else dim.name) if label else dim for dim in dims]
 
+    @t.overload
+    def get_dimension(self, dimension, default=None, strict=True) -> Dimension: ...
     def get_dimension(self, dimension, default=None, strict=False) -> Dimension | None:
         """Get a Dimension object by name or index.
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -1091,10 +1091,14 @@ class Dimensioned(LabelledData):
         return [(dim.label if label == "long" else dim.name) if label else dim for dim in dims]
 
     @t.overload
-    def get_dimension(self, dimension, default=None, strict=True) -> Dimension: ...
+    def get_dimension(
+        self, dimension, *, default=..., strict: t.Literal[False] = False
+    ) -> Dimension | None: ...
     @t.overload
-    def get_dimension(self, dimension, default=None, strict: bool = False) -> Dimension | None: ...
-    def get_dimension(self, dimension, default=None, strict=False):
+    def get_dimension(
+        self, dimension, *, default=..., strict: t.Literal[True] = True
+    ) -> Dimension: ...
+    def get_dimension(self, dimension, *, default=None, strict=False):
         """Get a Dimension object by name or index.
 
         Parameters

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -285,6 +285,13 @@ class Tabular(Element):
 
     __abstract = True
 
+    # Defined in Dataset
+    iloc: property
+
+    def __len__(self):
+        # Defined in Dataset
+        raise NotImplementedError
+
     @property
     def rows(self):
         """Number of rows in table (including header)"""
@@ -429,7 +436,7 @@ class Collator(NdMapping):
     _deep_indexable = False
     _auxiliary_component = False
 
-    _nest_order = {
+    _nest_order: dict[type[NdMapping], type | tuple[type, ...]] = {
         HoloMap: ViewableElement,
         GridSpace: (HoloMap, CompositeOverlay, ViewableElement),
         NdLayout: (GridSpace, HoloMap, ViewableElement),
@@ -462,19 +469,19 @@ class Collator(NdMapping):
             if isinstance(data, AttrTree):
                 data = data.filter(self.filters)
             if len(self.vdims) and self.value_transform:
-                vargs = dict(zip(self.dimensions("value", label=True), data, strict=None))
+                vargs = dict(zip(self.dimensions("value", label=True), data, strict=False))
                 data = self.value_transform(vargs)
             if not isinstance(data, Dimensioned):
                 raise ValueError("Collator values must be Dimensioned objects before collation.")
 
             varying_keys = [
                 (d, k)
-                for d, k in zip(self.kdims, key, strict=None)
+                for d, k in zip(self.kdims, key, strict=False)
                 if not self.drop_constant or (d not in constant_dims and d not in self.drop)
             ]
             constant_keys = {
                 d: k
-                for d, k in zip(self.kdims, key, strict=None)
+                for d, k in zip(self.kdims, key, strict=False)
                 if d in constant_dims and d not in self.drop and self.drop_constant
             }
             if varying_keys or constant_keys:
@@ -508,18 +515,18 @@ class Collator(NdMapping):
             item.fixed = False
 
         dim_vals = [(dim, val) for dim, val in dims[::-1] if dim not in self.drop]
-        if isinstance(item, self.merge_type):
+        if isinstance(item, self.merge_type):  # ty:ignore[invalid-argument-type], upstream param
             new_item = item.clone(cdims=constant_keys)
             for dim, val in dim_vals:
                 dim = asdim(dim)
                 if dim not in new_item.kdims:
                     new_item = new_item.add_dimension(dim, 0, val)
-        elif isinstance(item, self._nest_order[self.merge_type]):
+        elif isinstance(item, self._nest_order[self.merge_type]):  # ty:ignore[invalid-argument-type], upstream param
             if dim_vals:
-                dimensions, key = zip(*dim_vals, strict=None)
+                dimensions, key = zip(*dim_vals, strict=True)
                 new_item = self.merge_type(
                     {key: item}, kdims=list(dimensions), cdims=constant_keys
-                )
+                )  # ty:ignore[call-non-callable], upstream param
             else:
                 new_item = item
         else:

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -515,18 +515,18 @@ class Collator(NdMapping):
             item.fixed = False
 
         dim_vals = [(dim, val) for dim, val in dims[::-1] if dim not in self.drop]
-        if isinstance(item, self.merge_type):  # ty:ignore[invalid-argument-type], upstream param
+        if isinstance(item, self.merge_type):
             new_item = item.clone(cdims=constant_keys)
             for dim, val in dim_vals:
                 dim = asdim(dim)
                 if dim not in new_item.kdims:
                     new_item = new_item.add_dimension(dim, 0, val)
-        elif isinstance(item, self._nest_order[self.merge_type]):  # ty:ignore[invalid-argument-type], upstream param
+        elif isinstance(item, self._nest_order[self.merge_type]):
             if dim_vals:
                 dimensions, key = zip(*dim_vals, strict=True)
                 new_item = self.merge_type(
                     {key: item}, kdims=list(dimensions), cdims=constant_keys
-                )  # ty:ignore[call-non-callable], upstream param
+                )
             else:
                 new_item = item
         else:

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -329,7 +329,7 @@ class Tabular(Element):
                     return ""
             return self.kdims[col].pprint_label
         else:
-            dim = self.get_dimension(col)
+            dim = self.get_dimension(col, strict=True)
             return dim.pprint_value(self.iloc[row - 1, col])
 
     def cell_type(self, row, col):

--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -120,6 +120,13 @@ class Exporter(param.ParameterizedFunction):
         contain items that will be quick to load and inspect. """,
     )
 
+    file_ext = param.String(
+        "pkl",
+        doc="""
+        The file extension associated with the corresponding file
+        format (if applicable).""",
+    )
+
     @classmethod
     def encode(cls, entry):
         """Classmethod that applies conditional encoding based on
@@ -142,8 +149,8 @@ class Exporter(param.ParameterizedFunction):
         else:
             return filename
 
-    @bothmethod
-    def _merge_metadata(self_or_cls, obj, fn, *dicts):
+    @staticmethod
+    def _merge_metadata(obj, fn, *dicts):
         """Returns a merged metadata info dictionary from the supplied
         function and additional dictionaries
 
@@ -151,7 +158,7 @@ class Exporter(param.ParameterizedFunction):
         merged = {k: v for d in dicts for (k, v) in d.items()}
         return dict(merged, **fn(obj)) if fn else merged
 
-    def __call__(self, obj, fmt=None):
+    def __call__(self, obj, **kwargs):
         """Given a HoloViews object return the raw exported data and
         corresponding metadata as the tuple (data, metadata). The
         metadata should include:
@@ -166,8 +173,8 @@ class Exporter(param.ParameterizedFunction):
         """
         raise NotImplementedError("Exporter not implemented.")
 
-    @bothmethod
-    def save(self_or_cls, obj, basename, fmt=None, key=None, info=None, **kwargs):
+    @staticmethod
+    def save(obj, basename, fmt=None, key=None, info=None, **kwargs):
         """Similar to the call method except saves exporter data to disk
         into a file with specified basename. For exporters that
         support multiple formats, the fmt argument may also be
@@ -246,13 +253,6 @@ class Serializer(Exporter):
         "application/python-pickle",
         allow_None=True,
         doc="The mime-type associated with the serializer (if applicable).",
-    )
-
-    file_ext = param.String(
-        "pkl",
-        doc="""
-        The file extension associated with the corresponding file
-        format (if applicable).""",
     )
 
     def __call__(self, obj, **kwargs):
@@ -387,7 +387,7 @@ class Pickler(Exporter):
                 ]
                 components = [obj]
 
-            for component, entry in zip(components, entries, strict=None):
+            for component, entry in zip(components, entries, strict=False):
                 f.writestr(entry, Store.dumps(component, protocol=self_or_cls.protocol))
             f.writestr("metadata", pickle.dumps({"info": info, "key": key}))
 
@@ -666,14 +666,14 @@ class FileArchive(Archive):
     ffields = {"type", "group", "label", "obj", "SHA", "timestamp", "dimensions"}
     efields = {"timestamp"}
 
-    @classmethod
-    def parse_fields(cls, formatter):
+    @staticmethod
+    def parse_fields(formatter):
         """Returns the format fields otherwise raise exception"""
         if formatter is None:
             return []
         try:
-            parse = list(string.Formatter().parse(formatter))
-            return {f for f in list(zip(*parse, strict=None))[1] if f is not None}
+            parse = string.Formatter().parse(formatter)
+            return {p[1] for p in parse} - {None}
         except Exception as e:
             raise SyntaxError(f"Could not parse formatter {formatter!r}") from e
 
@@ -915,7 +915,7 @@ class FileArchive(Archive):
 
         fnames = [self._truncate_name(*k, maxlen=maxlen) for k in self._files]
         max_len = max([len(f) for f in fnames])
-        for name, v in zip(fnames, self._files.values(), strict=None):
+        for name, v in zip(fnames, self._files.values(), strict=True):
             mime_type = v[1].get("mime_type", "no mime type")
             lines.append(f"{name.ljust(max_len)} : {mime_type}")
         print("\n".join(lines))

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -299,6 +299,9 @@ class AdjointLayout(Layoutable, Dimensioned):
     def keys(self):
         return list(self.data.keys())
 
+    def values(self):
+        return list(self.data.values())
+
     def items(self):
         return list(self.data.items())
 

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -107,7 +107,7 @@ class AdjointLayout(Layoutable, Dimensioned):
             if wrong_pos:
                 raise Exception("Wrong AdjointLayout positions provided.")
         elif isinstance(data, list):
-            data = dict(zip(self.layout_order, data, strict=None))
+            data = dict(zip(self.layout_order, data, strict=False))
         else:
             data = {}
 

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -16,6 +16,7 @@ import param
 from . import util
 from .dimension import Dimension, Dimensioned, ViewableElement, asdim
 from .util import (
+    _is_deep_indexable,
     dimension_sort,
     dtype_kind,
     get_ndmapping_label,
@@ -251,7 +252,7 @@ class MultiDimensionalMapping(Dimensioned):
         been declared deep indexable.
 
         """
-        if self._deep_indexable and isinstance(data, Dimensioned) and indices:
+        if _is_deep_indexable(self) and isinstance(data, Dimensioned) and indices:
             return data[indices]
         elif len(indices) > 0:
             self.param.warning("Cannot index into data element, extra data indices ignored.")
@@ -355,7 +356,7 @@ class MultiDimensionalMapping(Dimensioned):
         if dimension in self.dimensions():
             raise Exception(f"{dimension.name} dimension already defined")
 
-        if vdim and self._deep_indexable:
+        if vdim and _is_deep_indexable(self):
             raise Exception("Cannot add value dimension to object that is deep indexable")
 
         if vdim:
@@ -880,10 +881,8 @@ class UniformNdMapping(NdMapping):
                     )
                 )
             else:
-                raise ValueError(
-                    "Could not determine correct collapse operation "
-                    "for items of type: {group.type!r}."
-                )
+                msg = f"Could not determine correct collapse operation for items of type: {group.type!r}."
+                raise ValueError(msg)
             collapsed[key] = group_data
         return collapsed if self.ndims - len(dimensions) else collapsed.last
 

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -27,7 +27,13 @@ from .util import (
 )
 
 if t.TYPE_CHECKING:
-    from collections.abc import Callable
+    from typing_extensions import TypeIs
+
+    from .spaces import HoloMap
+
+
+def _has_split_overlays(obj) -> TypeIs[HoloMap]:
+    return hasattr(obj, "_split_overlays")
 
 
 class item_check:
@@ -109,9 +115,6 @@ class MultiDimensionalMapping(Dimensioned):
     data_type = None  # Optional type checking of elements
     _deep_indexable = False
     _check_items = True
-
-    # Defined in HoloMap / DynamicMap
-    _split_overlays: Callable[[], tuple[list[t.Any], list[t.Any]]]
 
     def __init__(self, initial_items=None, kdims=None, **params):
         if isinstance(initial_items, MultiDimensionalMapping):
@@ -870,7 +873,7 @@ class UniformNdMapping(NdMapping):
                 if function:
                     agg = group_data.aggregate(group.last.kdims, function, spreadfn, **kwargs)
                     group_data = group.type(agg)
-            elif issubclass(group.type, CompositeOverlay) and hasattr(self, "_split_overlays"):
+            elif issubclass(group.type, CompositeOverlay) and _has_split_overlays(self):
                 keys, maps = self._split_overlays()
                 group_data = group.type(
                     dict(

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -6,6 +6,7 @@ also enables slicing over multiple dimension ranges.
 
 from __future__ import annotations
 
+import typing as t
 from itertools import cycle
 from operator import itemgetter
 
@@ -23,6 +24,9 @@ from .util import (
     unique_iterator,
     wrap_tuple,
 )
+
+if t.TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class item_check:
@@ -61,7 +65,7 @@ class sorted_context:
         MultiDimensionalMapping.sort = self.enabled
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        MultiDimensionalMapping.sort = self._enabled
+        MultiDimensionalMapping.sort = self._enabled  # ty:ignore[invalid-assignment]
 
 
 class MultiDimensionalMapping(Dimensioned):
@@ -104,6 +108,9 @@ class MultiDimensionalMapping(Dimensioned):
     data_type = None  # Optional type checking of elements
     _deep_indexable = False
     _check_items = True
+
+    # Defined in HoloMap / DynamicMap
+    _split_overlays: Callable[[], tuple[list[t.Any], list[t.Any]]]
 
     def __init__(self, initial_items=None, kdims=None, **params):
         if isinstance(initial_items, MultiDimensionalMapping):
@@ -168,9 +175,9 @@ class MultiDimensionalMapping(Dimensioned):
         self._item_check(dim_vals, data)
 
         # Apply dimension types
-        dim_types = zip([kd.type for kd in self.kdims], dim_vals, strict=None)
+        dim_types = zip([kd.type for kd in self.kdims], dim_vals, strict=False)
         dim_vals = tuple(v if None in [t, v] else t(v) for t, v in dim_types)
-        valid_vals = zip(self.kdims, dim_vals, strict=None)
+        valid_vals = zip(self.kdims, dim_vals, strict=False)
 
         for dim, val in valid_vals:
             if dim.values and val is not None and val not in dim.values:
@@ -195,7 +202,7 @@ class MultiDimensionalMapping(Dimensioned):
 
         """
         typed_key = ()
-        for dim, key in zip(self.kdims, keys, strict=None):
+        for dim, key in zip(self.kdims, keys, strict=False):
             key_type = dim.type
             if key_type is None:
                 typed_key += (key,)
@@ -367,7 +374,7 @@ class MultiDimensionalMapping(Dimensioned):
             raise ValueError("Added dimension values must be same lengthas existing keys.")
 
         items = {}
-        for dval, (key, val) in zip(dim_val, self.data.items(), strict=None):
+        for dval, (key, val) in zip(dim_val, self.data.items(), strict=False):
             if vdim:
                 new_val = list(val)
                 new_val.insert(dim_pos, dval)
@@ -444,7 +451,7 @@ class MultiDimensionalMapping(Dimensioned):
         indices = [self.get_dimension_index(el) for el in kdims]
 
         keys = [tuple(k[i] for i in indices) for k in self.data.keys()]
-        reindexed_items = dict((k, v) for (k, v) in zip(keys, self.data.values(), strict=None))
+        reindexed_items = dict((k, v) for (k, v) in zip(keys, self.data.values(), strict=False))
         reduced_dims = {d.name for d in self.kdims}.difference(kdims)
         dimensions = [self.get_dimension(d) for d in kdims if d not in reduced_dims]
 
@@ -532,7 +539,7 @@ class MultiDimensionalMapping(Dimensioned):
 
     def items(self):
         """Returns all elements as a list in (key,value) format."""
-        return list(zip(list(self.keys()), list(self.values()), strict=None))
+        return list(zip(self.keys(), self.values(), strict=True))
 
     def get(self, key, default=None):
         """Standard get semantics for all mapping types"""
@@ -594,26 +601,26 @@ class NdMapping(MultiDimensionalMapping):
 
     group = param.String(default="NdMapping", constant=True)
 
-    def __getitem__(self, indexslice):
+    def __getitem__(self, key):
         """Allows slicing operations along the key and data
         dimensions. If no data slice is supplied it will return all
         data elements, otherwise it will return the requested slice of
         the data.
 
         """
-        if isinstance(indexslice, np.ndarray) and dtype_kind(indexslice) == "b":
-            if not len(indexslice) == len(self):
+        if isinstance(key, np.ndarray) and dtype_kind(key) == "b":
+            if not len(key) == len(self):
                 raise IndexError("Boolean index must match length of sliced object")
-            selection = zip(indexslice, self.data.items(), strict=None)
+            selection = zip(key, self.data.items(), strict=False)
             return self.clone([item for c, item in selection if c])
-        elif isinstance(indexslice, tuple) and indexslice == () and not self.kdims:
+        elif isinstance(key, tuple) and key == () and not self.kdims:
             return self.data[()]
-        elif (isinstance(indexslice, tuple) and indexslice == ()) or indexslice is Ellipsis:
+        elif (isinstance(key, tuple) and key == ()) or key is Ellipsis:
             return self
-        elif any(Ellipsis is sl for sl in wrap_tuple(indexslice)):
-            indexslice = process_ellipses(self, indexslice)
+        elif any(Ellipsis is sl for sl in wrap_tuple(key)):
+            key = process_ellipses(self, key)
 
-        map_slice, data_slice = self._split_index(indexslice)
+        map_slice, data_slice = self._split_index(key)
         map_slice = self._transform_indices(map_slice)
         map_slice = self._expand_slice(map_slice)
 
@@ -624,7 +631,7 @@ class NdMapping(MultiDimensionalMapping):
         else:
             conditions = self._generate_conditions(map_slice)
             items = self.data.items()
-            for cidx, (condition, dim) in enumerate(zip(conditions, self.kdims, strict=None)):
+            for cidx, (condition, dim) in enumerate(zip(conditions, self.kdims, strict=False)):
                 values = dim.values
                 items = [
                     (k, v)
@@ -672,7 +679,7 @@ class NdMapping(MultiDimensionalMapping):
     def _generate_conditions(self, map_slice):
         """Generates filter conditions used for slicing the data structure."""
         conditions = []
-        for dim, dim_slice in zip(self.kdims, map_slice, strict=None):
+        for dim, dim_slice in zip(self.kdims, map_slice, strict=False):
             if isinstance(dim_slice, slice):
                 start, stop = dim_slice.start, dim_slice.stop
                 if dim.values:
@@ -868,7 +875,7 @@ class UniformNdMapping(NdMapping):
                     dict(
                         [
                             (key, ndmap.collapse(function=function, spreadfn=spreadfn, **kwargs))
-                            for key, ndmap in zip(keys, maps, strict=None)
+                            for key, ndmap in zip(keys, maps, strict=True)
                         ]
                     )
                 )

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -912,7 +912,9 @@ class UniformNdMapping(NdMapping):
             outer_dimensions = self.kdims
             inner_dimensions = None
         else:
-            outer_dimensions = [self.get_dimension(d) for d in dimensions if d in self.kdims]
+            outer_dimensions = [
+                self.get_dimension(d, strict=True) for d in dimensions if d in self.kdims
+            ]
             inner_dimensions = [d for d in dimensions if d not in outer_dimensions]
         inds = [(d, self.get_dimension_index(d)) for d in outer_dimensions]
 

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -149,8 +149,6 @@ class Operation(param.ParameterizedFunction):
         for hook in self._preprocess_hooks:
             kwargs.update(hook(self, element))
 
-        element_pipeline = getattr(element, "_pipeline", None)
-
         if hasattr(element, "_in_method"):
             in_method = element._in_method
             if not in_method:
@@ -172,6 +170,7 @@ class Operation(param.ParameterizedFunction):
             and isinstance(element, Dataset)
             and not in_method
         ):
+            element_pipeline = element._pipeline
             ret._dataset = element.dataset.clone()
             ret._pipeline = element_pipeline.instance(
                 operations=[*element_pipeline.operations, self.instance(**self.p)],

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -246,7 +246,7 @@ class OperationCallable(Callable):
     operation = param.ClassSelector(
         class_=Operation,
         doc="The Operation being wrapped into an OperationCallable.",
-    )
+    )  # ty:ignore[no-matching-overload], https://github.com/astral-sh/ruff/pull/24698
 
     def __init__(self, callable, **kwargs):
         if "operation" not in kwargs:

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -51,6 +51,7 @@ from .tree import AttrTree
 from .util import group_sanitizer, label_sanitizer, sanitize_identifier
 
 if t.TYPE_CHECKING:
+    from ..util import _BackendT
     from ..util.settings import OutputSettings
 
 
@@ -1222,7 +1223,7 @@ class Store:
     load_counter_offset = None
     save_option_state = False
 
-    current_backend = "matplotlib"
+    current_backend: _BackendT = "matplotlib"
 
     _backend_switch_hooks = []
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -45,6 +45,7 @@ from contextlib import contextmanager
 import numpy as np
 import param
 
+from ..util.warnings import HoloviewsUserWarning, warn
 from .accessors import Opts  # noqa (clean up in 2.0)
 from .pprint import InfoPrinter
 from .tree import AttrTree
@@ -327,8 +328,8 @@ class Cycle(param.Parameterized):
         super().__init__(**params)
         self.values = self._get_values()
 
-    def __getitem__(self, num):
-        return self(values=self.values[:num])
+    def __getitem__(self, key):
+        return self(values=self.values[:key])
 
     def _get_values(self):
         if self.values:
@@ -415,7 +416,7 @@ class Palette(Cycle):
         super(Cycle, self).__init__(key=key, **params)
         self.values = self._get_values()
 
-    def __getitem__(self, slc):
+    def __getitem__(self, key):
         """Provides a convenient interface to override the
         range and samples parameters of the Cycle.
         Supplying a slice step or index overrides the
@@ -423,21 +424,21 @@ class Palette(Cycle):
         inherited.
 
         """
-        (start, stop), step = self.range, self.samples
-        if isinstance(slc, slice):
-            if slc.start is not None:
-                start = slc.start
-            if slc.stop is not None:
-                stop = slc.stop
-            if slc.step is not None:
-                step = slc.step
+        (start, stop), step = self.range, self.samples  # ty:ignore[not-iterable], upstream param
+        if isinstance(key, slice):
+            if key.start is not None:
+                start = key.start
+            if key.stop is not None:
+                stop = key.stop
+            if key.step is not None:
+                step = key.step
         else:
-            step = slc
+            step = key
         return self(range=(start, stop), samples=step)
 
     def _get_values(self):
         cmap = self.colormaps[self.key]
-        (start, stop), steps = self.range, self.samples
+        (start, stop), steps = self.range, self.samples  # ty:ignore[not-iterable], upstream param
         samples = [cmap(n) for n in self.sample_fn(start, stop, steps)]
         return samples[::-1] if self.reverse else samples
 
@@ -491,8 +492,9 @@ class Options:
             error = OptionError(invalid_kw, allowed_keywords, group_name=key)
             StoreOptions.record_skipped_option(error)
         if invalid_kws and self.warn_on_skip:
-            self.param.warning(
-                f"Invalid options {invalid_kws!r}, valid options are: {allowed_keywords!s}"
+            warn(
+                f"Invalid options {invalid_kws!r}, valid options are: {allowed_keywords!s}",
+                category=HoloviewsUserWarning,
             )
 
         self.kwargs = dict([(k, kwargs[k]) for k in sorted(kwargs.keys()) if k not in invalid_kws])
@@ -688,21 +690,16 @@ class OptionTree(AttrTree):
                 e.invalid_keyword, e.allowed_keywords, group_name=group_name, path=self.path
             ) from e
 
-    def __getitem__(self, item):
-        if item in self.groups:
-            return self.groups[item]
-        return super().__getitem__(item)
+    def __getitem__(self, key):
+        if key in self.groups:
+            return self.groups[key]
+        return super().__getitem__(key)
 
     def __getattr__(self, identifier):
         """Allows creating sub OptionTree instances using attribute
         access, inheriting the group options.
 
         """
-        try:
-            return super(AttrTree, self).__getattr__(identifier)
-        except AttributeError:
-            pass
-
         if identifier.startswith("_"):
             raise AttributeError(str(identifier))
         elif self.fixed == True:
@@ -997,14 +994,8 @@ class Compositor(param.Parameterized):
             result = applicable_op.apply(sliced, ranges, backend)
             if applicable_op.group:
                 result = result.relabel(group=applicable_op.group)
-            if isinstance(overlay, Overlay):
-                result = [result]
-            else:
-                result = list(zip(sliced.keys(), [result], strict=None))
-            processed[applicable_op] += [
-                el for r in result for el in r.traverse(lambda x: x, [Element])
-            ]
-            overlay = overlay.clone(values[:start] + result + values[stop:])
+            processed[applicable_op] += result.traverse(lambda x: x, [Element])
+            overlay = overlay.clone([*values[:start], result, *values[stop:]])
 
             # Guard against infinite recursion for no-ops
             spec_fn = lambda x: not isinstance(x, CompositeOverlay)
@@ -1023,7 +1014,7 @@ class Compositor(param.Parameterized):
         # Apply compositors
         clone = holomap.clone(shared_data=False)
         data = (
-            zip(ranges[1], holomap.data.values(), strict=None) if ranges else holomap.data.items()
+            zip(ranges[1], holomap.data.values(), strict=False) if ranges else holomap.data.items()
         )
         for key, overlay in data:
             clone[key] = cls.collapse_element(overlay, ranges, mode)
@@ -1114,7 +1105,7 @@ class Compositor(param.Parameterized):
 
         """
         level = 0
-        for spec, el in zip(self._pattern_spec, overlay_items, strict=None):
+        for spec, el in zip(self._pattern_spec, overlay_items, strict=False):
             if spec[0] != type(el).__name__:
                 return None
             level += 1  # Types match
@@ -1722,7 +1713,7 @@ class StoreOptions:
         return expanded_spec, applied_keys
 
     @classmethod
-    def create_custom_trees(cls, obj, options=None, backend=None):
+    def create_custom_trees(cls, obj, options, backend=None):
         """Returns the appropriate set of customized subtree clones for
         an object, suitable for merging with Store.custom_options (i.e
         with the ids appropriately offset). Note if an object has no

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1226,7 +1226,7 @@ class Store:
 
     _backend_switch_hooks = []
 
-    output_settings: OutputSettings
+    output_settings: type[OutputSettings]
 
     @classmethod
     def set_current_backend(cls, backend):

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -424,7 +424,7 @@ class Palette(Cycle):
         inherited.
 
         """
-        (start, stop), step = self.range, self.samples  # ty:ignore[not-iterable], upstream param
+        (start, stop), step = self.range, self.samples
         if isinstance(key, slice):
             if key.start is not None:
                 start = key.start
@@ -438,7 +438,7 @@ class Palette(Cycle):
 
     def _get_values(self):
         cmap = self.colormaps[self.key]
-        (start, stop), steps = self.range, self.samples  # ty:ignore[not-iterable], upstream param
+        (start, stop), steps = self.range, self.samples
         samples = [cmap(n) for n in self.sample_fn(start, stop, steps)]
         return samples[::-1] if self.reverse else samples
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -38,6 +38,7 @@ import difflib
 import inspect
 import pickle
 import traceback
+import typing as t
 from collections import defaultdict
 from contextlib import contextmanager
 
@@ -48,6 +49,9 @@ from .accessors import Opts  # noqa (clean up in 2.0)
 from .pprint import InfoPrinter
 from .tree import AttrTree
 from .util import group_sanitizer, label_sanitizer, sanitize_identifier
+
+if t.TYPE_CHECKING:
+    from ..util.settings import OutputSettings
 
 
 def cleanup_custom_options(id, weakref=None):
@@ -844,26 +848,28 @@ class OptionTree(AttrTree):
             if groups[group].kwargs != {}:
                 accumulator.append((".", groups[group].kwargs))
 
-            for t, v in sorted(self.items()):
+            for k, v in sorted(self.items()):
                 kwargs = v.groups[group].kwargs
-                accumulator.append((".".join(t), kwargs))
+                accumulator.append((".".join(k), kwargs))
 
-            for t, kws in accumulator:
+            for name, kws in accumulator:
                 if group == "norm" and all(
                     kws.get(k, False) is False for k in ["axiswise", "framewise"]
                 ):
                     continue
                 elif kws:
-                    especs.append((t, kws))
+                    especs.append((name, kws))
 
             if especs:
                 format_kws = [
-                    (t, f"dict({', '.join(f'{k}={v}' for k, v in sorted(kws.items()))})")
-                    for t, kws in especs
+                    (name, f"dict({', '.join(f'{k}={v}' for k, v in sorted(kws.items()))})")
+                    for name, kws in especs
                 ]
-                ljust = max(len(t) for t, _ in format_kws)
+                ljust = max(len(name) for name, _ in format_kws)
                 sep = (tab * 2) if len(format_kws) > 1 else ""
-                entries = sep + esep.join([f"{sep}{t.ljust(ljust)} : {v}" for t, v in format_kws])
+                entries = sep + esep.join(
+                    [f"{sep}{name.ljust(ljust)} : {v}" for name, v in format_kws]
+                )
                 gspecs.append(
                     ("%s%s={\n%s}" if len(format_kws) > 1 else "%s%s={%s}") % (tab, group, entries)
                 )
@@ -1219,6 +1225,8 @@ class Store:
     current_backend = "matplotlib"
 
     _backend_switch_hooks = []
+
+    output_settings: OutputSettings
 
     @classmethod
     def set_current_backend(cls, backend):

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -8,6 +8,7 @@ for indexing, slicing and animating collections of Views.
 
 from __future__ import annotations
 
+import typing as t
 from functools import reduce
 
 import numpy as np
@@ -17,6 +18,9 @@ from .dimension import Dimension, Dimensioned, ViewableElement, ViewableTree
 from .layout import AdjointLayout, Composable, Layout, Layoutable
 from .ndmapping import UniformNdMapping
 from .util import dimensioned_streams, sanitize_identifier, unique_array
+
+if t.TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class Overlayable:
@@ -64,6 +68,13 @@ class CompositeOverlay(ViewableElement, Composable):
     """CompositeOverlay provides a common baseclass for Overlay classes."""
 
     _deep_indexable = True
+
+    # Defined in AttrTree, but can't inherit without test failings
+    keys: Callable[[], list[t.Any]]
+    values: Callable[[], list[t.Any]]
+    items: Callable[[], list[list[t.Any]]]
+    main_layer: int
+    __len__: Callable[[], int]
 
     def hist(
         self,
@@ -165,7 +176,7 @@ class CompositeOverlay(ViewableElement, Composable):
             return super().dimension_values(dimension, expanded, flat)
         values = [v for v in values if v is not None and len(v)]
         if not values:
-            return np.array()
+            return np.array([])
         vals = np.concatenate(values)
         return vals if expanded else unique_array(vals)
 

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -17,10 +17,7 @@ import param
 from .dimension import Dimension, Dimensioned, ViewableElement, ViewableTree
 from .layout import AdjointLayout, Composable, Layout, Layoutable
 from .ndmapping import UniformNdMapping
-from .util import dimensioned_streams, sanitize_identifier, unique_array
-
-if t.TYPE_CHECKING:
-    from collections.abc import Callable
+from .util import _is_deep_indexable, dimensioned_streams, sanitize_identifier, unique_array
 
 
 class Overlayable:
@@ -69,13 +66,6 @@ class CompositeOverlay(ViewableElement, Composable):
 
     _deep_indexable = True
 
-    # Defined in AttrTree, but can't inherit without test failings
-    keys: Callable[[], list[t.Any]]
-    values: Callable[[], list[t.Any]]
-    items: Callable[[], list[list[t.Any]]]
-    main_layer: int
-    __len__: Callable[[], int]
-
     def hist(
         self,
         dimension=None,
@@ -113,6 +103,9 @@ class CompositeOverlay(ViewableElement, Composable):
         AdjointLayout of element and histogram or just the
         histogram
         """
+        if not _is_deep_indexable(self):
+            msg = f"Histogram can only be computed for deeply indexable types, supplied type is {type(self).__name__}"
+            raise TypeError(msg)
         # Get main layer to get plot dimensions
         main_layer_int_index = getattr(self, "main_layer", None) or 0
         # Validate index, and extract as integer if not None
@@ -154,7 +147,7 @@ class CompositeOverlay(ViewableElement, Composable):
             for dim, hists in hists_per_dim.items()
         }
         if adjoin:
-            layout = self
+            layout = t.cast("AdjointLayout", self)
             for dim in reversed(self.values()[main_layer_int_index].kdims):
                 if dim.name in hists_overlay_per_dim:
                     layout = layout << hists_overlay_per_dim[dim.name]

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -15,12 +15,16 @@ from __future__ import annotations
 
 import re
 import textwrap
+import typing as t
 
 import param
 from param.ipython import ParamPager
 from param.parameterized import bothmethod
 
 from .util import group_sanitizer, label_sanitizer
+
+if t.TYPE_CHECKING:
+    from .options import Store
 
 
 class ParamFilter(param.ParameterizedFunction):
@@ -91,7 +95,7 @@ class InfoPrinter:
     headings = ["\x1b[1;35m%s\x1b[0m", "\x1b[1;32m%s\x1b[0m"]
     ansi_escape = re.compile(r"\x1b[^m]*m")
     ppager = ParamPager()
-    store = None
+    store: Store | None = None
     elements = []
 
     @classmethod
@@ -148,6 +152,9 @@ class InfoPrinter:
 
         isclass = isinstance(obj, type)
         name = obj.__name__ if isclass else obj.__class__.__name__
+        if cls.store is None:
+            msg = f"Store is not set on InfoPrinter. Cannot look up plot class for backend {backend!r}."
+            raise RuntimeError(msg)
         backend_registry = cls.store.registry.get(backend, {})
         plot_class = backend_registry.get(obj if isclass else type(obj), None)
         # Special case to handle PlotSelectors
@@ -159,6 +166,8 @@ class InfoPrinter:
                 obj = ParamFilter(obj, ParamFilter.regexp_filter(pattern))
                 if len(list(obj.param)) <= 1:
                     return f"No {name!r} parameters found matching specified pattern {pattern!r}"
+            import param.ipython
+
             info = param.ipython.ParamPager()(obj)
             if ansi is False:
                 info = ansi_escape.sub("", info)
@@ -188,7 +197,7 @@ class InfoPrinter:
             return ""
 
         targets = obj.traverse(cls.get_target)
-        elements, containers = zip(*targets, strict=None)
+        elements, containers = zip(*targets, strict=True)
         element_set = {el for el in elements if el is not None}
         container_set = {c for c in containers if c is not None}
 

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -21,7 +21,7 @@ import param
 from param.ipython import ParamPager
 from param.parameterized import bothmethod
 
-from .util import group_sanitizer, label_sanitizer
+from .util import _is_deep_indexable, group_sanitizer, label_sanitizer
 
 if t.TYPE_CHECKING:
     from .options import Store
@@ -229,7 +229,7 @@ class InfoPrinter:
 
     @classmethod
     def object_info(cls, obj, name, backend, ansi=False):
-        element = not getattr(obj, "_deep_indexable", False)
+        element = not _is_deep_indexable(obj)
         element_url = "https://holoviews.org/reference/elements/{backend}/{obj}.html"
         container_url = "https://holoviews.org/reference/containers/{backend}/{obj}.html"
         url = element_url if element else container_url
@@ -360,7 +360,7 @@ class PrettyPrinter(param.Parameterized):
             opts = cls_or_slf.option_info(node)
         elif hasattr(node, "main"):
             (lvl, lines) = cls_or_slf.adjointlayout_info(node, siblings, level, value_dims)
-        elif getattr(node, "_deep_indexable", False):
+        elif _is_deep_indexable(node):
             (lvl, lines) = cls_or_slf.ndmapping_info(node, siblings, level, value_dims)
         elif hasattr(node, "unit_format"):
             (lvl, lines) = level, [(level, repr(node))]
@@ -442,7 +442,7 @@ class PrettyPrinter(param.Parameterized):
             return level, lines
         # .last has different semantics for GridSpace
         last = list(node.data.values())[-1]
-        if last is not None and last._deep_indexable and not hasattr(last, "children"):
+        if last is not None and _is_deep_indexable(last) and not hasattr(last, "children"):
             level, additional_lines = cls_or_slf.ndmapping_info(last, [], level, value_dims)
         else:
             additional_lines = cls_or_slf.recurse(last, level=level, value_dims=value_dims)

--- a/holoviews/core/sheetcoords.py
+++ b/holoviews/core/sheetcoords.py
@@ -77,10 +77,15 @@ outside of the actual matrix.
 
 from __future__ import annotations
 
+import typing as t
+
 import numpy as np
 
 from .boundingregion import BoundingBox
 from .util import datetime_types, dtype_kind
+
+if t.TYPE_CHECKING:
+    from numpy.dtypes import _DateTimeUnit
 
 # Note about the 'bounds-master' approach we have adopted
 # =======================================================
@@ -149,7 +154,7 @@ class SheetCoordinateSystem:
 
     # Determines the unit of time densities are defined relative to
     # when one or both axes are datetime types
-    _time_unit = "us"
+    _time_unit: _DateTimeUnit = "us"
 
     def __init__(self, bounds, xdensity, ydensity=None):
         """Store the bounds (as l,b,r,t in an array), xdensity, and

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -24,6 +24,10 @@ from .options import Store, StoreOptions
 from .overlay import CompositeOverlay, NdOverlay, Overlay, Overlayable
 from .util import dtype_kind
 
+NoNone = False
+if t.TYPE_CHECKING:
+    from param.parameters import NoNone  # noqa: TC004, move up when 2.4 is lower pin
+
 
 class HoloMap(Layoutable, UniformNdMapping, Overlayable):
     """A HoloMap is an n-dimensional mapping of viewable elements or
@@ -694,6 +698,7 @@ class Generator(Callable):
 
     callable = param.ClassSelector(
         class_=types.GeneratorType,
+        allow_None=NoNone,
         constant=True,
         doc="The generator that is wrapped by this Generator.",
     )
@@ -850,6 +855,7 @@ class DynamicMap(HoloMap):
     callback = param.ClassSelector(
         class_=Callable,
         constant=True,
+        allow_None=NoNone,
         doc="""
         The callable used to generate the elements. The arguments to the
         callable includes any number of declared key dimensions as well

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1711,7 +1711,7 @@ class DynamicMap(HoloMap):
         container_type = container_type if container_type else type(self)
         group_type = group_type if group_type else type(self)
 
-        outer_kdims = [self.get_dimension(d) for d in dimensions]
+        outer_kdims = [self.get_dimension(d, strict=True) for d in dimensions]
         inner_kdims = [d for d in self.kdims if d not in outer_kdims]
 
         outer_dynamic = issubclass(container_type, DynamicMap)
@@ -1750,7 +1750,9 @@ class DynamicMap(HoloMap):
             else:
                 return outer_fn(())
         else:
-            outer_product = itertools.product(*[self.get_dimension(d).values for d in dimensions])
+            outer_product = itertools.product(
+                *[self.get_dimension(d, strict=True).values for d in dimensions]
+            )
             groups = []
             for outer in outer_product:
                 outer_vals = [(d.name, [o]) for d, o in zip(outer_kdims, outer, strict=False)]
@@ -1768,7 +1770,9 @@ class DynamicMap(HoloMap):
                         group = inner_fn(outer_vals, ())
                     groups.append((outer, group))
                 else:
-                    inner_vals = [(d.name, self.get_dimension(d).values) for d in inner_kdims]
+                    inner_vals = [
+                        (d.name, self.get_dimension(d, strict=True).values) for d in inner_kdims
+                    ]
                     with item_check(False):
                         selected = HoloMap(self.select(**dict(outer_vals + inner_vals)))
                         group = group_type(selected.reindex(inner_kdims))

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -467,11 +467,11 @@ class HoloMap(Layoutable, UniformNdMapping, Overlayable):
                 histmaps[0][k] = hists
 
         if adjoin:
-            layout = self
+            layout = t.cast("AdjointLayout", self)
             for hist in histmaps:
                 layout = layout << hist
             if issubclass(self.type, (NdOverlay, Overlay)):
-                t.cast("NdOverlay|Overlay", layout).main_layer = kwargs["index"]
+                layout.main_layer = kwargs["index"]
             return layout
         elif len(histmaps) > 1:
             return Layout(histmaps)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import types
+import typing as t
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import partial
@@ -13,6 +14,7 @@ import numpy as np
 import param
 
 from ..streams import Params, Stream, streams_list_from_dict
+from ..util.warnings import HoloviewsUserWarning, warn
 from . import traversal, util
 from .accessors import Opts, Redim
 from .dimension import Dimension, ViewableElement
@@ -177,7 +179,7 @@ class HoloMap(Layoutable, UniformNdMapping, Overlayable):
 
         """
         return [
-            tuple(zip([d.name for d in self.kdims], [k] if self.ndims == 1 else k, strict=None))
+            tuple(zip([d.name for d in self.kdims], [k] if self.ndims == 1 else k, strict=True))
             for k in self.keys()
         ]
 
@@ -204,7 +206,7 @@ class HoloMap(Layoutable, UniformNdMapping, Overlayable):
             streams = map_obj.streams
 
         def dynamic_mul(*key, **kwargs):
-            key_map = {d.name: k for d, k in zip(dimensions, key, strict=None)}
+            key_map = {d.name: k for d, k in zip(dimensions, key, strict=False)}
             layers = []
             try:
                 self_el = self.select(HoloMap, **key_map) if self.kdims else self[()]
@@ -445,7 +447,7 @@ class HoloMap(Layoutable, UniformNdMapping, Overlayable):
             map_range = self.range(kwargs["dimension"])
 
         bin_range = map_range if bin_range is None else bin_range
-        style_prefix = "Custom[<" + self.name + ">]_"
+        style_prefix = f"Custom[<{self.name}>]_"
         if issubclass(self.type, (NdOverlay, Overlay)) and "index" not in kwargs:
             kwargs["index"] = 0
 
@@ -469,7 +471,7 @@ class HoloMap(Layoutable, UniformNdMapping, Overlayable):
             for hist in histmaps:
                 layout = layout << hist
             if issubclass(self.type, (NdOverlay, Overlay)):
-                layout.main_layer = kwargs["index"]
+                t.cast("NdOverlay|Overlay", layout).main_layer = kwargs["index"]
             return layout
         elif len(histmaps) > 1:
             return Layout(histmaps)
@@ -511,7 +513,6 @@ class Callable(param.Parameterized):
     """
 
     callable = param.Callable(
-        default=None,
         constant=True,
         allow_refs=False,
         doc="The callable function being wrapped.",
@@ -651,7 +652,7 @@ class Callable(param.Parameterized):
             # Missing information on positional argument names, cannot promote to keywords
             pass
         elif len(args) != 0:  # Turn positional arguments into keyword arguments
-            pos_kwargs = {k: v for k, v in zip(self.argspec.args, args, strict=None)}
+            pos_kwargs = {k: v for k, v in zip(self.argspec.args, args, strict=False)}
             ignored = range(len(self.argspec.args), len(args))
             if ignored:
                 self.param.warning(
@@ -692,7 +693,6 @@ class Generator(Callable):
     """
 
     callable = param.ClassSelector(
-        default=None,
         class_=types.GeneratorType,
         constant=True,
         doc="The generator that is wrapped by this Generator.",
@@ -708,8 +708,8 @@ class Generator(Callable):
         except StopIteration:
             raise
         except Exception:
-            msg = "Generator {name} raised the following exception:"
-            self.param.warning(msg.format(name=self.name))
+            msg = f"Generator {self.name} raised the following exception:"
+            self.param.warning(msg)
             raise
 
 
@@ -819,7 +819,10 @@ class periodic:
 
     def stop(self):
         """Stop the periodic process."""
-        self.instance.stop()
+        if self.instance is None:
+            warn("No periodic process to stop.", HoloviewsUserWarning)
+        else:
+            self.instance.stop()
 
     def __str__(self):
         return "<holoviews.core.spaces.periodic method>"
@@ -1098,7 +1101,7 @@ class DynamicMap(HoloMap):
             kwargs = {}
             args = args + tuple([s.contents for s in self.streams])
         elif self._posarg_keys:
-            kwargs = dict(flattened, **dict(zip(self._posarg_keys, args, strict=None)))
+            kwargs = dict(flattened, **dict(zip(self._posarg_keys, args, strict=False)))
             args = ()
         else:
             kwargs = dict(flattened)
@@ -1563,7 +1566,7 @@ class DynamicMap(HoloMap):
 
         return decollate(self)
 
-    def collate(self):
+    def collate(self, merge_type=None, drop=None, drop_constant=False):
         """Unpacks DynamicMap into container of DynamicMaps
 
         Collation allows unpacking DynamicMaps which return Layout,
@@ -1719,8 +1722,8 @@ class DynamicMap(HoloMap):
                 if inner_dynamic:
 
                     def inner_fn(*inner_key, **dynkwargs):
-                        outer_vals = zip(outer_kdims, util.wrap_tuple(outer_key), strict=None)
-                        inner_vals = zip(inner_kdims, util.wrap_tuple(inner_key), strict=None)
+                        outer_vals = zip(outer_kdims, util.wrap_tuple(outer_key), strict=False)
+                        inner_vals = zip(inner_kdims, util.wrap_tuple(inner_key), strict=False)
                         inner_sel = [(k.name, v) for k, v in inner_vals]
                         outer_sel = [(k.name, v) for k, v in outer_vals]
                         return self.select(**dict(inner_sel + outer_sel))
@@ -1730,7 +1733,7 @@ class DynamicMap(HoloMap):
                     dim_vals = [(d.name, d.values) for d in inner_kdims]
                     dim_vals += [
                         (d.name, [v])
-                        for d, v in zip(outer_kdims, util.wrap_tuple(outer_key), strict=None)
+                        for d, v in zip(outer_kdims, util.wrap_tuple(outer_key), strict=False)
                     ]
                     with item_check(False):
                         selected = HoloMap(self.select(**dict(dim_vals)))
@@ -1744,11 +1747,11 @@ class DynamicMap(HoloMap):
             outer_product = itertools.product(*[self.get_dimension(d).values for d in dimensions])
             groups = []
             for outer in outer_product:
-                outer_vals = [(d.name, [o]) for d, o in zip(outer_kdims, outer, strict=None)]
+                outer_vals = [(d.name, [o]) for d, o in zip(outer_kdims, outer, strict=False)]
                 if inner_dynamic or not inner_kdims:
 
                     def inner_fn(outer_vals, *key, **dynkwargs):
-                        inner_dims = zip(inner_kdims, util.wrap_tuple(key), strict=None)
+                        inner_dims = zip(inner_kdims, util.wrap_tuple(key), strict=False)
                         inner_vals = [(d.name, k) for d, k in inner_dims]
                         return self.select(**dict(outer_vals + inner_vals)).last
 
@@ -1821,7 +1824,9 @@ class DynamicMap(HoloMap):
         dims = [d for d in self.kdims if d not in dimensions]
         return self.groupby(dims, group_type=NdOverlay)
 
-    def hist(self, dimension=None, num_bins=20, bin_range=None, adjoin=True, **kwargs):
+    def hist(
+        self, dimension=None, num_bins=20, bin_range=None, adjoin=True, individually=True, **kwargs
+    ):
         """Computes and adjoins histogram along specified dimension(s).
 
         Defaults to first value dimension if present otherwise falls
@@ -1933,7 +1938,7 @@ class GridSpace(Layoutable, UniformNdMapping):
         else:
             raise TypeError(f"Cannot append {type(other).__name__} to a AdjointLayout")
 
-    def _transform_indices(self, key):
+    def _transform_indices(self, indices):
         """Snaps indices into the GridSpace to the closest coordinate.
 
         Parameters
@@ -1946,19 +1951,19 @@ class GridSpace(Layoutable, UniformNdMapping):
         Transformed key snapped to closest numeric coordinates
         """
         ndims = self.ndims
-        if all(not (isinstance(el, slice) or callable(el)) for el in key):
+        if all(not (isinstance(el, slice) or callable(el)) for el in indices):
             dim_inds = []
             for dim in self.kdims:
                 dim_type = self.get_dimension_type(dim)
                 if isinstance(dim_type, type) and issubclass(dim_type, Number):
                     dim_inds.append(self.get_dimension_index(dim))
-            str_keys = iter(key[i] for i in range(self.ndims) if i not in dim_inds)
-            num_keys = []
+            str_keys = iter(indices[i] for i in range(self.ndims) if i not in dim_inds)
+            num_keys = iter([])
             if dim_inds:
                 keys = list(
                     {tuple(k[i] if ndims > 1 else k for i in dim_inds) for k in self.keys()}
                 )
-                q = np.array([tuple(key[i] if ndims > 1 else key for i in dim_inds)])
+                q = np.array([tuple(indices[i] if ndims > 1 else indices for i in dim_inds)])
                 idx = np.argmin(
                     [
                         np.inner(q - np.array(x), q - np.array(x))
@@ -1968,22 +1973,22 @@ class GridSpace(Layoutable, UniformNdMapping):
                     ]
                 )
                 num_keys = iter(keys[idx])
-            key = tuple(
+            indices = tuple(
                 next(num_keys) if i in dim_inds else next(str_keys) for i in range(self.ndims)
             )
-        elif any(not (isinstance(el, slice) or callable(el)) for el in key):
+        elif any(not (isinstance(el, slice) or callable(el)) for el in indices):
             keys = self.keys()
-            for i, k in enumerate(key):
+            for i, k in enumerate(indices):
                 if isinstance(k, slice):
                     continue
                 dim_keys = np.array([ke[i] for ke in keys])
                 if dtype_kind(dim_keys) in "OSU":
                     continue
                 snapped_val = dim_keys[np.argmin(np.abs(dim_keys - k))]
-                key = list(key)
-                key[i] = snapped_val
-            key = tuple(key)
-        return key
+                indices = list(indices)
+                indices[i] = snapped_val
+            indices = tuple(indices)
+        return indices
 
     def keys(self, full_grid=False):
         """Returns the keys of the GridSpace

--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -15,7 +15,7 @@ from .util import merge_dimensions
 
 def create_ndkey(length, indexes, values):
     key = [None] * length
-    for i, v in zip(indexes, values, strict=None):
+    for i, v in zip(indexes, values, strict=False):
         key[i] = v
     return tuple(key)
 
@@ -50,7 +50,7 @@ def unique_dimkeys(obj, default_dim="Frame"):
     key_dims = obj.traverse(lambda x: (tuple(x.kdims), list(x.data.keys())), (HoloMap,))
     if not key_dims:
         return [Dimension(default_dim)], [(0,)]
-    dim_groups, keys = zip(*sorted(key_dims, key=lambda x: -len(x[0])), strict=None)
+    dim_groups, keys = zip(*sorted(key_dims, key=lambda x: -len(x[0])), strict=True)
     dgroups = [frozenset(d.name for d in dg) for dg in dim_groups]
     subset = all(g1 <= g2 or g1 >= g2 for g1 in dgroups for g2 in dgroups)
     # Find unique keys
@@ -69,7 +69,7 @@ def unique_dimkeys(obj, default_dim="Frame"):
         dim_keys = {}
         for dims, keys in key_dims:
             for key in keys:
-                for d, k in zip(dims, key, strict=None):
+                for d, k in zip(dims, key, strict=False):
                     dim_keys[d.name] = k
         if dim_keys:
             keys = [tuple(dim_keys.get(dim.name) for dim in dimensions)]
@@ -79,7 +79,7 @@ def unique_dimkeys(obj, default_dim="Frame"):
 
     ndims = len(all_dims)
     unique_keys = []
-    for group, subkeys in zip(dim_groups, keys, strict=None):
+    for group, subkeys in zip(dim_groups, keys, strict=True):
         dim_idxs = [all_dims.index(dim) for dim in group]
         for key in subkeys:
             padded_key = create_ndkey(ndims, dim_idxs, key)
@@ -87,7 +87,7 @@ def unique_dimkeys(obj, default_dim="Frame"):
                 item
                 for item in unique_keys
                 if padded_key
-                == tuple(k if k is None else i for i, k in zip(item, padded_key, strict=None))
+                == tuple(k if k is None else i for i, k in zip(item, padded_key, strict=False))
             ]
             if not matches:
                 unique_keys.append(padded_key)
@@ -124,8 +124,8 @@ def hierarchical(keys):
     ndims = len(keys[0])
     if ndims <= 1:
         return True
-    dim_vals = list(zip(*keys, strict=None))
-    combinations = (zip(*dim_vals[i : i + 2], strict=None) for i in range(ndims - 1))
+    dim_vals = list(zip(*keys, strict=True))
+    combinations = (zip(*dim_vals[i : i + 2], strict=True) for i in range(ndims - 1))
     hierarchies = []
     for combination in combinations:
         hierarchy = True

--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -158,7 +158,7 @@ class AttrTree:
                 items = [
                     (key, v)
                     for key, v in self.data.items()
-                    if not all(k == p for k, p in zip(key, path, strict=None))
+                    if not all(k == p for k, p in zip(key, path, strict=False))
                 ]
                 self.data = dict(items)
         else:
@@ -166,32 +166,30 @@ class AttrTree:
         if self.parent is not None:
             self.parent._propagate((self.identifier, *path), val)
 
-    def __setitem__(self, identifier, val):
+    def __setitem__(self, key, val):
         """Set a value at a child node with given identifier. If at a root
         node, multi-level path specifications is allowed (i.e. 'A.B.C'
         format or tuple format) in which case the behaviour matches
         that of set_path.
 
         """
-        if isinstance(identifier, str) and "." not in identifier:
-            self.__setattr__(identifier, val)
-        elif isinstance(identifier, str) and self.parent is None:
-            self.set_path(tuple(identifier.split(".")), val)
-        elif isinstance(identifier, tuple) and self.parent is None:
-            self.set_path(identifier, val)
+        if isinstance(key, str) and "." not in key:
+            self.__setattr__(key, val)
+        elif isinstance(key, str) and self.parent is None:
+            self.set_path(tuple(key.split(".")), val)
+        elif isinstance(key, tuple) and self.parent is None:
+            self.set_path(key, val)
         else:
             raise Exception("Multi-level item setting only allowed from root node.")
 
-    def __getitem__(self, identifier):
+    def __getitem__(self, key):
         """For a given non-root node, access a child element by identifier.
 
         If the node is a root node, you may also access elements using
         either tuple format or the 'A.B.C' string format.
 
         """
-        split_label = (
-            tuple(identifier.split(".")) if isinstance(identifier, str) else tuple(identifier)
-        )
+        split_label = tuple(key.split(".")) if isinstance(key, str) else tuple(key)
         if len(split_label) == 1:
             identifier = split_label[0]
             if identifier in self.children:
@@ -203,10 +201,8 @@ class AttrTree:
             path_item = path_item[identifier]
         return path_item
 
-    def __delitem__(self, identifier):
-        split_label = (
-            tuple(identifier.split(".")) if isinstance(identifier, str) else tuple(identifier)
-        )
+    def __delitem__(self, key):
+        split_label = tuple(key.split(".")) if isinstance(key, str) else tuple(key)
         if len(split_label) == 1:
             identifier = split_label[0]
             if identifier in self.children:
@@ -241,7 +237,7 @@ class AttrTree:
 
         """
         try:
-            return super().__getattr__(identifier)
+            return super().__getattr__(identifier)  # ty:ignore[unresolved-attribute]
         except AttributeError:
             pass
 

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -45,15 +45,9 @@ from .types import (
     timedelta_types,
 )
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    import dask.dataframe as dd
-    import pandas as pd
-    import polars as pl
-else:
-    dd = _LazyModule("dask.dataframe", bool_use_sys_modules=True)
-    pd = _LazyModule("pandas", bool_use_sys_modules=True)
-    pl = _LazyModule("polars", bool_use_sys_modules=True)
+dd = _LazyModule("dask.dataframe", bool_use_sys_modules=True)
+pd = _LazyModule("pandas", bool_use_sys_modules=True)
+pl = _LazyModule("polars", bool_use_sys_modules=True)
 
 # Python 2 builtins
 basestring = str

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -32,7 +32,12 @@ from .dependencies import (  # noqa: F401
     PANDAS_VERSION,
     PARAM_VERSION,
     VersionError,
-    _LazyModule,
+    cp,
+    da,
+    dd,
+    ibis,
+    pd,
+    pl,
 )
 from .types import (
     arraylike_types,
@@ -44,10 +49,6 @@ from .types import (
     pandas_timedelta_types,
     timedelta_types,
 )
-
-dd = _LazyModule("dask.dataframe", bool_use_sys_modules=True)
-pd = _LazyModule("pandas", bool_use_sys_modules=True)
-pl = _LazyModule("polars", bool_use_sys_modules=True)
 
 # Python 2 builtins
 basestring = str
@@ -955,8 +956,6 @@ def isfinite(val):
     if val is None:
         return False
     elif is_dask:
-        import dask.array as da
-
         return da.isfinite(val)
     elif isinstance(val, np.ndarray):
         if dtype_kind(val) == "M":
@@ -1680,28 +1679,16 @@ def is_series(data):
     return isinstance(data, tuple(types))
 
 
-def is_dask_array(data):
-    if "dask.array" in sys.modules:
-        import dask.array as da
-
-        return isinstance(data, da.Array)
-    return False
+def is_dask_array(data) -> bool:
+    return da and isinstance(data, da.Array)
 
 
-def is_cupy_array(data):
-    if "cupy" in sys.modules:
-        import cupy
-
-        return isinstance(data, cupy.ndarray)
-    return False
+def is_cupy_array(data) -> bool:
+    return cp and isinstance(data, cp.ndarray)
 
 
-def is_ibis_expr(data):
-    if "ibis" in sys.modules:
-        import ibis
-
-        return isinstance(data, ibis.expr.types.ColumnExpr)
-    return False
+def is_ibis_expr(data) -> bool:
+    return ibis and isinstance(data, ibis.expr.types.ColumnExpr)
 
 
 def get_param_values(data):

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -53,6 +53,13 @@ from .types import (
     timedelta_types,
 )
 
+if t.TYPE_CHECKING:
+    from typing_extensions import TypeIs
+
+    from ..dimension import ViewableTree
+    from ..layout import AdjointLayout
+    from ..ndmapping import UniformNdMapping
+
 # Python 2 builtins
 basestring = str
 long = int
@@ -2571,3 +2578,7 @@ def dtype_kind(obj) -> str:
         return "U"
     else:
         return "O"
+
+
+def _is_deep_indexable(obj) -> TypeIs[ViewableTree | UniformNdMapping | AdjointLayout]:
+    return getattr(obj, "_deep_indexable", False)

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import builtins
 import datetime as dt
 import hashlib
@@ -11,6 +13,7 @@ import pickle
 import string
 import sys
 import time
+import typing as t
 import unicodedata
 import warnings
 from collections import defaultdict, namedtuple
@@ -64,6 +67,7 @@ anonymous_dimension_label = "_"
 ArgSpec = namedtuple("ArgSpec", "args varargs keywords defaults")
 
 _STANDARD_CALENDARS = {"standard", "gregorian", "proleptic_gregorian"}
+_TIME_SCALES = {"us": 1e6, "ms": 1e3, "s": 1, "m": 1/60, "h1": 1/3600, "D": 1/86400, "W": 1/604800}
 _ARRAY_SIZE_LARGE = 1_000_000
 _ARRAY_SAMPLE_SIZE = 1_000_000
 _DATAFRAME_ROWS_LARGE = 1_000_000
@@ -192,48 +196,48 @@ class HashableJSON(json.JSONEncoder):
     string_hashable = (dt.datetime,)
     repr_hashable = ()
 
-    def default(self, obj):
-        if isinstance(obj, set):
-            return hash(frozenset(obj))
-        elif isinstance(obj, np.ndarray):
+    def default(self, o):
+        if isinstance(o, set):
+            return hash(frozenset(o))
+        elif isinstance(o, np.ndarray):
             h = hashlib.new("md5")
-            for s in obj.shape:
+            for s in o.shape:
                 h.update(_int_to_bytes(s))
-            if obj.size >= _ARRAY_SIZE_LARGE:
+            if o.size >= _ARRAY_SIZE_LARGE:
                 state = np.random.RandomState(0)
-                obj = state.choice(obj.flat, size=_ARRAY_SAMPLE_SIZE)
-            h.update(obj.tobytes())
+                o = state.choice(o.flat, size=_ARRAY_SAMPLE_SIZE)
+            h.update(o.tobytes())
             return h.hexdigest()
-        if pd and isinstance(obj, (pd.Series, pd.DataFrame)):
-            if len(obj) > _DATAFRAME_ROWS_LARGE:
-                obj = obj.sample(n=_DATAFRAME_SAMPLE_SIZE, random_state=0)
+        if pd and isinstance(o, (pd.Series, pd.DataFrame)):
+            if len(o) > _DATAFRAME_ROWS_LARGE:
+                o = o.sample(n=_DATAFRAME_SAMPLE_SIZE, random_state=0)
             try:
-                pd_values = list(pd.util.hash_pandas_object(obj, index=True).values)
+                pd_values = list(pd.util.hash_pandas_object(o, index=True).values)
             except TypeError:
                 # Use pickle if pandas cannot hash the object for example if
                 # it contains unhashable objects.
-                pd_values = [pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)]
-            if isinstance(obj, pd.Series):
-                columns = [obj.name]
-            elif isinstance(obj.columns, pd.MultiIndex):
-                columns = [name for cols in obj.columns for name in cols]
+                pd_values = [pickle.dumps(o, pickle.HIGHEST_PROTOCOL)]
+            if isinstance(o, pd.Series):
+                columns = [o.name]
+            elif isinstance(o.columns, pd.MultiIndex):
+                columns = [name for cols in o.columns for name in cols]
             else:
-                columns = list(obj.columns)
-            all_vals = pd_values + columns + list(obj.index.names)
+                columns = list(o.columns)
+            all_vals = pd_values + columns + list(o.index.names)
             h = hashlib.md5()
             for val in all_vals:
                 if not isinstance(val, bytes):
                     val = str(val).encode("utf-8")
                 h.update(val)
             return h.hexdigest()
-        elif isinstance(obj, self.string_hashable):
-            return str(obj)
-        elif isinstance(obj, self.repr_hashable):
-            return repr(obj)
+        elif isinstance(o, self.string_hashable):
+            return str(o)
+        elif isinstance(o, self.repr_hashable):
+            return repr(o)
         try:
-            return hash(obj)
+            return hash(o)
         except Exception:
-            return id(obj)
+            return id(o)
 
 
 def merge_option_dicts(old_opts, new_opts):
@@ -364,6 +368,8 @@ class periodic(Thread):
         return repr(self)
 
     def run(self):
+        if self._start_time is None:
+            self._start_time = time.perf_counter()
         while not self.completed:
             if self.block:
                 time.sleep(self.period)
@@ -748,8 +754,8 @@ class sanitize_identifier_fn(param.ParameterizedFunction):
             return True
         return unicodedata.category(identifier[0]) in invalid_starting
 
-    @param.parameterized.bothmethod
-    def remove_diacritics(self_or_cls, identifier):
+    @staticmethod
+    def remove_diacritics(identifier):
         """Remove diacritics and accents from the input leaving other
         unicode characters alone.
 
@@ -763,10 +769,8 @@ class sanitize_identifier_fn(param.ParameterizedFunction):
                 chars += c
         return chars
 
-    @param.parameterized.bothmethod
-    def shortened_character_name(
-        self_or_cls, c, eliminations=None, substitutions=None, transforms=None
-    ):
+    @staticmethod
+    def shortened_character_name(c, eliminations=None, substitutions=None, transforms=None):
         """Given a unicode character c, return the shortened unicode name
         (as a list of tokens) by applying the eliminations,
         substitutions and transforms.
@@ -995,7 +999,7 @@ def find_minmax(lims, olims):
 
     """
     try:
-        limzip = zip(list(lims), list(olims), [np.nanmin, np.nanmax], strict=None)
+        limzip = zip(list(lims), list(olims), [np.nanmin, np.nanmax], strict=False)
         limits = tuple([float(fn([l, ol])) for l, ol, fn in limzip])
     except Exception:
         limits = (np.nan, np.nan)
@@ -1187,8 +1191,8 @@ def max_extents(extents, zrange=False):
     else:
         num = 4
         inds = [(0, 2), (1, 3)]
-    arr = list(zip(*extents, strict=None)) if extents else []
-    extents = [np.nan] * num
+    arr = list(zip(*extents, strict=True)) if extents else []
+    extents: list[t.Any] = [np.nan] * num
     if len(arr) == 0:
         return extents
     with warnings.catch_warnings():
@@ -1290,12 +1294,12 @@ def unique_iterator(seq):
             yield item
 
 
-def lzip(*args, strict=None):
+def lzip(*args, strict: bool = False):
     """Zip function that returns a list."""
     return list(zip(*args, strict=strict))
 
 
-def unique_zip(*args, strict=None):
+def unique_zip(*args, strict: bool = False):
     """Returns a unique list of zipped values."""
     return list(unique_iterator(zip(*args, strict=strict)))
 
@@ -1426,7 +1430,7 @@ def dimension_sort(odict, kdims, vdims, key_index):
     else:
         sortkws["key"] = lambda x: tuple(
             cached_values[dim.name].index(x[t][d]) if dim.values else x[t][d]
-            for i, (dim, t, d) in enumerate(indexes)
+            for dim, t, d in indexes
         )
     return python2sort(odict.items(), **sortkws)
 
@@ -1437,7 +1441,7 @@ def is_number(obj):
         return True
     elif isinstance(obj, np.str_):
         return False
-    elif np.__version__[0] < "2" and isinstance(obj, np.unicode_):  # noqa: NPY201
+    elif not NUMPY_GE_2_0_0 and isinstance(obj, np.unicode_):  # noqa: NPY201  # ty: ignore[unresolved-attribute]
         return False
     # The extra check is for classes that behave like numbers, such as those
     # found in numpy, gmpy, etc.
@@ -1599,9 +1603,7 @@ def layer_sort(hmap):
         if len(okeys) == 1 and okeys[0] not in orderings:
             orderings[okeys[0]] = []
         else:
-            orderings.update(
-                {k: [] if k == v else [v] for k, v in zip(okeys[1:], okeys, strict=None)}
-            )
+            orderings.update({k: [] if k == v else [v] for v, k in itertools.pairwise(okeys)})
     return [i for g in sort_topologically(orderings) for i in sorted(g)]
 
 
@@ -1617,13 +1619,19 @@ def layer_groups(ordering, length=2):
     return group_orderings
 
 
-def group_select(selects, length=None, depth=None):
+def group_select(
+    selects, length: int | None = None, depth: int | None = None
+) -> defaultdict | list:
     """Given a list of key tuples to select, groups them into sensible
     chunks to avoid duplicating indexing operations.
 
     """
     if length is None and depth is None:
         length = depth = len(selects[0])
+    if length is None or depth is None:
+        msg = "Must specify both length and depth"
+        raise ValueError(msg)
+
     getter = operator.itemgetter(depth - length)
     if length > 1:
         selects = sorted(selects, key=getter)
@@ -1688,7 +1696,7 @@ def is_cupy_array(data) -> bool:
 
 
 def is_ibis_expr(data) -> bool:
-    return ibis and isinstance(data, ibis.expr.types.ColumnExpr)
+    return ibis and isinstance(data, ibis.expr.types.ColumnExpr)  # ty:ignore[possibly-missing-submodule]
 
 
 def get_param_values(data):
@@ -1745,7 +1753,6 @@ def resolve_dependent_value(value):
     """
     from panel.widgets import RangeSlider
 
-    range_widget = False
     if isinstance(value, list):
         value = [resolve_dependent_value(v) for v in value]
     elif isinstance(value, tuple):
@@ -1809,7 +1816,7 @@ def disable_constant(parameterized):
     try:
         yield
     finally:
-        for p, const in zip(params, constants, strict=None):
+        for p, const in zip(params, constants, strict=False):
             p.constant = const
 
 
@@ -1968,7 +1975,7 @@ def drop_streams(streams, kdims, keys):
     """Drop any dimensioned streams from the keys and kdims."""
     stream_params = stream_parameters(streams)
     inds, dims = zip(
-        *[(ind, kdim) for ind, kdim in enumerate(kdims) if kdim not in stream_params], strict=None
+        *[(ind, kdim) for ind, kdim in enumerate(kdims) if kdim not in stream_params], strict=False
     )
     get = operator.itemgetter(*inds)  # itemgetter used for performance
     keys = (get(k) for k in keys)
@@ -2019,7 +2026,7 @@ def get_path(item):
             path = path[:1]
     else:
         path = (item.group, item.label) if item.label else (item.group,)
-    return tuple(capitalize(fn(p)) for (p, fn) in zip(path, sanitizers, strict=None))
+    return tuple(capitalize(fn(p)) for (p, fn) in zip(path, sanitizers, strict=False))
 
 
 def make_path_unique(path, counts, new):
@@ -2055,10 +2062,8 @@ class ndmapping_groupby(param.ParameterizedFunction):
         fn = self.groupby_pandas if pd else self.groupby_python
         return fn(ndmapping, dimensions, container_type, group_type, sort=sort, **kwargs)
 
-    @param.parameterized.bothmethod
-    def groupby_pandas(
-        self_or_cls, ndmapping, dimensions, container_type, group_type, sort=False, **kwargs
-    ):
+    @staticmethod
+    def groupby_pandas(ndmapping, dimensions, container_type, group_type, sort=False, **kwargs):
         if "kdims" in kwargs:
             idims = [ndmapping.get_dimension(d) for d in kwargs["kdims"]]
         else:
@@ -2066,7 +2071,7 @@ class ndmapping_groupby(param.ParameterizedFunction):
 
         all_dims = [d.name for d in ndmapping.kdims]
         inds = [ndmapping.get_dimension_index(dim) for dim in idims]
-        getter = operator.itemgetter(*inds) if inds else lambda x: ()
+        getter = operator.itemgetter(*inds) if inds else lambda _: ()
 
         multi_index = pd.MultiIndex.from_tuples(ndmapping.keys(), names=all_dims)
         df = pd.DataFrame(list(map(wrap_tuple, ndmapping.values())), index=multi_index)
@@ -2092,10 +2097,8 @@ class ndmapping_groupby(param.ParameterizedFunction):
 
         return container_type(groups, kdims=dimensions, sort=sort)
 
-    @param.parameterized.bothmethod
-    def groupby_python(
-        self_or_cls, ndmapping, dimensions, container_type, group_type, sort=False, **kwargs
-    ):
+    @staticmethod
+    def groupby_python(ndmapping, dimensions, container_type, group_type, sort=False, **kwargs):
         idims = [dim for dim in ndmapping.kdims if dim not in dimensions]
         dim_names = [dim.name for dim in dimensions]
         selects = get_unique_keys(ndmapping, dimensions)
@@ -2137,7 +2140,7 @@ def cross_index(values, index):
         indexes.append(index // p)
         index -= indexes[-1] * p
     indexes.append(index)
-    return tuple(v[i] for v, i in zip(values, indexes, strict=None))
+    return tuple(v[i] for v, i in zip(values, indexes, strict=False))
 
 
 def arglexsort(arrays):
@@ -2240,7 +2243,10 @@ def validate_regular_sampling(values, rtol=10e-6):
 
     """
     diffs = np.diff(values)
-    return (len(diffs) < 1) or abs(diffs.min() - diffs.max()) < abs(diffs.min() * rtol)
+    if len(diffs) < 1:
+        return True
+    min_diff = diffs.min()
+    return abs(min_diff - diffs.max()) < abs(min_diff * rtol)
 
 
 def compute_density(start, end, length, time_unit="us"):
@@ -2256,11 +2262,11 @@ def compute_density(start, end, length, time_unit="us"):
     diff = end - start
     if isinstance(diff, timedelta_types):
         if isinstance(diff, np.timedelta64):
+            # NOTE: time_unit not in _TIME_SCALES will be converted to int
             diff = np.timedelta64(diff, time_unit).tolist()
-        tscale = 1.0 / np.timedelta64(1, time_unit).tolist().total_seconds()
-        return length / (diff.total_seconds() * tscale)
-    else:
-        return length / diff
+        if isinstance(diff, dt.timedelta):
+            return length / (diff.total_seconds() * _TIME_SCALES[time_unit])
+    return length / diff
 
 
 def date_range(start, end, length, time_unit="us"):
@@ -2332,25 +2338,24 @@ def dt_to_int(value, time_unit="us"):
     if isinstance(value, cftime_types):
         return cftime_to_timestamp(value, time_unit)
 
-    # date class is a parent for datetime class
-    if isinstance(value, dt.date) and not isinstance(value, dt.datetime):
-        value = dt.datetime(*value.timetuple()[:6])
-
     # Handle datetime64 separately
     if isinstance(value, np.datetime64):
         try:
-            value = np.datetime64(value, "ns")
+            value = value.astype("datetime64[ns]")
             tscale = np.timedelta64(1, time_unit) / np.timedelta64(1, "ns")
             return int(value.tolist() / tscale)
-        except Exception:
+        except Exception as e:
             # If it can't handle ns precision fall back to datetime
             value = value.tolist()
+            if isinstance(value, int) or value is None:
+                msg = "Cannot convert np.datetime64 to datetime object"
+                raise ValueError(msg) from e
 
-    if time_unit == "ns":
-        tscale = 1e9
-    else:
-        tscale = 1.0 / np.timedelta64(1, time_unit).tolist().total_seconds()
+    # date class is a parent for datetime class
+    if isinstance(value, dt.date) and not isinstance(value, dt.datetime):
+        value = dt.datetime(year=value.year, month=value.month, day=value.day)
 
+    tscale = 1e9 if time_unit == "ns" else _TIME_SCALES[time_unit]
     if value.tzinfo is None:
         _epoch = dt.datetime(1970, 1, 1)
     else:

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -36,6 +36,7 @@ from .dependencies import (  # noqa: F401
     PARAM_VERSION,
     VersionError,
     cp,
+    cudf,
     da,
     dd,
     ibis,

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -67,7 +67,15 @@ anonymous_dimension_label = "_"
 ArgSpec = namedtuple("ArgSpec", "args varargs keywords defaults")
 
 _STANDARD_CALENDARS = {"standard", "gregorian", "proleptic_gregorian"}
-_TIME_SCALES = {"us": 1e6, "ms": 1e3, "s": 1, "m": 1/60, "h1": 1/3600, "D": 1/86400, "W": 1/604800}
+_TIME_SCALES = {
+    "us": 1e6,
+    "ms": 1e3,
+    "s": 1,
+    "m": 1 / 60,
+    "h": 1 / 3600,
+    "D": 1 / 86400,
+    "W": 1 / 604800,
+}
 _ARRAY_SIZE_LARGE = 1_000_000
 _ARRAY_SAMPLE_SIZE = 1_000_000
 _DATAFRAME_ROWS_LARGE = 1_000_000

--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -36,7 +36,6 @@ from .dependencies import (  # noqa: F401
     PARAM_VERSION,
     VersionError,
     cp,
-    cudf,
     da,
     dd,
     ibis,

--- a/holoviews/core/util/dependencies.py
+++ b/holoviews/core/util/dependencies.py
@@ -2,10 +2,22 @@ from __future__ import annotations
 
 import re
 import sys
+import typing as t
 from functools import lru_cache
 from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
 from importlib.util import find_spec
+
+if t.TYPE_CHECKING:
+    import cftime
+    import cupy
+    import dask.array as da
+    import dask.dataframe as dd
+    import ibis
+    import pandas as pd
+    import polars as pl
+    from ty_extensions import TypeOf
+
 
 _re_no = re.compile(r"\d+")
 
@@ -46,24 +58,48 @@ _MIN_SUPPORTED_VERSION = {
 
 
 class _LazyModule:
-    def __init__(self, module_name, package_name=None, *, bool_use_sys_modules=False):
-        """
-        Lazy import module
+    """
+    Lazy import module
 
-        This will wait and import the module when an attribute is accessed.
+    This will wait and import the module when an attribute is accessed.
 
-        Parameters
-        ----------
-        module_name: str
-            The import name of the module, e.g. `import PIL`
-        package_name: str, optional
-            Name of the package, this is the named used for installing the package, e.g. `pip install pillow`.
-            Used for the __version__ if the module is not imported.
-            If not set uses the module_name.
-        bool_use_sys_modules: bool, optional, default False
-            Also check `sys.modules` for module in __bool__ check if True.
-            This means that bool can only be True if the module is already imported.
-        """
+    Parameters
+    ----------
+    module_name: str
+        The import name of the module, e.g. `import PIL`
+    package_name: str, optional
+        Name of the package, this is the named used for installing the package, e.g. `pip install pillow`.
+        Used for the __version__ if the module is not imported.
+        If not set uses the module_name.
+    bool_use_sys_modules: bool, optional, default False
+        Also check `sys.modules` for module in __bool__ check if True.
+        This means that bool can only be True if the module is already imported.
+    """
+
+    @t.overload
+    def __new__(cls, module_name: t.Literal["cftime"], *args, **kwargs) -> TypeOf[cftime]: ...
+    @t.overload
+    def __new__(cls, module_name: t.Literal["cupy"], *args, **kwargs) -> TypeOf[cupy]: ...
+    @t.overload
+    def __new__(cls, module_name: t.Literal["dask.array"], *args, **kwargs) -> TypeOf[da]: ...
+    @t.overload
+    def __new__(cls, module_name: t.Literal["dask.dataframe"], *args, **kwargs) -> TypeOf[dd]: ...
+    @t.overload
+    def __new__(cls, module_name: t.Literal["ibis"], *args, **kwargs) -> TypeOf[ibis]: ...
+    @t.overload
+    def __new__(cls, module_name: t.Literal["pandas"], *args, **kwargs) -> TypeOf[pd]: ...
+    @t.overload
+    def __new__(cls, module_name: t.Literal["polars"], *args, **kwargs) -> TypeOf[pl]: ...
+    def __new__(cls, *args: t.Any, **kwargs: t.Any) -> _LazyModule:
+        return super().__new__(cls)
+
+    def __init__(
+        self,
+        module_name: str,
+        package_name: str | None = None,
+        *,
+        bool_use_sys_modules: bool = False,
+    ):
         self.__module = None
         self.__module_name = module_name
         self.__package_name = package_name or module_name

--- a/holoviews/core/util/dependencies.py
+++ b/holoviews/core/util/dependencies.py
@@ -50,11 +50,7 @@ _MIN_SUPPORTED_VERSION = {
 
 
 class _LazyModule:
-    def __init__(
-        self,
-        module_name: str,
-        package_name: str | None = None,
-    ):
+    def __init__(self, module_name: str, package_name: str | None = None):
         """
         Lazy import module
 

--- a/holoviews/core/util/dependencies.py
+++ b/holoviews/core/util/dependencies.py
@@ -34,7 +34,7 @@ def _get_version(package_name):
         return "0.0.0"
 
 
-def _no_import_version(package_name) -> tuple[int, int, int]:
+def _no_import_version(package_name) -> tuple[int, ...]:
     """Get version number without importing the library"""
     version_str = _get_version(package_name)
     return tuple(map(int, _re_no.findall(version_str)[:3]))

--- a/holoviews/core/util/dependencies.py
+++ b/holoviews/core/util/dependencies.py
@@ -9,15 +9,7 @@ from importlib.metadata import PackageNotFoundError, version
 from importlib.util import find_spec
 
 if t.TYPE_CHECKING:
-    import cftime
-    import cupy
-    import dask.array as da
-    import dask.dataframe as dd
-    import ibis
-    import pandas as pd
-    import polars as pl
-    from ty_extensions import TypeOf
-
+    from types import ModuleType
 
 _re_no = re.compile(r"\d+")
 
@@ -58,55 +50,31 @@ _MIN_SUPPORTED_VERSION = {
 
 
 class _LazyModule:
-    """
-    Lazy import module
-
-    This will wait and import the module when an attribute is accessed.
-
-    Parameters
-    ----------
-    module_name: str
-        The import name of the module, e.g. `import PIL`
-    package_name: str, optional
-        Name of the package, this is the named used for installing the package, e.g. `pip install pillow`.
-        Used for the __version__ if the module is not imported.
-        If not set uses the module_name.
-    bool_use_sys_modules: bool, optional, default False
-        Also check `sys.modules` for module in __bool__ check if True.
-        This means that bool can only be True if the module is already imported.
-    """
-
-    @t.overload
-    def __new__(cls, module_name: t.Literal["cftime"], *args, **kwargs) -> TypeOf[cftime]: ...
-    @t.overload
-    def __new__(cls, module_name: t.Literal["cupy"], *args, **kwargs) -> TypeOf[cupy]: ...
-    @t.overload
-    def __new__(cls, module_name: t.Literal["dask.array"], *args, **kwargs) -> TypeOf[da]: ...
-    @t.overload
-    def __new__(cls, module_name: t.Literal["dask.dataframe"], *args, **kwargs) -> TypeOf[dd]: ...
-    @t.overload
-    def __new__(cls, module_name: t.Literal["ibis"], *args, **kwargs) -> TypeOf[ibis]: ...
-    @t.overload
-    def __new__(cls, module_name: t.Literal["pandas"], *args, **kwargs) -> TypeOf[pd]: ...
-    @t.overload
-    def __new__(cls, module_name: t.Literal["polars"], *args, **kwargs) -> TypeOf[pl]: ...
-    def __new__(cls, *args: t.Any, **kwargs: t.Any) -> _LazyModule:
-        return super().__new__(cls)
-
     def __init__(
         self,
         module_name: str,
         package_name: str | None = None,
-        *,
-        bool_use_sys_modules: bool = False,
     ):
+        """
+        Lazy import module
+
+        This will wait and import the module when an attribute is accessed.
+
+        Parameters
+        ----------
+        module_name: str
+            The import name of the module, e.g. `import PIL`
+        package_name: str, optional
+            Name of the package, this is the named used for installing the package, e.g. `pip install pillow`.
+            Used for the __version__ if the module is not imported.
+            If not set uses the module_name.
+        """
         self.__module = None
         self.__module_name = module_name
         self.__package_name = package_name or module_name
-        self.__bool_use_sys_modules = bool_use_sys_modules
 
     @property
-    def _module(self):
+    def _module(self) -> ModuleType:
         if self.__module is None:
             self.__module = import_module(self.__module_name)
             if self.__package_name in _MIN_SUPPORTED_VERSION:
@@ -123,19 +91,16 @@ class _LazyModule:
     def __getattr__(self, attr):
         return getattr(self._module, attr)
 
-    def __dir__(self):
+    def __dir__(self) -> list[str]:
         return dir(self._module)
 
-    def __bool__(self):
-        if self.__bool_use_sys_modules:
-            return bool(
-                self.__module
-                or (_is_installed(self.__module_name) and self.__module_name in sys.modules)
-            )
-        else:
-            return bool(self.__module or _is_installed(self.__module_name))
+    def __bool__(self) -> bool:
+        return bool(
+            self.__module
+            or (_is_installed(self.__module_name) and self.__module_name in sys.modules)
+        )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.__module:
             return repr(self.__module).replace("<module", "<lazy-module")
         else:
@@ -145,6 +110,23 @@ class _LazyModule:
     def __version__(self):
         return self.__module and self.__module.__version__ or _get_version(self.__package_name)
 
+
+if t.TYPE_CHECKING:
+    import cftime
+    import cupy as cp
+    import dask.array as da
+    import dask.dataframe as dd
+    import ibis
+    import pandas as pd
+    import polars as pl
+else:
+    cftime = _LazyModule("cftime")
+    cp = _LazyModule("cupy")
+    da = _LazyModule("dask.array")
+    dd = _LazyModule("dask.dataframe")
+    ibis = _LazyModule("ibis", "ibis-framework")
+    pd = _LazyModule("pandas")
+    pl = _LazyModule("polars")
 
 # Versions
 NUMPY_VERSION = _no_import_version("numpy")
@@ -164,5 +146,4 @@ __all__ = [
     "PANDAS_GE_3_0_0",
     "PANDAS_VERSION",
     "PARAM_VERSION",
-    "_LazyModule",
 ]

--- a/holoviews/core/util/dependencies.py
+++ b/holoviews/core/util/dependencies.py
@@ -113,6 +113,7 @@ class _LazyModule:
 
 if t.TYPE_CHECKING:
     import cftime
+    import cudf
     import cupy as cp
     import dask.array as da
     import dask.dataframe as dd
@@ -121,6 +122,7 @@ if t.TYPE_CHECKING:
     import polars as pl
 else:
     cftime = _LazyModule("cftime")
+    cudf = _LazyModule("cudf")
     cp = _LazyModule("cupy")
     da = _LazyModule("dask.array")
     dd = _LazyModule("dask.dataframe")

--- a/holoviews/core/util/types.py
+++ b/holoviews/core/util/types.py
@@ -11,12 +11,8 @@ import numpy as np
 
 from .dependencies import _LazyModule
 
-if t.TYPE_CHECKING:
-    import cftime
-    import pandas as pd
-else:
-    cftime = _LazyModule("cftime", bool_use_sys_modules=True)
-    pd = _LazyModule("pandas", bool_use_sys_modules=True)
+cftime = _LazyModule("cftime", bool_use_sys_modules=True)
+pd = _LazyModule("pandas", bool_use_sys_modules=True)
 
 
 # gen_types is copied from param, can be removed when

--- a/holoviews/core/util/types.py
+++ b/holoviews/core/util/types.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 import datetime as dt
 import inspect
 import sys
+import typing as t
 from types import GeneratorType
-from typing import TYPE_CHECKING
 
 import narwhals.stable.v2 as nw
 import numpy as np
 
 from .dependencies import _LazyModule
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     import cftime
     import pandas as pd
 else:
@@ -26,6 +26,8 @@ _module_count = 0
 
 
 class _GeneratorIsMeta(type):
+    types: t.Callable[[], t.Iterable[type]]
+
     def _get_types(cls) -> tuple[type, ...]:
         # Cache types and invalidate on new imports
         global _module_count  # noqa: PLW0603

--- a/holoviews/core/util/types.py
+++ b/holoviews/core/util/types.py
@@ -9,11 +9,7 @@ from types import GeneratorType
 import narwhals.stable.v2 as nw
 import numpy as np
 
-from .dependencies import _LazyModule
-
-cftime = _LazyModule("cftime", bool_use_sys_modules=True)
-pd = _LazyModule("pandas", bool_use_sys_modules=True)
-
+from .dependencies import cftime, pd
 
 # gen_types is copied from param, can be removed when
 # we support 2.2 or greater

--- a/holoviews/core/util/types.py
+++ b/holoviews/core/util/types.py
@@ -11,8 +11,28 @@ import numpy as np
 
 from .dependencies import cftime, pd
 
-# gen_types is copied from param, can be removed when
-# we support 2.2 or greater
+if t.TYPE_CHECKING:
+    from pandas.core.arrays.masked import BaseMaskedArray
+    from pandas.core.dtypes.dtypes import DatetimeTZDtype
+    from pandas.core.dtypes.generic import ABCExtensionArray, ABCIndex, ABCSeries
+
+    _PdDatetimeT: t.TypeAlias = pd.Timestamp | pd.Period | DatetimeTZDtype
+    _PdTimedeltaT: t.TypeAlias = pd.Timedelta
+    _CftimeT: t.TypeAlias = cftime.datetime
+    _DatetimeT: t.TypeAlias = (
+        dt.datetime | dt.date | dt.time | np.datetime64 | _PdDatetimeT | _CftimeT
+    )
+    _TimedeltaT: t.TypeAlias = dt.timedelta | np.timedelta64 | _PdTimedeltaT
+    _ArraylikeT: t.TypeAlias = np.ndarray | nw.Series | ABCIndex | ABCSeries | ABCExtensionArray
+    _MaskedT: t.TypeAlias = np.ma.core.MaskedArray | BaseMaskedArray
+
+    _YieldT = t.TypeVar("_YieldT")
+
+    class _GenFunc(t.Protocol[_YieldT]):
+        __name__: str
+
+        def __call__(self) -> t.Iterator[_YieldT]: ...
+
 
 _module_count = 0
 
@@ -50,11 +70,13 @@ class _GeneratorIs(metaclass=_GeneratorIsMeta):
         yield from cls._get_types()
 
 
-def gen_types(gen_func):
+def gen_types(gen_func: _GenFunc[_YieldT]) -> tuple[_YieldT, ...]:
     """
     Decorator which takes a generator function which yields difference types
     make it so it can be called with isinstance and issubclass.
     """
+    if t.TYPE_CHECKING:
+        return tuple(gen_func())
     if not inspect.isgeneratorfunction(gen_func):
         msg = "gen_types decorator can only be applied to generator"
         raise TypeError(msg)
@@ -66,7 +88,7 @@ generator_types = (zip, range, GeneratorType)
 
 
 @gen_types
-def pandas_datetime_types():
+def pandas_datetime_types() -> t.Iterator[type[_PdDatetimeT]]:
     if pd:
         from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
@@ -74,32 +96,32 @@ def pandas_datetime_types():
 
 
 @gen_types
-def pandas_timedelta_types():
+def pandas_timedelta_types() -> t.Iterator[type[_PdTimedeltaT]]:
     if pd:
         yield pd.Timedelta
 
 
 @gen_types
-def cftime_types():
+def cftime_types() -> t.Iterator[type[_CftimeT]]:
     if cftime:
         yield cftime.datetime
 
 
 @gen_types
-def datetime_types():
+def datetime_types() -> t.Iterator[type[_DatetimeT]]:
     yield from (dt.datetime, dt.date, dt.time, np.datetime64)
     yield from pandas_datetime_types
     yield from cftime_types
 
 
 @gen_types
-def timedelta_types():
+def timedelta_types() -> t.Iterator[type[_TimedeltaT]]:
     yield from (dt.timedelta, np.timedelta64)
     yield from pandas_timedelta_types
 
 
 @gen_types
-def arraylike_types():
+def arraylike_types() -> t.Iterator[type[_ArraylikeT]]:
     yield from (np.ndarray, nw.Series)
     if pd:
         from pandas.core.dtypes.generic import ABCExtensionArray, ABCIndex, ABCSeries

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -10,7 +10,8 @@ from importlib.util import find_spec
 import numpy as np
 
 from ..core import Dataset, NdOverlay, util
-from ..core.util import cp, cudf, dd, dtype_kind, pd
+from ..core.util import dtype_kind
+from ..core.util.dependencies import cp, cudf, dd, pd
 from ..streams import Lasso, Selection1D, SelectionXY
 from ..util.transform import dim
 from .annotation import HSpan, VSpan

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -5,13 +5,12 @@ elements.
 
 from __future__ import annotations
 
-import sys
 from importlib.util import find_spec
 
 import numpy as np
 
 from ..core import Dataset, NdOverlay, util
-from ..core.util import dtype_kind
+from ..core.util import cp, cudf, dd, dtype_kind, pd
 from ..streams import Lasso, Selection1D, SelectionXY
 from ..util.transform import dim
 from .annotation import HSpan, VSpan
@@ -87,7 +86,6 @@ def spatial_select_gridded(xvals, yvals, geometry):
 
 
 def _cuspatial_old(xvals, yvals, geometry):
-    import cudf
     import cuspatial
 
     result = cuspatial.point_in_polygon(
@@ -102,7 +100,6 @@ def _cuspatial_old(xvals, yvals, geometry):
 
 
 def _cuspatial_new(xvals, yvals, geometry):
-    import cudf
     import cuspatial
     import geopandas
     from shapely.geometry import Polygon
@@ -115,12 +112,7 @@ def _cuspatial_new(xvals, yvals, geometry):
 
 
 def spatial_select_columnar(xvals, yvals, geometry, geom_method=None):
-    import pandas as pd
-
-    if "cudf" in sys.modules:
-        import cudf
-        import cupy as cp
-
+    if cudf:
         if isinstance(xvals, cudf.Series):
             xvals = xvals.values.astype("float")
             yvals = yvals.values.astype("float")
@@ -132,9 +124,7 @@ def spatial_select_columnar(xvals, yvals, geometry, geom_method=None):
             except ImportError:
                 xvals = cp.asnumpy(xvals)
                 yvals = cp.asnumpy(yvals)
-    if "dask" in sys.modules:
-        import dask.dataframe as dd
-
+    if dd:
         if isinstance(xvals, dd.Series):
             try:
                 xvals.name = "xvals"

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -43,7 +43,7 @@ from ..core.util import (
     dtype_kind,
     get_param_values,
 )
-from ..core.util.dependencies import PANDAS_GE_3_0_0, _LazyModule
+from ..core.util.dependencies import PANDAS_GE_3_0_0, dd
 from ..element import (
     RGB,
     Area,
@@ -76,8 +76,6 @@ DATASHADER_GE_0_18_1 = DATASHADER_VERSION >= (0, 18, 1)
 
 if TYPE_CHECKING:
     from ._datashader_bundling import bundle_graph, directly_connect_edges  # noqa: F401
-
-dd = _LazyModule("dask.dataframe", bool_use_sys_modules=True)
 
 
 def __getattr__(attr):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -75,11 +75,9 @@ DATASHADER_GE_0_16_0 = DATASHADER_VERSION >= (0, 16, 0)
 DATASHADER_GE_0_18_1 = DATASHADER_VERSION >= (0, 18, 1)
 
 if TYPE_CHECKING:
-    import dask.dataframe as dd
-
     from ._datashader_bundling import bundle_graph, directly_connect_edges  # noqa: F401
-else:
-    dd = _LazyModule("dask.dataframe", bool_use_sys_modules=True)
+
+dd = _LazyModule("dask.dataframe", bool_use_sys_modules=True)
 
 
 def __getattr__(attr):

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -11,6 +11,8 @@ from ...core import NdOverlay
 from ...core.dimension import Dimension, Dimensioned
 from ...core.ndmapping import sorted_context
 from ...core.util import (
+    cp,
+    da,
     dimension_sanitizer,
     is_cupy_array,
     is_dask_array,
@@ -165,13 +167,9 @@ class BoxWhiskerPlot(MultiDistributionMixin, CompositeElementPlot, ColorbarPlot,
         is_dask = is_dask_array(vals)
         is_cupy = is_cupy_array(vals)
         if is_cupy:
-            import cupy
-
-            percentile = cupy.percentile
-            is_finite = cupy.isfinite
+            percentile = cp.percentile
+            is_finite = cp.isfinite
         elif is_dask:
-            import dask.array as da
-
             percentile = da.percentile
         else:
             percentile = np.percentile
@@ -195,7 +193,7 @@ class BoxWhiskerPlot(MultiDistributionMixin, CompositeElementPlot, ColorbarPlot,
                 q3.item(),
                 upper.item(),
                 lower.item(),
-                cupy.asnumpy(outliers),
+                cp.asnumpy(outliers),
             )
         elif is_dask:
             return da.compute(q1, q2, q3, upper, lower, outliers)

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -11,8 +11,6 @@ from ...core import NdOverlay
 from ...core.dimension import Dimension, Dimensioned
 from ...core.ndmapping import sorted_context
 from ...core.util import (
-    cp,
-    da,
     dimension_sanitizer,
     is_cupy_array,
     is_dask_array,
@@ -20,6 +18,7 @@ from ...core.util import (
     unique_iterator,
     wrap_tuple,
 )
+from ...core.util.dependencies import cp, da
 from ...operation.stats import univariate_kde
 from ...util.transform import dim
 from ..mixins import MultiDistributionMixin

--- a/holoviews/pyodide.py
+++ b/holoviews/pyodide.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import typing as t
 
 from bokeh.document import Document
 from bokeh.embed.elements import script_for_render_items
@@ -9,10 +10,14 @@ from bokeh.embed.util import standalone_docs_json_and_render_items
 from bokeh.embed.wrappers import wrap_in_script_tag
 from panel.io.pyodide import _link_docs
 from panel.pane import panel as as_panel
+from panel.viewable import Viewable
 
 from .core.dimension import LabelledData
 from .core.options import Store
 from .util import extension as _extension
+
+if t.TYPE_CHECKING:
+    from bokeh.core.types import ID
 
 # -----------------------------------------------------------------------------
 # Private API
@@ -37,17 +42,19 @@ def render_html(obj):
     from js import document
 
     if hasattr(sys.stdout, "_out"):
-        target = sys.stdout._out  # type: ignore
+        target = t.cast("ID", sys.stdout._out)
     else:
-        raise ValueError("Could not determine target node to write to.")
+        msg = "Could not determine target node to write to."
+        raise ValueError(msg)
     doc = Document()
-    as_panel(obj).server_doc(doc, location=False)
-    (
-        docs_json,
-        [
-            render_item,
-        ],
-    ) = standalone_docs_json_and_render_items(doc.roots, suppress_callback_warning=True)
+    obj = as_panel(obj)
+    if not isinstance(obj, Viewable):
+        msg = "Object could not be converted to a Panel viewable."
+        raise ValueError(msg)
+    obj.server_doc(doc, location=False)
+    docs_json, [render_item] = standalone_docs_json_and_render_items(
+        doc.roots, suppress_callback_warning=True
+    )
     for root in doc.roots:
         render_item.roots._roots[root] = target
     document.getElementById(target).classList.add("bk-root")

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -465,8 +465,8 @@ class link_selections(_base_link_selections):
         filtered = data[expr.apply(data)]
         return filtered if is_dataset else filtered.data
 
-    @bothmethod
-    def _install_param_callbacks(self_or_cls, inst):
+    @staticmethod
+    def _install_param_callbacks(inst):
         def update_selection_mode(*_):
             # Reset selection state of streams
             for stream in inst._selection_expr_streams.values():
@@ -584,8 +584,6 @@ class SelectionDisplay:
     def build_selection(
         self, selection_streams, hvobj, operations, region_stream=None, cache=None
     ):
-        if cache is None:
-            cache = {}
         raise NotImplementedError()
 
     @staticmethod

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -57,7 +57,7 @@ _Styles = Stream.define("Styles", colors=[], alpha=1.0)
 _RegionElement = Stream.define("RegionElement", region_element=None)
 
 
-_SelectionStreams = namedtuple("SelectionStreams", "style_stream exprs_stream cmap_streams ")
+_SelectionStreams = namedtuple("_SelectionStreams", "style_stream exprs_stream cmap_streams ")
 
 
 class _base_link_selections(param.ParameterizedFunction):

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing as t
 from collections import defaultdict, namedtuple
 
 import numpy as np
@@ -82,6 +83,25 @@ class _base_link_selections(param.ParameterizedFunction):
         doc="Whether to highlight the selected regions.",
     )
 
+    index_cols = param.List(
+        default=None,
+        doc="""
+        If provided, selection switches to index mode where all queries are
+        expressed solely in terms of discrete values along the index_cols.
+        All Elements given to link_selections must define the index_cols,
+        either as explicit dimensions or by sharing an underlying Dataset
+        that defines them.""",
+    )
+
+    _cache: dict[str, t.Any]  # TODO: Narrow?
+    _cross_filter_stream: CrossFilterSet
+    _plot_reset_streams: dict[str, t.Any]  # TODO: Narrow?
+    _selection_expr_streams: dict[str, t.Any]  # TODO: Narrow?
+    _selection_override = _SelectionExprOverride
+    _selection_streams: list[_SelectionStreams]
+    _streams: dict[t.Any, list[t.Any]]  # TODO: Narrow?
+    _datasets: list[t.Any]  # TODO: Narrow?
+
     @bothmethod
     def instance(self_or_cls, **params):
         inst = super().instance(**params)
@@ -95,6 +115,10 @@ class _base_link_selections(param.ParameterizedFunction):
 
         # Init selection streams
         inst._selection_streams = self_or_cls._build_selection_streams(inst)
+
+        # _datasets caches
+        inst._datasets = []
+        inst._cache = {}
 
         return inst
 
@@ -323,14 +347,6 @@ class link_selections(_base_link_selections):
         elements.""",
     )
 
-    index_cols = param.List(
-        default=None,
-        doc="""
-        If provided, selection switches to index mode where all queries
-        are expressed solely in terms of discrete values along the
-        index_cols.  All Elements given to link_selections must define the index_cols, either as explicit dimensions or by sharing an underlying Dataset that defines them.""",
-    )
-
     selection_expr = param.Parameter(
         default=None,
         doc="""
@@ -364,6 +380,8 @@ class link_selections(_base_link_selections):
         doc="Color of unselected data.",
     )
 
+    _updating_show_regions_internal: bool
+
     @bothmethod
     def instance(self_or_cls, **params):
         inst = super().instance(**params)
@@ -374,10 +392,6 @@ class link_selections(_base_link_selections):
         inst._reset_regions = True
         inst._user_show_regions = inst.show_regions
         inst._updating_show_regions_internal = False
-
-        # _datasets caches
-        inst._datasets = []
-        inst._cache = {}
 
         self_or_cls._install_param_callbacks(inst)
 
@@ -424,7 +438,7 @@ class link_selections(_base_link_selections):
             data = Dataset(data)
         pipe = Pipe()
         self._datasets.append((pipe, data, raw))
-        self._update_pipes()
+        self._update_pipes()  # ty:ignore[missing-argument] NOTE: fix in param
         return pipe.param.data
 
     def filter(self, data, selection_expr=None):
@@ -785,7 +799,7 @@ class ColorListSelectionDisplay(SelectionDisplay):
 
             color_inds = np.zeros(n, dtype="int8")
 
-            for i, expr in zip(range(1, len(clrs)), selection_exprs, strict=None):
+            for i, expr in zip(range(1, len(clrs)), selection_exprs, strict=False):
                 if not expr:
                     color_inds[:] = i
                 else:

--- a/holoviews/selection.py
+++ b/holoviews/selection.py
@@ -438,7 +438,7 @@ class link_selections(_base_link_selections):
             data = Dataset(data)
         pipe = Pipe()
         self._datasets.append((pipe, data, raw))
-        self._update_pipes()  # ty:ignore[missing-argument] NOTE: fix in param
+        self._update_pipes()
         return pipe.param.data
 
     def filter(self, data, selection_expr=None):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1348,11 +1348,12 @@ class CrossFilterSet(Derived):
                     vals = set.intersection(
                         *(set(expr.ops[2]["args"][0]) for expr in selection_exprs)
                     )
-                    old = selection_exprs[0]
+                    old = t.cast("dim", selection_exprs[0])
                     selection_expr = dim("new")
                     selection_expr.dimension = old.dimension
                     selection_expr.ops = list(old.ops)
-                    selection_expr.ops[2] = dict(selection_expr.ops[2], args=(list(vals),))
+                    selection_expr.ops[2] = selection_expr.ops[2].copy()
+                    selection_expr.ops[2]["args"] = (list(vals),)
             else:
                 selection_expr = selection_exprs[0]
                 for expr in selection_exprs[1:]:

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -498,11 +498,7 @@ class Counter(Stream):
 
 
 class Pipe(Stream):
-    """A Stream used to pipe arbitrary data to a callback.
-    Unlike other streams memoization can be disabled for a
-    Pipe stream (and is disabled by default).
-
-    """
+    """A Stream used to pipe arbitrary data to a callback."""
 
     data = param.Parameter(
         default=None,

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -6,6 +6,7 @@ server-side or in Javascript in the Jupyter notebook (client-side).
 
 from __future__ import annotations
 
+import typing as t
 import weakref
 from collections import defaultdict
 from contextlib import contextmanager
@@ -13,7 +14,6 @@ from functools import partial
 from itertools import groupby
 from numbers import Number
 from types import FunctionType
-from typing import TYPE_CHECKING
 
 import numpy as np
 import param
@@ -21,8 +21,10 @@ import param
 from .core import util
 from .core.ndmapping import UniformNdMapping
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     import pandas as pd
+
+    from .core import Element
 else:
     pd = util.dependencies._LazyModule("pandas", bool_use_sys_modules=True)
 
@@ -142,29 +144,28 @@ class Stream(param.Parameterized):
         Supported types: bool, int, float, str, dict, tuple and list
 
         """
-        params = {"name": param.String(default=name)}
+        params: dict[str, param.Parameter] = {"name": param.String(default=name)}
         for k, v in kwargs.items():
-            kws = dict(default=v, constant=True)
             if isinstance(v, param.Parameter):
                 params[k] = v
             elif isinstance(v, bool):
-                params[k] = param.Boolean(**kws)
+                params[k] = param.Boolean(default=v, constant=True)
             elif isinstance(v, int):
-                params[k] = param.Integer(**kws)
+                params[k] = param.Integer(default=v, constant=True)
             elif isinstance(v, float):
-                params[k] = param.Number(**kws)
+                params[k] = param.Number(default=v, constant=True)
             elif isinstance(v, str):
-                params[k] = param.String(**kws)
+                params[k] = param.String(default=v, constant=True)
             elif isinstance(v, dict):
-                params[k] = param.Dict(**kws)
+                params[k] = param.Dict(default=v, constant=True)
             elif isinstance(v, tuple):
-                params[k] = param.Tuple(**kws)
+                params[k] = param.Tuple(default=v, constant=True)
             elif isinstance(v, list):
-                params[k] = param.List(**kws)
+                params[k] = param.List(default=v, constant=True)
             elif isinstance(v, np.ndarray):
-                params[k] = param.Array(**kws)
+                params[k] = param.Array(default=v, constant=True)
             else:
-                params[k] = param.Parameter(**kws)
+                params[k] = param.Parameter(default=v, constant=True)
 
         # Dynamic class creation using type
         return type(name, (Stream,), params)
@@ -221,7 +222,7 @@ class Stream(param.Parameterized):
         """Called when a stream has been triggered"""
 
     @classmethod
-    def _process_streams(cls, streams):
+    def _process_streams(cls, streams: list[t.Any]) -> tuple[list[Params], list[Params]]:
         """Processes a list of streams promoting Parameterized objects and
         methods to Param based streams.
 
@@ -321,7 +322,7 @@ class Stream(param.Parameterized):
     @property
     def subscribers(self):
         """Property returning the subscriber list"""
-        return [s for p, s in sorted(self._subscribers, key=lambda x: x[0])]
+        return [s for _, s in sorted(self._subscribers, key=lambda x: x[0])]
 
     def clear(self, policy="all"):
         """Clear all subscribers registered to this stream.
@@ -604,7 +605,7 @@ class Buffer(Pipe):
             elif len({len(v) for v in x.values()}) > 1:
                 raise ValueError("Input columns expected to have the same number of rows.")
 
-    def clear(self):
+    def clear(self, policy="all"):
         """Clears the data in the stream"""
         if isinstance(self.data, np.ndarray):
             data = self.data[:, :0]
@@ -757,9 +758,17 @@ class Params(Stream):
     )
 
     def __init__(
-        self, parameterized=None, parameters=None, watch=True, watch_only=False, **params
-    ):
+        self,
+        parameterized: param.Parameterized | type[param.Parameterized] | None = None,
+        parameters: list[param.Parameter] | None = None,
+        watch: bool = True,
+        watch_only: bool = False,
+        **params,
+    ) -> None:
+
         if parameters is None:
+            if parameterized is None:
+                raise ValueError(...)
             parameters = [parameterized.param[p] for p in parameterized.param if p != "name"]
         else:
             parameters = [
@@ -877,7 +886,6 @@ class Params(Stream):
                     owner.param.update(**updates)
         elif isinstance(self.parameterized, Stream):
             self.parameterized.update(**kwargs)
-            return
         else:
             self.parameterized.param.update(**kwargs)
 
@@ -1810,6 +1818,8 @@ class CDSStream(LinkedStream):
         path-like data).""",
     )
 
+    element: Element
+
 
 class PointDraw(CDSStream):
     """Attaches a PointDrawTool and syncs the datasource.
@@ -2050,7 +2060,7 @@ class FreehandDraw(CDSStream):
     def dynamic(self):
         from .core.spaces import DynamicMap
 
-        return DynamicMap(lambda *args, **kwargs: self.element, streams=[self])
+        return DynamicMap(lambda: self.element, streams=[self])
 
 
 class BoxEdit(CDSStream):
@@ -2106,7 +2116,7 @@ class BoxEdit(CDSStream):
             return source.clone(data, id=None)
         paths = []
         for i, (x0, x1, y0, y1) in enumerate(
-            zip(data["x0"], data["x1"], data["y0"], data["y1"], strict=None)
+            zip(data["x0"], data["x1"], data["y0"], data["y1"], strict=False)
         ):
             xs = [x0, x0, x1, x1]
             ys = [y0, y1, y1, y0]
@@ -2122,7 +2132,7 @@ class BoxEdit(CDSStream):
     def dynamic(self):
         from .core.spaces import DynamicMap
 
-        return DynamicMap(lambda *args, **kwargs: self.element, streams=[self])
+        return DynamicMap(lambda: self.element, streams=[self])
 
 
 class PolyEdit(PolyDraw):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -20,14 +20,13 @@ import param
 
 from .core import util
 from .core.ndmapping import UniformNdMapping
+from .core.util.dependencies import pd
 
 if t.TYPE_CHECKING:
     from collections.abc import Sequence
 
     from .core import Dataset
     from .element import Path
-
-pd = util.dependencies._LazyModule("pandas", bool_use_sys_modules=True)
 
 
 # Types supported by Pointer derived streams

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -26,7 +26,8 @@ if t.TYPE_CHECKING:
 
     import pandas as pd
 
-    from .core import Element
+    from .core import Dataset
+    from .element import Path
 else:
     pd = util.dependencies._LazyModule("pandas", bool_use_sys_modules=True)
 
@@ -512,7 +513,7 @@ class Pipe(Stream):
         doc="Arbitrary data being streamed to a DynamicMap callback.",
     )
 
-    def __init__(self, data=None, memoize=False, **params):
+    def __init__(self, data=None, **params):
         super().__init__(data=data, **params)
         self._memoize_counter = 0
 
@@ -1798,7 +1799,6 @@ class Selection1D(LinkedStream):
 
     index = param.List(
         default=[],
-        allow_None=True,
         constant=True,
         doc="Indices into a 1D datastructure.",
     )
@@ -1829,7 +1829,7 @@ class CDSStream(LinkedStream):
         path-like data).""",
     )
 
-    element: Element
+    element: Dataset
 
 
 class PointDraw(CDSStream):
@@ -1899,7 +1899,7 @@ class PointDraw(CDSStream):
     def dynamic(self):
         from .core.spaces import DynamicMap
 
-        return DynamicMap(lambda *args, **kwargs: self.element, streams=[self])
+        return DynamicMap(lambda: self.element, streams=[self])
 
 
 class CurveEdit(PointDraw):
@@ -1992,7 +1992,7 @@ class PolyDraw(CDSStream):
         super().__init__(**params)
 
     @property
-    def element(self):
+    def element(self) -> Path:
         source = self.source
         if isinstance(source, UniformNdMapping):
             source = source.last
@@ -2012,7 +2012,7 @@ class PolyDraw(CDSStream):
     def dynamic(self):
         from .core.spaces import DynamicMap
 
-        return DynamicMap(lambda *args, **kwargs: self.element, streams=[self])
+        return DynamicMap(lambda: self.element, streams=[self])
 
 
 class FreehandDraw(CDSStream):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -2128,7 +2128,7 @@ class BoxEdit(CDSStream):
             return source.clone(data, id=None)
         paths = []
         for i, (x0, x1, y0, y1) in enumerate(
-            zip(data["x0"], data["x1"], data["y0"], data["y1"], strict=False)
+            zip(data["x0"], data["x1"], data["y0"], data["y1"], strict=True)
         ):
             xs = [x0, x0, x1, x1]
             ys = [y0, y1, y1, y0]

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -24,12 +24,10 @@ from .core.ndmapping import UniformNdMapping
 if t.TYPE_CHECKING:
     from collections.abc import Sequence
 
-    import pandas as pd
-
     from .core import Dataset
     from .element import Path
-else:
-    pd = util.dependencies._LazyModule("pandas", bool_use_sys_modules=True)
+
+pd = util.dependencies._LazyModule("pandas", bool_use_sys_modules=True)
 
 
 # Types supported by Pointer derived streams

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -22,9 +22,13 @@ from .core import util
 from .core.ndmapping import UniformNdMapping
 
 if t.TYPE_CHECKING:
+    from collections.abc import Sequence
+
     import pandas as pd
 
     from .core import Element
+
+    BufferData: t.TypeAlias = "np.ndarray | pd.DataFrame | dict[str, np.ndarray]"
 else:
     pd = util.dependencies._LazyModule("pandas", bool_use_sys_modules=True)
 
@@ -581,7 +585,7 @@ class Buffer(Pipe):
 
     def verify(self, x):
         """Verify consistency of dataframes that pass through this stream"""
-        if type(x) != type(self.data):  # noqa: E721
+        if type(x) is not type(self.data):
             raise TypeError(
                 f"Input expected to be of type {type(self.data).__name__}, got {type(x).__name__}."
             )
@@ -617,7 +621,7 @@ class Buffer(Pipe):
             self.data = data
         self.send(data)
 
-    def _concat(self, data):
+    def _concat(self, data: BufferData) -> BufferData:
         """Concatenate and slice the accepted data types to the defined
         length.
 
@@ -630,7 +634,7 @@ class Buffer(Pipe):
                 prev_chunk = self.data[-(self.length - data_length) :]
                 data = np.concatenate([prev_chunk, data])
             elif data_length > self.length:
-                data = data[-self.length :]
+                data = np.asarray(data)[-self.length :]
         elif pd and isinstance(data, pd.DataFrame):
             data_length = len(data)
             if not self.length:
@@ -760,7 +764,7 @@ class Params(Stream):
     def __init__(
         self,
         parameterized: param.Parameterized | type[param.Parameterized] | None = None,
-        parameters: list[param.Parameter] | None = None,
+        parameters: Sequence[param.Parameter | str] | None = None,
         watch: bool = True,
         watch_only: bool = False,
         **params,
@@ -768,12 +772,20 @@ class Params(Stream):
 
         if parameters is None:
             if parameterized is None:
-                raise ValueError(...)
+                msg = "Must supply a parameterized object if parameters are not set."
+                raise ValueError(msg)
             parameters = [parameterized.param[p] for p in parameterized.param if p != "name"]
         else:
-            parameters = [
-                p if isinstance(p, param.Parameter) else parameterized.param[p] for p in parameters
-            ]
+            resolved_parameters = []
+            for p in parameters:
+                if isinstance(p, param.Parameter):
+                    resolved_parameters.append(p)
+                elif parameterized is None:
+                    msg = "Must supply a parameterized object if parameters are given as strings."
+                    raise ValueError(msg)
+                else:
+                    resolved_parameters.append(parameterized.param[p])
+            parameters = resolved_parameters
 
         if "rename" in params:
             rename = {}

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -27,8 +27,6 @@ if t.TYPE_CHECKING:
     import pandas as pd
 
     from .core import Element
-
-    BufferData: t.TypeAlias = "np.ndarray | pd.DataFrame | dict[str, np.ndarray]"
 else:
     pd = util.dependencies._LazyModule("pandas", bool_use_sys_modules=True)
 
@@ -621,7 +619,7 @@ class Buffer(Pipe):
             self.data = data
         self.send(data)
 
-    def _concat(self, data: BufferData) -> BufferData:
+    def _concat(self, data):
         """Concatenate and slice the accepted data types to the defined
         length.
 
@@ -645,6 +643,7 @@ class Buffer(Pipe):
             elif data_length > self.length:
                 data = data.iloc[-self.length :]
         elif isinstance(data, dict) and data:
+            data = t.cast("dict[str, np.ndarray]", data)
             data_length = len(next(iter(data.values())))
             new_data = {}
             for k, v in data.items():

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -633,7 +633,7 @@ class Buffer(Pipe):
                 prev_chunk = self.data[-(self.length - data_length) :]
                 data = np.concatenate([prev_chunk, data])
             elif data_length > self.length:
-                data = np.asarray(data)[-self.length :]
+                data = data[-self.length :]
         elif pd and isinstance(data, pd.DataFrame):
             data_length = len(data)
             if not self.length:

--- a/holoviews/tests/core/data/test_daskinterface.py
+++ b/holoviews/tests/core/data/test_daskinterface.py
@@ -12,13 +12,8 @@ from holoviews.core.util.dependencies import (
 )
 from holoviews.testing import assert_data_equal, assert_element_equal
 
-from ...utils import optional_dependencies
+from ...utils import dask, dask_skip, dd
 from .test_pandasinterface import BasePandasInterfaceTests
-
-dask, dask_skip = optional_dependencies("dask")
-
-if dask:
-    import dask.dataframe as dd
 
 _DASK_CONVERT_STRING = _no_import_version("dask") >= (2023, 7, 1) and dask.config.get(
     "dataframe.convert-string"

--- a/holoviews/tests/core/data/test_gridinterface.py
+++ b/holoviews/tests/core/data/test_gridinterface.py
@@ -12,7 +12,7 @@ from holoviews.core.data.interface import DataError
 from holoviews.core.util import date_range
 from holoviews.testing import assert_data_equal, assert_element_equal
 
-from ...utils import optional_dependencies
+from ...utils import da, da_skip
 from .base import (
     DatatypeContext,
     GriddedInterfaceTests,
@@ -24,8 +24,6 @@ from .test_imageinterface import (
     BaseImageElementInterfaceTests,
     BaseRGBElementInterfaceTests,
 )
-
-da, dask_skip = optional_dependencies("dask.array")
 
 
 class BaseGridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, InterfaceTests):
@@ -422,7 +420,7 @@ class GridInterfaceTests(BaseGridInterfaceTests):
     __test__ = True
 
 
-@dask_skip
+@da_skip
 class DaskGridInterfaceTests(GridInterfaceTests):
     def init_column_data(self):
         self.xs = np.arange(11)

--- a/holoviews/tests/core/data/test_ibisinterface.py
+++ b/holoviews/tests/core/data/test_ibisinterface.py
@@ -12,10 +12,8 @@ from holoviews.core.data.ibis import IBIS_VERSION, IbisInterface
 from holoviews.core.util.dependencies import PANDAS_GE_3_0_0
 from holoviews.testing import assert_element_equal
 
-from ...utils import optional_dependencies
+from ...utils import ibis, ibis_skip
 from .base import HeterogeneousColumnTests, InterfaceTests, ScalarColumnTests
-
-ibis, ibis_skip = optional_dependencies("ibis")
 
 
 def create_temp_db(df, name, index=False):

--- a/holoviews/tests/core/data/test_narwhalsinterface.py
+++ b/holoviews/tests/core/data/test_narwhalsinterface.py
@@ -12,10 +12,8 @@ from holoviews.core.data import NarwhalsInterface
 from holoviews.core.util.dependencies import _no_import_version
 from holoviews.testing import assert_data_equal
 
-from ...utils import optional_dependencies
+from ...utils import pl_skip
 from .base import HeterogeneousColumnTests, InterfaceTests
-
-_, pl_skip = optional_dependencies("polars")
 
 
 class BaseNarwhalsInterfaceTests(HeterogeneousColumnTests, InterfaceTests):

--- a/holoviews/tests/core/data/test_spatialpandas.py
+++ b/holoviews/tests/core/data/test_spatialpandas.py
@@ -14,11 +14,8 @@ from holoviews.core.data.interface import DataError
 from holoviews.core.data.spatialpandas import get_value_array
 from holoviews.testing import assert_data_equal, assert_element_equal
 
-from ...utils import optional_dependencies
+from ...utils import dd_skip, spd, spd_skip
 from .test_multiinterface import GeomTests
-
-spd, spd_skip = optional_dependencies("spatialpandas")
-dd, dask_skip = optional_dependencies("dask.dataframe")
 
 if spd:
     import spatialpandas.geometry as sgeom
@@ -325,7 +322,7 @@ class SpatialPandasTest(GeomTests, RoundTripTests):
 
 
 @spd_skip
-@dask_skip
+@dd_skip
 class DaskSpatialPandasTest(GeomTests, RoundTripTests):
     """
     Test of the DaskSpatialPandasInterface.

--- a/holoviews/tests/core/data/test_xarrayinterface.py
+++ b/holoviews/tests/core/data/test_xarrayinterface.py
@@ -10,16 +10,13 @@ import holoviews as hv
 from holoviews.core.data import XArrayInterface, concat
 from holoviews.testing import assert_data_equal, assert_element_equal
 
-from ...utils import optional_dependencies
+from ...utils import da, da_skip, xr, xr_skip
 from .test_gridinterface import BaseGridInterfaceTests
 from .test_imageinterface import (
     BaseHSVElementInterfaceTests,
     BaseImageElementInterfaceTests,
     BaseRGBElementInterfaceTests,
 )
-
-xr, xr_skip = optional_dependencies("xarray")
-da, dask_skip = optional_dependencies("dask.array")
 
 
 @xr_skip
@@ -386,7 +383,7 @@ class XArrayInterfaceTests(BaseGridInterfaceTests):
         pytest.skip("Not supported")
 
 
-@dask_skip
+@da_skip
 class DaskXArrayInterfaceTest(XArrayInterfaceTests):
     """
     Tests for XArray interface wrapping dask arrays

--- a/holoviews/tests/core/test_datasetproperty.py
+++ b/holoviews/tests/core/test_datasetproperty.py
@@ -9,16 +9,10 @@ from holoviews.core import Apply, Redim
 from holoviews.operation import function, histogram
 from holoviews.testing import assert_element_equal
 
-from ..utils import optional_dependencies
-
-ds, ds_skip = optional_dependencies("datashader")
-dask, dask_skip = optional_dependencies("dask")
+from ..utils import dask, dask_skip, dd, ds, ds_skip
 
 if ds:
     from holoviews.operation.datashader import datashade, dynspread, rasterize
-
-if dask:
-    import dask.dataframe as dd
 
 
 class DatasetPropertyTestCase:

--- a/holoviews/tests/core/test_decollation.py
+++ b/holoviews/tests/core/test_decollation.py
@@ -6,9 +6,8 @@ import holoviews as hv
 from holoviews.streams import PlotSize, RangeXY, Stream
 from holoviews.testing import assert_element_equal
 from holoviews.tests.test_streams import Sum, Val
-from holoviews.tests.utils import optional_dependencies
+from holoviews.tests.utils import ds, ds_skip
 
-ds, ds_skip = optional_dependencies("datashader")
 if ds:
     from holoviews.operation.datashader import datashade, spread
 

--- a/holoviews/tests/core/test_options.py
+++ b/holoviews/tests/core/test_options.py
@@ -12,12 +12,9 @@ from holoviews.core.options import OptionError, OptionTree, options_policy
 from holoviews.plotting import bokeh  # noqa: F401
 from holoviews.testing import assert_element_equal
 
-from ..utils import optional_dependencies
+from ..utils import mpl, mpl_skip, plotly, plotly_skip
 
 hv.Options.skip_invalid = False
-
-mpl, mpl_skip = optional_dependencies("matplotlib")
-plotly, plotly_skip = optional_dependencies("plotly")
 
 if mpl:
     import holoviews.plotting.mpl

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -10,9 +10,8 @@ import numpy as np
 import holoviews as hv
 from holoviews.plotting import bokeh  # noqa: F401
 
-from ..utils import optional_dependencies
+from ..utils import mpl, mpl_skip
 
-mpl, mpl_skip = optional_dependencies("matplotlib")
 if mpl:
     import holoviews.plotting.mpl
 

--- a/holoviews/tests/element/test_graphelement.py
+++ b/holoviews/tests/element/test_graphelement.py
@@ -12,10 +12,7 @@ import holoviews as hv
 from holoviews.element.util import circular_layout, connect_edges, connect_edges_pd
 from holoviews.testing import assert_data_equal, assert_element_equal
 
-from ..utils import optional_dependencies
-
-nx, nx_skip = optional_dependencies("networkx")
-scipy, scipy_skip = optional_dependencies("scipy")
+from ..utils import nx, nx_skip, scipy_skip
 
 
 class GraphTests:

--- a/holoviews/tests/element/test_selection.py
+++ b/holoviews/tests/element/test_selection.py
@@ -12,12 +12,7 @@ import holoviews as hv
 from holoviews.element.selection import spatial_select_columnar
 from holoviews.testing import assert_data_equal, assert_dict_equal, assert_element_equal
 
-from ..utils import optional_dependencies
-
-ds, ds_skip = optional_dependencies("datashader")
-spd, spd_skip = optional_dependencies("spatialpandas")
-shapely, shapely_skip = optional_dependencies("shapely")
-dd, dask_skip = optional_dependencies("dask.dataframe")
+from ..utils import dd, dd_skip, ds_skip, shapely_skip, spd_skip
 
 
 class TestIndexExpr:
@@ -735,12 +730,12 @@ class TestSpatialSelectColumnar:
         )
         assert np.array_equal(mask, pt_mask)
 
-    @dask_skip
+    @dd_skip
     def test_dask(self, geometry, pt_mask, dask_df):
         mask = spatial_select_columnar(dask_df.x, dask_df.y, geometry, self.method)
         assert np.array_equal(mask.compute(), pt_mask)
 
-    @dask_skip
+    @dd_skip
     def test_meta_dtype(self, geometry, pt_mask, dask_df):
         mask = spatial_select_columnar(dask_df.x, dask_df.y, geometry, self.method)
         assert mask._meta.dtype == np.bool_

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -15,10 +15,7 @@ from holoviews.operation import apply_when
 from holoviews.streams import Tap
 from holoviews.testing import assert_data_equal, assert_element_equal
 
-from ..utils import optional_dependencies
-
-ds, ds_skip = optional_dependencies("datashader")
-spd, spd_skip = optional_dependencies("spatialpandas")
+from ..utils import ds, spd, spd_skip
 
 if not ds:
     pytest.skip("datashader not installed", allow_module_level=True)

--- a/holoviews/tests/operation/test_downsample.py
+++ b/holoviews/tests/operation/test_downsample.py
@@ -7,9 +7,7 @@ import pytest
 import holoviews as hv
 from holoviews.operation.downsample import _ALGORITHMS, downsample1d
 
-from ..utils import optional_dependencies
-
-tsdownsample, tsdownsample_skip = optional_dependencies("tsdownsample")
+from ..utils import tsdownsample_skip
 
 algorithms = _ALGORITHMS.copy()
 algorithms.pop("viewport", None)  # viewport return slice(len(data)) no matter the width

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -26,11 +26,7 @@ from holoviews.operation.element import (
 )
 from holoviews.testing import assert_element_equal
 
-from ..utils import optional_dependencies
-
-mpl, mpl_skip = optional_dependencies("matplotlib")
-da, dask_skip = optional_dependencies("dask.array")
-ibis, ibis_skip = optional_dependencies("ibis")
+from ..utils import da, da_skip, ibis, ibis_skip, mpl_skip
 
 
 class OperationTests:
@@ -539,10 +535,8 @@ class OperationTests:
             np.testing.assert_equal(exp, h.data["xy"])
             assert (h.data["xy_count"] == 5).all()
 
-    @dask_skip
+    @da_skip
     def test_dataset_histogram_dask(self):
-        import dask.array as da
-
         ds = hv.Dataset(
             (da.from_array(np.array(range(10), dtype="f"), chunks=(3)),), ["x"], datatype=["dask"]
         )
@@ -554,10 +548,8 @@ class OperationTests:
         assert isinstance(op_hist.data["x_frequency"], da.Array)
         assert_element_equal(op_hist, hist)
 
-    @dask_skip
+    @da_skip
     def test_dataset_cumulative_histogram_dask(self):
-        import dask.array as da
-
         ds = hv.Dataset(
             (da.from_array(np.array(range(10), dtype="f"), chunks=(3)),), ["x"], datatype=["dask"]
         )
@@ -567,10 +559,8 @@ class OperationTests:
         assert isinstance(op_hist.data["x_frequency"], da.Array)
         assert_element_equal(op_hist, hist)
 
-    @dask_skip
+    @da_skip
     def test_dataset_weighted_histogram_dask(self):
-        import dask.array as da
-
         ds = hv.Dataset(
             (
                 da.from_array(np.array(range(10), dtype="f"), chunks=3),
@@ -1197,7 +1187,7 @@ class TestDendrogramOperation:
         xr = pytest.importorskip("xarray")
 
         N = 10
-        da = xr.DataArray(
+        xda = xr.DataArray(
             rng.normal(size=(N, N)),
             name="main",
             dims=("cluster", "gene"),
@@ -1207,7 +1197,7 @@ class TestDendrogramOperation:
             },
         )
 
-        dendro = dendrogram(hv.Dataset(da), adjoint_dims=adjoint_dims, main_dim="main")
+        dendro = dendrogram(hv.Dataset(xda), adjoint_dims=adjoint_dims, main_dim="main")
         assert isinstance(dendro, hv.AdjointLayout)
 
     def test_failed_linkage(self):

--- a/holoviews/tests/operation/test_statsoperations.py
+++ b/holoviews/tests/operation/test_statsoperations.py
@@ -6,9 +6,7 @@ import holoviews as hv
 from holoviews.operation.stats import bivariate_kde, univariate_kde
 from holoviews.testing import assert_element_equal
 
-from ..utils import optional_dependencies
-
-scipy, scipy_skip = optional_dependencies("scipy")
+from ..utils import scipy_skip
 
 
 @scipy_skip

--- a/holoviews/tests/operation/test_timeseriesoperations.py
+++ b/holoviews/tests/operation/test_timeseriesoperations.py
@@ -8,9 +8,7 @@ import holoviews as hv
 from holoviews.operation.timeseries import resample, rolling, rolling_outlier_std
 from holoviews.testing import assert_element_equal
 
-from ..utils import optional_dependencies
-
-scipy, scipy_skip = optional_dependencies("scipy")
+from ..utils import scipy_skip
 
 
 class TimeseriesOperationTests:

--- a/holoviews/tests/plotting/bokeh/test_violinplot.py
+++ b/holoviews/tests/plotting/bokeh/test_violinplot.py
@@ -8,10 +8,8 @@ from holoviews.operation.stats import univariate_kde
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal
 
-from ...utils import optional_dependencies
+from ...utils import scipy_skip
 from .test_plot import TestBokehPlot, bokeh_renderer
-
-scipy, scipy_skip = optional_dependencies("scipy")
 
 
 @scipy_skip

--- a/holoviews/tests/plotting/matplotlib/test_overlayplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_overlayplot.py
@@ -4,10 +4,9 @@ import numpy as np
 
 import holoviews as hv
 
-from ...utils import LoggingComparison, optional_dependencies
+from ...utils import LoggingComparison, mpl, mpl_skip
 from .test_plot import TestMPLPlot, mpl_renderer
 
-mpl, mpl_skip = optional_dependencies("matplotlib")
 if mpl:
     from holoviews.plotting.mpl import OverlayPlot
 

--- a/holoviews/tests/plotting/matplotlib/test_radialheatmap.py
+++ b/holoviews/tests/plotting/matplotlib/test_radialheatmap.py
@@ -7,10 +7,9 @@ import numpy as np
 import holoviews as hv
 from holoviews.testing import assert_data_equal
 
-from ...utils import optional_dependencies
+from ...utils import mpl, mpl_skip
 from .test_plot import TestMPLPlot, mpl_renderer
 
-mpl, mpl_skip = optional_dependencies("matplotlib")
 if mpl:
     from holoviews.plotting.mpl import RadialHeatMapPlot
 

--- a/holoviews/tests/plotting/plotly/test_distributionplot.py
+++ b/holoviews/tests/plotting/plotly/test_distributionplot.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import holoviews as hv
 
-from ...utils import optional_dependencies
+from ...utils import scipy_skip
 from .test_plot import TestPlotlyPlot
-
-_, scipy_skip = optional_dependencies("scipy")
 
 
 @scipy_skip

--- a/holoviews/tests/plotting/plotly/test_imagestack.py
+++ b/holoviews/tests/plotting/plotly/test_imagestack.py
@@ -5,10 +5,8 @@ import numpy as np
 import holoviews as hv
 from holoviews.plotting.plotly import RGBPlot
 
-from ...utils import optional_dependencies
+from ...utils import ds_skip
 from .test_plot import TestPlotlyPlot, plotly_renderer
-
-ds, ds_skip = optional_dependencies("datashader")
 
 
 @ds_skip

--- a/holoviews/tests/test_selection.py
+++ b/holoviews/tests/test_selection.py
@@ -9,10 +9,8 @@ from holoviews.plotting.util import linear_gradient
 from holoviews.streams import SelectionXY
 from holoviews.testing import assert_data_equal, assert_dict_equal, assert_element_equal
 
-from .utils import optional_dependencies
+from .utils import ds, ds_skip, plotly_skip
 
-plotly, plotly_skip = optional_dependencies("plotly")
-ds, ds_skip = optional_dependencies("datashader")
 if ds:
     from holoviews.operation.datashader import datashade, dynspread
 

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -38,9 +38,7 @@ from holoviews.streams import (
 from holoviews.testing import assert_data_equal, assert_dict_equal, assert_element_equal
 from holoviews.util import Dynamic
 
-from .utils import LoggingComparison, optional_dependencies
-
-_, shapely_skip = optional_dependencies("shapely")
+from .utils import LoggingComparison, shapely_skip
 
 PARAM_GE_2_0_0 = PARAM_VERSION >= (2, 0, 0)
 

--- a/holoviews/tests/util/test_transform.py
+++ b/holoviews/tests/util/test_transform.py
@@ -15,14 +15,7 @@ import pytest
 import holoviews as hv
 from holoviews.testing import assert_element_equal
 
-from ..utils import optional_dependencies
-
-dask, dask_skip = optional_dependencies("dask")
-xr, xr_skip = optional_dependencies("xarray")
-
-if dask:
-    import dask.array as da
-    import dask.dataframe as dd
+from ..utils import da, dask, dd, xr, xr_skip
 
 dask_conversion_warning = pytest.mark.filterwarnings(
     "ignore:Dask currently has limited support for converting pandas extension dtypes to arrays:UserWarning"

--- a/holoviews/tests/util/test_utils.py
+++ b/holoviews/tests/util/test_utils.py
@@ -11,12 +11,9 @@ from holoviews.core.options import OptionTree
 from holoviews.plotting import bokeh
 from holoviews.util import OutputSettings
 
-from ..utils import LoggingComparison, optional_dependencies
+from ..utils import LoggingComparison, mpl_skip, notebook_skip
 
 BACKENDS = ["matplotlib", "bokeh"]
-
-_, notebook_skip = optional_dependencies("notebook")
-_, mpl_skip = optional_dependencies("matplotlib")
 
 
 @mpl_skip

--- a/holoviews/tests/utils.py
+++ b/holoviews/tests/utils.py
@@ -4,37 +4,13 @@ import importlib
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING
 
 import param
 import pytest
 
 from holoviews.core.util.dependencies import _is_installed
 from holoviews.util.warnings import deprecated
-
-if TYPE_CHECKING:
-    from types import ModuleType
-
-    import dask
-    import dask.array as da
-    import dask.dataframe as dd
-    import datashader
-    import ibis
-    import matplotlib as mpl
-    import networkx as nx
-    import notebook
-    import plotly
-    import polars as pl
-    import pyparsing
-    import scipy
-    import shapely
-    import spatialpandas
-    import tsdownsample
-    import xarray
-    from _pytest.mark.structures import MarkDecorator
-    from ty_extensions import TypeOf
-
-    MaybeModuleType = ModuleType | None
 
 cwd = os.path.abspath(os.path.split(__file__)[0])
 sys.path.insert(0, os.path.join(cwd, ".."))
@@ -204,90 +180,60 @@ class LoggingComparison:
                     log.log(LEVELS[level], msg)
 
 
-@overload
-def optional_dependencies(name: Literal["scipy"], /) -> tuple[TypeOf[scipy], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(name: Literal["ibis"], /) -> tuple[TypeOf[ibis], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(name: Literal["dask"], /) -> tuple[TypeOf[dask], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(name: Literal["dask.array"], /) -> tuple[TypeOf[da], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(
-    name: Literal["dask.dataframe"], /
-) -> tuple[TypeOf[dd], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(
-    name: Literal["datashader"], /
-) -> tuple[TypeOf[datashader], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(name: Literal["matplotlib"], /) -> tuple[TypeOf[mpl], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(name: Literal["networkx"], /) -> tuple[TypeOf[nx], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(
-    name: Literal["notebook"], /
-) -> tuple[TypeOf[notebook], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(name: Literal["plotly"], /) -> tuple[TypeOf[plotly], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(
-    name: Literal["pyparsing"], /
-) -> tuple[TypeOf[pyparsing], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(
-    name: Literal["shapely"], /
-) -> tuple[TypeOf[shapely], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(
-    name: Literal["spatialpandas"], /
-) -> tuple[TypeOf[spatialpandas], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(
-    name: Literal["tsdownsample"], /
-) -> tuple[TypeOf[tsdownsample], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(name: Literal["xarray"], /) -> tuple[TypeOf[xarray], MarkDecorator]: ...
-
-
-@overload
-def optional_dependencies(name: Literal["polars"], /) -> tuple[TypeOf[pl], MarkDecorator]: ...
-
-
-def optional_dependencies(name: str, /) -> tuple[MaybeModuleType, MarkDecorator]:
+def optional_dependencies(name: str):
     """Check if a dependency is installed and return the module and a fixture that skips test."""
     if _is_installed(name):
-        module = importlib.import_module(name)
-    else:
-        module = None
+        return importlib.import_module(name)
 
-    fixture = pytest.mark.skipif(module is None, reason=f"{name} is not installed")
-    return module, fixture
+
+if TYPE_CHECKING:
+    import dask
+    import dask.array as da
+    import dask.dataframe as dd
+    import datashader as ds
+    import ibis
+    import matplotlib as mpl
+    import networkx as nx
+    import notebook
+    import plotly
+    import polars as pl
+    import scipy
+    import shapely
+    import spatialpandas as spd
+    import tsdownsample
+    import xarray as xr
+else:
+    dask = optional_dependencies("dask")
+    da = optional_dependencies("dask.array")
+    dd = optional_dependencies("dask.dataframe")
+    ds = optional_dependencies("datashader")
+    ibis = optional_dependencies("ibis")
+    mpl = optional_dependencies("matplotlib")
+    nx = optional_dependencies("networkx")
+    notebook = optional_dependencies("notebook")
+    plotly = optional_dependencies("plotly")
+    pl = optional_dependencies("polars")
+    scipy = optional_dependencies("scipy")
+    shapely = optional_dependencies("shapely")
+    spd = optional_dependencies("spatialpandas")
+    tsdownsample = optional_dependencies("tsdownsample")
+    xr = optional_dependencies("xarray")
+
+
+dask_skip = pytest.mark.skipif(dask is None, reason="dask is not installed")
+da_skip = pytest.mark.skipif(da is None, reason="dask.array is not installed")
+dd_skip = pytest.mark.skipif(dd is None, reason="dask.dataframe is not installed")
+ds_skip = pytest.mark.skipif(ds is None, reason="datashader is not installed")
+ibis_skip = pytest.mark.skipif(ibis is None, reason="ibis is not installed")
+mpl_skip = pytest.mark.skipif(mpl is None, reason="matplotlib is not installed")
+nx_skip = pytest.mark.skipif(nx is None, reason="networkx is not installed")
+notebook_skip = pytest.mark.skipif(notebook is None, reason="notebook is not installed")
+plotly_skip = pytest.mark.skipif(plotly is None, reason="plotly is not installed")
+pl_skip = pytest.mark.skipif(pl is None, reason="polars is not installed")
+scipy_skip = pytest.mark.skipif(scipy is None, reason="scipy is not installed")
+shapely_skip = pytest.mark.skipif(shapely is None, reason="shapely is not installed")
+spd_skip = pytest.mark.skipif(spd is None, reason="spatialpandas is not installed")
+tsdownsample_skip = pytest.mark.skipif(
+    tsdownsample is None, reason="tsdownsample is not installed"
+)
+xr_skip = pytest.mark.skipif(xr is None, reason="xarray is not installed")

--- a/holoviews/tests/utils.py
+++ b/holoviews/tests/utils.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     import networkx as nx
     import notebook
     import plotly
+    import polars as pl
     import pyparsing
     import scipy
     import shapely
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
     import tsdownsample
     import xarray
     from _pytest.mark.structures import MarkDecorator
+    from ty_extensions import TypeOf
 
     MaybeModuleType = ModuleType | None
 
@@ -203,72 +205,86 @@ class LoggingComparison:
 
 
 @overload
-def optional_dependencies(name: Literal["scipy"], /) -> tuple[scipy, MarkDecorator]: ...
+def optional_dependencies(name: Literal["scipy"], /) -> tuple[TypeOf[scipy], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["ibis"], /) -> tuple[ibis, MarkDecorator]: ...
+def optional_dependencies(name: Literal["ibis"], /) -> tuple[TypeOf[ibis], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["dask"], /) -> tuple[dask, MarkDecorator]: ...
+def optional_dependencies(name: Literal["dask"], /) -> tuple[TypeOf[dask], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["dask.array"], /) -> tuple[da, MarkDecorator]: ...
+def optional_dependencies(name: Literal["dask.array"], /) -> tuple[TypeOf[da], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["dask.dataframe"], /) -> tuple[dd, MarkDecorator]: ...
+def optional_dependencies(
+    name: Literal["dask.dataframe"], /
+) -> tuple[TypeOf[dd], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["datashader"], /) -> tuple[datashader, MarkDecorator]: ...
+def optional_dependencies(
+    name: Literal["datashader"], /
+) -> tuple[TypeOf[datashader], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["matplotlib"], /) -> tuple[mpl, MarkDecorator]: ...
+def optional_dependencies(name: Literal["matplotlib"], /) -> tuple[TypeOf[mpl], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["networkx"], /) -> tuple[nx, MarkDecorator]: ...
+def optional_dependencies(name: Literal["networkx"], /) -> tuple[TypeOf[nx], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["notebook"], /) -> tuple[notebook, MarkDecorator]: ...
+def optional_dependencies(
+    name: Literal["notebook"], /
+) -> tuple[TypeOf[notebook], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["plotly"], /) -> tuple[plotly, MarkDecorator]: ...
+def optional_dependencies(name: Literal["plotly"], /) -> tuple[TypeOf[plotly], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["pyparsing"], /) -> tuple[pyparsing, MarkDecorator]: ...
+def optional_dependencies(
+    name: Literal["pyparsing"], /
+) -> tuple[TypeOf[pyparsing], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["shapely"], /) -> tuple[shapely, MarkDecorator]: ...
+def optional_dependencies(
+    name: Literal["shapely"], /
+) -> tuple[TypeOf[shapely], MarkDecorator]: ...
 
 
 @overload
 def optional_dependencies(
     name: Literal["spatialpandas"], /
-) -> tuple[spatialpandas, MarkDecorator]: ...
+) -> tuple[TypeOf[spatialpandas], MarkDecorator]: ...
 
 
 @overload
 def optional_dependencies(
     name: Literal["tsdownsample"], /
-) -> tuple[tsdownsample, MarkDecorator]: ...
+) -> tuple[TypeOf[tsdownsample], MarkDecorator]: ...
 
 
 @overload
-def optional_dependencies(name: Literal["xarray"], /) -> tuple[xarray, MarkDecorator]: ...
+def optional_dependencies(name: Literal["xarray"], /) -> tuple[TypeOf[xarray], MarkDecorator]: ...
+
+
+@overload
+def optional_dependencies(name: Literal["polars"], /) -> tuple[TypeOf[pl], MarkDecorator]: ...
 
 
 def optional_dependencies(name: str, /) -> tuple[MaybeModuleType, MarkDecorator]:
     """Check if a dependency is installed and return the module and a fixture that skips test."""
-    if _is_installed(name):
+    if _is_installed(name) or TYPE_CHECKING:
         module = importlib.import_module(name)
     else:
         module = None

--- a/holoviews/tests/utils.py
+++ b/holoviews/tests/utils.py
@@ -284,7 +284,7 @@ def optional_dependencies(name: Literal["polars"], /) -> tuple[TypeOf[pl], MarkD
 
 def optional_dependencies(name: str, /) -> tuple[MaybeModuleType, MarkDecorator]:
     """Check if a dependency is installed and return the module and a fixture that skips test."""
-    if _is_installed(name) or TYPE_CHECKING:
+    if _is_installed(name):
         module = importlib.import_module(name)
     else:
         module = None

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -719,17 +719,18 @@ class extension(_pyviz_extension):
 
     _loaded = False
 
-    if t.TYPE_CHECKING:
-        # Can be removed when pyviz_comms support typing
-        def __init__(
-            self, backend: t.Literal["bokeh", "matplotlib", "plotly"], *args, **params
-        ) -> None: ...
+    def __new__(
+        cls,
+        *backends: t.Literal["bokeh", "matplotlib", "plotly"],
+        **kwargs,
+    ) -> t.Any:
+        return super().__new__(cls, *backends, **kwargs)
 
-    def __call__(self, *args, **params):
+    def __call__(self, *backends, **params):
         # Get requested backends
         config = params.pop("config", {})
         util.config.param.update(**config)
-        imports = [(arg, self._backends[arg]) for arg in args if arg in self._backends]
+        imports = [(b, self._backends[b]) for b in backends if b in self._backends]
         for p, _val in sorted(params.items()):
             if p in self._backends:
                 imports.append((p, self._backends[p]))
@@ -740,7 +741,6 @@ class extension(_pyviz_extension):
             )
             raise TypeError(msg)
 
-        args = list(args)
         selected_backend = None
         for backend, imp in imports:
             try:

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -30,6 +30,8 @@ from .settings import OutputSettings, list_backends, list_formats
 
 Store.output_settings = OutputSettings
 
+_BackendT: t.TypeAlias = t.Literal["bokeh", "matplotlib", "plotly"]
+
 _STR_OPTIONS_ERR = (
     "String-based options specification is no longer supported. "
     "Use dictionary or option objects instead."
@@ -675,7 +677,7 @@ output.__doc__ = Store.output_settings._generate_docstring(signature=False)
 output.__init__.__signature__ = Store.output_settings._generate_signature()  # ty:ignore[unresolved-attribute]
 
 
-def renderer(name: t.Literal["bokeh", "matplotlib", "plotly"]):
+def renderer(name: _BackendT):
     """Helper utility to access the active renderer for a given extension."""
     try:
         if name not in Store.renderers:
@@ -719,11 +721,7 @@ class extension(_pyviz_extension):
 
     _loaded = False
 
-    def __new__(
-        cls,
-        *backends: t.Literal["bokeh", "matplotlib", "plotly"],
-        **kwargs,
-    ) -> t.Any:
+    def __new__(cls, *backends: _BackendT, **kwargs) -> t.Any:
         return super().__new__(cls, *backends, **kwargs)
 
     def __call__(self, *backends, **params):
@@ -889,7 +887,7 @@ def save(
     return renderer_obj.save(obj, filename, fmt=fmt, resources=resources, title=title)
 
 
-def render(obj, backend=None, **kwargs):
+def render(obj, backend: _BackendT | None = None, **kwargs):
     """Renders the HoloViews object to the corresponding object in the
     specified backend, e.g. a Matplotlib or Bokeh figure.
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -2,6 +2,7 @@ import inspect
 import os
 import shutil
 import sys
+import typing as t
 from collections import defaultdict
 from inspect import Parameter, Signature
 from pathlib import Path
@@ -59,7 +60,7 @@ class OptsMeta(param.parameterized.ParameterizedMetaclass):
 
     def __getattr__(self, attr):
         try:
-            return super().__getattr__(attr)
+            return super().__getattr__(attr)  # ty:ignore[unresolved-attribute]
         except AttributeError:
             msg = (
                 f"No entry for {attr!r} registered; this name may not refer to a valid object "
@@ -532,7 +533,7 @@ class opts(param.ParameterizedFunction, metaclass=OptsMeta):
             [Parameter("spec", Parameter.POSITIONAL_OR_KEYWORD)]
             + [Parameter(kw, Parameter.KEYWORD_ONLY) for kw in sorted_kw_set]
         )
-        builder.__signature__ = signature
+        builder.__signature__ = signature  # ty:ignore[unresolved-attribute]
         return classmethod(builder)
 
     @classmethod
@@ -576,7 +577,7 @@ class opts(param.ParameterizedFunction, metaclass=OptsMeta):
             [Parameter("args", Parameter.VAR_POSITIONAL)]
             + [Parameter(kw, Parameter.KEYWORD_ONLY) for kw in sorted_kw_set]
         )
-        cls.__init__.__signature__ = signature
+        cls.__init__.__signature__ = signature  # ty:ignore[unresolved-attribute]
 
 
 Store._backend_switch_hooks.append(opts._update_backend)
@@ -671,10 +672,10 @@ class output(param.ParameterizedFunction):
 
 
 output.__doc__ = Store.output_settings._generate_docstring(signature=False)
-output.__init__.__signature__ = Store.output_settings._generate_signature()
+output.__init__.__signature__ = Store.output_settings._generate_signature()  # ty:ignore[unresolved-attribute]
 
 
-def renderer(name):
+def renderer(name: t.Literal["bokeh", "matplotlib", "plotly"]):
     """Helper utility to access the active renderer for a given extension."""
     try:
         if name not in Store.renderers:
@@ -717,6 +718,12 @@ class extension(_pyviz_extension):
     _backend_hooks = defaultdict(list)
 
     _loaded = False
+
+    if t.TYPE_CHECKING:
+        # Can be removed when pyviz_comms support typing
+        def __init__(
+            self, backend: t.Literal["bokeh", "matplotlib", "plotly"], *args, **params
+        ) -> None: ...
 
     def __call__(self, *args, **params):
         # Get requested backends
@@ -780,11 +787,11 @@ class extension(_pyviz_extension):
 
         if pn.config.comms == "default":
             if "google.colab" in sys.modules:
-                pn.config.comms = "colab"
+                pn.config.comms = "colab"  # ty:ignore[invalid-assignment]
                 return
 
             if "VSCODE_CWD" in os.environ or "VSCODE_PID" in os.environ:
-                pn.config.comms = "vscode"
+                pn.config.comms = "vscode"  # ty:ignore[invalid-assignment]
                 self._ignore_bokeh_warnings()
                 return
 
@@ -1162,11 +1169,11 @@ class Dynamic(param.ParameterizedFunction):
             if isinstance(hmap, Overlay):
                 dmap.callback.inputs[:] = list(hmap)
             return dmap
-        dim_values = zip(*hmap.data.keys(), strict=None)
+        dim_values = zip(*hmap.data.keys(), strict=True)
         params = util.get_param_values(hmap)
         kdims = [
             d.clone(values=list(util.unique_iterator(values)))
-            for d, values in zip(hmap.kdims, dim_values, strict=None)
+            for d, values in zip(hmap.kdims, dim_values, strict=False)
         ]
         return DynamicMap(dynamic_fn, streams=streams, **dict(params, kdims=kdims))
 

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import typing as t
 from collections import defaultdict
 
 from ..core import Store
+
+if t.TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class KeywordSettings:
@@ -82,7 +86,6 @@ class KeywordSettings:
         unprocessed = list(reversed(line.split("=")))
         while unprocessed:
             chunk = unprocessed.pop()
-            key = None
             if chunk.strip() in cls.allowed:
                 key = chunk.strip()
             else:
@@ -480,7 +483,7 @@ class OutputSettings(KeywordSettings):
         # Switch format if mode does not allow it
         for p in ["fig", "holomap"]:
             if backend_options.get(p) not in cls.allowed[p]:
-                backend_options[p] = cls.allowed[p][0]
+                backend_options[p] = t.cast("Sequence", cls.allowed[p])[0]
 
         # Ensure backend and mode are set
         backend_options["backend"] = backend_spec

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import operator
+import typing as t
 from types import BuiltinFunctionType, BuiltinMethodType, FunctionType, MethodType
 
 import narwhals.stable.v2 as nw
@@ -10,6 +11,14 @@ import param
 from ..core.data import PandasInterface
 from ..core.dimension import Dimension
 from ..core.util import dtype_kind, flatten, resolve_dependent_value, unique_iterator
+
+if t.TYPE_CHECKING:
+
+    class _OpT(t.TypedDict):
+        args: tuple
+        fn: t.Any
+        kwargs: dict
+        reverse: bool
 
 
 def _maybe_map(numpy_fn):
@@ -150,7 +159,7 @@ def bin(values, bins, labels=None):
         labels = np.asarray(labels)
     dtype = "float" if dtype_kind(labels) == "f" else "O"
     binned = np.full_like(values, (np.nan if dtype == "f" else None), dtype=dtype)
-    for lower, upper, label in zip(bins[:-1], bins[1:], labels, strict=None):
+    for lower, upper, label in zip(bins[:-1], bins[1:], labels, strict=True):
         condition = (values > lower) & (values <= upper)
         binned[np.where(condition)[0]] = label
     return binned
@@ -290,7 +299,7 @@ class dim:
     def __init__(self, obj, *args, **kwargs):
         from panel.widgets import Widget
 
-        self.ops = []
+        self.ops: list[_OpT] = []
         self._ns = np.ndarray
         self.coerce = kwargs.get("coerce", True)
         if isinstance(obj, (str, tuple)):
@@ -303,7 +312,7 @@ class dim:
             self.dimension = obj.param.value
         else:
             self.dimension = obj.dimension
-            self.ops = obj.ops
+            self.ops = t.cast("list[_OpT]", obj.ops)
         if args:
             fn = args[0]
         else:
@@ -314,15 +323,13 @@ class dim:
                 or any(fn in funcs for funcs in self._all_funcs)
             ):
                 raise ValueError(f"Second argument must be a function, found {type(fn)} type")
-            self.ops = [
-                *self.ops,
-                {
-                    "args": args[1:],
-                    "fn": fn,
-                    "kwargs": kwargs,
-                    "reverse": kwargs.pop("reverse", False),
-                },
-            ]
+            op: _OpT = {
+                "args": args[1:],
+                "fn": fn,
+                "kwargs": kwargs,
+                "reverse": kwargs.pop("reverse", False),
+            }
+            self.ops = [*self.ops, op]
 
     def __getstate__(self):
         return self.__dict__
@@ -349,9 +356,9 @@ class dim:
             )
         op = self.ops[-1]
         if op["fn"] == "str":
-            new_op = dict(op, fn=astype, args=(str,), kwargs={})
+            new_op = {**op, "fn": astype, "args": (str,), "kwargs": {}}
         else:
-            new_op = dict(op, args=args, kwargs=kwargs)
+            new_op = {**op, "args": args, "kwargs": kwargs}
         return self.clone(self.dimension, [*self.ops[:-1], new_op])
 
     def __getattribute__(self, attr):
@@ -491,9 +498,6 @@ class dim:
     def __and__(self, other):
         return type(self)(self, operator.and_, other)
 
-    def __div__(self, other):
-        return type(self)(self, operator.div, other)
-
     def __eq__(self, other):
         return type(self)(self, operator.eq, other)
 
@@ -546,14 +550,8 @@ class dim:
     def __rand__(self, other):
         return type(self)(self, operator.and_, other)
 
-    def __rdiv__(self, other):
-        return type(self)(self, operator.div, other, reverse=True)
-
     def __rfloordiv__(self, other):
         return type(self)(self, operator.floordiv, other, reverse=True)
-
-    def __rlshift__(self, other):
-        return type(self)(self, operator.rlshift, other)
 
     def __rmod__(self, other):
         return type(self)(self, operator.mod, other, reverse=True)
@@ -566,9 +564,6 @@ class dim:
 
     def __rpow__(self, other):
         return type(self)(self, operator.pow, other, reverse=True)
-
-    def __rrshift__(self, other):
-        return type(self)(self, operator.rrshift, other)
 
     def __rsub__(self, other):
         return type(self)(self, operator.sub, other, reverse=True)
@@ -1116,16 +1111,19 @@ class df_dim(dim):
             return data.to_numpy()
         return data.values
 
-    def _coerce(self, dataset):
-        if self.interface_applies(dataset, coerce=False):
-            return dataset
-        pandas_interfaces = param.concrete_descendents(PandasInterface)
+    def _coerce(self, data):
+        if self.interface_applies(data, coerce=False):
+            return data
+        pandas_interfaces = t.cast(
+            "dict[str, type[PandasInterface]]",
+            param.concrete_descendents(parentclass=PandasInterface),
+        )
         datatypes = [
             intfc.datatype
             for intfc in pandas_interfaces.values()
-            if dataset.interface.multi == intfc.multi
+            if data.interface.multi == intfc.multi
         ]
-        return dataset.clone(datatype=datatypes)
+        return data.clone(datatype=datatypes)
 
     @property
     def loc(self):
@@ -1163,10 +1161,10 @@ class xr_dim(dim):
             data = data.compute()
         return data
 
-    def _coerce(self, dataset):
-        if self.interface_applies(dataset, coerce=False):
-            return dataset
-        return dataset.clone(datatype=["xarray"])
+    def _coerce(self, data):
+        if self.interface_applies(data, coerce=False):
+            return data
+        return data.clone(datatype=["xarray"])
 
 
 def lon_lat_to_easting_northing(longitude, latitude):

--- a/holoviews/util/warnings.py
+++ b/holoviews/util/warnings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import os
 import sys
+import typing as t
 import warnings
 
 import param
@@ -43,7 +44,7 @@ def find_stack_level():
     )
 
     if ipc := sys.modules.get("IPython.core"):
-        ignore_paths = (*ignore_paths, os.path.dirname(ipc.__file__))
+        ignore_paths = (*ignore_paths, os.path.dirname(t.cast("str", ipc.__file__)))
 
     frame = inspect.currentframe()
     try:
@@ -71,9 +72,7 @@ def deprecated(remove_version, old, new=None, extra=None, *, repr_old=True, repr
     if isinstance(remove_version, str):
         remove_version = Version(remove_version)
 
-    if remove_version <= current_version and not (
-        full_version.is_prerelease and full_version.pre[0] == "a"
-    ):
+    if remove_version <= current_version and not (full_version.pre and full_version.pre[0] == "a"):
         # This error is mainly for developers to remove the deprecated.
         raise ValueError(
             f"{old!r} should have been removed in {remove_version}, current version {current_version}."

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,6 +14,7 @@ default = [
     "test-ui",
     "lint",
     "dev",
+    "type",
 ]
 
 [environments.test-310]
@@ -58,6 +59,10 @@ no-default-feature = true
 
 [environments.lint]
 features = ["lint"]
+no-default-feature = true
+
+[environments.type]
+features = ["required", "py310", "optional", "test-core", "type"]
 no-default-feature = true
 
 [feature.required.dependencies]
@@ -278,3 +283,13 @@ pre-commit = "*"
 [feature.lint.tasks]
 lint = 'pre-commit run --all-files'
 lint-install = 'pre-commit install'
+
+# =============================================
+# =================== TYPE ====================
+# =============================================
+[feature.type.dependencies]
+ty = "*"
+param = ">=2.4.0a0"
+
+[feature.type.tasks]
+type-ty = 'ty check .'

--- a/pixi.toml
+++ b/pixi.toml
@@ -290,6 +290,7 @@ lint-install = 'pre-commit install'
 [feature.type.dependencies]
 ty = "*"
 param = ">=2.4.0a0"
+pandas-stubs = "*"
 
 [feature.type-task.tasks]
 type-ty = 'ty check .'

--- a/pixi.toml
+++ b/pixi.toml
@@ -288,8 +288,7 @@ lint-install = 'pre-commit install'
 # =================== TYPE ====================
 # =============================================
 [feature.type.dependencies]
-ty = "==0.0.31"
-param = "==2.4.0a1"
+ty = "==0.0.32"
 pandas-stubs = "*"
 typing-extensions = "*"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -291,6 +291,7 @@ lint-install = 'pre-commit install'
 ty = "==0.0.32"
 pandas-stubs = "*"
 typing-extensions = "*"
+param = "==2.4.0rc1" # >=2.4.0
 
 [feature.type-task.tasks]
 type-ty = 'ty check .'

--- a/pixi.toml
+++ b/pixi.toml
@@ -288,7 +288,7 @@ lint-install = 'pre-commit install'
 # =================== TYPE ====================
 # =============================================
 [feature.type.dependencies]
-ty = "==0.0.31"
+ty = "==0.0.32"
 pandas-stubs = "*"
 typing-extensions = "*"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -288,8 +288,8 @@ lint-install = 'pre-commit install'
 # =================== TYPE ====================
 # =============================================
 [feature.type.dependencies]
-ty = "*"
-param = ">=2.4.0a0"
+ty = "==0.0.30"
+param = "==2.4.0a1"
 pandas-stubs = "*"
 
 [feature.type-task.tasks]

--- a/pixi.toml
+++ b/pixi.toml
@@ -62,7 +62,7 @@ features = ["lint"]
 no-default-feature = true
 
 [environments.type]
-features = ["required", "py310", "optional", "test-core", "type"]
+features = ["required", "py310", "optional", "test-core", "type", "type-task"]
 no-default-feature = true
 
 [feature.required.dependencies]
@@ -291,5 +291,5 @@ lint-install = 'pre-commit install'
 ty = "*"
 param = ">=2.4.0a0"
 
-[feature.type.tasks]
+[feature.type-task.tasks]
 type-ty = 'ty check .'

--- a/pixi.toml
+++ b/pixi.toml
@@ -288,9 +288,10 @@ lint-install = 'pre-commit install'
 # =================== TYPE ====================
 # =============================================
 [feature.type.dependencies]
-ty = "==0.0.30"
+ty = "==0.0.31"
 param = "==2.4.0a1"
 pandas-stubs = "*"
+typing-extensions = "*"
 
 [feature.type-task.tasks]
 type-ty = 'ty check .'

--- a/pixi.toml
+++ b/pixi.toml
@@ -288,7 +288,7 @@ lint-install = 'pre-commit install'
 # =================== TYPE ====================
 # =============================================
 [feature.type.dependencies]
-ty = "==0.0.32"
+ty = "==0.0.31"
 pandas-stubs = "*"
 typing-extensions = "*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,6 @@ include = [
 exclude = [
     "holoviews/*version.py",
     "holoviews/core/dimension.py", # 21
-    "holoviews/core/element.py", # 13
     "holoviews/core/ndmapping.py", # 21
     "holoviews/core/spaces.py", # 28
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,17 @@ typing = "t"
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
+[tool.ty.src]
+include = ["holoviews/*.py", "holoviews/core/util/dependencies.py", "holoviews/core/util/types.py"]
+exclude = [
+    "holoviews/*version.py",
+    "holoviews/annotators.py", # TODO
+    "holoviews/selection.py", # TODO
+]
+
+[tool.ty.rules]
+unresolved-import = "ignore"
+
 [tool.typos.default]
 extend-ignore-re = [
     ".*(?:#|--|//|/*).*(?:typos):\\s?ignore[^\\n]*\\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,7 @@ include = [
     "holoviews/util/*.py",
     "holoviews/core/util/dependencies.py",
     "holoviews/core/util/types.py",
+    "scripts/*.py",
 ]
 exclude = ["holoviews/*version.py"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,6 @@ convention = "numpy"
 include = ["holoviews/*.py", "holoviews/core/util/dependencies.py", "holoviews/core/util/types.py"]
 exclude = [
     "holoviews/*version.py",
-    "holoviews/annotators.py", # TODO
     "holoviews/selection.py", # TODO
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,10 +244,7 @@ convention = "numpy"
 
 [tool.ty.src]
 include = ["holoviews/*.py", "holoviews/core/util/dependencies.py", "holoviews/core/util/types.py"]
-exclude = [
-    "holoviews/*version.py",
-    "holoviews/selection.py", # TODO
-]
+exclude = ["holoviews/*version.py"]
 
 [tool.ty.rules]
 unresolved-import = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,10 +250,7 @@ include = [
     "holoviews/util/*.py",
     "scripts/*.py",
 ]
-exclude = [
-    "holoviews/*version.py",
-    "holoviews/core/dimension.py", # 21
-]
+exclude = ["holoviews/*version.py"]
 
 [tool.ty.rules]
 unresolved-import = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,7 +254,6 @@ exclude = [
     "holoviews/*version.py",
     "holoviews/core/dimension.py", # 21
     "holoviews/core/element.py", # 13
-    "holoviews/core/io.py", # 10
     "holoviews/core/ndmapping.py", # 21
     "holoviews/core/options.py", # 13
     "holoviews/core/overlay.py", # 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,6 @@ exclude = [
     "holoviews/core/ndmapping.py", # 21
     "holoviews/core/options.py", # 13
     "holoviews/core/spaces.py", # 28
-    "holoviews/core/traversal.py", # 14
 ]
 
 [tool.ty.rules]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,6 @@ exclude = [
     "holoviews/core/element.py", # 13
     "holoviews/core/ndmapping.py", # 21
     "holoviews/core/options.py", # 13
-    "holoviews/core/overlay.py", # 7
     "holoviews/core/spaces.py", # 28
     "holoviews/core/traversal.py", # 14
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,8 +243,24 @@ typing = "t"
 convention = "numpy"
 
 [tool.ty.src]
-include = ["holoviews/*.py", "holoviews/core/util/*.py", "holoviews/util/*.py", "scripts/*.py"]
-exclude = ["holoviews/*version.py"]
+include = [
+    "holoviews/*.py",
+    "holoviews/core/*.py",
+    "holoviews/core/util/*.py",
+    "holoviews/util/*.py",
+    "scripts/*.py",
+]
+exclude = [
+    "holoviews/*version.py",
+    "holoviews/core/dimension.py", # 21
+    "holoviews/core/element.py", # 13
+    "holoviews/core/io.py", # 10
+    "holoviews/core/ndmapping.py", # 21
+    "holoviews/core/options.py", # 13
+    "holoviews/core/overlay.py", # 7
+    "holoviews/core/spaces.py", # 28
+    "holoviews/core/traversal.py", # 14
+]
 
 [tool.ty.rules]
 unresolved-import = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,7 +255,6 @@ exclude = [
     "holoviews/core/dimension.py", # 21
     "holoviews/core/element.py", # 13
     "holoviews/core/ndmapping.py", # 21
-    "holoviews/core/options.py", # 13
     "holoviews/core/spaces.py", # 28
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,6 @@ include = [
 exclude = [
     "holoviews/*version.py",
     "holoviews/core/dimension.py", # 21
-    "holoviews/core/ndmapping.py", # 21
     "holoviews/core/spaces.py", # 28
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,6 @@ include = [
 exclude = [
     "holoviews/*version.py",
     "holoviews/core/dimension.py", # 21
-    "holoviews/core/spaces.py", # 28
 ]
 
 [tool.ty.rules]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,13 +243,7 @@ typing = "t"
 convention = "numpy"
 
 [tool.ty.src]
-include = [
-    "holoviews/*.py",
-    "holoviews/util/*.py",
-    "holoviews/core/util/dependencies.py",
-    "holoviews/core/util/types.py",
-    "scripts/*.py",
-]
+include = ["holoviews/*.py", "holoviews/core/util/*.py", "holoviews/util/*.py", "scripts/*.py"]
 exclude = ["holoviews/*version.py"]
 
 [tool.ty.rules]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,12 @@ typing = "t"
 convention = "numpy"
 
 [tool.ty.src]
-include = ["holoviews/*.py", "holoviews/core/util/dependencies.py", "holoviews/core/util/types.py"]
+include = [
+    "holoviews/*.py",
+    "holoviews/util/*.py",
+    "holoviews/core/util/dependencies.py",
+    "holoviews/core/util/types.py",
+]
 exclude = ["holoviews/*version.py"]
 
 [tool.ty.rules]

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -22,7 +22,7 @@ def retry(func, *args, **kwargs):
 if Version(bokeh.__version__).release < (3, 5, 0):
     import bokeh.sampledata
 
-    retry(bokeh.sampledata.download)
+    retry(bokeh.sampledata.download)  # ty:ignore[unresolved-attribute]
     print("Downloaded bokeh sampledata")
 
 with suppress(ImportError):


### PR DESCRIPTION
## Description

With param now having type hints. I want to start adding it to HoloViews. I have chosen to start soft by only using `TY` and starting with a small number files, this is done to avoid having one big PR and never having it merged.

The files I chosen for is defined in `pyproject.toml` and copied below for convenience: 

``` toml
[tool.ty.src]
include = [
    "holoviews/*.py",
    "holoviews/core/*.py",
    "holoviews/core/util/*.py",
    "holoviews/util/*.py",
    "scripts/*.py",
]
exclude = ["holoviews/*version.py"]
```


Most of the changes are related to tree things:

- Liskov substitution principle
- `zip(..., strict=None)` which I set to avoid enable linting rule on new code, but is flagged with type checking. Have tried my best to set `strict=True` but if in doubt I have used `False`
- Optional imports both in the codebase and in tests, where we now define them in one file to avoid a lot of the boilerplate needed for type checker. For codebase it is in `holoviews/core/util/dependencies.py` and for tests it is `holoviews/tests/utils.py`.

Resolves #6653

## How Has This Been Tested?

CI + Locally
## Checklist

<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format


<!--
Conventional format: <Type>(<Scope>): <Subject>
Valid Types: `build`, `chore`, `ci`, `compat`, `docs`, `enh`, `feat`, `fix`, `perf`, `refactor`, `test`, and `type`
Valid Scopes (optional): `dev`, `data`, `plotting`, `bokeh`, `matplotlib`, `plotly`, and `notebook`

For more information on how to contribute to this repository, see the [developer guide](https://www.holoviews.org/developer_guide/index.html)
-->
