### PR TITLE
test: lazy import directly_connect_edges and actual run test

### DIFF
--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -28,7 +28,6 @@ from holoviews.operation.datashader import (
     AggregationOperation,
     aggregate,
     datashade,
-    directly_connect_edges,
     dynspread,
     inspect,
     inspect_points,
@@ -1843,17 +1842,13 @@ class DatashaderStackTests:
         assert_element_equal(combined, self.rgb2)
 
 
-class GraphBundlingTests:
-    def setup_method(self):
-        if DATASHADER_VERSION <= (0, 7, 0):
-            pytest.skip("Regridding operations require datashader>=0.7.0")
-        self.source = np.arange(8)
-        self.target = np.zeros(8)
-        self.graph = hv.Graph(((self.source, self.target),))
+def test_directly_connect_paths(bokeh_backend):
+    # Import here to avoid slow collect time
+    from holoviews.operation._datashader_bundling import directly_connect_edges
 
-    def test_directly_connect_paths(self):
-        direct = directly_connect_edges(self.graph)._split_edgepaths
-        assert_element_equal(direct, self.graph.edgepaths)
+    graph = hv.Graph(((np.arange(8), np.zeros(8)),))
+    direct = directly_connect_edges(graph)._split_edgepaths
+    assert_element_equal(direct, graph.edgepaths)
 
 
 class InspectorTests:


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

`directly_connect_edges` is a very slow import which is why we have hidden by the `__getattr__`, around 4 seconds. This will run all time when we collected the test. 

When making it an inline import I saw the wrong datashader comparison, which meant it was never actually ran... simplified the test to be a single function and fixed the test so it actually passes now