### PR TITLE
fix: Handle undeclared aggregator column in `_resolve_agg_column_name`

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -171,6 +171,8 @@ class AggregationOperation(ResampleOperation2D):
         dimension = inner_element.get_dimension(column)
         if dimension is None and isinstance(element, NdOverlay):
             dimension = element.get_dimension(column)
+        if dimension is None:
+            return column
         return dimension.label if is_wide and dimension in ydims else dimension.name
 
     @classmethod

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1526,6 +1526,18 @@ def test_rasterize_where_agg_with_column(point_plot, agg_input_fn):
     np.testing.assert_array_equal(img["s"], img_no_column["s"])
 
 
+@pytest.mark.parametrize("agg_input_fn", [ds.first, ds.last, ds.min, ds.max])
+def test_rasterize_where_agg_with_undeclared_selector_column(point_data, agg_input_fn):
+    points = hv.Points(point_data, kdims=["x", "y"], vdims=["val"])
+    agg_fn = ds.where(agg_input_fn("s"), "val")
+    rast_input = dict(dynamic=False, x_range=(-1, 1), y_range=(-1, 1), width=2, height=2)
+    img = rasterize(points, aggregator=agg_fn, **rast_input)
+
+    assert list(img.data) == ["val"]
+    img_full = rasterize(hv.Points(point_data), aggregator=agg_fn, **rast_input)
+    np.testing.assert_array_equal(img["val"], img_full["val"])
+
+
 def test_rasterize_summarize(point_plot):
     agg_fn_count, agg_fn_first = ds.count(), ds.first("val")
     agg_fn = ds.summary(count=agg_fn_count, first=agg_fn_first)


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes problem seen in hvplot downstream [ci](https://github.com/holoviz/hvplot/actions/runs/26963970405/job/79561751866). Introduced in #6853

``` python
import hvplot.pandas
import datashader as ds

df = hvplot.sampledata.synthetic_clusters("pandas")

p = df.hvplot.points(
    rasterize=True,
    aggregator=ds.where(ds.min("s"), "val")
)
```

And can be recreated with:

``` python
import holoviews as hv
from holoviews.operation.datashader import rasterize

points = hv.Points(df, kdims=["x", "y"], vdims=["val"])
p = rasterize(points, aggregator=ds.where(ds.min("s"), "val"))
```