### PR TITLE
enh: Add baseline opt to Bars for floating bar charts

### DIFF
--- a/examples/reference/elements/bokeh/Bars.ipynb
+++ b/examples/reference/elements/bokeh/Bars.ipynb
@@ -237,6 +237,18 @@
   },
   {
    "cell_type": "markdown",
+   "source": "A `baseline` also applies to grouped `Bars`: each bar in a group floats between its own pair of value dimensions. (Stacked `Bars` cannot use a `baseline`, since stacking already defines each segment's lower edge.)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "ranges = pd.DataFrame({\n    'Quarter': ['Q1', 'Q1', 'Q2', 'Q2', 'Q3', 'Q3', 'Q4', 'Q4'],\n    'Region':  ['East', 'West'] * 4,\n    'Low':     [3, 1,  5, 2,  6, 4,  4, 3],\n    'High':    [9, 6, 12, 8, 14, 10, 11, 9],\n})\n\nhv.Bars(ranges, ['Quarter', 'Region'], ['High', 'Low']).opts(baseline='Low', width=600)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.Bars)``."

--- a/examples/reference/elements/bokeh/Bars.ipynb
+++ b/examples/reference/elements/bokeh/Bars.ipynb
@@ -216,24 +216,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "For single-category `Bars`, the `baseline` option lets each bar float between two value dimensions instead of growing from zero. The first value dimension (`vdims[0]`) supplies one end of each bar and the dimension named by `baseline` supplies the other, which is useful for ranges such as daily low/high temperatures. The value axis is no longer forced to include zero:"
-   ]
+   "source": "The `baseline` option lets each bar float between two value dimensions instead of growing from zero. `baseline` names the lower end of each bar and the remaining value dimension supplies the upper end, so `vdims=['Low', 'High']` with `baseline='Low'` spans Low to High (the order of the value dimensions doesn't matter). This is useful for ranges such as daily low/high temperatures, and the value axis is no longer forced to include zero:"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "temps = pd.DataFrame({\n",
-    "    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May'],\n",
-    "    'Low': [-3, -1, 2, 6, 10],\n",
-    "    'High': [4, 6, 11, 16, 21],\n",
-    "})\n",
-    "\n",
-    "hv.Bars(temps, 'Month', ['High', 'Low']).opts(baseline='Low')"
-   ]
+   "source": "temps = pd.DataFrame({\n    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May'],\n    'Low': [-3, -1, 2, 6, 10],\n    'High': [4, 6, 11, 16, 21],\n})\n\nhv.Bars(temps, 'Month', ['Low', 'High']).opts(baseline='Low')"
   },
   {
    "cell_type": "markdown",
@@ -242,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "source": "ranges = pd.DataFrame({\n    'Quarter': ['Q1', 'Q1', 'Q2', 'Q2', 'Q3', 'Q3', 'Q4', 'Q4'],\n    'Region':  ['East', 'West'] * 4,\n    'Low':     [3, 1,  5, 2,  6, 4,  4, 3],\n    'High':    [9, 6, 12, 8, 14, 10, 11, 9],\n})\n\nhv.Bars(ranges, ['Quarter', 'Region'], ['High', 'Low']).opts(baseline='Low', width=600)",
+   "source": "ranges = pd.DataFrame({\n    'Quarter': ['Q1', 'Q1', 'Q2', 'Q2', 'Q3', 'Q3', 'Q4', 'Q4'],\n    'Region':  ['East', 'West'] * 4,\n    'Low':     [3, 1,  5, 2,  6, 4,  4, 3],\n    'High':    [9, 6, 12, 8, 14, 10, 11, 9],\n})\n\nhv.Bars(ranges, ['Quarter', 'Region'], ['Low', 'High']).opts(baseline='Low', width=600)",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/examples/reference/elements/bokeh/Bars.ipynb
+++ b/examples/reference/elements/bokeh/Bars.ipynb
@@ -217,6 +217,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "For single-category `Bars`, the `baseline` option lets each bar float between two value dimensions instead of growing from zero. The first value dimension (`vdims[0]`) supplies one end of each bar and the dimension named by `baseline` supplies the other, which is useful for ranges such as daily low/high temperatures. The value axis is no longer forced to include zero:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temps = pd.DataFrame({\n",
+    "    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May'],\n",
+    "    'Low': [-3, -1, 2, 6, 10],\n",
+    "    'High': [4, 6, 11, 16, 21],\n",
+    "})\n",
+    "\n",
+    "hv.Bars(temps, 'Month', ['High', 'Low']).opts(baseline='Low')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.Bars)``."
    ]
   }

--- a/examples/reference/elements/matplotlib/Bars.ipynb
+++ b/examples/reference/elements/matplotlib/Bars.ipynb
@@ -193,27 +193,48 @@
   },
   {
    "cell_type": "markdown",
-   "source": "For single-category `Bars`, the `baseline` option lets each bar float between two value dimensions instead of growing from zero. The first value dimension (`vdims[0]`) supplies one end of each bar and the dimension named by `baseline` supplies the other, which is useful for ranges such as daily low/high temperatures. The value axis is no longer forced to include zero:",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "The `baseline` option lets each bar float between two value dimensions instead of growing from zero. `baseline` names the lower end of each bar and the remaining value dimension supplies the upper end, so `vdims=['Low', 'High']` with `baseline='Low'` spans Low to High (the order of the value dimensions doesn't matter). This is useful for ranges such as daily low/high temperatures, and the value axis is no longer forced to include zero:"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "temps = pd.DataFrame({\n    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May'],\n    'Low': [-3, -1, 2, 6, 10],\n    'High': [4, 6, 11, 16, 21],\n})\n\nhv.Bars(temps, 'Month', ['High', 'Low']).opts(baseline='Low')",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temps = pd.DataFrame({\n",
+    "    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May'],\n",
+    "    'Low': [-3, -1, 2, 6, 10],\n",
+    "    'High': [4, 6, 11, 16, 21],\n",
+    "})\n",
+    "\n",
+    "hv.Bars(temps, 'Month', ['Low', 'High']).opts(baseline='Low')"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": "A `baseline` also applies to grouped `Bars`: each bar in a group floats between its own pair of value dimensions. (Stacked `Bars` cannot use a `baseline`, since stacking already defines each segment's lower edge.)",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "A `baseline` also applies to grouped `Bars`: each bar in a group floats between its own pair of value dimensions. (Stacked `Bars` cannot use a `baseline`, since stacking already defines each segment's lower edge.)"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "ranges = pd.DataFrame({\n    'Quarter': ['Q1', 'Q1', 'Q2', 'Q2', 'Q3', 'Q3', 'Q4', 'Q4'],\n    'Region':  ['East', 'West'] * 4,\n    'Low':     [3, 1,  5, 2,  6, 4,  4, 3],\n    'High':    [9, 6, 12, 8, 14, 10, 11, 9],\n})\n\nhv.Bars(ranges, ['Quarter', 'Region'], ['High', 'Low']).opts(baseline='Low', fig_size=300, aspect=2)",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ranges = pd.DataFrame({\n",
+    "    'Quarter': ['Q1', 'Q1', 'Q2', 'Q2', 'Q3', 'Q3', 'Q4', 'Q4'],\n",
+    "    'Region':  ['East', 'West'] * 4,\n",
+    "    'Low':     [3, 1,  5, 2,  6, 4,  4, 3],\n",
+    "    'High':    [9, 6, 12, 8, 14, 10, 11, 9],\n",
+    "})\n",
+    "\n",
+    "hv.Bars(ranges, ['Quarter', 'Region'], ['Low', 'High']).opts(baseline='Low', fig_size=300, aspect=2)"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/examples/reference/elements/matplotlib/Bars.ipynb
+++ b/examples/reference/elements/matplotlib/Bars.ipynb
@@ -205,6 +205,18 @@
   },
   {
    "cell_type": "markdown",
+   "source": "A `baseline` also applies to grouped `Bars`: each bar in a group floats between its own pair of value dimensions. (Stacked `Bars` cannot use a `baseline`, since stacking already defines each segment's lower edge.)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "ranges = pd.DataFrame({\n    'Quarter': ['Q1', 'Q1', 'Q2', 'Q2', 'Q3', 'Q3', 'Q4', 'Q4'],\n    'Region':  ['East', 'West'] * 4,\n    'Low':     [3, 1,  5, 2,  6, 4,  4, 3],\n    'High':    [9, 6, 12, 8, 14, 10, 11, 9],\n})\n\nhv.Bars(ranges, ['Quarter', 'Region'], ['High', 'Low']).opts(baseline='Low', fig_size=300, aspect=2)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.Bars).``"

--- a/examples/reference/elements/matplotlib/Bars.ipynb
+++ b/examples/reference/elements/matplotlib/Bars.ipynb
@@ -193,6 +193,18 @@
   },
   {
    "cell_type": "markdown",
+   "source": "For single-category `Bars`, the `baseline` option lets each bar float between two value dimensions instead of growing from zero. The first value dimension (`vdims[0]`) supplies one end of each bar and the dimension named by `baseline` supplies the other, which is useful for ranges such as daily low/high temperatures. The value axis is no longer forced to include zero:",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "temps = pd.DataFrame({\n    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May'],\n    'Low': [-3, -1, 2, 6, 10],\n    'High': [4, 6, 11, 16, 21],\n})\n\nhv.Bars(temps, 'Month', ['High', 'Low']).opts(baseline='Low')",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.Bars).``"

--- a/examples/reference/elements/plotly/Bars.ipynb
+++ b/examples/reference/elements/plotly/Bars.ipynb
@@ -193,12 +193,12 @@
   },
   {
    "cell_type": "markdown",
-   "source": "For single-category `Bars`, the `baseline` option lets each bar float between two value dimensions instead of growing from zero. The first value dimension (`vdims[0]`) supplies one end of each bar and the dimension named by `baseline` supplies the other, which is useful for ranges such as daily low/high temperatures. The value axis is no longer forced to include zero:",
+   "source": "The `baseline` option lets each bar float between two value dimensions instead of growing from zero. `baseline` names the lower end of each bar and the remaining value dimension supplies the upper end, so `vdims=['Low', 'High']` with `baseline='Low'` spans Low to High (the order of the value dimensions doesn't matter). This is useful for ranges such as daily low/high temperatures, and the value axis is no longer forced to include zero:",
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "source": "temps = pd.DataFrame({\n    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May'],\n    'Low': [-3, -1, 2, 6, 10],\n    'High': [4, 6, 11, 16, 21],\n})\n\nhv.Bars(temps, 'Month', ['High', 'Low']).opts(baseline='Low')",
+   "source": "temps = pd.DataFrame({\n    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May'],\n    'Low': [-3, -1, 2, 6, 10],\n    'High': [4, 6, 11, 16, 21],\n})\n\nhv.Bars(temps, 'Month', ['Low', 'High']).opts(baseline='Low')",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -210,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "source": "ranges = pd.DataFrame({\n    'Quarter': ['Q1', 'Q1', 'Q2', 'Q2', 'Q3', 'Q3', 'Q4', 'Q4'],\n    'Region':  ['East', 'West'] * 4,\n    'Low':     [3, 1,  5, 2,  6, 4,  4, 3],\n    'High':    [9, 6, 12, 8, 14, 10, 11, 9],\n})\n\nhv.Bars(ranges, ['Quarter', 'Region'], ['High', 'Low']).opts(baseline='Low', width=600)",
+   "source": "ranges = pd.DataFrame({\n    'Quarter': ['Q1', 'Q1', 'Q2', 'Q2', 'Q3', 'Q3', 'Q4', 'Q4'],\n    'Region':  ['East', 'West'] * 4,\n    'Low':     [3, 1,  5, 2,  6, 4,  4, 3],\n    'High':    [9, 6, 12, 8, 14, 10, 11, 9],\n})\n\nhv.Bars(ranges, ['Quarter', 'Region'], ['Low', 'High']).opts(baseline='Low', width=600)",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/examples/reference/elements/plotly/Bars.ipynb
+++ b/examples/reference/elements/plotly/Bars.ipynb
@@ -205,6 +205,18 @@
   },
   {
    "cell_type": "markdown",
+   "source": "A `baseline` also applies to grouped `Bars`: each bar in a group floats between its own pair of value dimensions. (Stacked `Bars` cannot use a `baseline`, since stacking already defines each segment's lower edge.)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "ranges = pd.DataFrame({\n    'Quarter': ['Q1', 'Q1', 'Q2', 'Q2', 'Q3', 'Q3', 'Q4', 'Q4'],\n    'Region':  ['East', 'West'] * 4,\n    'Low':     [3, 1,  5, 2,  6, 4,  4, 3],\n    'High':    [9, 6, 12, 8, 14, 10, 11, 9],\n})\n\nhv.Bars(ranges, ['Quarter', 'Region'], ['High', 'Low']).opts(baseline='Low', width=600)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.Bars).``"

--- a/examples/reference/elements/plotly/Bars.ipynb
+++ b/examples/reference/elements/plotly/Bars.ipynb
@@ -193,6 +193,18 @@
   },
   {
    "cell_type": "markdown",
+   "source": "For single-category `Bars`, the `baseline` option lets each bar float between two value dimensions instead of growing from zero. The first value dimension (`vdims[0]`) supplies one end of each bar and the dimension named by `baseline` supplies the other, which is useful for ranges such as daily low/high temperatures. The value axis is no longer forced to include zero:",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "temps = pd.DataFrame({\n    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May'],\n    'Low': [-3, -1, 2, 6, 10],\n    'High': [4, 6, 11, 16, 21],\n})\n\nhv.Bars(temps, 'Month', ['High', 'Low']).opts(baseline='Low')",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.Bars).``"

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -1005,8 +1005,9 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         each bar), making the bars float between two value dimensions
         instead of growing from a zero baseline. Accepts a dimension
         name or index; vdims[0] supplies one end and this dimension the
-        other. Only supported for a single key dimension (ungrouped,
-        unstacked) Bars.""",
+        other, and must be the lower end of every bar. Supported for
+        ungrouped and grouped Bars; combining it with stacked raises an
+        error.""",
     )
 
     multi_level = param.Boolean(
@@ -1212,7 +1213,8 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         if grouping == "stacked":
             mapping = {"x": xdim.name, "top": "top", "bottom": "bottom", "width": width}
         elif grouping == "grouped":
-            mapping = {"x": "xoffsets", "top": ydim.name, "bottom": bottom, "width": width}
+            bar_bottom = "bottom" if baseline_dim is not None else bottom
+            mapping = {"x": "xoffsets", "top": ydim.name, "bottom": bar_bottom, "width": width}
         else:
             # Floating bars carry a per-bar lower coordinate in a "bottom"
             # column (as the stacked branch does), otherwise it is the scalar 0.
@@ -1288,6 +1290,8 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
                 ]
                 data["xoffsets"].append(xoffsets)
                 data[ydim.name].append(ys)
