### PR TITLE
docs: import panel in Flask + Bokeh deployment example

### DIFF
--- a/examples/user_guide/Deploying_Bokeh_Apps.ipynb
+++ b/examples/user_guide/Deploying_Bokeh_Apps.ipynb
@@ -643,6 +643,8 @@
     "from flask import Flask, render_template\n",
     "from flask import send_from_directory\n",
     "\n",
+    "import panel  # registers panel models with bokeh so server_session() can deserialize them\n",
+    "\n",
     "app = Flask(__name__)\n",
     "\n",
     "# locally creates a page\n",


### PR DESCRIPTION
## Description

The Combining Bokeh Application and Flask Application example in the Deploying Bokeh Apps user guide gives a runnable `flaskApp.py` that fails the moment Panel renders a HoloViews `DynamicMap`:

```
bokeh.core.serialization.DeserializationError: can't resolve type 'panel.models.browser.BrowserInfo'
```

`pn.serve(...)` adds Panel-specific models (e.g. `panel.models.browser.BrowserInfo`) to the document, but `flaskApp.py` only imports from `bokeh.client` / `bokeh.embed` / `flask`, so when `pull_session(...)` deserializes the session those types aren't registered with bokeh and the request 500s.

In #6041 philippjfr identified two fixes, including that "the HoloViews docs should be updated to include `import panel`." Importing `panel` registers its bokeh model classes so `pull_session` / `server_session` can deserialize them on the Flask side. This PR adds that single `import panel` line to the `flaskApp.py` block in `examples/user_guide/Deploying_Bokeh_Apps.ipynb`, with a short comment explaining why the import is there even though the symbol isn't otherwise referenced (so a linter or a curious reader doesn't strip it).

Fixes #6041

## How Has This Been Tested?

This is a single import-line addition to a Python code block inside a markdown cell of a `.ipynb` that the docs build skips (`:skip_execute: True` in `doc/user_guide/Deploying_Bokeh_Apps.rst`), so the change has no runtime effect on `nbsite`/Sphinx output beyond rendering the extra line. I verified:

- `python -c "import json; json.load(open('examples/user_guide/Deploying_Bokeh_Apps.ipynb'))"` still parses the notebook cleanly.
- The diff is a 2-line insert inside the `flaskApp.py` markdown code block and does not touch any other cell, executed code, or metadata.

I did not stand up the full Flask + Bokeh + Panel stack locally to re-run the original repro; the maintainer comment on #6041 already established that `import panel` is the docs-side fix. If you'd prefer the docs to also include `import panel.models.browser` (the full workaround philippjfr suggested for users hitting the error today), happy to add it in a fixup commit.

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

Tools and Models: Claude Code + Opus 4.7. Used to draft the one-line docs change and this PR body; I reviewed the diff and the notebook JSON before pushing.

## Checklist

- [x] Pull request title follows the conventional format
- [x] Added documentation
