### PR TITLE
fix: hv-anndata scatter matrix in plotly backend

### DIFF
--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -259,7 +259,7 @@ class BarPlot(BarsMixin, ElementPlot):
             for v in xvals:
                 sel = element[[v]]
                 if baseline_dim is None:
-                    values.append(sel.iloc[0, 1] if len(sel) else 0)
+                    values.append(sel.dimension_values(1)[0] if len(sel) else 0)
                     continue
                 # Floating bars: base sets the lower end, y the bar length.
                 top = sel.dimension_values(top_dim)[0] if len(sel) else 0
@@ -287,7 +287,7 @@ class BarPlot(BarsMixin, ElementPlot):
                 for v in xvals:
                     sel = el[[v]]
                     if baseline_dim is None:
-                        values.append(sel.iloc[0, 1] if len(sel) else 0)
+                        values.append(sel.dimension_values(1)[0] if len(sel) else 0)
                         continue
                     top = sel.dimension_values(top_dim)[0] if len(sel) else 0
                     base = sel.dimension_values(baseline_dim)[0] if len(sel) else 0


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Part of the fixes of the problem reported here: https://github.com/holoviz-topics/hv-anndata/issues/45#issuecomment-4684386018

``` python
import holoviews as hv

import hv_anndata.plotting.scanpy as hv_sc
from hv_anndata import A, data, register

hv.extension("plotly")

register()

adata = data.pbmc68k_processed()
markers = ["C1QA", "PSAP", "CD79A", "CD79B", "CST3", "LYZ"]
a = hv_sc.matrixplot(
    adata[:, markers], A.obs["bulk_labels"], data=A.layers["counts"], add_totals=True
)
```



## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing

