### PR TITLE
fix: Remove extra space in some warnings of irregular sampling

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -390,7 +390,7 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
         )
         dims = None
         if not xvalid:
-            dims = f" {xdim} is " if yvalid else f"(s) {xdim} and {ydim} are"
+            dims = f" {xdim} is" if yvalid else f"(s) {xdim} and {ydim} are"
         elif not yvalid:
             dims = f" {ydim} is"
         if dims:


### PR DESCRIPTION
## Description

Before this PR, warnings such as the following (which is verbatim but line-wrapped for readability) contain an extra space before "not evenly sampled" when the *x* axis is invalid and the *y* axis is valid:

>   ```
>   WARNING:param.Image00260: Image dimension x is  not evenly sampled to relative
>   tolerance of 0.001. Please use the QuadMesh element for irregularly sampled
>   data or set a higher tolerance on hv.config.image_rtol or the rtol parameter
>   in the Image constructor.
>   ```

This PR removes the space.


## Checklist

- [X] Pull request title follows the conventional format