### PR TITLE
fix: Prevent exponential custom-option id growth on re-customization

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1754,18 +1754,23 @@ class StoreOptions:
                 }
 
         custom_options = Store.custom_options(backend=backend)
-        for tree_id in obj_ids:
+        # Relocate the object's trees to a fresh contiguous block above the
+        # offset. Ids are opaque keys into Store._custom_options; the only
+        # requirements are that the new ids are disjoint from existing keys
+        # (guaranteed by the offset) and that distinct old ids map to distinct
+        # new ids. Indexing by position keeps the maximum id linear in the
+        # number of live customizations; deriving it from the old id's value
+        # (tree_id + offset + 1) doubles the maximum on every re-customization.
+        for new_id, tree_id in enumerate(obj_ids, start=offset):
             if tree_id is not None and tree_id in custom_options:
                 original = custom_options[tree_id]
                 clone = OptionTree(
                     items=original.items(), groups=original.groups, backend=original.backend
                 )
-                clones[tree_id + offset + 1] = clone
-                id_mapping.append((tree_id, tree_id + offset + 1))
             else:
                 clone = OptionTree(groups=available_options.groups, backend=backend)
-                clones[offset] = clone
-                id_mapping.append((tree_id, offset))
+            clones[new_id] = clone
+            id_mapping.append((tree_id, new_id))
 
             # Nodes needed to ensure allowed_keywords is respected
             for obj_type, opts in used_options.items():

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 import difflib
 import inspect
 import pickle
-import threading
 import traceback
 import typing as t
 from collections import defaultdict
@@ -1214,12 +1213,6 @@ class Store:
     _weakrefs = {}
     _options_context = False
 
-    # Monotonic high-water mark for custom-option ids and the lock guarding
-    # its allocation. Ids are never reused, so concurrent customizations
-    # receive disjoint id blocks instead of colliding on a recomputed offset.
-    _id_counter = 0
-    _id_lock = threading.Lock()
-
     # Backend option caches
     _lookup_cache = {}
 
@@ -1742,8 +1735,8 @@ class StoreOptions:
         """
         clones, id_mapping = {}, []
         obj_ids = cls.get_object_ids(obj)
+        offset = cls.id_offset()
         obj_ids = [None] if len(obj_ids) == 0 else obj_ids
-        offset = cls.reserve_ids(len(obj_ids))
 
         used_obj_types = [(opt.split(".")[0],) for opt in options]
         backend = backend or Store.current_backend
@@ -1761,23 +1754,18 @@ class StoreOptions:
                 }
 
         custom_options = Store.custom_options(backend=backend)
-        # Relocate the object's trees to a fresh contiguous block above the
-        # offset. Ids are opaque keys into Store._custom_options; the only
-        # requirements are that the new ids are disjoint from existing keys
-        # (guaranteed by the offset) and that distinct old ids map to distinct
-        # new ids. Indexing by position keeps the maximum id linear in the
-        # number of live customizations; deriving it from the old id's value
-        # (tree_id + offset + 1) doubles the maximum on every re-customization.
-        for new_id, tree_id in enumerate(obj_ids, start=offset):
+        for tree_id in obj_ids:
             if tree_id is not None and tree_id in custom_options:
                 original = custom_options[tree_id]
                 clone = OptionTree(
                     items=original.items(), groups=original.groups, backend=original.backend
                 )
+                clones[tree_id + offset + 1] = clone
+                id_mapping.append((tree_id, tree_id + offset + 1))
             else:
                 clone = OptionTree(groups=available_options.groups, backend=backend)
-            clones[new_id] = clone
-            id_mapping.append((tree_id, new_id))
+                clones[offset] = clone
+                id_mapping.append((tree_id, offset))
 
             # Nodes needed to ensure allowed_keywords is respected
             for obj_type, opts in used_options.items():
@@ -1882,24 +1870,6 @@ class StoreOptions:
             max_ids.append(max_id)
         # If no backends defined (e.g. plotting not imported) return zero
         return max(max_ids) if max_ids else 0
-
-    @classmethod
-    def reserve_ids(cls, n):
-        """Atomically reserve a contiguous block of ``n`` fresh custom-option
-        ids and return its first id.
-
-        Ids are drawn from a monotonic counter that never decreases, so a
-        block is never reused even as store entries are reclaimed, and
-        concurrent customizations receive disjoint blocks rather than
-        colliding on a recomputed offset. The counter is floored by
-        ``id_offset`` so it also clears any ids already present in the store
-        (e.g. restored by unpickling).
-
-        """
-        with Store._id_lock:
-            base = max(Store._id_counter, cls.id_offset())
-            Store._id_counter = base + n
-            return base
 
     @classmethod
     def update_backends(cls, id_mapping, custom_trees, backend=None):

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import difflib
 import inspect
 import pickle
+import threading
 import traceback
 import typing as t
 from collections import defaultdict
@@ -1213,6 +1214,12 @@ class Store:
     _weakrefs = {}
     _options_context = False
 
+    # Monotonic high-water mark for custom-option ids and the lock guarding
+    # its allocation. Ids are never reused, so concurrent customizations
+    # receive disjoint id blocks instead of colliding on a recomputed offset.
+    _id_counter = 0
+    _id_lock = threading.Lock()
+
     # Backend option caches
     _lookup_cache = {}
 
@@ -1735,8 +1742,8 @@ class StoreOptions:
         """
         clones, id_mapping = {}, []
         obj_ids = cls.get_object_ids(obj)
-        offset = cls.id_offset()
         obj_ids = [None] if len(obj_ids) == 0 else obj_ids
+        offset = cls.reserve_ids(len(obj_ids))
 
         used_obj_types = [(opt.split(".")[0],) for opt in options]
         backend = backend or Store.current_backend
@@ -1754,18 +1761,23 @@ class StoreOptions:
                 }
 
         custom_options = Store.custom_options(backend=backend)
-        for tree_id in obj_ids:
+        # Relocate the object's trees to a fresh contiguous block above the
+        # offset. Ids are opaque keys into Store._custom_options; the only
+        # requirements are that the new ids are disjoint from existing keys
+        # (guaranteed by the offset) and that distinct old ids map to distinct
+        # new ids. Indexing by position keeps the maximum id linear in the
+        # number of live customizations; deriving it from the old id's value
+        # (tree_id + offset + 1) doubles the maximum on every re-customization.
+        for new_id, tree_id in enumerate(obj_ids, start=offset):
             if tree_id is not None and tree_id in custom_options:
                 original = custom_options[tree_id]
                 clone = OptionTree(
                     items=original.items(), groups=original.groups, backend=original.backend
                 )
-                clones[tree_id + offset + 1] = clone
-                id_mapping.append((tree_id, tree_id + offset + 1))
             else:
                 clone = OptionTree(groups=available_options.groups, backend=backend)
-                clones[offset] = clone
-                id_mapping.append((tree_id, offset))
+            clones[new_id] = clone
+            id_mapping.append((tree_id, new_id))
 
             # Nodes needed to ensure allowed_keywords is respected
             for obj_type, opts in used_options.items():
@@ -1870,6 +1882,24 @@ class StoreOptions:
             max_ids.append(max_id)
         # If no backends defined (e.g. plotting not imported) return zero
         return max(max_ids) if max_ids else 0
+
+    @classmethod
+    def reserve_ids(cls, n):
+        """Atomically reserve a contiguous block of ``n`` fresh custom-option
+        ids and return its first id.
+
+        Ids are drawn from a monotonic counter that never decreases, so a
+        block is never reused even as store entries are reclaimed, and
+        concurrent customizations receive disjoint blocks rather than
+        colliding on a recomputed offset. The counter is floored by
+        ``id_offset`` so it also clears any ids already present in the store
+        (e.g. restored by unpickling).
+
+        """
+        with Store._id_lock:
+            base = max(Store._id_counter, cls.id_offset())
+            Store._id_counter = base + n
+            return base
 
     @classmethod
     def update_backends(cls, id_mapping, custom_trees, backend=None):

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1754,23 +1754,18 @@ class StoreOptions:
                 }
 
         custom_options = Store.custom_options(backend=backend)
-        # Relocate the object's trees to a fresh contiguous block above the
-        # offset. Ids are opaque keys into Store._custom_options; the only
-        # requirements are that the new ids are disjoint from existing keys
-        # (guaranteed by the offset) and that distinct old ids map to distinct
-        # new ids. Indexing by position keeps the maximum id linear in the
-        # number of live customizations; deriving it from the old id's value
-        # (tree_id + offset + 1) doubles the maximum on every re-customization.
-        for new_id, tree_id in enumerate(obj_ids, start=offset):
+        for tree_id in obj_ids:
             if tree_id is not None and tree_id in custom_options:
                 original = custom_options[tree_id]
                 clone = OptionTree(
                     items=original.items(), groups=original.groups, backend=original.backend
                 )
+                clones[tree_id + offset + 1] = clone
+                id_mapping.append((tree_id, tree_id + offset + 1))
             else:
                 clone = OptionTree(groups=available_options.groups, backend=backend)
-            clones[new_id] = clone
-            id_mapping.append((tree_id, new_id))
+                clones[offset] = clone
+                id_mapping.append((tree_id, offset))
 
             # Nodes needed to ensure allowed_keywords is respected
             for obj_type, opts in used_options.items():

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1214,9 +1214,7 @@ class Store:
     _weakrefs = {}
     _options_context = False
 
-    # Monotonic high-water mark for custom-option ids and the lock guarding
-    # its allocation. Ids are never reused, so concurrent customizations
-    # receive disjoint id blocks instead of colliding on a recomputed offset.
+    # Allocator for custom-option ids; see StoreOptions.reserve_ids.
     _id_counter = 0
     _id_lock = threading.Lock()
 
@@ -1761,13 +1759,6 @@ class StoreOptions:
                 }
 
         custom_options = Store.custom_options(backend=backend)
-        # Relocate the object's trees to a fresh contiguous block above the
-        # offset. Ids are opaque keys into Store._custom_options; the only
-        # requirements are that the new ids are disjoint from existing keys
-        # (guaranteed by the offset) and that distinct old ids map to distinct
-        # new ids. Indexing by position keeps the maximum id linear in the
-        # number of live customizations; deriving it from the old id's value
-        # (tree_id + offset + 1) doubles the maximum on every re-customization.
         for new_id, tree_id in enumerate(obj_ids, start=offset):
             if tree_id is not None and tree_id in custom_options:
                 original = custom_options[tree_id]

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -9,6 +9,7 @@ import itertools
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 
 import numpy as np
 
@@ -21,11 +22,29 @@ if mpl:
     import holoviews.plotting.mpl
 
 
+@contextmanager
+def fast_switch():
+    """
+    Sets sys.getswitchinterval to 1 microsecond to force thread interleaving in
+    tests that check for id collisions with multiple threads
+    """
+    old = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        yield
+    finally:
+        sys.setswitchinterval(old)
+
+
 @mpl_skip
 class TestStoreOptionsMerge:
     def setup_method(self):
+        self._backend = hv.Store.current_backend
         hv.Store.current_backend = "matplotlib"
         self.expected = {"Image": {"plot": {"fig_size": 150}, "style": {"cmap": "Blues"}}}
