### PR TITLE
fix: norm and vmin/vmax in raster.py

### DIFF
--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -216,11 +216,11 @@ class QuadMeshPlot(ColorbarPlot):
 
     def init_artists(self, ax, plot_args, plot_kwargs):
         locs = plot_kwargs.pop("locs", None)
-        artist = ax.pcolormesh(*plot_args, **plot_kwargs)
-        colorbar = self.handles.get("cbar")
         if "norm" in plot_kwargs:  # vmin/vmax should now be exclusively in norm
             plot_kwargs.pop("vmin", None)
             plot_kwargs.pop("vmax", None)
+        artist = ax.pcolormesh(*plot_args, **plot_kwargs)
+        colorbar = self.handles.get("cbar")
         if colorbar and MPL_VERSION < (3, 1, 0):
             colorbar.set_norm(artist.norm)
             if hasattr(colorbar, "set_array"):

--- a/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
@@ -62,7 +62,7 @@ class TestQuadMeshPlot(TestMPLPlot):
     def test_quadmesh_with_norm(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
 
-        qmesh = hv.QuadMesh(hv.Image(arr)).opts(norm=Normalize())
+        qmesh = hv.QuadMesh(hv.Image(arr)).opts(norm=Normalize(), cmap="viridis")
 
         # Before PR 6889, getting the plot would raise a ValueError from
         # matplotlib because vmin and vmax were passed alongside the norm.

--- a/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
@@ -59,15 +59,15 @@ class TestQuadMeshPlot(TestMPLPlot):
             [cbar.vmin, cbar.vmax], [-1.7481711049213744, 1.7008913273857975]
         )
 
-def test_quadmesh_with_norm(self):
+    def test_quadmesh_with_norm(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])
-        
+
         qmesh = hv.QuadMesh(hv.Image(arr)).opts(norm=Normalize())
-        
+
         # Before PR 6889, getting the plot would raise a ValueError from 
         # matplotlib because vmin and vmax were passed alongside the norm.
         plot = mpl_renderer.get_plot(qmesh)
-        
+
         # Verify the plot handles were created and the norm is correctly applied
         artist = plot.handles["artist"]
         assert isinstance(artist.norm, Normalize)

--- a/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
@@ -64,7 +64,7 @@ class TestQuadMeshPlot(TestMPLPlot):
 
         qmesh = hv.QuadMesh(hv.Image(arr)).opts(norm=Normalize())
 
-        # Before PR 6889, getting the plot would raise a ValueError from 
+        # Before PR 6889, getting the plot would raise a ValueError from
         # matplotlib because vmin and vmax were passed alongside the norm.
         plot = mpl_renderer.get_plot(qmesh)
 

--- a/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
@@ -6,6 +6,7 @@ import holoviews as hv
 
 from .test_plot import MPL_GE_3_8_0, TestMPLPlot, mpl_renderer
 
+from matplotlib.colors import Normalize
 
 class TestQuadMeshPlot(TestMPLPlot):
     def test_quadmesh_invert_axes(self):
@@ -57,3 +58,16 @@ class TestQuadMeshPlot(TestMPLPlot):
         np.testing.assert_allclose(
             [cbar.vmin, cbar.vmax], [-1.7481711049213744, 1.7008913273857975]
         )
+
+def test_quadmesh_with_norm(self):
+        arr = np.array([[0, 1, 2], [3, 4, 5]])
+        
+        qmesh = hv.QuadMesh(hv.Image(arr)).opts(norm=Normalize())
+        
+        # Before PR 6889, getting the plot would raise a ValueError from 
+        # matplotlib because vmin and vmax were passed alongside the norm.
+        plot = mpl_renderer.get_plot(qmesh)
+        
+        # Verify the plot handles were created and the norm is correctly applied
+        artist = plot.handles["artist"]
+        assert isinstance(artist.norm, Normalize)

--- a/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
@@ -7,6 +7,7 @@ import holoviews as hv
 
 from .test_plot import MPL_GE_3_8_0, TestMPLPlot, mpl_renderer
 
+
 class TestQuadMeshPlot(TestMPLPlot):
     def test_quadmesh_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4, 5]])

--- a/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_quadmeshplot.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import numpy as np
+from matplotlib.colors import Normalize
 
 import holoviews as hv
 
 from .test_plot import MPL_GE_3_8_0, TestMPLPlot, mpl_renderer
-
-from matplotlib.colors import Normalize
 
 class TestQuadMeshPlot(TestMPLPlot):
     def test_quadmesh_invert_axes(self):


### PR DESCRIPTION
Fixing buggy code for when norm is passed to quadmesh using the matplotlib backend. Passing norm should make vmin and vmax equal to None BEFORE passing the plot_kwargs to pcolormesh. This is the proper fix that I tried to implement some years ago in #6029, apologies for not doing it properly in the first place. sigh.

Fixes #5966 