### PR TITLE
compat: numpy 2.5.0 part 2

### DIFF
--- a/holoviews/core/util/__init__.py
+++ b/holoviews/core/util/__init__.py
@@ -26,7 +26,7 @@ import narwhals.stable.v2 as nw
 import numpy as np
 import param
 
-from ...util.warnings import warn
+from ...util.warnings import deprecated, warn
 from .dependencies import (  # noqa: F401
     NUMPY_GE_2_0_0,
     NUMPY_VERSION,
@@ -77,7 +77,6 @@ _TIME_SCALES = {
     "D": 1 / 86400,
     "W": 1 / 604800,
 }
-nat_as_integer = -9223372036854775808  # np.datetime64("NAT", "ns").view("i8") or (- 2 ** 64 // 2)
 _ARRAY_SIZE_LARGE = 1_000_000
 _ARRAY_SAMPLE_SIZE = 1_000_000
 _DATAFRAME_ROWS_LARGE = 1_000_000
@@ -115,6 +114,14 @@ _PANDAS_FUNC_LOOKUP = {
     np.cumsum: "cumsum",
     np.nancumsum: "cumsum",
 }
+
+
+def __getattr__(attr):
+    if attr == "nat_as_integer":
+        deprecated("1.25.0", old="nat_as_integer", new=-9223372036854775808)
+        # np.datetime64("NAT", "ns").view("i8") or (- 2 ** 64 // 2)
+        return np.int64(-9223372036854775808)
+    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
 
 
 class Config(param.ParameterizedFunction):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -396,7 +396,7 @@ class AggregationOperation(ResampleOperation2D):
                 elif kind == "O":
                     val[neg1] = "-"
                 elif kind == "M":
-                    val[neg1] = np.datetime64("NaT")
+                    val[neg1] = np.datetime64("NaT", "ns")
                 else:
                     val = val.astype(np.float64)
                     val[neg1] = np.nan


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

After sleeping a bit on it I think we should deprecate `nat_as_integer` as it is not used in the code base. Deprecating this as we are about to make a release and don't want to break anything.

Also found one more place where `ns` was missing, which was not flagged by CI because it is in datashader, code which does not support numpy 1.25.0 yet. 

Follow up to https://github.com/holoviz/holoviews/pull/6924