+                if baseline_dim is not None:
+                    data["bottom"].append(ds.dimension_values(baseline_dim))
                 if hover:
                     data[xdim.name].append(xs)
                 if group_dim not in ds.dimensions():

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -1003,11 +1003,12 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         doc="""
         Value dimension to use as a per-bar baseline (the other end of
         each bar), making the bars float between two value dimensions
-        instead of growing from a zero baseline. Accepts a dimension
-        name or index; vdims[0] supplies one end and this dimension the
-        other, and must be the lower end of every bar. Supported for
-        ungrouped and grouped Bars; combining it with stacked raises an
-        error.""",
+        instead of growing from a zero baseline. Accepts a dimension name
+        or index naming the lower end of each bar; the first remaining value
+        dimension (once the baseline is removed) is the upper end, so
+        vdims=['Low', 'High'] with baseline='Low' spans Low to High. The
+        baseline must be the lower end of every bar. Supported for ungrouped
+        and grouped Bars; combining it with stacked raises an error.""",
     )
 
     multi_level = param.Boolean(
@@ -1161,8 +1162,13 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         xdim = element.get_dimension(0)
         ydim = element.vdims[0]
 
-        baseline_dim = self._baseline_dimension(element)
+        # Floating bars span baseline_dim (bottom) up to top_dim (the value
+        # dimension left once the baseline is removed). Treat top_dim as the
+        # plotted value so the existing top/data handling applies unchanged.
+        top_dim, baseline_dim = self._baseline_dimensions(element)
         self._warn_unused_baseline(element, baseline_dim)
+        if baseline_dim is not None:
+            ydim = top_dim
 
         no_cidx = self.color_index is None
         color_index = (group_dim or stack_dim) if no_cidx else self.color_index

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -996,6 +996,19 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
 
     """
 
+    baseline = param.ClassSelector(
+        default=None,
+        class_=(str, int),
+        allow_None=True,
+        doc="""
+        Value dimension to use as a per-bar baseline (the other end of
+        each bar), making the bars float between two value dimensions
+        instead of growing from a zero baseline. Accepts a dimension
+        name or index; vdims[0] supplies one end and this dimension the
+        other. Only supported for a single key dimension (ungrouped,
+        unstacked) Bars.""",
+    )
+
     multi_level = param.Boolean(
         default=True,
         doc="Whether the Bars should be grouped into a second categorical axis level.",
@@ -1146,6 +1159,10 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         data = defaultdict(list)
         xdim = element.get_dimension(0)
         ydim = element.vdims[0]
+
+        baseline_dim = self._baseline_dimension(element)
+        self._warn_unused_baseline(element, baseline_dim)
+
         no_cidx = self.color_index is None
         color_index = (group_dim or stack_dim) if no_cidx else self.color_index
         color_dim = element.get_dimension(color_index)
@@ -1197,7 +1214,10 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         elif grouping == "grouped":
             mapping = {"x": "xoffsets", "top": ydim.name, "bottom": bottom, "width": width}
         else:
-            mapping = {"x": xdim.name, "top": ydim.name, "bottom": bottom, "width": width}
+            # Floating bars carry a per-bar lower coordinate in a "bottom"
+            # column (as the stacked branch does), otherwise it is the scalar 0.
+            bar_bottom = "bottom" if baseline_dim is not None else bottom
+            mapping = {"x": xdim.name, "top": ydim.name, "bottom": bar_bottom, "width": width}
 
         # Get colors
         cdim = color_dim or group_dim
@@ -1276,6 +1296,8 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
             else:
                 data[xdim.name].append(xvals)
                 data[ydim.name].append(ds.dimension_values(ydim))
+                if baseline_dim is not None:
+                    data["bottom"].append(ds.dimension_values(baseline_dim))
 
             if hover and grouping != "stacked":
                 for vd in ds.vdims[1:]:

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -1001,14 +1001,12 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         class_=(str, int),
         allow_None=True,
         doc="""
-        Value dimension to use as a per-bar baseline (the other end of
-        each bar), making the bars float between two value dimensions
-        instead of growing from a zero baseline. Accepts a dimension name
-        or index naming the lower end of each bar; the first remaining value
-        dimension (once the baseline is removed) is the upper end, so
-        vdims=['Low', 'High'] with baseline='Low' spans Low to High. The
-        baseline must be the lower end of every bar. Supported for ungrouped
-        and grouped Bars; combining it with stacked raises an error.""",
+        Value dimension naming the lower end of each bar, making bars
+        float between two value dimensions instead of growing from zero.
+        The first remaining value dimension is the upper end, so
+        vdims=['Low', 'High'] with baseline='Low' spans Low to High.
+        Supported for ungrouped and grouped Bars; combining it with
+        stacked raises an error.""",
     )
 
     multi_level = param.Boolean(
@@ -1162,9 +1160,8 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         xdim = element.get_dimension(0)
         ydim = element.vdims[0]
 
-        # Floating bars span baseline_dim (bottom) up to top_dim (the value
-        # dimension left once the baseline is removed). Treat top_dim as the
-        # plotted value so the existing top/data handling applies unchanged.
+        # Floating bars span baseline_dim (bottom) up to top_dim (the
+        # remaining value dimension); treat top_dim as the plotted value.
         top_dim, baseline_dim = self._baseline_dimensions(element)
         self._warn_unused_baseline(element, baseline_dim)
         if baseline_dim is not None:
@@ -1222,8 +1219,8 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
             bar_bottom = "bottom" if baseline_dim is not None else bottom
             mapping = {"x": "xoffsets", "top": ydim.name, "bottom": bar_bottom, "width": width}
         else:
-            # Floating bars carry a per-bar lower coordinate in a "bottom"
-            # column (as the stacked branch does), otherwise it is the scalar 0.
+            # Floating bars carry a per-bar lower coordinate in "bottom",
+            # otherwise it is the scalar 0.
             bar_bottom = "bottom" if baseline_dim is not None else bottom
             mapping = {"x": xdim.name, "top": ydim.name, "bottom": bar_bottom, "width": width}
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -1021,6 +1021,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         top_dim, baseline_dim = self._baseline_dimensions(element)
         self._warn_unused_baseline(element, baseline_dim)
         if baseline_dim is not None:
+            self._validate_baseline(element, top_dim, baseline_dim)
             ydim = top_dim
 
         color_dim = element.get_dimension(group_dim or stack_dim)

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -330,11 +330,20 @@ class BarsMixin:
         """Resolve the (top, bottom) value dimensions for floating bars.
 
         `baseline` names the lower end of each bar; the first remaining
-        value dimension is the upper end, so ['Low', 'High'] and
-        ['High', 'Low'] both span Low -> High with baseline='Low'. Returns
-        (None, None) when the baseline is unset, unresolved, not a value
-        dimension, or the only value dimension. Raises ValueError for
-        stacked Bars.
+        value dimension is the upper end, so `['Low', 'High']` and
+        `['High', 'Low']` both span Low -> High with `baseline='Low'`.
+
+        Returns
+        -------
+        tuple[Dimension | None, Dimension | None]
+            `(top_dim, baseline_dim)`, or `(None, None)` when the
+            baseline is unset, unresolved, not a value dimension, or the
+            only value dimension.
+
+        Raises
+        ------
+        ValueError
+            If both `self.stacked` and `self.baseline` are set.
         """
         if self.baseline is None:
             return None, None

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -326,58 +326,67 @@ class AreaMixin:
 
 
 class BarsMixin:
-    def _baseline_dimension(self, element):
-        """Resolve the value dimension used as a per-bar baseline for
-        floating bars, or None when not applicable.
+    def _baseline_dimensions(self, element):
+        """Resolve the (top, bottom) value dimensions for floating bars, or
+        (None, None) when no floating baseline applies.
 
-        Floating bars are supported for ungrouped and grouped Bars (one
-        floating bar per category combination) but not stacked Bars, where
-        the segment baselines are defined by the cumulative stack. The
-        `baseline` param is declared on each backend's BarPlot rather than
-        this mixin, so all consumers expose the attribute.
+        `baseline` names the lower end of each bar; removing it from the
+        value dimensions, the first one remaining supplies the upper end.
+        So vdims=['Low', 'High'] with baseline='Low' spans Low -> High, and
+        vdims=['High', 'Low'] with baseline='Low' is equivalent. Floating
+        bars are supported for ungrouped and grouped Bars (one floating bar
+        per category combination). The `baseline` param is declared on each
+        backend's BarPlot rather than this mixin, so all consumers expose
+        the attribute.
 
-        Returns None when the baseline cannot be used as a distinct lower
-        end: unset, an unresolved dimension, or the same dimension as
-        vdims[0] (which would give zero-height bars). Callers warn about
-        those fall-back cases.
+        Returns (None, None) when the baseline is unset, unresolved, not a
+        value dimension, or the only value dimension (no upper end remains);
+        callers warn about those fall-back cases.
 
-        Raises ValueError if the baseline is combined with stacking, or if
-        it runs past vdims[0] for any bar: the baseline must be the lower
-        end of every bar, so an inverted range is a usage error rather than
-        a bar drawn upside down.
+        Raises ValueError for stacked Bars (where the cumulative stack
+        already defines each segment's baseline), or if the baseline runs
+        past its upper dimension for any bar: the baseline must be the lower
+        end of every bar, so an inverted range is a usage error.
         """
         if self.baseline is None:
-            return None
+            return None, None
         if self.stacked:
             raise ValueError(
                 "baseline is not supported for stacked Bars; set stacked=False "
                 "to draw floating bars."
             )
         baseline_dim = element.get_dimension(self.baseline)
-        if baseline_dim is None or baseline_dim == element.vdims[0]:
-            return None
-        top = element.dimension_values(element.vdims[0])
+        names = [vd.name for vd in element.vdims]
+        if baseline_dim is None or baseline_dim.name not in names:
+            return None, None
+        # Pop the baseline out; the first remaining value dimension is the top.
+        remaining = [vd for vd in element.vdims if vd.name != baseline_dim.name]
+        if not remaining:
+            return None, None
+        top_dim = remaining[0]
         base = element.dimension_values(baseline_dim)
+        top = element.dimension_values(top_dim)
         # NaN comparisons are False, so missing values are left to the backend.
         if np.any(base > top):
             raise ValueError(
                 f"baseline dimension {baseline_dim.name!r} has values that exceed "
-                f"the {element.vdims[0].name!r} dimension; the baseline must be the "
-                "lower end of every bar."
+                f"the {top_dim.name!r} dimension; the baseline must be the lower "
+                "end of every bar."
             )
-        return baseline_dim
+        return top_dim, baseline_dim
 
     def _warn_unused_baseline(self, element, baseline_dim):
-        """Warn when a resolvable baseline was requested but falls back to
-        a zero baseline because the dimension is unresolved or identical to
-        vdims[0]. Kept separate from `_baseline_dimension` so range
-        computation can resolve the baseline without emitting warnings.
+        """Warn when a baseline was requested but falls back to a zero
+        baseline because the dimension is unresolved, is not a value
+        dimension, or is the last value dimension (so there is no upper end).
+        Kept separate from `_baseline_dimensions` so range computation can
+        resolve the baseline without emitting warnings.
         """
         if self.baseline is not None and baseline_dim is None:
             self.param.warning(
                 f"Could not use baseline dimension {self.baseline!r}: it must name "
-                "a value dimension other than the first; drawing bars from a zero "
-                "baseline."
+                "a value dimension, leaving at least one other value dimension as "
+                "the upper end; drawing bars from a zero baseline."
             )
 
     def _get_axis_dims(self, element):
@@ -385,7 +394,9 @@ class BarsMixin:
             xdims = element.kdims
         else:
             xdims = element.kdims[0]
-        return (xdims, element.vdims[0])
+        # Floating bars: label the value axis with the upper dimension.
+        top_dim, _ = self._baseline_dimensions(element)
+        return (xdims, top_dim if top_dim is not None else element.vdims[0])
 
     def get_extents(self, element, ranges, range_type="combined", **kwargs):
         """Make adjustments to plot extents by computing
@@ -402,16 +413,17 @@ class BarsMixin:
                 ranges[kd.label]["combined"] = overlay.range(kd)
 
         vdim = element.vdims[0].label
-        # Floating bars (a value dimension used as per-bar baseline) must
+        # Floating bars (spanning a baseline up to its upper dimension) must
         # not force 0 into the value-axis range; the lower end is data.
-        baseline_dim = self._baseline_dimension(element)
+        top_dim, baseline_dim = self._baseline_dimensions(element)
         floating = baseline_dim is not None
         if not floating:
             s0, s1 = ranges[vdim]["soft"]
             s0 = min(s0, 0) if util.isfinite(s0) else 0
             s1 = max(s1, 0) if util.isfinite(s1) else 0
             ranges[vdim]["soft"] = (s0, s1)
-        l, b, r, t = super().get_extents(element, ranges, range_type, ydim=element.vdims[0])
+        ydim = top_dim if floating else element.vdims[0]
+        l, b, r, t = super().get_extents(element, ranges, range_type, ydim=ydim)
         if range_type not in ("combined", "data"):
             return l, b, r, t
 
@@ -423,11 +435,11 @@ class BarsMixin:
             neg_range = ds.select(**{vdim: (None, 0)}).aggregate(xdim, function=np.sum).range(vdim)
             y0, y1 = util.max_range([pos_range, neg_range])
         elif floating:
-            # Span both ends from the data directly so the value axis
-            # covers the baseline as well as vdims[0]. Note: this reads
-            # from the element rather than the combined ranges, so an
-            # overlay of floating Bars is not range-combined.
-            y0, y1 = util.max_range([element.range(element.vdims[0]), element.range(baseline_dim)])
+            # Span both ends from the data directly so the value axis covers
+            # the baseline and its upper dimension. Note: this reads from the
+            # element rather than the combined ranges, so an overlay of
+            # floating Bars is not range-combined.
+            y0, y1 = util.max_range([element.range(top_dim), element.range(baseline_dim)])
         else:
             y0, y1 = ranges[vdim]["combined"]
 

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -330,22 +330,29 @@ class BarsMixin:
         """Resolve the value dimension used as a per-bar baseline for
         floating bars, or None when not applicable.
 
-        Floating bars are only supported for a single key dimension
-        (ungrouped, unstacked). The `baseline` param is declared on each
-        backend's BarPlot rather than this mixin, so all consumers expose
-        the attribute.
+        Floating bars are supported for ungrouped and grouped Bars (one
+        floating bar per category combination) but not stacked Bars, where
+        the segment baselines are defined by the cumulative stack. The
+        `baseline` param is declared on each backend's BarPlot rather than
+        this mixin, so all consumers expose the attribute.
 
         Returns None when the baseline cannot be used as a distinct lower
-        end: unset, not a single-kdim element, an unresolved dimension, or
-        the same dimension as vdims[0] (which would give zero-height bars).
-        Callers warn about the misconfigured cases.
+        end: unset, an unresolved dimension, or the same dimension as
+        vdims[0] (which would give zero-height bars). Callers warn about
+        those fall-back cases.
 
-        Raises ValueError if the baseline runs past vdims[0] for any bar:
-        the baseline must be the lower end of every bar, so an inverted
-        range is a usage error rather than a bar drawn upside down.
+        Raises ValueError if the baseline is combined with stacking, or if
+        it runs past vdims[0] for any bar: the baseline must be the lower
+        end of every bar, so an inverted range is a usage error rather than
+        a bar drawn upside down.
         """
-        if self.baseline is None or self.stacked or element.ndims != 1:
+        if self.baseline is None:
             return None
+        if self.stacked:
+            raise ValueError(
+                "baseline is not supported for stacked Bars; set stacked=False "
+                "to draw floating bars."
+            )
         baseline_dim = element.get_dimension(self.baseline)
         if baseline_dim is None or baseline_dim == element.vdims[0]:
             return None
@@ -361,22 +368,12 @@ class BarsMixin:
         return baseline_dim
 
     def _warn_unused_baseline(self, element, baseline_dim):
-        """Warn when a baseline was requested but cannot be applied.
-
-        `baseline_dim` is the result of `_baseline_dimension`; None here means
-        the baseline is being ignored, either because the Bars are grouped or
-        stacked or because the dimension is unresolved or identical to vdims[0].
-        Kept separate from `_baseline_dimension` so range computation can
-        resolve the baseline without emitting warnings.
+        """Warn when a resolvable baseline was requested but falls back to
+        a zero baseline because the dimension is unresolved or identical to
+        vdims[0]. Kept separate from `_baseline_dimension` so range
+        computation can resolve the baseline without emitting warnings.
         """
-        if self.baseline is None or baseline_dim is not None:
-            return
-        if self.stacked or element.ndims != 1:
-            self.param.warning(
-                "baseline is only supported for ungrouped, unstacked Bars with a "
-                "single key dimension; ignoring."
-            )
-        else:
+        if self.baseline is not None and baseline_dim is None:
             self.param.warning(
                 f"Could not use baseline dimension {self.baseline!r}: it must name "
                 "a value dimension other than the first; drawing bars from a zero "

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -327,26 +327,14 @@ class AreaMixin:
 
 class BarsMixin:
     def _baseline_dimensions(self, element):
-        """Resolve the (top, bottom) value dimensions for floating bars, or
-        (None, None) when no floating baseline applies.
+        """Resolve the (top, bottom) value dimensions for floating bars.
 
-        `baseline` names the lower end of each bar; removing it from the
-        value dimensions, the first one remaining supplies the upper end.
-        So vdims=['Low', 'High'] with baseline='Low' spans Low -> High, and
-        vdims=['High', 'Low'] with baseline='Low' is equivalent. Floating
-        bars are supported for ungrouped and grouped Bars (one floating bar
-        per category combination). The `baseline` param is declared on each
-        backend's BarPlot rather than this mixin, so all consumers expose
-        the attribute.
-
-        Returns (None, None) when the baseline is unset, unresolved, not a
-        value dimension, or the only value dimension (no upper end remains);
-        callers warn about those fall-back cases.
-
-        Raises ValueError for stacked Bars (where the cumulative stack
-        already defines each segment's baseline), or if the baseline runs
-        past its upper dimension for any bar: the baseline must be the lower
-        end of every bar, so an inverted range is a usage error.
+        `baseline` names the lower end of each bar; the first remaining
+        value dimension is the upper end, so ['Low', 'High'] and
+        ['High', 'Low'] both span Low -> High with baseline='Low'. Returns
+        (None, None) when the baseline is unset, unresolved, not a value
+        dimension, or the only value dimension. Raises ValueError for
+        stacked Bars or when the baseline exceeds its upper dimension.
         """
         if self.baseline is None:
             return None, None
@@ -359,14 +347,13 @@ class BarsMixin:
         names = [vd.name for vd in element.vdims]
         if baseline_dim is None or baseline_dim.name not in names:
             return None, None
-        # Pop the baseline out; the first remaining value dimension is the top.
         remaining = [vd for vd in element.vdims if vd.name != baseline_dim.name]
         if not remaining:
             return None, None
         top_dim = remaining[0]
         base = element.dimension_values(baseline_dim)
         top = element.dimension_values(top_dim)
-        # NaN comparisons are False, so missing values are left to the backend.
+        # NaN comparisons are False, so missing values fall through to the backend.
         if np.any(base > top):
             raise ValueError(
                 f"baseline dimension {baseline_dim.name!r} has values that exceed "
@@ -376,12 +363,7 @@ class BarsMixin:
         return top_dim, baseline_dim
 
     def _warn_unused_baseline(self, element, baseline_dim):
-        """Warn when a baseline was requested but falls back to a zero
-        baseline because the dimension is unresolved, is not a value
-        dimension, or is the last value dimension (so there is no upper end).
-        Kept separate from `_baseline_dimensions` so range computation can
-        resolve the baseline without emitting warnings.
-        """
+        """Warn when a requested baseline can't be used and falls back to zero."""
         if self.baseline is not None and baseline_dim is None:
             self.param.warning(
                 f"Could not use baseline dimension {self.baseline!r}: it must name "
@@ -394,7 +376,7 @@ class BarsMixin:
             xdims = element.kdims
         else:
             xdims = element.kdims[0]
-        # Floating bars: label the value axis with the upper dimension.
+        # Floating bars label the value axis with the upper dimension.
         top_dim, _ = self._baseline_dimensions(element)
         return (xdims, top_dim if top_dim is not None else element.vdims[0])
 
@@ -413,8 +395,7 @@ class BarsMixin:
                 ranges[kd.label]["combined"] = overlay.range(kd)
 
         vdim = element.vdims[0].label
-        # Floating bars (spanning a baseline up to its upper dimension) must
-        # not force 0 into the value-axis range; the lower end is data.
+        # Floating bars must not force 0 into the value-axis range.
         top_dim, baseline_dim = self._baseline_dimensions(element)
         floating = baseline_dim is not None
         if not floating:
@@ -435,10 +416,7 @@ class BarsMixin:
             neg_range = ds.select(**{vdim: (None, 0)}).aggregate(xdim, function=np.sum).range(vdim)
             y0, y1 = util.max_range([pos_range, neg_range])
         elif floating:
-            # Span both ends from the data directly so the value axis covers
-            # the baseline and its upper dimension. Note: this reads from the
-            # element rather than the combined ranges, so an overlay of
-            # floating Bars is not range-combined.
+            # Span both ends from the element directly (overlays are not range-combined).
             y0, y1 = util.max_range([element.range(top_dim), element.range(baseline_dim)])
         else:
             y0, y1 = ranges[vdim]["combined"]

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -420,8 +420,9 @@ class BarsMixin:
             neg_range = ds.select(**{vdim: (None, 0)}).aggregate(xdim, function=np.sum).range(vdim)
             y0, y1 = util.max_range([pos_range, neg_range])
         elif floating:
-            # Span both ends from the element directly (overlays are not range-combined).
-            y0, y1 = util.max_range([element.range(top_dim), element.range(baseline_dim)])
+            y0, y1 = util.max_range(
+                [ranges[top_dim.label]["data"], ranges[baseline_dim.label]["data"]]
+            )
         else:
             y0, y1 = ranges[vdim]["combined"]
 
@@ -431,8 +432,9 @@ class BarsMixin:
 
         padding = 0 if self.overlaid else self.padding
         _, ypad, _ = get_axis_padding(padding)
+        ydim_label = top_dim.label if floating else vdim
         y0, y1 = util.dimension_range(
-            y0, y1, ranges[vdim]["hard"], ranges[vdim]["soft"], ypad, self.logy
+            y0, y1, ranges[ydim_label]["hard"], ranges[ydim_label]["soft"], ypad, self.logy
         )
         y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))
         return (x0, y0, x1, y1)

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -334,7 +334,7 @@ class BarsMixin:
         ['High', 'Low'] both span Low -> High with baseline='Low'. Returns
         (None, None) when the baseline is unset, unresolved, not a value
         dimension, or the only value dimension. Raises ValueError for
-        stacked Bars or when the baseline exceeds its upper dimension.
+        stacked Bars.
         """
         if self.baseline is None:
             return None, None
@@ -350,17 +350,21 @@ class BarsMixin:
         remaining = [vd for vd in element.vdims if vd.name != baseline_dim.name]
         if not remaining:
             return None, None
-        top_dim = remaining[0]
+        return remaining[0], baseline_dim
+
+    def _validate_baseline(self, element, top_dim, baseline_dim):
+        """Raise if any baseline value exceeds its top value.
+
+        NaN comparisons are False, so missing values fall through to the backend.
+        """
         base = element.dimension_values(baseline_dim)
         top = element.dimension_values(top_dim)
-        # NaN comparisons are False, so missing values fall through to the backend.
         if np.any(base > top):
             raise ValueError(
                 f"baseline dimension {baseline_dim.name!r} has values that exceed "
                 f"the {top_dim.name!r} dimension; the baseline must be the lower "
                 "end of every bar."
             )
-        return top_dim, baseline_dim
 
     def _warn_unused_baseline(self, element, baseline_dim):
         """Warn when a requested baseline can't be used and falls back to zero."""

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -326,6 +326,63 @@ class AreaMixin:
 
 
 class BarsMixin:
+    def _baseline_dimension(self, element):
+        """Resolve the value dimension used as a per-bar baseline for
+        floating bars, or None when not applicable.
+
+        Floating bars are only supported for a single key dimension
+        (ungrouped, unstacked). The `baseline` param is declared on each
+        backend's BarPlot rather than this mixin, so all consumers expose
+        the attribute.
+
+        Returns None when the baseline cannot be used as a distinct lower
+        end: unset, not a single-kdim element, an unresolved dimension, or
+        the same dimension as vdims[0] (which would give zero-height bars).
+        Callers warn about the misconfigured cases.
+
+        Raises ValueError if the baseline runs past vdims[0] for any bar:
+        the baseline must be the lower end of every bar, so an inverted
+        range is a usage error rather than a bar drawn upside down.
+        """
+        if self.baseline is None or self.stacked or element.ndims != 1:
+            return None
+        baseline_dim = element.get_dimension(self.baseline)
+        if baseline_dim is None or baseline_dim == element.vdims[0]:
+            return None
+        top = element.dimension_values(element.vdims[0])
+        base = element.dimension_values(baseline_dim)
+        # NaN comparisons are False, so missing values are left to the backend.
+        if np.any(base > top):
+            raise ValueError(
+                f"baseline dimension {baseline_dim.name!r} has values that exceed "
+                f"the {element.vdims[0].name!r} dimension; the baseline must be the "
+                "lower end of every bar."
+            )
+        return baseline_dim
+
+    def _warn_unused_baseline(self, element, baseline_dim):
+        """Warn when a baseline was requested but cannot be applied.
+
+        `baseline_dim` is the result of `_baseline_dimension`; None here means
+        the baseline is being ignored, either because the Bars are grouped or
+        stacked or because the dimension is unresolved or identical to vdims[0].
+        Kept separate from `_baseline_dimension` so range computation can
+        resolve the baseline without emitting warnings.
+        """
+        if self.baseline is None or baseline_dim is not None:
+            return
+        if self.stacked or element.ndims != 1:
+            self.param.warning(
+                "baseline is only supported for ungrouped, unstacked Bars with a "
+                "single key dimension; ignoring."
+            )
+        else:
+            self.param.warning(
+                f"Could not use baseline dimension {self.baseline!r}: it must name "
+                "a value dimension other than the first; drawing bars from a zero "
+                "baseline."
+            )
+
     def _get_axis_dims(self, element):
         if element.ndims > 1 and not (self.stacked or not self.multi_level):
             xdims = element.kdims
@@ -348,10 +405,15 @@ class BarsMixin:
                 ranges[kd.label]["combined"] = overlay.range(kd)
 
         vdim = element.vdims[0].label
-        s0, s1 = ranges[vdim]["soft"]
-        s0 = min(s0, 0) if util.isfinite(s0) else 0
-        s1 = max(s1, 0) if util.isfinite(s1) else 0
-        ranges[vdim]["soft"] = (s0, s1)
+        # Floating bars (a value dimension used as per-bar baseline) must
+        # not force 0 into the value-axis range; the lower end is data.
+        baseline_dim = self._baseline_dimension(element)
+        floating = baseline_dim is not None
+        if not floating:
+            s0, s1 = ranges[vdim]["soft"]
+            s0 = min(s0, 0) if util.isfinite(s0) else 0
+            s1 = max(s1, 0) if util.isfinite(s1) else 0
+            ranges[vdim]["soft"] = (s0, s1)
         l, b, r, t = super().get_extents(element, ranges, range_type, ydim=element.vdims[0])
         if range_type not in ("combined", "data"):
             return l, b, r, t
@@ -363,6 +425,12 @@ class BarsMixin:
             pos_range = ds.select(**{vdim: (0, None)}).aggregate(xdim, function=np.sum).range(vdim)
             neg_range = ds.select(**{vdim: (None, 0)}).aggregate(xdim, function=np.sum).range(vdim)
             y0, y1 = util.max_range([pos_range, neg_range])
+        elif floating:
+            # Span both ends from the data directly so the value axis
+            # covers the baseline as well as vdims[0]. Note: this reads
+            # from the element rather than the combined ranges, so an
+            # overlay of floating Bars is not range-combined.
+            y0, y1 = util.max_range([element.range(element.vdims[0]), element.range(baseline_dim)])
         else:
             y0, y1 = ranges[vdim]["combined"]
 

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -980,6 +980,19 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         doc="Defines the padding between groups.",
     )
 
+    baseline = param.ClassSelector(
+        default=None,
+        class_=(str, int),
+        allow_None=True,
+        doc="""
+        Value dimension to use as a per-bar baseline (the other end of
+        each bar), making the bars float between two value dimensions
+        instead of growing from a zero baseline. Accepts a dimension
+        name or index; vdims[0] supplies one end and this dimension the
+        other. Only supported for a single key dimension (ungrouped,
+        unstacked) Bars.""",
+    )
+
     multi_level = param.Boolean(
         default=True,
         doc="Whether the Bars should be grouped into a second categorical axis level.",
@@ -1084,6 +1097,9 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         # Get values dimensions, and style information
         (gdim, cdim, sdim), values = self._get_values(element, ranges)
 
+        baseline_dim = self._baseline_dimension(element)
+        self._warn_unused_baseline(element, baseline_dim)
+
         cats = None
         style_dim = None
         xslice = slice(None)
@@ -1166,20 +1182,30 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
                     val = float(vals[0]) if len(vals) else np.nan
                     xval = xpos
 
+                    # Floating bars span from a per-bar baseline dimension up
+                    # to vdims[0] rather than growing from the stacked base.
+                    if baseline_dim is not None:
+                        bvals = el.dimension_values(baseline_dim)
+                        bottom_val = float(bvals[0]) if len(bvals) else 0.0
+                        height_val = val - bottom_val
+                    else:
+                        bottom_val = prev
+                        height_val = val
+
                     if label in bar_data:
                         group = bar_data[label]
                         group[x].append(xval)
-                        group[y].append(val)
-                        group[bottom].append(prev)
+                        group[y].append(height_val)
+                        group[bottom].append(bottom_val)
                     else:
                         bar_style = dict(style, **style_map.get(label, {}))
                         with abbreviated_exception():
                             bar_style = self._apply_transforms(el, ranges, bar_style)
                         bar_data[label] = {
                             x: [xval],
-                            y: [val],
+                            y: [height_val],
                             w: width,
-                            bottom: [prev],
+                            bottom: [bottom_val],
                             "label": label,
                         }
                         bar_data[label].update(bar_style)

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -985,14 +985,12 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         class_=(str, int),
         allow_None=True,
         doc="""
-        Value dimension to use as a per-bar baseline (the other end of
-        each bar), making the bars float between two value dimensions
-        instead of growing from a zero baseline. Accepts a dimension name
-        or index naming the lower end of each bar; the first remaining value
-        dimension (once the baseline is removed) is the upper end, so
-        vdims=['Low', 'High'] with baseline='Low' spans Low to High. The
-        baseline must be the lower end of every bar. Supported for ungrouped
-        and grouped Bars; combining it with stacked raises an error.""",
+        Value dimension naming the lower end of each bar, making bars
+        float between two value dimensions instead of growing from zero.
+        The first remaining value dimension is the upper end, so
+        vdims=['Low', 'High'] with baseline='Low' spans Low to High.
+        Supported for ungrouped and grouped Bars; combining it with
+        stacked raises an error.""",
     )
 
     multi_level = param.Boolean(
@@ -1101,8 +1099,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
 
         top_dim, baseline_dim = self._baseline_dimensions(element)
         self._warn_unused_baseline(element, baseline_dim)
-        # For floating bars the upper end is top_dim (the value dimension left
-        # once the baseline is removed); otherwise the plotted value is vdims[0].
+        # For floating bars the upper end is top_dim; otherwise it is vdims[0].
         value_dim = top_dim if baseline_dim is not None else element.vdims[0]
 
         cats = None
@@ -1187,8 +1184,8 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
                     val = float(vals[0]) if len(vals) else np.nan
                     xval = xpos
 
-                    # Floating bars span from a per-bar baseline dimension up
-                    # to the upper dimension rather than growing from the base.
+                    # Floating bars span from a per-bar baseline up to the
+                    # upper dimension rather than growing from the base.
                     if baseline_dim is not None:
                         bvals = el.dimension_values(baseline_dim)
                         bottom_val = float(bvals[0]) if len(bvals) else 0.0

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -987,11 +987,12 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         doc="""
         Value dimension to use as a per-bar baseline (the other end of
         each bar), making the bars float between two value dimensions
-        instead of growing from a zero baseline. Accepts a dimension
-        name or index; vdims[0] supplies one end and this dimension the
-        other, and must be the lower end of every bar. Supported for
-        ungrouped and grouped Bars; combining it with stacked raises an
-        error.""",
+        instead of growing from a zero baseline. Accepts a dimension name
+        or index naming the lower end of each bar; the first remaining value
+        dimension (once the baseline is removed) is the upper end, so
+        vdims=['Low', 'High'] with baseline='Low' spans Low to High. The
+        baseline must be the lower end of every bar. Supported for ungrouped
+        and grouped Bars; combining it with stacked raises an error.""",
     )
 
     multi_level = param.Boolean(
@@ -1098,8 +1099,11 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         # Get values dimensions, and style information
         (gdim, cdim, sdim), values = self._get_values(element, ranges)
 
-        baseline_dim = self._baseline_dimension(element)
+        top_dim, baseline_dim = self._baseline_dimensions(element)
         self._warn_unused_baseline(element, baseline_dim)
+        # For floating bars the upper end is top_dim (the value dimension left
+        # once the baseline is removed); otherwise the plotted value is vdims[0].
+        value_dim = top_dim if baseline_dim is not None else element.vdims[0]
 
         cats = None
         style_dim = None
@@ -1179,12 +1183,12 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
                         label = sdim.pprint_value(stk)
                         sel_key[sdim.name] = [stk]
                     el = element.select(**sel_key)
-                    vals = el.dimension_values(element.vdims[0].name)
+                    vals = el.dimension_values(value_dim)
                     val = float(vals[0]) if len(vals) else np.nan
                     xval = xpos
 
                     # Floating bars span from a per-bar baseline dimension up
-                    # to vdims[0] rather than growing from the stacked base.
+                    # to the upper dimension rather than growing from the base.
                     if baseline_dim is not None:
                         bvals = el.dimension_values(baseline_dim)
                         bottom_val = float(bvals[0]) if len(bvals) else 0.0

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -989,8 +989,9 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         each bar), making the bars float between two value dimensions
         instead of growing from a zero baseline. Accepts a dimension
         name or index; vdims[0] supplies one end and this dimension the
-        other. Only supported for a single key dimension (ungrouped,
-        unstacked) Bars.""",
+        other, and must be the lower end of every bar. Supported for
+        ungrouped and grouped Bars; combining it with stacked raises an
+        error.""",
     )
 
     multi_level = param.Boolean(

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -952,6 +952,8 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
 
         top_dim, baseline_dim = self._baseline_dimensions(element)
         self._warn_unused_baseline(element, baseline_dim)
+        if baseline_dim is not None:
+            self._validate_baseline(element, top_dim, baseline_dim)
         # For floating bars the upper end is top_dim; otherwise it is vdims[0].
         value_dim = top_dim if baseline_dim is not None else element.vdims[0]
 

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -190,14 +190,12 @@ class BarPlot(BarsMixin, ElementPlot):
         class_=(str, int),
         allow_None=True,
         doc="""
-        Value dimension to use as a per-bar baseline (the other end of
-        each bar), making the bars float between two value dimensions
-        instead of growing from a zero baseline. Accepts a dimension name
-        or index naming the lower end of each bar; the first remaining value
-        dimension (once the baseline is removed) is the upper end, so
-        vdims=['Low', 'High'] with baseline='Low' spans Low to High. The
-        baseline must be the lower end of every bar. Supported for ungrouped
-        and grouped Bars; combining it with stacked raises an error.""",
+        Value dimension naming the lower end of each bar, making bars
+        float between two value dimensions instead of growing from zero.
+        The first remaining value dimension is the upper end, so
+        vdims=['Low', 'High'] with baseline='Low' spans Low to High.
+        Supported for ungrouped and grouped Bars; combining it with
+        stacked raises an error.""",
     )
 
     multi_level = param.Boolean(
@@ -242,8 +240,7 @@ class BarPlot(BarsMixin, ElementPlot):
         # Get x, y, group, stack and color dimensions
         xdim = element.kdims[0]
         vdim = element.vdims[0]
-        # Floating bars span baseline_dim (bottom) up to top_dim (the value
-        # dimension left once the baseline is removed).
+        # Floating bars span baseline_dim (bottom) up to top_dim.
         top_dim, baseline_dim = self._baseline_dimensions(element)
         self._warn_unused_baseline(element, baseline_dim)
         group_dim, stack_dim = None, None
@@ -277,8 +274,7 @@ class BarPlot(BarsMixin, ElementPlot):
                 if baseline_dim is None:
                     values.append(sel.iloc[0, 1] if len(sel) else 0)
                     continue
-                # Floating bars: the trace base sets the lower end and the bar
-                # length is measured from it, so y holds top minus baseline.
+                # Floating bars: base sets the lower end, y the bar length.
                 top = sel.dimension_values(top_dim)[0] if len(sel) else 0
                 base = sel.dimension_values(baseline_dim)[0] if len(sel) else 0
                 values.append(top - base)

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -194,8 +194,9 @@ class BarPlot(BarsMixin, ElementPlot):
         each bar), making the bars float between two value dimensions
         instead of growing from a zero baseline. Accepts a dimension
         name or index; vdims[0] supplies one end and this dimension the
-        other. Only supported for a single key dimension (ungrouped,
-        unstacked) Bars.""",
+        other, and must be the lower end of every bar. Supported for
+        ungrouped and grouped Bars; combining it with stacked raises an
+        error.""",
     )
 
     multi_level = param.Boolean(
@@ -294,30 +295,41 @@ class BarPlot(BarsMixin, ElementPlot):
                 els.items(), key=lambda x: order.index(x[0]) if x[0] in order else -1
             )
             for k, el in sorted_groups[::-1]:
-                values = []
+                values, bases = [], []
                 for v in xvals:
                     sel = el[[v]]
-                    values.append(sel.iloc[0, 1] if len(sel) else 0)
-                bars.append(
-                    {
-                        "orientation": orientation,
-                        "name": group_dim.pprint_value(k),
-                        x: xvals,
-                        y: np.nan_to_num(values),
-                    }
-                )
-        else:
-            values = element.dimension_values(vdim)
-            bars.append(
-                {
+                    top = sel.iloc[0, 1] if len(sel) else 0
+                    if baseline_dim is None:
+                        values.append(top)
+                        continue
+                    base = sel.dimension_values(baseline_dim)[0] if len(sel) else 0
+                    values.append(top - base)
+                    bases.append(base)
+                bar = {
                     "orientation": orientation,
-                    x: [
-                        [d.pprint_value(v) for v in element.dimension_values(d)]
-                        for d in (xdim, group_dim)
-                    ],
+                    "name": group_dim.pprint_value(k),
+                    x: xvals,
                     y: np.nan_to_num(values),
                 }
-            )
+                if baseline_dim is not None:
+                    bar["base"] = np.nan_to_num(bases)
+                bars.append(bar)
+        else:
+            values = element.dimension_values(vdim)
+            bar = {
+                "orientation": orientation,
+                x: [
+                    [d.pprint_value(v) for v in element.dimension_values(d)]
+                    for d in (xdim, group_dim)
+                ],
+                y: np.nan_to_num(values),
+            }
+            if baseline_dim is not None:
+                # Floating grouped bars: base is the lower end, y the length.
+                base = element.dimension_values(baseline_dim)
+                bar[y] = np.nan_to_num(values - base)
+                bar["base"] = np.nan_to_num(base)
+            bars.append(bar)
 
         return bars
 

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -185,6 +185,19 @@ class ErrorBarsPlot(ChartPlot, ColorbarPlot):
 
 
 class BarPlot(BarsMixin, ElementPlot):
+    baseline = param.ClassSelector(
+        default=None,
+        class_=(str, int),
+        allow_None=True,
+        doc="""
+        Value dimension to use as a per-bar baseline (the other end of
+        each bar), making the bars float between two value dimensions
+        instead of growing from a zero baseline. Accepts a dimension
+        name or index; vdims[0] supplies one end and this dimension the
+        other. Only supported for a single key dimension (ungrouped,
+        unstacked) Bars.""",
+    )
+
     multi_level = param.Boolean(
         default=True,
         doc="Whether the Bars should be grouped into a second categorical axis level.",
@@ -225,6 +238,8 @@ class BarPlot(BarsMixin, ElementPlot):
         # Get x, y, group, stack and color dimensions
         xdim = element.kdims[0]
         vdim = element.vdims[0]
+        baseline_dim = self._baseline_dimension(element)
+        self._warn_unused_baseline(element, baseline_dim)
         group_dim, stack_dim = None, None
         if element.ndims == 1:
             pass
@@ -250,18 +265,27 @@ class BarPlot(BarsMixin, ElementPlot):
 
         bars = []
         if element.ndims == 1:
-            values = []
+            values, bases = [], []
             for v in xvals:
                 sel = element[[v]]
-                values.append(sel.iloc[0, 1] if len(sel) else 0)
-            bars.append(
-                {
-                    "orientation": orientation,
-                    "showlegend": False,
-                    x: xvals,
-                    y: np.nan_to_num(values),
-                }
-            )
+                top = sel.iloc[0, 1] if len(sel) else 0
+                if baseline_dim is None:
+                    values.append(top)
+                    continue
+                # Floating bars: the trace base sets the lower end and the bar
+                # length is measured from it, so y holds top minus baseline.
+                base = sel.dimension_values(baseline_dim)[0] if len(sel) else 0
+                values.append(top - base)
+                bases.append(base)
+            bar = {
+                "orientation": orientation,
+                "showlegend": False,
+                x: xvals,
+                y: np.nan_to_num(values),
+            }
+            if baseline_dim is not None:
+                bar["base"] = np.nan_to_num(bases)
+            bars.append(bar)
         elif stack_dim or not self.multi_level:
             group_dim = stack_dim or group_dim
             order = list(svals if stack_dim else gvals)

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -228,6 +228,8 @@ class BarPlot(BarsMixin, ElementPlot):
         # Floating bars span baseline_dim (bottom) up to top_dim.
         top_dim, baseline_dim = self._baseline_dimensions(element)
         self._warn_unused_baseline(element, baseline_dim)
+        if baseline_dim is not None:
+            self._validate_baseline(element, top_dim, baseline_dim)
         group_dim, stack_dim = None, None
         if element.ndims == 1:
             pass

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -192,11 +192,12 @@ class BarPlot(BarsMixin, ElementPlot):
         doc="""
         Value dimension to use as a per-bar baseline (the other end of
         each bar), making the bars float between two value dimensions
-        instead of growing from a zero baseline. Accepts a dimension
-        name or index; vdims[0] supplies one end and this dimension the
-        other, and must be the lower end of every bar. Supported for
-        ungrouped and grouped Bars; combining it with stacked raises an
-        error.""",
+        instead of growing from a zero baseline. Accepts a dimension name
+        or index naming the lower end of each bar; the first remaining value
+        dimension (once the baseline is removed) is the upper end, so
+        vdims=['Low', 'High'] with baseline='Low' spans Low to High. The
+        baseline must be the lower end of every bar. Supported for ungrouped
+        and grouped Bars; combining it with stacked raises an error.""",
     )
 
     multi_level = param.Boolean(
@@ -227,7 +228,9 @@ class BarPlot(BarsMixin, ElementPlot):
             xdims = element.kdims
         else:
             xdims = element.kdims[0]
-        return (xdims, element.vdims[0])
+        # Floating bars: label the value axis with the upper dimension.
+        top_dim, _ = self._baseline_dimensions(element)
+        return (xdims, top_dim if top_dim is not None else element.vdims[0])
 
     def get_extents(self, element, ranges, range_type="combined", **kwargs):
         x0, y0, x1, y1 = BarsMixin.get_extents(self, element, ranges, range_type)
@@ -239,7 +242,9 @@ class BarPlot(BarsMixin, ElementPlot):
         # Get x, y, group, stack and color dimensions
         xdim = element.kdims[0]
         vdim = element.vdims[0]
-        baseline_dim = self._baseline_dimension(element)
+        # Floating bars span baseline_dim (bottom) up to top_dim (the value
+        # dimension left once the baseline is removed).
+        top_dim, baseline_dim = self._baseline_dimensions(element)
         self._warn_unused_baseline(element, baseline_dim)
         group_dim, stack_dim = None, None
         if element.ndims == 1:
@@ -269,12 +274,12 @@ class BarPlot(BarsMixin, ElementPlot):
             values, bases = [], []
             for v in xvals:
                 sel = element[[v]]
-                top = sel.iloc[0, 1] if len(sel) else 0
                 if baseline_dim is None:
-                    values.append(top)
+                    values.append(sel.iloc[0, 1] if len(sel) else 0)
                     continue
                 # Floating bars: the trace base sets the lower end and the bar
                 # length is measured from it, so y holds top minus baseline.
+                top = sel.dimension_values(top_dim)[0] if len(sel) else 0
                 base = sel.dimension_values(baseline_dim)[0] if len(sel) else 0
                 values.append(top - base)
                 bases.append(base)
@@ -298,10 +303,10 @@ class BarPlot(BarsMixin, ElementPlot):
                 values, bases = [], []
                 for v in xvals:
                     sel = el[[v]]
-                    top = sel.iloc[0, 1] if len(sel) else 0
                     if baseline_dim is None:
-                        values.append(top)
+                        values.append(sel.iloc[0, 1] if len(sel) else 0)
                         continue
+                    top = sel.dimension_values(top_dim)[0] if len(sel) else 0
                     base = sel.dimension_values(baseline_dim)[0] if len(sel) else 0
                     values.append(top - base)
                     bases.append(base)
@@ -315,7 +320,8 @@ class BarPlot(BarsMixin, ElementPlot):
                     bar["base"] = np.nan_to_num(bases)
                 bars.append(bar)
         else:
-            values = element.dimension_values(vdim)
+            value_dim = top_dim if baseline_dim is not None else vdim
+            values = element.dimension_values(value_dim)
             bar = {
                 "orientation": orientation,
                 x: [

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -152,12 +152,10 @@ class TestBarPlot(TestBokehPlot):
         source = plot.handles["source"]
         glyph = plot.handles["glyph"]
         assert_data_equal(source.data["bottom"], np.array(expected_bottom))
-        # Both ends are column references (floating), not the scalar 0 baseline.
         assert property_to_dict(glyph.top) == "high"
         assert property_to_dict(glyph.bottom) == "bottom"
 
     def test_bars_baseline_floating_inverted(self):
-        # invert_axes draws hbars: bottom/top map to the left/right ends.
         df = pd.DataFrame({"x": ["a", "b", "c"], "high": [3, 5, 4], "low": [1, 2, 1.5]})
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low", invert_axes=True)
         plot = bokeh_renderer.get_plot(bars)
@@ -168,7 +166,6 @@ class TestBarPlot(TestBokehPlot):
         assert property_to_dict(glyph.right) == "high"
 
     def test_bars_baseline_floating_timedelta(self):
-        # Gantt-style: timedelta value dimensions float between Start and End.
         df = pd.DataFrame(
             {
                 "Task": ["Build", "Test", "Deploy"],
@@ -194,7 +191,6 @@ class TestBarPlot(TestBokehPlot):
         assert property_to_dict(glyph.right) == "End"
 
     def test_bars_baseline_floating_range_excludes_zero(self):
-        # Floating bars span [low, high]; 0 must not be forced into the range.
         df = pd.DataFrame({"x": ["a", "b"], "high": [30.0, 40.0], "low": [10.0, 20.0]})
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low", padding=0)
         plot = bokeh_renderer.get_plot(bars)
@@ -203,7 +199,6 @@ class TestBarPlot(TestBokehPlot):
         assert y_range.end == 40.0
 
     def test_bars_baseline_range_includes_zero_without_baseline(self):
-        # Without baseline the same data is anchored at 0 (regression guard).
         df = pd.DataFrame({"x": ["a", "b"], "high": [30.0, 40.0], "low": [10.0, 20.0]})
         bars = hv.Bars(df, "x", ["high", "low"]).opts(padding=0)
         plot = bokeh_renderer.get_plot(bars)
@@ -221,16 +216,12 @@ class TestBarPlot(TestBokehPlot):
 
     @pytest.mark.parametrize("low", [[6.0, 8.0], [1.0, 8.0]], ids=["all_exceed", "one_exceeds"])
     def test_bars_baseline_exceeds_errors(self, low):
-        # The baseline must be the lower end of every bar; an inverted range
-        # (low > high) is a usage error, even for a single bar.
         df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": low})
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
         with pytest.raises(ValueError, match="exceed"):
             bokeh_renderer.get_plot(bars)
 
     def test_bars_baseline_low_first(self):
-        # Order-flexible: baseline names the lower dim and the remaining value
-        # dimension is the upper end, so ['Low', 'High'] + baseline='Low' works.
         df = pd.DataFrame({"x": ["a", "b", "c"], "low": [1, 2, 1.5], "high": [3, 5, 4]})
         bars = hv.Bars(df, "x", ["low", "high"]).opts(baseline="low")
         plot = bokeh_renderer.get_plot(bars)
@@ -247,8 +238,6 @@ class TestBarPlot(TestBokehPlot):
         ids=["unresolved", "only_value_dim"],
     )
     def test_bars_baseline_unusable_warns(self, vdims, baseline):
-        # An unresolved baseline, or one that leaves no other value dimension
-        # as the upper end, falls back to a zero baseline.
         df = pd.DataFrame({"x": ["a", "b"], "high": [3, 5], "low": [1, 2]})
         bars = hv.Bars(df, "x", vdims).opts(baseline=baseline)
         with ParamLogStream() as log:
@@ -258,7 +247,6 @@ class TestBarPlot(TestBokehPlot):
         assert "bottom" not in plot.handles["source"].data
 
     def test_bars_baseline_grouped(self):
-        # Each grouped bar floats from its baseline (Low) up to vdims[0] (High).
         bars = hv.Bars(
             [("Q1", "E", 10, 2), ("Q1", "W", 7, 1), ("Q2", "E", 12, 3), ("Q2", "W", 9, 4)],
             kdims=["Quarter", "Region"],
@@ -272,7 +260,6 @@ class TestBarPlot(TestBokehPlot):
         assert sorted(source.data["High"]) == [7, 9, 10, 12]
 
     def test_bars_baseline_stacked_errors(self):
-        # Stacking defines the segment baselines, so a baseline is a usage error.
         bars = hv.Bars(
             [("A", 0, 1), ("A", 1, -1), ("B", 0, 2)], kdims=["Index", "Category"], vdims=["Value"]
         ).opts(stacked=True, baseline="Value")

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -157,6 +157,35 @@ class TestBarPlot(TestBokehPlot):
         source = plot.handles["source"]
         assert_data_equal(source.data["bottom"], np.array([1.0, 2.0, 1.5]))
 
+    def test_bars_baseline_floating_inverted(self):
+        # invert_axes draws hbars: bottom/top map to the left/right ends.
+        df = pd.DataFrame({"x": ["a", "b", "c"], "high": [3, 5, 4], "low": [1, 2, 1.5]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low", invert_axes=True)
+        plot = bokeh_renderer.get_plot(bars)
+        source = plot.handles["source"]
+        glyph = plot.handles["glyph"]
+        assert_data_equal(source.data["bottom"], np.array([1, 2, 1.5]))
+        assert property_to_dict(glyph.left) == "bottom"
+        assert property_to_dict(glyph.right) == "high"
+
+    def test_bars_baseline_floating_timedelta(self):
+        # Gantt-style: timedelta value dimensions float between Start and End.
+        df = pd.DataFrame(
+            {
+                "Task": ["Build", "Test", "Deploy"],
+                "Start": pd.to_timedelta(["1h", "3h", "5h30m"]),
+                "End": pd.to_timedelta(["3h", "5h30m", "7h"]),
+            }
+        )
+        bars = hv.Bars(df, "Task", ["End", "Start"]).opts(baseline="Start", invert_axes=True)
+        plot = bokeh_renderer.get_plot(bars)
+        source = plot.handles["source"]
+        glyph = plot.handles["glyph"]
+        assert_data_equal(source.data["bottom"], bars.dimension_values("Start"))
+        assert_data_equal(source.data["End"], bars.dimension_values("End"))
+        assert property_to_dict(glyph.left) == "bottom"
+        assert property_to_dict(glyph.right) == "End"
+
     def test_bars_baseline_floating_range_excludes_zero(self):
         # Floating bars span [low, high]; 0 must not be forced into the range.
         df = pd.DataFrame({"x": ["a", "b"], "high": [30.0, 40.0], "low": [10.0, 20.0]})
@@ -198,16 +227,27 @@ class TestBarPlot(TestBokehPlot):
         assert f"Could not use baseline dimension {baseline!r}" in log_msg
         assert "bottom" not in plot.handles["source"].data
 
-    def test_bars_baseline_ignored_when_grouped(self):
-        # Floating bars are only supported for a single key dimension.
+    def test_bars_baseline_grouped(self):
+        # Each grouped bar floats from its baseline (Low) up to vdims[0] (High).
         bars = hv.Bars(
-            [("a", 0, 1), ("a", 1, 2), ("b", 0, 3)], kdims=["x", "g"], vdims=["v"]
-        ).opts(baseline="v")
-        with ParamLogStream() as log:
-            plot = bokeh_renderer.get_plot(bars)
-        log_msg = log.stream.read()
-        assert "only supported for ungrouped" in log_msg
-        assert "bottom" not in plot.handles["source"].data
+            [("Q1", "E", 10, 2), ("Q1", "W", 7, 1), ("Q2", "E", 12, 3), ("Q2", "W", 9, 4)],
+            kdims=["Quarter", "Region"],
+            vdims=["High", "Low"],
+        ).opts(baseline="Low")
+        plot = bokeh_renderer.get_plot(bars)
+        source = plot.handles["source"]
+        # Order depends on the group iteration, so compare order-independently.
+        assert property_to_dict(plot.handles["glyph"].bottom) == "bottom"
+        assert sorted(source.data["bottom"]) == [1, 2, 3, 4]
+        assert sorted(source.data["High"]) == [7, 9, 10, 12]
+
+    def test_bars_baseline_stacked_errors(self):
+        # Stacking defines the segment baselines, so a baseline is a usage error.
+        bars = hv.Bars(
+            [("A", 0, 1), ("A", 1, -1), ("B", 0, 2)], kdims=["Index", "Category"], vdims=["Value"]
+        ).opts(stacked=True, baseline="Value")
+        with pytest.raises(ValueError, match="stacked"):
+            bokeh_renderer.get_plot(bars)
 
     def test_bars_logy(self):
         bars = hv.Bars([("A", 1), ("B", 2), ("C", 3)], kdims=["Index"], vdims=["Value"])

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -117,6 +117,98 @@ class TestBarPlot(TestBokehPlot):
         assert_data_equal(source.data["top"], np.array([0, 1, 2]))
         assert_data_equal(source.data["bottom"], np.array([-1, 0, 0]))
 
+    def test_bars_baseline_floating_source_data(self):
+        df = pd.DataFrame({"x": ["a", "b", "c"], "high": [3, 5, 4], "low": [1, 2, 1.5]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        plot = bokeh_renderer.get_plot(bars)
+        source = plot.handles["source"]
+        glyph = plot.handles["glyph"]
+        assert_data_equal(source.data["high"], np.array([3, 5, 4]))
+        assert_data_equal(source.data["bottom"], np.array([1, 2, 1.5]))
+        # Both ends are column references (floating), not the scalar 0 baseline.
+        assert property_to_dict(glyph.top) == "high"
+        assert property_to_dict(glyph.bottom) == "bottom"
+
+    def test_bars_baseline_by_index(self):
+        # baseline accepts a dimension index; 'low' is dimension 2 (x, high, low)
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3, 5], "low": [1, 2]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline=2)
+        plot = bokeh_renderer.get_plot(bars)
+        source = plot.handles["source"]
+        assert_data_equal(source.data["bottom"], np.array([1, 2]))
+
+    def test_bars_baseline_floating_nan(self):
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, np.nan]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        plot = bokeh_renderer.get_plot(bars)
+        source = plot.handles["source"]
+        assert_data_equal(source.data["bottom"], np.array([1.0, np.nan]))
+
+    def test_bars_baseline_floating_datetime(self):
+        df = pd.DataFrame(
+            {
+                "x": pd.date_range("2024-01-01", periods=3),
+                "high": [3.0, 5.0, 4.0],
+                "low": [1.0, 2.0, 1.5],
+            }
+        )
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        plot = bokeh_renderer.get_plot(bars)
+        source = plot.handles["source"]
+        assert_data_equal(source.data["bottom"], np.array([1.0, 2.0, 1.5]))
+
+    def test_bars_baseline_floating_range_excludes_zero(self):
+        # Floating bars span [low, high]; 0 must not be forced into the range.
+        df = pd.DataFrame({"x": ["a", "b"], "high": [30.0, 40.0], "low": [10.0, 20.0]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low", padding=0)
+        plot = bokeh_renderer.get_plot(bars)
+        y_range = plot.handles["y_range"]
+        assert y_range.start == 10.0
+        assert y_range.end == 40.0
+
+    def test_bars_baseline_range_includes_zero_without_baseline(self):
+        # Without baseline the same data is anchored at 0 (regression guard).
+        df = pd.DataFrame({"x": ["a", "b"], "high": [30.0, 40.0], "low": [10.0, 20.0]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(padding=0)
+        plot = bokeh_renderer.get_plot(bars)
+        y_range = plot.handles["y_range"]
+        assert y_range.start == 0
+
+    @pytest.mark.parametrize("low", [[6.0, 8.0], [1.0, 8.0]], ids=["all_exceed", "one_exceeds"])
+    def test_bars_baseline_exceeds_errors(self, low):
+        # The baseline must be the lower end of every bar; an inverted range
+        # (low > high) is a usage error, even for a single bar.
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": low})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        with pytest.raises(ValueError, match="exceed"):
+            bokeh_renderer.get_plot(bars)
+
+    @pytest.mark.parametrize(
+        ("vdims", "baseline"),
+        [(["high"], "nope"), (["high"], "high"), (["high", "low"], "high")],
+        ids=["unresolved", "single_vdim", "same_as_value_dim"],
+    )
+    def test_bars_baseline_unusable_warns(self, vdims, baseline):
+        # Unresolved or value-dimension baselines fall back to a zero baseline.
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3, 5], "low": [1, 2]})
+        bars = hv.Bars(df, "x", vdims).opts(baseline=baseline)
+        with ParamLogStream() as log:
+            plot = bokeh_renderer.get_plot(bars)
+        log_msg = log.stream.read()
+        assert f"Could not use baseline dimension {baseline!r}" in log_msg
+        assert "bottom" not in plot.handles["source"].data
+
+    def test_bars_baseline_ignored_when_grouped(self):
+        # Floating bars are only supported for a single key dimension.
+        bars = hv.Bars(
+            [("a", 0, 1), ("a", 1, 2), ("b", 0, 3)], kdims=["x", "g"], vdims=["v"]
+        ).opts(baseline="v")
+        with ParamLogStream() as log:
+            plot = bokeh_renderer.get_plot(bars)
+        log_msg = log.stream.read()
+        assert "only supported for ungrouped" in log_msg
+        assert "bottom" not in plot.handles["source"].data
+
     def test_bars_logy(self):
         bars = hv.Bars([("A", 1), ("B", 2), ("C", 3)], kdims=["Index"], vdims=["Value"])
         plot = bokeh_renderer.get_plot(bars.opts(logy=True))

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -117,45 +117,44 @@ class TestBarPlot(TestBokehPlot):
         assert_data_equal(source.data["top"], np.array([0, 1, 2]))
         assert_data_equal(source.data["bottom"], np.array([-1, 0, 0]))
 
-    def test_bars_baseline_floating_source_data(self):
-        df = pd.DataFrame({"x": ["a", "b", "c"], "high": [3, 5, 4], "low": [1, 2, 1.5]})
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+    @pytest.mark.parametrize(
+        ("df", "baseline", "expected_bottom"),
+        [
+            (
+                pd.DataFrame({"x": ["a", "b", "c"], "high": [3, 5, 4], "low": [1, 2, 1.5]}),
+                "low",
+                [1, 2, 1.5],
+            ),
+            # baseline by dimension index; 'low' is dimension 2 (x, high, low)
+            (pd.DataFrame({"x": ["a", "b"], "high": [3, 5], "low": [1, 2]}), 2, [1, 2]),
+            (
+                pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, np.nan]}),
+                "low",
+                [1.0, np.nan],
+            ),
+            (
+                pd.DataFrame(
+                    {
+                        "x": pd.date_range("2024-01-01", periods=3),
+                        "high": [3.0, 5.0, 4.0],
+                        "low": [1.0, 2.0, 1.5],
+                    }
+                ),
+                "low",
+                [1.0, 2.0, 1.5],
+            ),
+        ],
+        ids=["by_name", "by_index", "nan", "datetime_x"],
+    )
+    def test_bars_baseline_floating_source_data(self, df, baseline, expected_bottom):
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline=baseline)
         plot = bokeh_renderer.get_plot(bars)
         source = plot.handles["source"]
         glyph = plot.handles["glyph"]
-        assert_data_equal(source.data["high"], np.array([3, 5, 4]))
-        assert_data_equal(source.data["bottom"], np.array([1, 2, 1.5]))
+        assert_data_equal(source.data["bottom"], np.array(expected_bottom))
         # Both ends are column references (floating), not the scalar 0 baseline.
         assert property_to_dict(glyph.top) == "high"
         assert property_to_dict(glyph.bottom) == "bottom"
-
-    def test_bars_baseline_by_index(self):
-        # baseline accepts a dimension index; 'low' is dimension 2 (x, high, low)
-        df = pd.DataFrame({"x": ["a", "b"], "high": [3, 5], "low": [1, 2]})
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline=2)
-        plot = bokeh_renderer.get_plot(bars)
-        source = plot.handles["source"]
-        assert_data_equal(source.data["bottom"], np.array([1, 2]))
-
-    def test_bars_baseline_floating_nan(self):
-        df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, np.nan]})
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
-        plot = bokeh_renderer.get_plot(bars)
-        source = plot.handles["source"]
-        assert_data_equal(source.data["bottom"], np.array([1.0, np.nan]))
-
-    def test_bars_baseline_floating_datetime(self):
-        df = pd.DataFrame(
-            {
-                "x": pd.date_range("2024-01-01", periods=3),
-                "high": [3.0, 5.0, 4.0],
-                "low": [1.0, 2.0, 1.5],
-            }
-        )
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
-        plot = bokeh_renderer.get_plot(bars)
-        source = plot.handles["source"]
-        assert_data_equal(source.data["bottom"], np.array([1.0, 2.0, 1.5]))
 
     def test_bars_baseline_floating_inverted(self):
         # invert_axes draws hbars: bottom/top map to the left/right ends.

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -14,6 +14,7 @@ import holoviews as hv
 from holoviews.plotting.bokeh.util import property_to_dict
 from holoviews.testing import assert_data_equal
 
+from ...plotting.utils import ParamLogStream
 from .test_plot import TestBokehPlot, bokeh_renderer
 
 

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -118,40 +118,28 @@ class TestBarPlot(TestBokehPlot):
         assert_data_equal(source.data["bottom"], np.array([-1, 0, 0]))
 
     @pytest.mark.parametrize(
-        ("df", "baseline", "expected_bottom"),
+        ("data", "baseline"),
         [
+            ({"x": ["a", "b", "c"], "high": [3, 5, 4], "low": [1, 2, 1.5]}, "low"),
+            ({"x": ["a", "b"], "high": [3, 5], "low": [1, 2]}, 2),
+            ({"x": ["a", "b"], "high": [3, 5], "low": [1, np.nan]}, "low"),
             (
-                pd.DataFrame({"x": ["a", "b", "c"], "high": [3, 5, 4], "low": [1, 2, 1.5]}),
+                {
+                    "x": pd.date_range("2024-01-01", periods=3),
+                    "high": [3.0, 5.0, 4.0],
+                    "low": [1.0, 2.0, 1.5],
+                },
                 "low",
-                [1, 2, 1.5],
-            ),
-            # baseline by dimension index; 'low' is dimension 2 (x, high, low)
-            (pd.DataFrame({"x": ["a", "b"], "high": [3, 5], "low": [1, 2]}), 2, [1, 2]),
-            (
-                pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, np.nan]}),
-                "low",
-                [1.0, np.nan],
-            ),
-            (
-                pd.DataFrame(
-                    {
-                        "x": pd.date_range("2024-01-01", periods=3),
-                        "high": [3.0, 5.0, 4.0],
-                        "low": [1.0, 2.0, 1.5],
-                    }
-                ),
-                "low",
-                [1.0, 2.0, 1.5],
             ),
         ],
         ids=["by_name", "by_index", "nan", "datetime_x"],
     )
-    def test_bars_baseline_floating_source_data(self, df, baseline, expected_bottom):
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline=baseline)
+    def test_bars_baseline_floating_source_data(self, data, baseline):
+        bars = hv.Bars(pd.DataFrame(data), "x", ["high", "low"]).opts(baseline=baseline)
         plot = bokeh_renderer.get_plot(bars)
         source = plot.handles["source"]
         glyph = plot.handles["glyph"]
-        assert_data_equal(source.data["bottom"], np.array(expected_bottom))
+        assert_data_equal(source.data["bottom"], np.array(data["low"]))
         assert property_to_dict(glyph.top) == "high"
         assert property_to_dict(glyph.bottom) == "bottom"
 

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -210,6 +210,15 @@ class TestBarPlot(TestBokehPlot):
         y_range = plot.handles["y_range"]
         assert y_range.start == 0
 
+    def test_bars_baseline_range_uses_top_dim_when_baseline_is_vdims0(self):
+        low_dim = hv.Dimension("low", soft_range=(0, None))
+        df = pd.DataFrame({"x": ["a", "b"], "high": [30.0, 40.0], "low": [10.0, 20.0]})
+        bars = hv.Bars(df, "x", [low_dim, "high"]).opts(baseline="low", padding=0)
+        plot = bokeh_renderer.get_plot(bars)
+        y_range = plot.handles["y_range"]
+        assert y_range.start == 10.0
+        assert y_range.end == 40.0
+
     @pytest.mark.parametrize("low", [[6.0, 8.0], [1.0, 8.0]], ids=["all_exceed", "one_exceeds"])
     def test_bars_baseline_exceeds_errors(self, low):
         # The baseline must be the lower end of every bar; an inverted range

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -181,8 +181,16 @@ class TestBarPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(bars)
         source = plot.handles["source"]
         glyph = plot.handles["glyph"]
-        assert_data_equal(source.data["bottom"], bars.dimension_values("Start"))
-        assert_data_equal(source.data["End"], bars.dimension_values("End"))
+        # Normalize timedelta units before comparing (assert_data_equal uses
+        # almost-equal, which cannot promote timedelta64 to float).
+        np.testing.assert_array_equal(
+            np.asarray(source.data["bottom"]).astype("timedelta64[ns]"),
+            np.asarray(bars.dimension_values("Start")).astype("timedelta64[ns]"),
+        )
+        np.testing.assert_array_equal(
+            np.asarray(source.data["End"]).astype("timedelta64[ns]"),
+            np.asarray(bars.dimension_values("End")).astype("timedelta64[ns]"),
+        )
         assert property_to_dict(glyph.left) == "bottom"
         assert property_to_dict(glyph.right) == "End"
 
@@ -212,13 +220,27 @@ class TestBarPlot(TestBokehPlot):
         with pytest.raises(ValueError, match="exceed"):
             bokeh_renderer.get_plot(bars)
 
+    def test_bars_baseline_low_first(self):
+        # Order-flexible: baseline names the lower dim and the remaining value
+        # dimension is the upper end, so ['Low', 'High'] + baseline='Low' works.
+        df = pd.DataFrame({"x": ["a", "b", "c"], "low": [1, 2, 1.5], "high": [3, 5, 4]})
+        bars = hv.Bars(df, "x", ["low", "high"]).opts(baseline="low")
+        plot = bokeh_renderer.get_plot(bars)
+        source = plot.handles["source"]
+        glyph = plot.handles["glyph"]
+        assert_data_equal(source.data["high"], np.array([3, 5, 4]))
+        assert_data_equal(source.data["bottom"], np.array([1, 2, 1.5]))
+        assert property_to_dict(glyph.top) == "high"
+        assert property_to_dict(glyph.bottom) == "bottom"
+
     @pytest.mark.parametrize(
         ("vdims", "baseline"),
-        [(["high"], "nope"), (["high"], "high"), (["high", "low"], "high")],
-        ids=["unresolved", "single_vdim", "same_as_value_dim"],
+        [(["high"], "nope"), (["high"], "high")],
+        ids=["unresolved", "only_value_dim"],
     )
     def test_bars_baseline_unusable_warns(self, vdims, baseline):
-        # Unresolved or value-dimension baselines fall back to a zero baseline.
+        # An unresolved baseline, or one that leaves no other value dimension
+        # as the upper end, falls back to a zero baseline.
         df = pd.DataFrame({"x": ["a", "b"], "high": [3, 5], "low": [1, 2]})
         bars = hv.Bars(df, "x", vdims).opts(baseline=baseline)
         with ParamLogStream() as log:

--- a/holoviews/tests/plotting/matplotlib/test_barplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_barplot.py
@@ -163,7 +163,7 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
         plot = mpl_renderer.get_plot(bars)
         ax = plot.handles["axis"]
-        # Bottom of each bar is the baseline, height spans up to vdims[0].
+        # Bottom of each bar is the baseline, height spans up to the upper dim.
         np.testing.assert_allclose([p.get_y() for p in ax.patches], [1.0, 2.0, 1.5])
         np.testing.assert_allclose([p.get_height() for p in ax.patches], [2.0, 3.0, 2.5])
 
@@ -218,16 +218,17 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         with pytest.raises(ValueError, match="exceed"):
             mpl_renderer.get_plot(bars)
 
-    def test_bars_baseline_same_as_value_dim_warns(self):
-        df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]})
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="high")
+    def test_bars_baseline_low_first(self):
+        # Order-flexible: ['low', 'high'] + baseline='low' spans low -> high.
+        df = pd.DataFrame({"x": ["a", "b", "c"], "low": [1.0, 2.0, 1.5], "high": [3.0, 5.0, 4.0]})
+        bars = hv.Bars(df, "x", ["low", "high"]).opts(baseline="low")
         plot = mpl_renderer.get_plot(bars)
-        # Rejected (would give zero-height bars); falls back to a zero baseline.
-        np.testing.assert_allclose([p.get_y() for p in plot.handles["axis"].patches], [0.0, 0.0])
-        self.log_handler.assert_contains("WARNING", "Could not use baseline dimension 'high'")
+        ax = plot.handles["axis"]
+        np.testing.assert_allclose([p.get_y() for p in ax.patches], [1.0, 2.0, 1.5])
+        np.testing.assert_allclose([p.get_height() for p in ax.patches], [2.0, 3.0, 2.5])
 
     def test_bars_baseline_grouped(self):
-        # Each grouped bar floats from its baseline (Low) up to vdims[0] (High).
+        # Each grouped bar floats from its baseline (Low) up to the upper dim (High).
         bars = hv.Bars(
             [("Q1", "E", 10, 2), ("Q1", "W", 7, 1), ("Q2", "E", 12, 3), ("Q2", "W", 9, 4)],
             kdims=["Quarter", "Region"],

--- a/holoviews/tests/plotting/matplotlib/test_barplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_barplot.py
@@ -158,41 +158,52 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         for i, tick in enumerate(ax.get_xticklabels()):
             assert tick.get_text() == xticklabels[i]
 
-    def test_bars_baseline_floating(self):
-        df = pd.DataFrame({"x": ["a", "b", "c"], "high": [3.0, 5.0, 4.0], "low": [1.0, 2.0, 1.5]})
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
-        plot = mpl_renderer.get_plot(bars)
-        ax = plot.handles["axis"]
-        # Bottom of each bar is the baseline, height spans up to the upper dim.
-        np.testing.assert_allclose([p.get_y() for p in ax.patches], [1.0, 2.0, 1.5])
-        np.testing.assert_allclose([p.get_height() for p in ax.patches], [2.0, 3.0, 2.5])
-
-    def test_bars_baseline_floating_datetime(self):
-        df = pd.DataFrame(
-            {
-                "x": pd.date_range("2024-01-01", periods=3),
-                "high": [3.0, 5.0, 4.0],
-                "low": [1.0, 2.0, 1.5],
-            }
-        )
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
-        plot = mpl_renderer.get_plot(bars)
-        ax = plot.handles["axis"]
-        np.testing.assert_allclose([p.get_y() for p in ax.patches], [1.0, 2.0, 1.5])
-        np.testing.assert_allclose([p.get_height() for p in ax.patches], [2.0, 3.0, 2.5])
-
-    def test_bars_baseline_floating_nan(self):
-        df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, np.nan]})
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
-        plot = mpl_renderer.get_plot(bars)
-        ax = plot.handles["axis"]
-        bottoms = [p.get_y() for p in ax.patches]
-        heights = [p.get_height() for p in ax.patches]
-        assert bottoms[0] == 1.0
-        assert heights[0] == 2.0
-        # A NaN baseline propagates rather than silently snapping to zero.
-        assert np.isnan(bottoms[1])
-        assert np.isnan(heights[1])
+    @pytest.mark.parametrize(
+        ("df", "baseline", "bottoms", "heights"),
+        [
+            (
+                pd.DataFrame(
+                    {"x": ["a", "b", "c"], "high": [3.0, 5.0, 4.0], "low": [1.0, 2.0, 1.5]}
+                ),
+                "low",
+                [1.0, 2.0, 1.5],
+                [2.0, 3.0, 2.5],
+            ),
+            # baseline by dimension index; 'low' is dimension 2 (x, high, low)
+            (
+                pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]}),
+                2,
+                [1.0, 2.0],
+                [2.0, 3.0],
+            ),
+            # A NaN baseline propagates rather than silently snapping to zero.
+            (
+                pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, np.nan]}),
+                "low",
+                [1.0, np.nan],
+                [2.0, np.nan],
+            ),
+            (
+                pd.DataFrame(
+                    {
+                        "x": pd.date_range("2024-01-01", periods=3),
+                        "high": [3.0, 5.0, 4.0],
+                        "low": [1.0, 2.0, 1.5],
+                    }
+                ),
+                "low",
+                [1.0, 2.0, 1.5],
+                [2.0, 3.0, 2.5],
+            ),
+        ],
+        ids=["by_name", "by_index", "nan", "datetime_x"],
+    )
+    def test_bars_baseline_floating(self, df, baseline, bottoms, heights):
+        # Bottom of each bar is the baseline; height spans up to the upper dim.
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline=baseline)
+        ax = mpl_renderer.get_plot(bars).handles["axis"]
+        np.testing.assert_allclose([p.get_y() for p in ax.patches], bottoms)
+        np.testing.assert_allclose([p.get_height() for p in ax.patches], heights)
 
     def test_bars_baseline_floating_inverted(self):
         df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]})

--- a/holoviews/tests/plotting/matplotlib/test_barplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_barplot.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import matplotlib.dates as mdates
 import numpy as np
 import pandas as pd
+import pytest
 from matplotlib.text import Text
 
 import holoviews as hv
@@ -156,3 +157,76 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         xticklabels = ["A", "1", "B", "A", "3", "B", "A", "10", "B"]
         for i, tick in enumerate(ax.get_xticklabels()):
             assert tick.get_text() == xticklabels[i]
+
+    def test_bars_baseline_floating(self):
+        df = pd.DataFrame({"x": ["a", "b", "c"], "high": [3.0, 5.0, 4.0], "low": [1.0, 2.0, 1.5]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        plot = mpl_renderer.get_plot(bars)
+        ax = plot.handles["axis"]
+        # Bottom of each bar is the baseline, height spans up to vdims[0].
+        np.testing.assert_allclose([p.get_y() for p in ax.patches], [1.0, 2.0, 1.5])
+        np.testing.assert_allclose([p.get_height() for p in ax.patches], [2.0, 3.0, 2.5])
+
+    def test_bars_baseline_floating_nan(self):
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, np.nan]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        plot = mpl_renderer.get_plot(bars)
+        ax = plot.handles["axis"]
+        bottoms = [p.get_y() for p in ax.patches]
+        heights = [p.get_height() for p in ax.patches]
+        assert bottoms[0] == 1.0
+        assert heights[0] == 2.0
+        # A NaN baseline propagates rather than silently snapping to zero.
+        assert np.isnan(bottoms[1])
+        assert np.isnan(heights[1])
+
+    def test_bars_baseline_floating_inverted(self):
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low", invert_axes=True)
+        plot = mpl_renderer.get_plot(bars)
+        ax = plot.handles["axis"]
+        np.testing.assert_allclose([p.get_x() for p in ax.patches], [1.0, 2.0])
+        np.testing.assert_allclose([p.get_width() for p in ax.patches], [2.0, 3.0])
+
+    def test_bars_baseline_floating_ylim_excludes_zero(self):
+        df = pd.DataFrame({"x": ["a", "b"], "high": [30.0, 40.0], "low": [10.0, 20.0]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low", padding=0)
+        plot = mpl_renderer.get_plot(bars)
+        y0, y1 = plot.handles["axis"].get_ylim()
+        assert y0 == 10.0
+        assert y1 == 40.0
+
+    def test_bars_baseline_exceeds_errors(self):
+        # The baseline must be the lower end of every bar; an inverted range
+        # (low > high) is a usage error.
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [6.0, 8.0]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        with pytest.raises(ValueError, match="exceed"):
+            mpl_renderer.get_plot(bars)
+
+    def test_bars_baseline_same_as_value_dim_warns(self):
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="high")
+        plot = mpl_renderer.get_plot(bars)
+        # Rejected (would give zero-height bars); falls back to a zero baseline.
+        np.testing.assert_allclose([p.get_y() for p in plot.handles["axis"].patches], [0.0, 0.0])
+        self.log_handler.assert_contains("WARNING", "Could not use baseline dimension 'high'")
+
+    def test_bars_baseline_ignored_when_grouped(self):
+        bars = (
+            hv.Bars(
+                ([3, 10, 1] * 10, ["A", "B"] * 15, np.random.randn(30)),
+                ["Group", "Category"],
+                "Value",
+            )
+            .aggregate(function=np.mean)
+            .opts(baseline="Value")
+        )
+        mpl_renderer.get_plot(bars)
+        self.log_handler.assert_contains("WARNING", "only supported for ungrouped")
+
+    def test_bars_baseline_unresolved_warns(self):
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3, 5]})
+        bars = hv.Bars(df, "x", ["high"]).opts(baseline="nope")
+        mpl_renderer.get_plot(bars)
+        self.log_handler.assert_contains("WARNING", "Could not use baseline dimension 'nope'")

--- a/holoviews/tests/plotting/matplotlib/test_barplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_barplot.py
@@ -199,7 +199,6 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         ids=["by_name", "by_index", "nan", "datetime_x"],
     )
     def test_bars_baseline_floating(self, df, baseline, bottoms, heights):
-        # Bottom of each bar is the baseline; height spans up to the upper dim.
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline=baseline)
         ax = mpl_renderer.get_plot(bars).handles["axis"]
         np.testing.assert_allclose([p.get_y() for p in ax.patches], bottoms)
@@ -222,15 +221,12 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         assert y1 == 40.0
 
     def test_bars_baseline_exceeds_errors(self):
-        # The baseline must be the lower end of every bar; an inverted range
-        # (low > high) is a usage error.
         df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [6.0, 8.0]})
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
         with pytest.raises(ValueError, match="exceed"):
             mpl_renderer.get_plot(bars)
 
     def test_bars_baseline_low_first(self):
-        # Order-flexible: ['low', 'high'] + baseline='low' spans low -> high.
         df = pd.DataFrame({"x": ["a", "b", "c"], "low": [1.0, 2.0, 1.5], "high": [3.0, 5.0, 4.0]})
         bars = hv.Bars(df, "x", ["low", "high"]).opts(baseline="low")
         plot = mpl_renderer.get_plot(bars)
@@ -239,7 +235,6 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         np.testing.assert_allclose([p.get_height() for p in ax.patches], [2.0, 3.0, 2.5])
 
     def test_bars_baseline_grouped(self):
-        # Each grouped bar floats from its baseline (Low) up to the upper dim (High).
         bars = hv.Bars(
             [("Q1", "E", 10, 2), ("Q1", "W", 7, 1), ("Q2", "E", 12, 3), ("Q2", "W", 9, 4)],
             kdims=["Quarter", "Region"],

--- a/holoviews/tests/plotting/matplotlib/test_barplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_barplot.py
@@ -167,6 +167,20 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         np.testing.assert_allclose([p.get_y() for p in ax.patches], [1.0, 2.0, 1.5])
         np.testing.assert_allclose([p.get_height() for p in ax.patches], [2.0, 3.0, 2.5])
 
+    def test_bars_baseline_floating_datetime(self):
+        df = pd.DataFrame(
+            {
+                "x": pd.date_range("2024-01-01", periods=3),
+                "high": [3.0, 5.0, 4.0],
+                "low": [1.0, 2.0, 1.5],
+            }
+        )
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        plot = mpl_renderer.get_plot(bars)
+        ax = plot.handles["axis"]
+        np.testing.assert_allclose([p.get_y() for p in ax.patches], [1.0, 2.0, 1.5])
+        np.testing.assert_allclose([p.get_height() for p in ax.patches], [2.0, 3.0, 2.5])
+
     def test_bars_baseline_floating_nan(self):
         df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, np.nan]})
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
@@ -212,18 +226,23 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         np.testing.assert_allclose([p.get_y() for p in plot.handles["axis"].patches], [0.0, 0.0])
         self.log_handler.assert_contains("WARNING", "Could not use baseline dimension 'high'")
 
-    def test_bars_baseline_ignored_when_grouped(self):
-        bars = (
-            hv.Bars(
-                ([3, 10, 1] * 10, ["A", "B"] * 15, np.random.randn(30)),
-                ["Group", "Category"],
-                "Value",
-            )
-            .aggregate(function=np.mean)
-            .opts(baseline="Value")
-        )
-        mpl_renderer.get_plot(bars)
-        self.log_handler.assert_contains("WARNING", "only supported for ungrouped")
+    def test_bars_baseline_grouped(self):
+        # Each grouped bar floats from its baseline (Low) up to vdims[0] (High).
+        bars = hv.Bars(
+            [("Q1", "E", 10, 2), ("Q1", "W", 7, 1), ("Q2", "E", 12, 3), ("Q2", "W", 9, 4)],
+            kdims=["Quarter", "Region"],
+            vdims=["High", "Low"],
+        ).opts(baseline="Low")
+        plot = mpl_renderer.get_plot(bars)
+        ax = plot.handles["axis"]
+        assert sorted(p.get_y() for p in ax.patches) == [1.0, 2.0, 3.0, 4.0]
+
+    def test_bars_baseline_stacked_errors(self):
+        bars = hv.Bars(
+            [("A", 0, 1), ("A", 1, -1), ("B", 0, 2)], kdims=["Index", "Category"], vdims=["Value"]
+        ).opts(stacked=True, baseline="Value")
+        with pytest.raises(ValueError, match="stacked"):
+            mpl_renderer.get_plot(bars)
 
     def test_bars_baseline_unresolved_warns(self):
         df = pd.DataFrame({"x": ["a", "b"], "high": [3, 5]})

--- a/holoviews/tests/plotting/matplotlib/test_barplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_barplot.py
@@ -159,50 +159,37 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
             assert tick.get_text() == xticklabels[i]
 
     @pytest.mark.parametrize(
-        ("df", "baseline", "bottoms", "heights"),
+        ("data", "baseline"),
         [
             (
-                pd.DataFrame(
-                    {"x": ["a", "b", "c"], "high": [3.0, 5.0, 4.0], "low": [1.0, 2.0, 1.5]}
-                ),
+                {"x": ["a", "b", "c"], "high": [3.0, 5.0, 4.0], "low": [1.0, 2.0, 1.5]},
                 "low",
-                [1.0, 2.0, 1.5],
-                [2.0, 3.0, 2.5],
             ),
-            # baseline by dimension index; 'low' is dimension 2 (x, high, low)
             (
-                pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]}),
+                {"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]},
                 2,
-                [1.0, 2.0],
-                [2.0, 3.0],
-            ),
-            # A NaN baseline propagates rather than silently snapping to zero.
-            (
-                pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, np.nan]}),
-                "low",
-                [1.0, np.nan],
-                [2.0, np.nan],
             ),
             (
-                pd.DataFrame(
-                    {
-                        "x": pd.date_range("2024-01-01", periods=3),
-                        "high": [3.0, 5.0, 4.0],
-                        "low": [1.0, 2.0, 1.5],
-                    }
-                ),
+                {"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, np.nan]},
                 "low",
-                [1.0, 2.0, 1.5],
-                [2.0, 3.0, 2.5],
+            ),
+            (
+                {
+                    "x": pd.date_range("2024-01-01", periods=3),
+                    "high": [3.0, 5.0, 4.0],
+                    "low": [1.0, 2.0, 1.5],
+                },
+                "low",
             ),
         ],
         ids=["by_name", "by_index", "nan", "datetime_x"],
     )
-    def test_bars_baseline_floating(self, df, baseline, bottoms, heights):
+    def test_bars_baseline_floating(self, data, baseline):
+        df = pd.DataFrame(data)
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline=baseline)
         ax = mpl_renderer.get_plot(bars).handles["axis"]
-        np.testing.assert_allclose([p.get_y() for p in ax.patches], bottoms)
-        np.testing.assert_allclose([p.get_height() for p in ax.patches], heights)
+        np.testing.assert_allclose([p.get_y() for p in ax.patches], data["low"])
+        np.testing.assert_allclose([p.get_height() for p in ax.patches], df["high"] - df["low"])
 
     def test_bars_baseline_floating_inverted(self):
         df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]})

--- a/holoviews/tests/plotting/plotly/test_barplot.py
+++ b/holoviews/tests/plotting/plotly/test_barplot.py
@@ -201,7 +201,6 @@ class TestBarsPlot(LoggingComparison, TestPlotlyPlot):
         ids=["by_name", "by_index", "datetime_x"],
     )
     def test_bars_baseline_floating(self, df, baseline, base, length):
-        # The trace base holds the baseline; y holds the bar length (high - low).
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline=baseline)
         state = self._get_plot_state(bars)
         assert_data_equal(state["data"][0]["base"], np.array(base))
@@ -223,15 +222,12 @@ class TestBarsPlot(LoggingComparison, TestPlotlyPlot):
         assert y1 == 40.0
 
     def test_bars_baseline_exceeds_errors(self):
-        # The baseline must be the lower end of every bar; an inverted range
-        # (low > high) is a usage error.
         df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [6.0, 8.0]})
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
         with pytest.raises(ValueError, match="exceed"):
             self._get_plot_state(bars)
 
     def test_bars_baseline_low_first(self):
-        # Order-flexible: ['low', 'high'] + baseline='low' spans low -> high.
         df = pd.DataFrame({"x": ["a", "b", "c"], "low": [1.0, 2.0, 1.5], "high": [3.0, 5.0, 4.0]})
         bars = hv.Bars(df, "x", ["low", "high"]).opts(baseline="low")
         state = self._get_plot_state(bars)
@@ -239,7 +235,6 @@ class TestBarsPlot(LoggingComparison, TestPlotlyPlot):
         assert_data_equal(state["data"][0]["y"], np.array([2.0, 3.0, 2.5]))
 
     def test_bars_baseline_grouped(self):
-        # Each grouped bar floats from its baseline (Low) up to the upper dim (High).
         bars = hv.Bars(
             [("Q1", "E", 10, 2), ("Q1", "W", 7, 1), ("Q2", "E", 12, 3), ("Q2", "W", 9, 4)],
             kdims=["Quarter", "Region"],

--- a/holoviews/tests/plotting/plotly/test_barplot.py
+++ b/holoviews/tests/plotting/plotly/test_barplot.py
@@ -167,26 +167,45 @@ class TestBarsPlot(LoggingComparison, TestPlotlyPlot):
         np.testing.assert_equal(set(plot["data"][0]["x"]), set(pets))
         np.testing.assert_equal(plot["data"][0]["y"], np.array([8, 7, 6, 7]))
 
-    def test_bars_baseline_floating(self):
-        df = pd.DataFrame({"x": ["a", "b", "c"], "high": [3.0, 5.0, 4.0], "low": [1.0, 2.0, 1.5]})
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
-        state = self._get_plot_state(bars)
+    @pytest.mark.parametrize(
+        ("df", "baseline", "base", "length"),
+        [
+            (
+                pd.DataFrame(
+                    {"x": ["a", "b", "c"], "high": [3.0, 5.0, 4.0], "low": [1.0, 2.0, 1.5]}
+                ),
+                "low",
+                [1.0, 2.0, 1.5],
+                [2.0, 3.0, 2.5],
+            ),
+            # baseline by dimension index; 'low' is dimension 2 (x, high, low)
+            (
+                pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]}),
+                2,
+                [1.0, 2.0],
+                [2.0, 3.0],
+            ),
+            (
+                pd.DataFrame(
+                    {
+                        "x": pd.date_range("2024-01-01", periods=3),
+                        "high": [3.0, 5.0, 4.0],
+                        "low": [1.0, 2.0, 1.5],
+                    }
+                ),
+                "low",
+                [1.0, 2.0, 1.5],
+                [2.0, 3.0, 2.5],
+            ),
+        ],
+        ids=["by_name", "by_index", "datetime_x"],
+    )
+    def test_bars_baseline_floating(self, df, baseline, base, length):
         # The trace base holds the baseline; y holds the bar length (high - low).
-        assert_data_equal(state["data"][0]["base"], np.array([1.0, 2.0, 1.5]))
-        assert_data_equal(state["data"][0]["y"], np.array([2.0, 3.0, 2.5]))
-
-    def test_bars_baseline_floating_datetime(self):
-        df = pd.DataFrame(
-            {
-                "x": pd.date_range("2024-01-01", periods=3),
-                "high": [3.0, 5.0, 4.0],
-                "low": [1.0, 2.0, 1.5],
-            }
-        )
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline=baseline)
         state = self._get_plot_state(bars)
-        assert_data_equal(state["data"][0]["base"], np.array([1.0, 2.0, 1.5]))
-        assert_data_equal(state["data"][0]["y"], np.array([2.0, 3.0, 2.5]))
+        assert_data_equal(state["data"][0]["base"], np.array(base))
+        assert_data_equal(state["data"][0]["y"], np.array(length))
 
     def test_bars_baseline_floating_inverted(self):
         df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]})

--- a/holoviews/tests/plotting/plotly/test_barplot.py
+++ b/holoviews/tests/plotting/plotly/test_barplot.py
@@ -168,43 +168,27 @@ class TestBarsPlot(LoggingComparison, TestPlotlyPlot):
         np.testing.assert_equal(plot["data"][0]["y"], np.array([8, 7, 6, 7]))
 
     @pytest.mark.parametrize(
-        ("df", "baseline", "base", "length"),
+        ("data", "baseline"),
         [
+            ({"x": ["a", "b", "c"], "high": [3.0, 5.0, 4.0], "low": [1.0, 2.0, 1.5]}, "low"),
+            ({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]}, 2),
             (
-                pd.DataFrame(
-                    {"x": ["a", "b", "c"], "high": [3.0, 5.0, 4.0], "low": [1.0, 2.0, 1.5]}
-                ),
+                {
+                    "x": pd.date_range("2024-01-01", periods=3),
+                    "high": [3.0, 5.0, 4.0],
+                    "low": [1.0, 2.0, 1.5],
+                },
                 "low",
-                [1.0, 2.0, 1.5],
-                [2.0, 3.0, 2.5],
-            ),
-            # baseline by dimension index; 'low' is dimension 2 (x, high, low)
-            (
-                pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]}),
-                2,
-                [1.0, 2.0],
-                [2.0, 3.0],
-            ),
-            (
-                pd.DataFrame(
-                    {
-                        "x": pd.date_range("2024-01-01", periods=3),
-                        "high": [3.0, 5.0, 4.0],
-                        "low": [1.0, 2.0, 1.5],
-                    }
-                ),
-                "low",
-                [1.0, 2.0, 1.5],
-                [2.0, 3.0, 2.5],
             ),
         ],
         ids=["by_name", "by_index", "datetime_x"],
     )
-    def test_bars_baseline_floating(self, df, baseline, base, length):
+    def test_bars_baseline_floating(self, data, baseline):
+        df = pd.DataFrame(data)
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline=baseline)
         state = self._get_plot_state(bars)
-        assert_data_equal(state["data"][0]["base"], np.array(base))
-        assert_data_equal(state["data"][0]["y"], np.array(length))
+        assert_data_equal(state["data"][0]["base"], df["low"])
+        assert_data_equal(state["data"][0]["y"], df["high"] - df["low"])
 
     def test_bars_baseline_floating_inverted(self):
         df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]})

--- a/holoviews/tests/plotting/plotly/test_barplot.py
+++ b/holoviews/tests/plotting/plotly/test_barplot.py
@@ -211,15 +211,16 @@ class TestBarsPlot(LoggingComparison, TestPlotlyPlot):
         with pytest.raises(ValueError, match="exceed"):
             self._get_plot_state(bars)
 
-    def test_bars_baseline_same_as_value_dim_warns(self):
-        df = pd.DataFrame({"x": ["a", "b"], "high": [3, 5], "low": [1, 2]})
-        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="high")
+    def test_bars_baseline_low_first(self):
+        # Order-flexible: ['low', 'high'] + baseline='low' spans low -> high.
+        df = pd.DataFrame({"x": ["a", "b", "c"], "low": [1.0, 2.0, 1.5], "high": [3.0, 5.0, 4.0]})
+        bars = hv.Bars(df, "x", ["low", "high"]).opts(baseline="low")
         state = self._get_plot_state(bars)
-        assert "base" not in state["data"][0]
-        self.log_handler.assert_contains("WARNING", "Could not use baseline dimension 'high'")
+        assert_data_equal(state["data"][0]["base"], np.array([1.0, 2.0, 1.5]))
+        assert_data_equal(state["data"][0]["y"], np.array([2.0, 3.0, 2.5]))
 
     def test_bars_baseline_grouped(self):
-        # Each grouped bar floats from its baseline (Low) up to vdims[0] (High).
+        # Each grouped bar floats from its baseline (Low) up to the upper dim (High).
         bars = hv.Bars(
             [("Q1", "E", 10, 2), ("Q1", "W", 7, 1), ("Q2", "E", 12, 3), ("Q2", "W", 9, 4)],
             kdims=["Quarter", "Region"],

--- a/holoviews/tests/plotting/plotly/test_barplot.py
+++ b/holoviews/tests/plotting/plotly/test_barplot.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
 
 import holoviews as hv
 from holoviews.plotting.plotly.util import PLOTLY_VERSION
 from holoviews.testing import assert_data_equal
 
+from ...utils import LoggingComparison
 from .test_plot import TestPlotlyPlot
 
 
-class TestBarsPlot(TestPlotlyPlot):
+class TestBarsPlot(LoggingComparison, TestPlotlyPlot):
     def test_bars_plot(self):
         bars = hv.Bars([3, 2, 1])
         state = self._get_plot_state(bars)
@@ -164,6 +166,57 @@ class TestBarsPlot(TestPlotlyPlot):
         plot = self._get_plot_state(bars)
         np.testing.assert_equal(set(plot["data"][0]["x"]), set(pets))
         np.testing.assert_equal(plot["data"][0]["y"], np.array([8, 7, 6, 7]))
+
+    def test_bars_baseline_floating(self):
+        df = pd.DataFrame({"x": ["a", "b", "c"], "high": [3.0, 5.0, 4.0], "low": [1.0, 2.0, 1.5]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        state = self._get_plot_state(bars)
+        # The trace base holds the baseline; y holds the bar length (high - low).
+        assert_data_equal(state["data"][0]["base"], np.array([1.0, 2.0, 1.5]))
+        assert_data_equal(state["data"][0]["y"], np.array([2.0, 3.0, 2.5]))
+
+    def test_bars_baseline_floating_inverted(self):
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low", invert_axes=True)
+        state = self._get_plot_state(bars)
+        assert_data_equal(state["data"][0]["base"], np.array([1.0, 2.0]))
+        assert_data_equal(state["data"][0]["x"], np.array([2.0, 3.0]))
+
+    def test_bars_baseline_floating_range_excludes_zero(self):
+        df = pd.DataFrame({"x": ["a", "b"], "high": [30.0, 40.0], "low": [10.0, 20.0]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low", padding=0)
+        state = self._get_plot_state(bars)
+        y0, y1 = state["layout"]["yaxis"]["range"]
+        assert y0 == 10.0
+        assert y1 == 40.0
+
+    def test_bars_baseline_exceeds_errors(self):
+        # The baseline must be the lower end of every bar; an inverted range
+        # (low > high) is a usage error.
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [6.0, 8.0]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        with pytest.raises(ValueError, match="exceed"):
+            self._get_plot_state(bars)
+
+    def test_bars_baseline_same_as_value_dim_warns(self):
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3, 5], "low": [1, 2]})
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="high")
+        state = self._get_plot_state(bars)
+        assert "base" not in state["data"][0]
+        self.log_handler.assert_contains("WARNING", "Could not use baseline dimension 'high'")
+
+    def test_bars_baseline_ignored_when_grouped(self):
+        bars = hv.Bars([("A", 1, 1), ("B", 2, 2), ("C", 2, 3)], kdims=["A", "B"]).opts(
+            baseline="A"
+        )
+        self._get_plot_state(bars)
+        self.log_handler.assert_contains("WARNING", "only supported for ungrouped")
+
+    def test_bars_baseline_unresolved_warns(self):
+        df = pd.DataFrame({"x": ["a", "b"], "high": [3, 5]})
+        bars = hv.Bars(df, "x", ["high"]).opts(baseline="nope")
+        self._get_plot_state(bars)
+        self.log_handler.assert_contains("WARNING", "Could not use baseline dimension 'nope'")
 
     def test_bar_color(self):
         data = pd.DataFrame({"A": range(5)})

--- a/holoviews/tests/plotting/plotly/test_barplot.py
+++ b/holoviews/tests/plotting/plotly/test_barplot.py
@@ -175,6 +175,19 @@ class TestBarsPlot(LoggingComparison, TestPlotlyPlot):
         assert_data_equal(state["data"][0]["base"], np.array([1.0, 2.0, 1.5]))
         assert_data_equal(state["data"][0]["y"], np.array([2.0, 3.0, 2.5]))
 
+    def test_bars_baseline_floating_datetime(self):
+        df = pd.DataFrame(
+            {
+                "x": pd.date_range("2024-01-01", periods=3),
+                "high": [3.0, 5.0, 4.0],
+                "low": [1.0, 2.0, 1.5],
+            }
+        )
+        bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low")
+        state = self._get_plot_state(bars)
+        assert_data_equal(state["data"][0]["base"], np.array([1.0, 2.0, 1.5]))
+        assert_data_equal(state["data"][0]["y"], np.array([2.0, 3.0, 2.5]))
+
     def test_bars_baseline_floating_inverted(self):
         df = pd.DataFrame({"x": ["a", "b"], "high": [3.0, 5.0], "low": [1.0, 2.0]})
         bars = hv.Bars(df, "x", ["high", "low"]).opts(baseline="low", invert_axes=True)
@@ -205,12 +218,22 @@ class TestBarsPlot(LoggingComparison, TestPlotlyPlot):
         assert "base" not in state["data"][0]
         self.log_handler.assert_contains("WARNING", "Could not use baseline dimension 'high'")
 
-    def test_bars_baseline_ignored_when_grouped(self):
-        bars = hv.Bars([("A", 1, 1), ("B", 2, 2), ("C", 2, 3)], kdims=["A", "B"]).opts(
-            baseline="A"
+    def test_bars_baseline_grouped(self):
+        # Each grouped bar floats from its baseline (Low) up to vdims[0] (High).
+        bars = hv.Bars(
+            [("Q1", "E", 10, 2), ("Q1", "W", 7, 1), ("Q2", "E", 12, 3), ("Q2", "W", 9, 4)],
+            kdims=["Quarter", "Region"],
+            vdims=["High", "Low"],
+        ).opts(baseline="Low")
+        state = self._get_plot_state(bars)
+        assert sorted(state["data"][0]["base"]) == [1.0, 2.0, 3.0, 4.0]
+
+    def test_bars_baseline_stacked_errors(self):
+        bars = hv.Bars([("A", "x", 1), ("A", "y", 2), ("B", "x", 3)], kdims=["A", "B"]).opts(
+            stacked=True, baseline="A"
         )
-        self._get_plot_state(bars)
-        self.log_handler.assert_contains("WARNING", "only supported for ungrouped")
+        with pytest.raises(ValueError, match="stacked"):
+            self._get_plot_state(bars)
 
     def test_bars_baseline_unresolved_warns(self):
         df = pd.DataFrame({"x": ["a", "b"], "high": [3, 5]})


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Closes https://github.com/holoviz/holoviews/issues/6097

Adds `baseline` opts to bar charts, inspired by Vega-lite
<img width="1058" height="333" alt="image" src="https://github.com/user-attachments/assets/e13b3ce0-0e97-446c-befa-502d2b94ef00" />


With Area, you can create area between the curves by passing two vdims, but I decided against automatically casting the first vdim as the baseline because that would be a breaking change (people might be using two vdims for hover).

Also, `baseline` mirrors `stacked`.

```
temps = pd.DataFrame({
    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May'],
    'Low': [-3, -1, 2, 6, 10],
    'High': [4, 6, 11, 16, 21],
})

hv.Bars(temps, 'Month', ['High', 'Low']).opts(baseline='Low')
```
<img width="846" height="529" alt="image" src="https://github.com/user-attachments/assets/be234842-af4d-41cd-8d57-b26fd72ad304" />

```
import pandas as pd
import holoviews as hv
hv.extension("bokeh")

# Daily low/high temperatures over a week — bars float between the two
df = pd.DataFrame({
    "Date": pd.date_range("2024-01-01", periods=7),
    "Low":  [-3, -1, 0, 2, 1, -2, -4],
    "High": [ 4,  6, 7, 9, 8,  5,  3],
})

hv.Bars(df, "Date", ["High", "Low"]).opts(baseline="Low", width=600)
```

<img width="1020" height="672" alt="image" src="https://github.com/user-attachments/assets/579415be-dbce-4ff7-95ba-11f2ac3b41ab" />

```
import pandas as pd
import holoviews as hv
hv.extension("bokeh")

# Task schedule: bars span start -> end, expressed as hours from midnight
df = pd.DataFrame({
    "Task":  ["Build", "Test", "Deploy", "Monitor"],
    "Start": pd.to_timedelta(["1h", "3h", "5h30m", "7h"]),
    "End":   pd.to_timedelta(["3h", "5h30m", "7h", "9h"]),
})

hv.Bars(df, "Task", ["End", "Start"]).opts(
    baseline="Start", invert_axes=True, ylabel="Hour of day", width=600,
)
```
<img width="969" height="494" alt="image" src="https://github.com/user-attachments/assets/0441f368-d174-4c58-9531-bc8f6c508bf3" />

bokeh
<img width="1501" height="685" alt="image" src="https://github.com/user-attachments/assets/246c54db-845d-4edd-898a-d7d3f26b1fff" />

mpl
<img width="1026" height="647" alt="image" src="https://github.com/user-attachments/assets/8655ecd4-9eb5-4ee9-ad60-b9c1351aec25" />

## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

- Tool & Model:
- Usage:

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
- [x] Added documentation
