### PR TITLE
fix: interpolation curves crash on empty input

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -1275,18 +1275,11 @@ class interpolate_curve(Operation):
         return dtype
 
     @classmethod
-    def _empty_plot(cls, x, values):
-        empty_x = np.empty(0, dtype=x.dtype if hasattr(x, "dtype") else float)
-        empty_vals = tuple(np.empty(0, dtype=cls._get_dtype(v)) for v in values)
-        return empty_x, empty_vals
-
-    @classmethod
     def pts_to_prestep(cls, x, values):
-        if len(x) == 0:
-            return cls._empty_plot(x, values)
-
-        steps = np.zeros(2 * len(x) - 1)
-        value_steps = tuple(np.empty(2 * len(x) - 1, dtype=cls._get_dtype(v)) for v in values)
+        # Make sure `size` is never < 0. See https://github.com/holoviz/holoviews/issues/6893
+        size = max(2 * len(x) - 1, 0)
+        steps = np.zeros(size)
+        value_steps = tuple(np.empty(size, dtype=cls._get_dtype(v)) for v in values)
 
         steps[0::2] = x
         steps[1::2] = steps[0:-2:2]
@@ -1301,14 +1294,12 @@ class interpolate_curve(Operation):
 
     @classmethod
     def pts_to_midstep(cls, x, values):
-        if len(x) == 0:
-            return cls._empty_plot(x, values)
-
         steps = np.zeros(2 * len(x))
         value_steps = tuple(np.empty(2 * len(x), dtype=cls._get_dtype(v)) for v in values)
 
-        steps[1:-1:2] = steps[2::2] = x[:-1] + (x[1:] - x[:-1]) / 2
-        steps[0], steps[-1] = x[0], x[-1]
+        if len(x):
+            steps[1:-1:2] = steps[2::2] = x[:-1] + (x[1:] - x[:-1]) / 2
+            steps[0], steps[-1] = x[0], x[-1]
 
         val_arrays = []
         for v, s in zip(values, value_steps, strict=True):
@@ -1320,11 +1311,9 @@ class interpolate_curve(Operation):
 
     @classmethod
     def pts_to_poststep(cls, x, values):
-        if len(x) == 0:
-            return cls._empty_plot(x, values)
-
-        steps = np.zeros(2 * len(x) - 1)
-        value_steps = tuple(np.empty(2 * len(x) - 1, dtype=cls._get_dtype(v)) for v in values)
+        size = max(2 * len(x) - 1, 0)
+        steps = np.zeros(size)
+        value_steps = tuple(np.empty(size, dtype=cls._get_dtype(v)) for v in values)
 
         steps[0::2] = x
         steps[1::2] = steps[2::2]

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -1275,7 +1275,16 @@ class interpolate_curve(Operation):
         return dtype
 
     @classmethod
+    def _empty_plot(cls, x, values):
+        empty_x = np.empty(0, dtype=x.dtype if hasattr(x, "dtype") else float)
+        empty_vals = tuple(np.empty(0, dtype=cls._get_dtype(v)) for v in values)
+        return empty_x, empty_vals
+
+    @classmethod
     def pts_to_prestep(cls, x, values):
+        if len(x) == 0:
+            return cls._empty_plot(x, values)
+
         steps = np.zeros(2 * len(x) - 1)
         value_steps = tuple(np.empty(2 * len(x) - 1, dtype=cls._get_dtype(v)) for v in values)
 
@@ -1292,6 +1301,9 @@ class interpolate_curve(Operation):
 
     @classmethod
     def pts_to_midstep(cls, x, values):
+        if len(x) == 0:
+            return cls._empty_plot(x, values)
+
         steps = np.zeros(2 * len(x))
         value_steps = tuple(np.empty(2 * len(x), dtype=cls._get_dtype(v)) for v in values)
 
@@ -1308,6 +1320,9 @@ class interpolate_curve(Operation):
 
     @classmethod
     def pts_to_poststep(cls, x, values):
+        if len(x) == 0:
+            return cls._empty_plot(x, values)
+
         steps = np.zeros(2 * len(x) - 1)
         value_steps = tuple(np.empty(2 * len(x) - 1, dtype=cls._get_dtype(v)) for v in values)
 

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -1276,7 +1276,6 @@ class interpolate_curve(Operation):
 
     @classmethod
     def pts_to_prestep(cls, x, values):
-        # Make sure `size` is never < 0. See https://github.com/holoviz/holoviews/issues/6893
         size = max(2 * len(x) - 1, 0)
         steps = np.zeros(size)
         value_steps = tuple(np.empty(size, dtype=cls._get_dtype(v)) for v in values)

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -997,6 +997,17 @@ class OperationTests:
         pd.testing.assert_series_equal(data["x"], output["x"])
         pd.testing.assert_series_equal(data["y"], output["y"])
 
+    @pytest.mark.parametrize("steps", ["steps-post", "steps-pre", "linear", "steps-mid"])
+    def test_empty_curve_interpolation(self, steps):
+        empty_curve = hv.Curve(([], []), "x", "y").opts(interpolation=steps)
+        hv.renderer("bokeh").get_plot(empty_curve)
+
+        x_values = empty_curve.data[("x")]
+        y_values = empty_curve.data[("y")]
+
+        assert len(x_values) == 0
+        assert len(y_values) == 0
+
 
 class TestCategoricalAgg:
     def test_categorical_agg_count(self):


### PR DESCRIPTION
Fixes #6893 

This PR improves how empty data is handled in step interpolation methods by returning an empty plot instead of an exception.

**Handling of empty data in interpolation methods:**
```python
import holoviews as hv

hv.extension("bokeh")

steps = ("steps-post", "steps-pre", "linear", "steps-mid")
curves = []

for step in steps:
    try:
        empty_curve = hv.Curve(([], []), "x", "y").opts(interpolation=step, title=f"{step} Curve")
        hv.render(empty_curve)
        curves.append(empty_curve)
    except Exception as e:
        print(f"Interpolation type: '{step}' raises an error: {type(e)}")

(curves[0] + curves[1] + curves[2] + curves[3]).cols(2)
```

<img width="714" height="682" alt="Screenshot 2026-06-02 at 4 42 36 PM" src="https://github.com/user-attachments/assets/a183a673-adad-4178-a865-5b73248472cb" />



## Checklist
- [x] Pull request title follows the conventional format
- [x] Tests added and are passing