### PR TITLE
fix: Seed range streams on initial draw of overlay plots

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -2309,6 +2309,27 @@ class GenericOverlayPlot(GenericElementPlot):
         if not (("multi_y" in self.param) and self.multi_y):
             y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))
 
+        # Seed any RangeX/RangeY/RangeXY streams (e.g. those driving a
+        # datashader operation) with the padded extents on the initial draw.
+        # Without this an overlay of rasterized elements would aggregate over
+        # the unpadded data range until a range event (e.g. clicking Reset)
+        # supplies the displayed range. See ElementPlot.get_extents for the
+        # equivalent logic used for non-overlay plots.
+        if not self.drawn:
+            x_range, y_range = ((y0, y1), (x0, x1)) if self.invert_axes else ((x0, x1), (y0, y1))
+            for stream in getattr(self, "source_streams", []):
+                if isinstance(stream, RangeX):
+                    params = {"x_range": x_range}
+                elif isinstance(stream, RangeY):
+                    params = {"y_range": y_range}
+                elif isinstance(stream, RangeXY):
+                    params = {"x_range": x_range, "y_range": y_range}
+                else:
+                    continue
+                stream.update(**params)
+                if stream not in self._trigger and (self.xlim or self.ylim):
+                    self._trigger.append(stream)
+
         if isinstance(self.projection, str) and self.projection == "3d":
             z0, z1 = util.dimension_range(
                 z0, z1, getattr(self, "zlim", (None, None)), (None, None)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1704,6 +1704,7 @@ class GenericElementPlot(DimensionedPlot):
             x0, x1 = util.dimension_range(x0, x1, self.xlim, (None, None))
             y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))
 
+        # Should match what is done in GenericOverlayPlot.get_extents
         if not self.drawn:
             x_range, y_range = ((y0, y1), (x0, x1)) if self.invert_axes else ((x0, x1), (y0, y1))
             for stream in getattr(self, "source_streams", []):
@@ -2309,12 +2310,7 @@ class GenericOverlayPlot(GenericElementPlot):
         if not (("multi_y" in self.param) and self.multi_y):
             y0, y1 = util.dimension_range(y0, y1, self.ylim, (None, None))
 
-        # Seed any RangeX/RangeY/RangeXY streams (e.g. those driving a
-        # datashader operation) with the padded extents on the initial draw.
-        # Without this an overlay of rasterized elements would aggregate over
-        # the unpadded data range until a range event (e.g. clicking Reset)
-        # supplies the displayed range. See ElementPlot.get_extents for the
-        # equivalent logic used for non-overlay plots.
+        # Should match what is done in ElementPlot.get_extents
         if not self.drawn:
             x_range, y_range = ((y0, y1), (x0, x1)) if self.invert_axes else ((x0, x1), (y0, y1))
             for stream in getattr(self, "source_streams", []):

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -12,7 +12,7 @@ import pytest
 import holoviews as hv
 from holoviews.core.util.dependencies import PANDAS_GE_3_0_0
 from holoviews.operation import apply_when
-from holoviews.streams import Tap
+from holoviews.streams import RangeXY, Tap
 from holoviews.testing import assert_data_equal, assert_element_equal
 
 from .._deps import ds, pl, pl_skip, spd, spd_skip
@@ -1662,6 +1662,30 @@ def test_selector_datashade_bad_column_name(point_data):
     msg = "Cannot use 'R', 'G', 'B', or 'A' as columns, when using datashade with selector"
     with pytest.raises(ValueError, match=msg):
         datashade(point_plot, selector=ds.min("val"), **inputs)
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_rasterize_overlay_seeds_range_streams():
+    # https://github.com/holoviz/holoviews/issues/6921
+    # An overlay of rasterized elements must seed its RangeXY stream with the
+    # padded extents on the initial draw. Otherwise the initial render is
+    # aggregated over the unpadded data range and looks incomplete until a
+    # range event (e.g. clicking Reset in the Bokeh toolbar) supplies the
+    # displayed range.
+    s1 = hv.Scatter((np.array([0, 10]), np.array([0, 0])), "x", "y")
+    s2 = hv.Scatter((np.array([0, 10]), np.array([5, 5])), "x", "y")
+    overlay = rasterize(s1 * s2).opts(padding=0.1)
+
+    plot = hv.renderer("bokeh").get_plot(overlay)
+
+    range_streams = [s for s in plot.source_streams if isinstance(s, RangeXY)]
+    assert range_streams, "RangeXY stream should be attached to the overlay plot"
+    stream = range_streams[0]
+
+    # Combined data range is x=(0, 10), y=(0, 5); with padding=0.1 the displayed
+    # (and therefore aggregated) range must be x=(-1, 11), y=(-0.5, 5.5).
+    assert stream.x_range == (-1.0, 11.0)
+    assert stream.y_range == (-0.5, 5.5)
 
 
 @pytest.mark.usefixtures("bokeh_backend")

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1666,24 +1666,14 @@ def test_selector_datashade_bad_column_name(point_data):
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_rasterize_overlay_seeds_range_streams():
-    # https://github.com/holoviz/holoviews/issues/6921
-    # An overlay of rasterized elements must seed its RangeXY stream with the
-    # padded extents on the initial draw. Otherwise the initial render is
-    # aggregated over the unpadded data range and looks incomplete until a
-    # range event (e.g. clicking Reset in the Bokeh toolbar) supplies the
-    # displayed range.
     s1 = hv.Scatter((np.array([0, 10]), np.array([0, 0])), "x", "y")
     s2 = hv.Scatter((np.array([0, 10]), np.array([5, 5])), "x", "y")
     overlay = rasterize(s1 * s2).opts(padding=0.1)
 
     plot = hv.renderer("bokeh").get_plot(overlay)
 
-    range_streams = [s for s in plot.source_streams if isinstance(s, RangeXY)]
-    assert range_streams, "RangeXY stream should be attached to the overlay plot"
-    stream = range_streams[0]
-
-    # Combined data range is x=(0, 10), y=(0, 5); with padding=0.1 the displayed
-    # (and therefore aggregated) range must be x=(-1, 11), y=(-0.5, 5.5).
+    stream = next((s for s in plot.source_streams if isinstance(s, RangeXY)), None)
+    assert stream
     assert stream.x_range == (-1.0, 11.0)
     assert stream.y_range == (-0.5, 5.5)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -174,6 +174,7 @@ nbval = "*"
 
 [feature.test-ui.dependencies]
 playwright = "*"
+playwright-python = "*"
 pytest-playwright = "*"
 
 [feature.test-ui.tasks]

--- a/pixi.toml
+++ b/pixi.toml
@@ -173,8 +173,7 @@ test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'
 nbval = "*"
 
 [feature.test-ui.dependencies]
-playwright = "*"
-playwright-python = "*"
+playwright = "!=1.61.0" # until python-playwright have a release
 pytest-playwright = "*"
 
 [feature.test-ui.tasks]


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes #6921

An overlay of rasterized elements rendered incompletely on initial load and only corrected itself after a range event (e.g. clicking Reset).

This now mirror the `ElementPlot` logic in `GenericOverlayPlot` to get padded extent.

https://github.com/holoviz/holoviews/blob/d2ae73a3e299669cf9856bb27b2b81fead658acc/holoviews/plotting/plot.py#L1707-L1720

## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Assisted-by: Claude Code:claude-opus-4-8

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
