### PR TITLE
fix: Allow image coordinate irregularity equal to the tolerance

### DIFF
--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -2255,7 +2255,7 @@ def validate_regular_sampling(values, rtol=10e-6):
     if len(diffs) < 1:
         return True
     min_diff = diffs.min()
-    return abs(min_diff - diffs.max()) < abs(min_diff * rtol)
+    return abs(min_diff - diffs.max()) <= abs(min_diff * rtol)
 
 
 def compute_density(start, end, length, time_unit="us"):

--- a/holoviews/tests/element/test_image.py
+++ b/holoviews/tests/element/test_image.py
@@ -118,8 +118,8 @@ class TestImage(LoggingComparison):
         Constructing an Image with an evenly spaced date-time coordinate does not warn
         about irregular sampling, even when the ratio of the date-time granularity to
         the coordinate step is greater than the default `image_rtol` (or twice
-        `image_rtol` for `datetime.datetime` types because of how they round when
-        multiplied by a `float`).
+        `image_rtol` for `dt.datetime` types because of how `dt.timedelta` instances
+        round when multiplied by a `float`).
         """
         y = np.arange(2)
         hv.Image((x, y, np.zeros((len(y), len(x)))))

--- a/holoviews/tests/element/test_image.py
+++ b/holoviews/tests/element/test_image.py
@@ -4,6 +4,8 @@ Unit tests of Image elements
 
 from __future__ import annotations
 
+import datetime as dt
+
 import numpy as np
 import pytest
 
@@ -73,6 +75,56 @@ class TestImage(LoggingComparison):
         hv.config.image_rtol = 10e-3
         hv.Image({"vals": vals, "xs": xs, "ys": ys}, ["xs", "ys"], "vals")
         hv.config.image_rtol = image_rtol
+
+    @pytest.mark.parametrize(
+        "x",
+        [
+            # max(|step|) / min(|step|) - 1 = 0.0015
+            [dt.datetime(2017, 1, 1, 0, 0, 0, ms) for ms in [0, 10000, 20015]],
+            *(
+                np.array([0, 10000, 20015]).astype(f"datetime64[{unit}]")
+                for unit in ["D", "h", "m", "s", "ms", "us"]
+            ),
+        ],
+    )
+    def test_image_datetime_rtol_failure(self, x):
+        """
+        Constructing an Image with a date-time coordinate warns about irregular sampling
+        if, approximately speaking, one less than the ratio of the max and min steps
+        exceeds the default `image_rtol`.
+        """
+        y = np.arange(2)
+        hv.Image((x, y, np.zeros((len(y), len(x)))))
+        self.log_handler.assert_endswith(
+            "WARNING",
+            "set a higher tolerance on hv.config.image_rtol or the rtol parameter in "
+            "the Image constructor.",
+        )
+
+    @pytest.mark.xfail
+    @pytest.mark.parametrize(
+        "x",
+        [
+            # |granularity / step| = 1/400 = 0.0025
+            [dt.datetime(2017, 1, 1, 0, 0, 0, ms) for ms in [0, 400]],
+            # |granularity / step| = 1/800 = 0.00125
+            *(
+                np.array([10000, 10800]).astype(f"datetime64[{unit}]")
+                for unit in ["D", "h", "m", "s", "ms", "us"]
+            ),
+        ],
+    )
+    def test_image_datetime_rtol_granularity(self, x):
+        """
+        Constructing an Image with an evenly spaced date-time coordinate does not warn
+        about irregular sampling, even when the ratio of the date-time granularity to
+        the coordinate step is greater than the default `image_rtol` (or twice
+        `image_rtol` for `datetime.datetime` types because of how they round when
+        multiplied by a `float`).
+        """
+        y = np.arange(2)
+        hv.Image((x, y, np.zeros((len(y), len(x)))))
+        assert len(self.log_handler.tail("WARNING", n=1)) == 0
 
     def test_image_clone(self):
         vals = np.random.rand(20, 20)

--- a/holoviews/tests/element/test_image.py
+++ b/holoviews/tests/element/test_image.py
@@ -101,7 +101,6 @@ class TestImage(LoggingComparison):
             "the Image constructor.",
         )
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize(
         "x",
         [


### PR DESCRIPTION
## Description

<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

The change prevents an erroneous warning such as the following for regular date-time coordinates whose minimum step has coarse granularity in the internal date-time representation:

> WARNING:param.Image00855: Image dimension x is not evenly sampled to relative tolerance of 0.001. Please use the QuadMesh element for irregularly sampled data or set a higher tolerance on hv.config.image_rtol or the rtol parameter in the Image constructor.

For such a step, the right-hand side of the inequality in `holoviews.core.util.validate_regular_sampling` can evaluate to a time delta of zero (depending on how the time-delta object rounds when multiplied), and the former `<` inequality cannot be satisfied. Also, the change conforms the function to its docstring ("at most") and to the documentation of `Config.image_rtol` ("maximal allowable sampling difference").

Fixes #6914.


## Checklist

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing