### PR TITLE
chore: Add tsdownsample to Python 3.14

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,11 +90,7 @@ jobs:
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
-              "environment": ["test-310", "test-314"],
-              "include": [
-                # Can be removed when tsdownsample support 3.14
-                {"environment": "test-313", "os": "ubuntu-latest"}
-              ]
+              "environment": ["test-310", "test-314"]
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'full' option

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,7 +6,7 @@ platforms = ["linux-64", "osx-arm64", "win-64"]
 [environments]
 default = [
     "required",
-    "py312",
+    "py314",
     "optional",
     "test-core",
     "test-example",
@@ -34,7 +34,7 @@ features = ["required", "py313", "optional", "test-core", "test-example", "test-
 no-default-feature = true
 
 [environments.test-314]
-features = ["required", "py314", "optional-314", "test-core", "test-example", "test-unit-task"]
+features = ["required", "py314", "optional", "test-core", "test-example", "test-unit-task"]
 no-default-feature = true
 
 [environments.test-ui]
@@ -138,42 +138,9 @@ scipy = "*"
 selenium = "*"
 shapely = "*"
 spatialpandas = "*"
+tsdownsample = "*"
 xarray = ">=0.10.4"
 xyzservices = "*"
-
-[feature.optional.target.unix.dependencies]
-tsdownsample = "*" # currently not available on Windows
-
-[feature.optional-314.dependencies]
-bokeh_sampledata = "*"
-cftime = "*"
-contourpy = "*"
-dask-core = "*"
-datashader = ">=0.11.1"
-ffmpeg = "*"
-ibis-sqlite = "*"
-ipython = ">=5.4.0"
-matplotlib-base = ">=3"
-nbconvert-core = "*"
-netcdf4 = "*"
-networkx = "*"
-notebook = "*"
-pillow = "*"
-plotly = ">=4.0"
-polars = "*"
-pooch = "*"
-pyarrow = "*"
-python-duckdb = "*"
-scikit-image = "*"
-scipy = "*"
-selenium = "*"
-shapely = "*"
-spatialpandas = "*"
-xarray = ">=0.10.4"
-xyzservices = "*"
-
-[feature.optional-314.target.unix.dependencies]
-# tsdownsample = "*" # currently not available on Windows
 
 [feature.dev.dependencies]
 jupyterlab = "*"


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

tsdownsample has finally been released with Python 3.14 support. Also added support to Windows on conda-forge.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