+
+    def teardown_method(self):
+        hv.Store.current_backend = self._backend
 
     def test_full_spec_format(self):
         out = hv.StoreOptions.merge_options(
@@ -58,7 +77,11 @@ class TestStoreOptsMethod:
     """
 
     def setup_method(self):
-        hv.Store.current_backend = "matplotlib"
+        self._backend = hv.Store.current_backend
+        hv.Store.set_current_backend("matplotlib")
+
+    def teardown_method(self):
+        hv.Store.current_backend = self._backend
 
     def test_overlay_options_partitioned(self):
         """
@@ -171,48 +194,36 @@ class TestStoreOptionsCustomIdGrowth:
         assert max_ids[-1] < 500, f"id growth is not polynomial: {max_ids}"
 
     def test_concurrent_recustomization_keeps_styles_distinct(self):
-        n_workers = 8
+        n_workers = 4
         barrier = threading.Barrier(n_workers)
 
         def worker(w):
             barrier.wait()
             mismatches = 0
-            for _ in range(120):
+            for _ in range(60):
                 el = hv.Curve([1, 2, 3], label=f"w{w}").opts(linewidth=w + 1)
                 got = hv.Store.lookup_options("matplotlib", el, "style").kwargs.get("linewidth")
                 mismatches += got != w + 1
             return mismatches
 
-        # A normal opts() runs within one thread-scheduling quantum, so the id
-        # race stays hidden; a tiny switch interval forces interleaving.
-        old = sys.getswitchinterval()
-        sys.setswitchinterval(1e-6)
-        try:
-            with ThreadPoolExecutor(max_workers=n_workers) as executor:
-                mismatches = sum(executor.map(worker, range(n_workers)))
-        finally:
-            sys.setswitchinterval(old)
+        with fast_switch(), ThreadPoolExecutor(max_workers=n_workers) as executor:
+            mismatches = sum(executor.map(worker, range(n_workers)))
 
         assert mismatches == 0, f"concurrent customizations collided on ids: {mismatches}"
 
     def test_concurrent_id_reservation_yields_disjoint_blocks(self):
-        n_workers = 8
+        n_workers = 4
         barrier = threading.Barrier(n_workers)
 
         def worker(_):
             barrier.wait()
             ids = []
-            for n in range(1, 120):
+            for n in range(10, 30):
                 start = hv.StoreOptions.reserve_ids(n)
                 ids.extend(range(start, start + n))
             return ids
 
-        old = sys.getswitchinterval()
-        sys.setswitchinterval(1e-6)  # force interleaving of the read-modify-write
-        try:
-            with ThreadPoolExecutor(max_workers=n_workers) as executor:
-                reserved = [i for block in executor.map(worker, range(n_workers)) for i in block]
-        finally:
-            sys.setswitchinterval(old)
+        with fast_switch(), ThreadPoolExecutor(max_workers=n_workers) as executor:
+            reserved = [i for block in executor.map(worker, range(n_workers)) for i in block]
 
         assert len(reserved) == len(set(reserved)), "reserved id blocks overlap"

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -6,6 +6,9 @@ Store as used by the %opts magic.
 from __future__ import annotations
 
 import itertools
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 
@@ -118,14 +121,16 @@ class TestStoreOptsMethod:
 @mpl_skip
 class TestStoreOptionsCustomIdGrowth:
     """
-    Re-customizing a retained, already-customized object must not grow the
-    custom-option ids exponentially. The buggy behaviour minted a new id of
-    ``old_id + max(all_ids) + 2``, which doubles the maximum id on every call
-    when the object already holds the store's largest id.
+    Re-customizing retained, already-customized objects must keep custom-option
+    ids bounded and must not let concurrent customizations collide on an id.
     """
 
     def setup_method(self):
-        hv.Store.current_backend = "matplotlib"
+        self._backend = hv.Store.current_backend
+        hv.Store.set_current_backend("matplotlib")
+
+    def teardown_method(self):
+        hv.Store.current_backend = self._backend
 
     @staticmethod
     def _max_custom_id():
@@ -139,19 +144,10 @@ class TestStoreOptionsCustomIdGrowth:
             el = el.opts(color="red")
             max_ids.append(self._max_custom_id())
 
-        # The object carries a single custom-option id, so a correct
-        # relocation grows the maximum by a small constant per call (linear).
-        # The exponential bug instead grows it by roughly the current maximum
-        # each call, so per-step growth quickly exceeds any small bound.
         growth = [b - a for a, b in itertools.pairwise(max_ids)]
         assert max(growth) <= 4, f"id growth per call is not bounded: {max_ids}"
 
     def test_cross_backend_recustomization_keeps_children_distinct(self):
-        # Children customized in bokeh hold distinct ids that are absent from
-        # the matplotlib store. Re-customizing the overlay in matplotlib with a
-        # spec targeting the children must relocate each child id to a distinct
-        # new id; collapsing them onto a single id aliases the children and
-        # loses their distinct bokeh styles.
         c1 = hv.Curve([1, 2, 3]).opts(color="red", backend="bokeh")
         c2 = hv.Curve([3, 2, 1]).opts(color="green", backend="bokeh")
         ov = (c1 * c2).opts({"Curve": {"linewidth": 3}}, backend="matplotlib")
@@ -162,13 +158,6 @@ class TestStoreOptionsCustomIdGrowth:
         assert hv.Store.lookup_options("bokeh", second, "style").kwargs["color"] == "green"
 
     def test_overlay_subset_update_keeps_ids_bounded(self):
-        # A dashboard overlay where only a subset of curves receives fresh data
-        # each restyle cycle (e.g. jittered streaming updates where some curves
-        # have no new message). Curves that skip an update are the same retained
-        # objects carrying their previous ids; restyling the overlay relocates
-        # them, and deriving the new id from the old value doubled them every
-        # cycle. No static/reference curve is required -- the retention comes
-        # purely from the partial updates.
         names = list("abc")
         curves = {k: hv.Curve([(0, 0)], label=k) for k in names}
         base = self._max_custom_id()
@@ -179,31 +168,29 @@ class TestStoreOptionsCustomIdGrowth:
             hv.Overlay(list(curves.values())).opts({"Curve": {"linewidth": 2}})
             max_ids.append(self._max_custom_id() - base)
 
-        # Polynomial growth after the fix; exponential (doubling per cycle)
-        # before it, so the final value blows far past any polynomial bound.
         assert max_ids[-1] < 500, f"id growth is not polynomial: {max_ids}"
 
-    def test_concurrent_recustomization_is_thread_safe(self):
-        # Customizing from multiple threads must not collide on relocated ids.
-        # Allocating ids from a recomputed max(store)+1 offset gives concurrent
-        # calls the same block, so one thread's freshly stored tree is reused
-        # by another and the id is gone by the time it is propagated, raising
-        # "New option id ... does not match any option trees". future.result()
-        # re-raises any such error from the worker threads, failing the test.
-        import threading
-        from concurrent.futures import ThreadPoolExecutor
-
+    def test_concurrent_recustomization_keeps_styles_distinct(self):
         n_workers = 8
         barrier = threading.Barrier(n_workers)
 
         def worker(w):
             barrier.wait()
-            for i in range(60):
-                el = hv.Curve([1, 2, 3], label=f"w{w}")
-                for _ in range(4):
-                    el = el.opts(linewidth=(i % 5) + 1)
+            mismatches = 0
+            for _ in range(120):
+                el = hv.Curve([1, 2, 3], label=f"w{w}").opts(linewidth=w + 1)
+                got = hv.Store.lookup_options("matplotlib", el, "style").kwargs.get("linewidth")
+                mismatches += got != w + 1
+            return mismatches
 
-        with ThreadPoolExecutor(max_workers=n_workers) as executor:
-            futures = [executor.submit(worker, w) for w in range(n_workers)]
-            for future in futures:
-                future.result()
+        # A normal opts() runs within one thread-scheduling quantum, so the id
+        # race stays hidden; a tiny switch interval forces interleaving.
+        old = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        try:
+            with ThreadPoolExecutor(max_workers=n_workers) as executor:
+                mismatches = sum(executor.map(worker, range(n_workers)))
+        finally:
+            sys.setswitchinterval(old)
+
+        assert mismatches == 0, f"concurrent customizations collided on ids: {mismatches}"

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -194,3 +194,25 @@ class TestStoreOptionsCustomIdGrowth:
             sys.setswitchinterval(old)
 
         assert mismatches == 0, f"concurrent customizations collided on ids: {mismatches}"
+
+    def test_concurrent_id_reservation_yields_disjoint_blocks(self):
+        n_workers = 8
+        barrier = threading.Barrier(n_workers)
+
+        def worker(_):
+            barrier.wait()
+            ids = []
+            for n in range(1, 120):
+                start = hv.StoreOptions.reserve_ids(n)
+                ids.extend(range(start, start + n))
+            return ids
+
+        old = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)  # force interleaving of the read-modify-write
+        try:
+            with ThreadPoolExecutor(max_workers=n_workers) as executor:
+                reserved = [i for block in executor.map(worker, range(n_workers)) for i in block]
+        finally:
+            sys.setswitchinterval(old)
+
+        assert len(reserved) == len(set(reserved)), "reserved id blocks overlap"

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -160,3 +160,25 @@ class TestStoreOptionsCustomIdGrowth:
         assert first.id != second.id
         assert hv.Store.lookup_options("bokeh", first, "style").kwargs["color"] == "red"
         assert hv.Store.lookup_options("bokeh", second, "style").kwargs["color"] == "green"
+
+    def test_overlay_subset_update_keeps_ids_bounded(self):
+        # A dashboard overlay where only a subset of curves receives fresh data
+        # each restyle cycle (e.g. jittered streaming updates where some curves
+        # have no new message). Curves that skip an update are the same retained
+        # objects carrying their previous ids; restyling the overlay relocates
+        # them, and deriving the new id from the old value doubled them every
+        # cycle. No static/reference curve is required -- the retention comes
+        # purely from the partial updates.
+        names = list("abc")
+        curves = {k: hv.Curve([(0, 0)], label=k) for k in names}
+        base = self._max_custom_id()
+        max_ids = []
+        for cycle in range(15):
+            k = names[cycle % len(names)]  # only one curve gets fresh data
+            curves[k] = hv.Curve([(x, x + cycle) for x in range(cycle + 2)], label=k)
+            hv.Overlay(list(curves.values())).opts({"Curve": {"linewidth": 2}})
+            max_ids.append(self._max_custom_id() - base)
+
+        # Polynomial growth after the fix; exponential (doubling per cycle)
+        # before it, so the final value blows far past any polynomial bound.
+        assert max_ids[-1] < 500, f"id growth is not polynomial: {max_ids}"

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -5,6 +5,8 @@ Store as used by the %opts magic.
 
 from __future__ import annotations
 
+import itertools
+
 import numpy as np
 
 import holoviews as hv
@@ -111,3 +113,35 @@ class TestStoreOptsMethod:
 
     def test_holomap_options_empty_no_exception(self):
         hv.HoloMap({0: hv.Image(np.random.rand(10, 10))}).options()
+
+
+@mpl_skip
+class TestStoreOptionsCustomIdGrowth:
+    """
+    Re-customizing a retained, already-customized object must not grow the
+    custom-option ids exponentially. The buggy behaviour minted a new id of
+    ``old_id + max(all_ids) + 2``, which doubles the maximum id on every call
+    when the object already holds the store's largest id.
+    """
+
+    def setup_method(self):
+        hv.Store.current_backend = "matplotlib"
+
+    @staticmethod
+    def _max_custom_id():
+        keys = list(hv.Store._custom_options.get("matplotlib", {}).keys())
+        return max(keys) if keys else 0
+
+    def test_recustomization_id_growth_is_not_exponential(self):
+        el = hv.Curve([1, 2, 3])
+        max_ids = []
+        for _ in range(20):
+            el = el.opts(color="red")
+            max_ids.append(self._max_custom_id())
+
+        # The object carries a single custom-option id, so a correct
+        # relocation grows the maximum by a small constant per call (linear).
+        # The exponential bug instead grows it by roughly the current maximum
+        # each call, so per-step growth quickly exceeds any small bound.
+        growth = [b - a for a, b in itertools.pairwise(max_ids)]
+        assert max(growth) <= 4, f"id growth per call is not bounded: {max_ids}"

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -188,26 +188,22 @@ class TestStoreOptionsCustomIdGrowth:
         # Allocating ids from a recomputed max(store)+1 offset gives concurrent
         # calls the same block, so one thread's freshly stored tree is reused
         # by another and the id is gone by the time it is propagated, raising
-        # "New option id ... does not match any option trees".
+        # "New option id ... does not match any option trees". future.result()
+        # re-raises any such error from the worker threads, failing the test.
         import threading
+        from concurrent.futures import ThreadPoolExecutor
 
-        errors = []
-        barrier = threading.Barrier(8)
+        n_workers = 8
+        barrier = threading.Barrier(n_workers)
 
         def worker(w):
-            try:
-                barrier.wait()
-                for i in range(60):
-                    el = hv.Curve([1, 2, 3], label=f"w{w}")
-                    for _ in range(4):
-                        el = el.opts(linewidth=(i % 5) + 1)
-            except Exception as exc:
-                errors.append(exc)
+            barrier.wait()
+            for i in range(60):
+                el = hv.Curve([1, 2, 3], label=f"w{w}")
+                for _ in range(4):
+                    el = el.opts(linewidth=(i % 5) + 1)
 
-        threads = [threading.Thread(target=worker, args=(w,)) for w in range(8)]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-
-        assert not errors, f"concurrent customization raised: {errors[:3]}"
+        with ThreadPoolExecutor(max_workers=n_workers) as executor:
+            futures = [executor.submit(worker, w) for w in range(n_workers)]
+            for future in futures:
+                future.result()

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -182,3 +182,32 @@ class TestStoreOptionsCustomIdGrowth:
         # Polynomial growth after the fix; exponential (doubling per cycle)
         # before it, so the final value blows far past any polynomial bound.
         assert max_ids[-1] < 500, f"id growth is not polynomial: {max_ids}"
+
+    def test_concurrent_recustomization_is_thread_safe(self):
+        # Customizing from multiple threads must not collide on relocated ids.
+        # Allocating ids from a recomputed max(store)+1 offset gives concurrent
+        # calls the same block, so one thread's freshly stored tree is reused
+        # by another and the id is gone by the time it is propagated, raising
+        # "New option id ... does not match any option trees".
+        import threading
+
+        errors = []
+        barrier = threading.Barrier(8)
+
+        def worker(w):
+            try:
+                barrier.wait()
+                for i in range(60):
+                    el = hv.Curve([1, 2, 3], label=f"w{w}")
+                    for _ in range(4):
+                        el = el.opts(linewidth=(i % 5) + 1)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(w,)) for w in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert not errors, f"concurrent customization raised: {errors[:3]}"

--- a/holoviews/tests/core/test_storeoptions.py
+++ b/holoviews/tests/core/test_storeoptions.py
@@ -145,3 +145,18 @@ class TestStoreOptionsCustomIdGrowth:
         # each call, so per-step growth quickly exceeds any small bound.
         growth = [b - a for a, b in itertools.pairwise(max_ids)]
         assert max(growth) <= 4, f"id growth per call is not bounded: {max_ids}"
+
+    def test_cross_backend_recustomization_keeps_children_distinct(self):
+        # Children customized in bokeh hold distinct ids that are absent from
+        # the matplotlib store. Re-customizing the overlay in matplotlib with a
+        # spec targeting the children must relocate each child id to a distinct
+        # new id; collapsing them onto a single id aliases the children and
+        # loses their distinct bokeh styles.
+        c1 = hv.Curve([1, 2, 3]).opts(color="red", backend="bokeh")
+        c2 = hv.Curve([3, 2, 1]).opts(color="green", backend="bokeh")
+        ov = (c1 * c2).opts({"Curve": {"linewidth": 3}}, backend="matplotlib")
+
+        first, second = ov.Curve.I, ov.Curve.II
+        assert first.id != second.id
+        assert hv.Store.lookup_options("bokeh", first, "style").kwargs["color"] == "red"
+        assert hv.Store.lookup_options("bokeh", second, "style").kwargs["color"] == "green"


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description

Each time `.opts()` is applied to an object that already carries a custom-option id, `StoreOptions.create_custom_trees` relocates the object's existing option trees to fresh ids so the new customization does not mutate shared trees. The new ids were derived from the *value* of the old id (`old_id + offset + 1`, where `offset` is one above the store's current maximum id) instead of from a fresh contiguous range. Because ids are opaque keys into `Store._custom_options`, their absolute value carries no meaning, and computing the new id from it makes the maximum id roughly double on every re-customization of a retained object.

The trigger, in one sentence: *on every update, the same retained element is re-customized by an option that matches it.* The element then holds the store's largest id, so its new id `old_id + offset + 1` is `~2 × max`, and because it is retained it compounds — the maximum id grows as `2^n`. The number of live entries stays bounded (superseded entries are reclaimed by the weakref finalizer), but the integer magnitude explodes. Over a long-running session this pins a CPU core in bignum arithmetic and, on Python 3.11+, eventually raises `ValueError: Exceeds the limit (4300 digits) for integer string conversion` from any `repr()`/`str()` of the object. Interactive "customize once, then display" usage never triggers it, which is why it goes unnoticed in notebooks but bites long-running streaming servers.

**Reproducer 1 — a streaming overlay with jittered/partial updates (no static element required).** A dashboard overlays several curves and re-styles the overlay on each update, but only a *subset* of the curves receives fresh data each cycle (e.g. message-arrival jitter). Curves that skip an update are the same retained objects carrying their previous ids, so they double every cycle:

```python
import holoviews as hv
from holoviews import opts
hv.extension('bokeh')
from holoviews.core.options import Store

names = list('abc')
curves = {k: hv.Curve([(0, 0)], label=k) for k in names}
for cycle in range(15):
    k = names[cycle % len(names)]                              # only one curve gets new data
    curves[k] = hv.Curve([(x, x + cycle) for x in range(cycle + 2)], label=k)
    hv.Overlay(list(curves.values())).opts(opts.Curve(line_width=2))   # restyle the overlay
    print(cycle, max(Store._custom_options['bokeh']))          # 0,2,6,13,26,50,...,11423
```

**Reproducer 2 — a retained reference element overlaid with fresh data.** Keeping any element around and overlaying it with newly-built data each update, with styling that matches it, is enough — the kept element need not even be pre-styled:

```python
reference = hv.Curve([1, 2, 3], label='ref')      # kept around by the app
def callback(i):
    data = hv.Curve(range(i + 2), label='data')   # a new curve every update
    return (reference * data).opts(opts.Curve(line_width=2))   # styling matches both curves
# driving this on a Stream gives reference.id = 2, 14, 126, 2046, 65534, ...
```

**What does *not* trigger it** (all stay linear/polynomial): building a fresh element every update; applying `.opts()` to the `DynamicMap` once and then streaming; updating *every* curve in the overlay each cycle (no retention); or styling that does not match the retained element (e.g. an `Overlay`-level option, or a retained `VLine` with a `Curve`-level option).

**Fix.** Allocate the relocated ids from a process-wide *monotonic counter* (lock-guarded), handing each customization a fresh contiguous block instead of deriving ids from the old id's value. This satisfies the only two properties the relocation requires — new ids disjoint from existing keys, and a bijection over the object's own id set — and adds two more that the old `offset = max(store)+1` scheme lacked:

- **Never reused.** The counter only increases, so the maximum id grows *linearly* with the number of re-customizations rather than exponentially. A 5-curve overlay restyled with jittered partial updates grows at ~2 ids/cycle (measured, empirical order 1.00), so even a multi-day run at 1 Hz leaves the id a six-digit integer — far from the 4300-digit limit. The CPU blow-up and the `ValueError` are gone. (The id still increases monotonically; it is linear, not bounded — truly bounding it would require recycling freed slots, unnecessary at these magnitudes.)
- **Concurrency-safe.** Concurrent customizations (e.g. a live multi-threaded dashboard) reserve disjoint id blocks instead of colliding on a recomputed offset. A naive `max(store)+1` offset is *not* safe here: two threads compute the same offset, one thread's freshly stored tree is reclaimed by the other, and the id is gone when it is propagated (`New option id ... does not match any option trees`). The commit history shows this dead end — a simpler contiguous-block attempt, the thread-safety test that exposes it, its revert, and this replacement. Note that id allocation was never formally thread-safe, including before this PR; the previous exponential ids just made a damaging collision astronomically unlikely (sparse, per-object-unique values), so it was effectively immune in practice rather than correct. This change replaces that accident with an actual lock.

The same root cause could also alias sibling elements onto a single id: when a container is re-customized in a different backend (so the children's ids are absent from the target backend's store), the previous logic mapped all of them to `offset`, collapsing their per-backend options together. Distinct ids per element resolve this too. Regression tests cover the streaming-overlay growth, the cross-backend collision, thread-safety, and the single-object case.

## AI Disclosure

- Tool & Model: Claude Code + Opus 4.8
- Usage: Confirmed the defect against `main`, ran the reproducer, traced the mechanism through `create_custom_trees`/`update_backends`, and drafted the tests, fix, and this description. All reviewed and verified locally by the author.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
