### PR TITLE
fix: streams memory leak for `partial.functools`

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -54,11 +54,15 @@ class _SkipTrigger:
     pass
 
 
-class _WeakMethodSubscriber:
-    def __init__(self, method):
-        self._ref = weakref.WeakMethod(method)
-        self._hash = self._generate_hash(method)
-        self._is_param_method = util.is_param_method(method)
+class _WeakSubscriber:
+    def __init__(self, subscriber):
+        if inspect.ismethod(subscriber):
+            self._ref = weakref.WeakMethod(subscriber)
+        else:
+            self._ref = weakref.ref(subscriber)
+
+        self._hash = self._generate_hash(subscriber)
+        self._is_param_method = util.is_param_method(subscriber)
 
     def __bool__(self) -> bool:
         method = self._ref()
@@ -70,13 +74,22 @@ class _WeakMethodSubscriber:
             return method(*args, **kwargs)
 
     @staticmethod
-    def _generate_hash(method) -> int:
-        return hash((id(method.__func__), id(method.__self__)))
+    def check(subscriber):
+        while isinstance(subscriber, partial):
+            subscriber = subscriber.func
+        return inspect.ismethod(subscriber)
+
+    @staticmethod
+    def _generate_hash(subscriber) -> int:
+        if inspect.ismethod(subscriber):
+            return hash((id(subscriber.__func__), id(subscriber.__self__)))
+        else:
+            return hash(id(subscriber))
 
     def __eq__(self, other) -> bool:
-        if isinstance(other, _WeakMethodSubscriber):
+        if isinstance(other, _WeakSubscriber):
             return self._hash == other._hash
-        if inspect.ismethod(other):
+        if self.check(other):
             return self._hash == self._generate_hash(other)
         return NotImplemented
 
@@ -413,8 +426,8 @@ class Stream(param.Parameterized):
         """
         if not callable(subscriber):
             raise TypeError("Subscriber must be a callable.")
-        if inspect.ismethod(subscriber):
-            subscriber = _WeakMethodSubscriber(subscriber)
+        if _WeakSubscriber.check(subscriber):
+            subscriber = _WeakSubscriber(subscriber)
         self._subscribers.append((precedence, subscriber))
 
     def _validate_rename(self, mapping):

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import weakref
 from collections import defaultdict
+from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -806,20 +807,35 @@ class TestSubscribers:
         # and the callback
         assert subscriber.call_count == 3
 
-    def test_bound_method_subscriber_does_not_pin_instance(self):
-        class Viewer:
-            def __init__(self):
-                self.plot = hv.Points([])
-                self.stream = hv.streams.RangeXY(source=self.plot)
-                self.stream.add_subscriber(self.on_update)
 
-            def on_update(self, x_range=None, y_range=None):
-                pass
-
+class TestWeakSubscriber:
+    def check(self, Viewer):
         viewer = Viewer()
         ref = weakref.ref(viewer)
         del viewer
         assert ref() is None
+
+    def test_bound_method(self):
+        class Viewer:
+            def __init__(self):
+                self.plot = hv.Points([])
+                self.stream = hv.streams.RangeX(source=self.plot)
+                self.stream.add_subscriber(self.on_update)
+
+            def on_update(self, x_range=None): ...
+
+        self.check(Viewer)
+
+    def test_bound_method_partial(self):
+        class Viewer:
+            def __init__(self):
+                self.plot = hv.Points([])
+                self.stream = hv.streams.RangeX(source=self.plot)
+                self.stream.add_subscriber(partial(self.on_update, extra=1))
+
+            def on_update(self, x_range=None, extra=0): ...
+
+        self.check(Viewer)
 
 
 class TestStreamSource:


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes #6934

By checking for `partial.functools` we can also avoid memory leak if partial is used on a class method.

I don't think that memory not being freed after a datashader plot is a problem as it happens only on the first plot, and is likely because some lazy module is now being imported.  

Tried to see if I could get it to work with lambda functions but that will not work as they will be garbage collect if not defined as a variable. 

## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
