### PR TITLE
fix: rasterize on spread

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -824,7 +824,7 @@ class spread_aggregate(area_aggregate):
         if df is element.data:
             df = df.copy()
 
-        pos, neg = element.vdims[1:3] if len(element.vdims) > 2 else element.vdims[1:2] * 2
+        neg, pos = element.vdims[1:3] if len(element.vdims) > 2 else element.vdims[1:2] * 2
         yvals = df[y.name]
         df[y.name] = yvals + df[pos.name]
         df["_lower"] = yvals - df[neg.name]

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -751,8 +751,8 @@ class DatashaderAggregateTests:
         )
         agg = rasterize(spread, width=4, height=4, dynamic=False)
         xs = [0.25, 0.75, 1.25, 1.75]
-        ys = [0.6125, 1.4375, 2.2625, 3.0875]
-        arr = np.array([[0, 0, 0, 0], [1, 0, 0, 0], [0, 1, 1, 0], [0, 0, 1, 1]])
+        ys = [1.025, 1.875, 2.725, 3.575]
+        arr = np.array([[0, 0, 0, 0], [1, 1, 1, 0], [0, 1, 1, 0], [0, 0, 0, 1]])
         expected = hv.Image((xs, ys, arr), vdims=hv.Dimension("Count", nodata=0))
         assert_element_equal(agg, expected)
 


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes #6931

The pos and neg variable assignments was swapped in `spread_aggregate._process`. Per the ErrorBars convention, `vdims[1]` is the negative error and `vdims[2]` is the positive error, but the code assigns them in reverse order.

Failing test looks like this before:
``` python
import holoviews as hv
from holoviews.operation.datashader import rasterize

hv.extension("bokeh")

spread = hv.Spread(
    [(0, 1, 0.4, 0.8), (1, 2, 0.8, 0.4), (2, 3, 0.5, 1)], vdims=["y", "pos", "neg"]
)
agg = rasterize(spread)
agg * spread
```
<img width="365" height="310" alt="image" src="https://github.com/user-attachments/assets/50be4bb1-dc0b-4ff1-8725-b19b74f3ca0b" />

And with this change:

<img width="375" height="310" alt="image" src="https://github.com/user-attachments/assets/2046c77f-4ad5-496e-ab7d-c0052a7c4d83" />


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: claude-code:claude-sonnet-4-8
Usage: Asked to find the problem. and it found this line.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
