### PR TITLE
fix: Add exception logging to `Stream.trigger`

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -245,14 +245,18 @@ class Stream(param.Parameterized):
         )
 
         with triggering_streams(streams):
+            errors = []
             for subscriber in subscribers:
                 try:
                     subscriber(**dict(union))
-                except Exception:
+                except Exception as e:
                     logger.exception(
                         "Stream subscriber %r exception raised; continuing remaining subscribers...",
                         getattr(subscriber, "__name__", type(subscriber).__name__),
                     )
+                    errors.append(e)
+            if errors:
+                raise errors[0]
 
         for stream in streams:
             with util.disable_constant(stream):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -7,7 +7,6 @@ server-side or in Javascript in the Jupyter notebook (client-side).
 from __future__ import annotations
 
 import inspect
-import logging
 import typing as t
 import weakref
 from collections import defaultdict
@@ -23,8 +22,6 @@ import param
 from .core import util
 from .core.ndmapping import UniformNdMapping
 from .core.util.dependencies import pd
-
-logger = logging.getLogger(__name__)
 
 if t.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -250,13 +247,19 @@ class Stream(param.Parameterized):
                 try:
                     subscriber(**dict(union))
                 except Exception as e:
-                    logger.exception(
-                        "Stream subscriber %r exception raised; continuing remaining subscribers...",
-                        getattr(subscriber, "__name__", type(subscriber).__name__),
-                    )
                     errors.append(e)
-            if errors:
+
+            # Re-raise a single error directly to preserve its original exception
+            # type (e.g. AbbreviatedException in some existing tests).
+            # Once Python 3.10 support is dropped, `errors[0].add_note()` can be used instead to attach
+            # the informative message below without changing the exception type.
+            if len(errors) == 1:
                 raise errors[0]
+            elif errors:
+                raise RuntimeError(
+                    f"{len(errors)} stream subscribers raised an exception. "
+                    "All subscribers were invoked regardless."
+                ) from Exception(*errors)
 
         for stream in streams:
             with util.disable_constant(stream):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -7,6 +7,7 @@ server-side or in Javascript in the Jupyter notebook (client-side).
 from __future__ import annotations
 
 import inspect
+import logging
 import typing as t
 import weakref
 from collections import defaultdict
@@ -22,6 +23,8 @@ import param
 from .core import util
 from .core.ndmapping import UniformNdMapping
 from .core.util.dependencies import pd
+
+logger = logging.getLogger(__name__)
 
 if t.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -243,7 +246,13 @@ class Stream(param.Parameterized):
 
         with triggering_streams(streams):
             for subscriber in subscribers:
-                subscriber(**dict(union))
+                try:
+                    subscriber(**dict(union))
+                except Exception:
+                    logger.exception(
+                        "Stream subscriber %r exception raised; continuing remaining subscribers...",
+                        getattr(subscriber, "__name__", type(subscriber).__name__),
+                    )
 
         for stream in streams:
             with util.disable_constant(stream):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -250,9 +250,8 @@ class Stream(param.Parameterized):
                     errors.append(e)
 
             # Re-raise a single error directly to preserve its original exception
-            # type (e.g. AbbreviatedException in some existing tests).
-            # Once Python 3.10 support is dropped, `errors[0].add_note()` can be used instead to attach
-            # the informative message below without changing the exception type.
+            # type e.g. AbbreviatedException.
+            # NOTE: With Python 3.11 we can use an ExceptionGroup.
             if len(errors) == 1:
                 raise errors[0]
             elif errors:

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -176,7 +176,8 @@ class TestStreamsDefine:
         xy.add_subscriber(good_subscriber)
 
         with caplog.at_level(logging.ERROR, logger="holoviews.streams"):
-            Stream.trigger([xy])
+            with pytest.raises(RuntimeError):
+                Stream.trigger([xy])
 
         assert "simulated upstream bug" in caplog.text
         assert "bad_subscriber" in caplog.text

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -4,6 +4,7 @@ Unit test of the streams system
 
 from __future__ import annotations
 
+import logging
 import weakref
 from collections import defaultdict
 
@@ -159,6 +160,28 @@ class TestStreamsDefine:
         assert isinstance(self.ExplicitTest.param["test"], param.Integer) is True
         assert self.ExplicitTest.param["test"].default == 42
         assert self.ExplicitTest.param["test"].doc == "Test docstring"
+
+    def test_subscriber_error_logging_isolation(self, caplog):
+        xy = self.XY()
+        calls = []
+
+        def bad_subscriber(**kw):
+            calls.append("bad")
+            raise RuntimeError("simulated upstream bug")
+
+        def good_subscriber(**kw):
+            calls.append("good")
+
+        xy.add_subscriber(bad_subscriber)
+        xy.add_subscriber(good_subscriber)
+
+        with caplog.at_level(logging.ERROR, logger="holoviews.streams"):
+            Stream.trigger([xy])
+
+        assert "simulated upstream bug" in caplog.text
+        assert "bad_subscriber" in caplog.text
+        assert len(calls) == 2
+        assert calls == ["bad", "good"]
 
 
 class _Subscriber:

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -4,7 +4,6 @@ Unit test of the streams system
 
 from __future__ import annotations
 
-import logging
 import weakref
 from collections import defaultdict
 
@@ -161,13 +160,13 @@ class TestStreamsDefine:
         assert self.ExplicitTest.param["test"].default == 42
         assert self.ExplicitTest.param["test"].doc == "Test docstring"
 
-    def test_subscriber_error_logging_isolation(self, caplog):
+    def test_subscriber_error_logging_isolation(self):
         xy = self.XY()
         calls = []
 
         def bad_subscriber(**kw):
             calls.append("bad")
-            raise RuntimeError("simulated upstream bug")
+            raise RuntimeError("bad subscriber")
 
         def good_subscriber(**kw):
             calls.append("good")
@@ -175,12 +174,9 @@ class TestStreamsDefine:
         xy.add_subscriber(bad_subscriber)
         xy.add_subscriber(good_subscriber)
 
-        with caplog.at_level(logging.ERROR, logger="holoviews.streams"):
-            with pytest.raises(RuntimeError):
-                Stream.trigger([xy])
+        with pytest.raises(RuntimeError, match="bad subscriber"):
+            Stream.trigger([xy])
 
-        assert "simulated upstream bug" in caplog.text
-        assert "bad_subscriber" in caplog.text
         assert len(calls) == 2
         assert calls == ["bad", "good"]
 


### PR DESCRIPTION
Fixes #6894

This PR adds logging for exceptions raised in the stream subscriber system and also ensures that the remaining subscribers continue and not fail silently.

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing