### PR TITLE
docs: Clarify the style angle convention

### DIFF
--- a/examples/user_guide/04-Style_Mapping.ipynb
+++ b/examples/user_guide/04-Style_Mapping.ipynb
@@ -55,7 +55,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is the simplest approach to style mapping, dimensions can be mapped to visual attributes directly by name. However often columns in the data will not directly map to a visual property, e.g. we might want to normalize values before mapping them to the alpha, or apply a scaling factor to some values before mapping them to the point size; this is where ``dim`` transforms come in. Below are a few examples of using ``dim`` transforms to map a dimension in the data to the visual style in the plot:"
+    "This is the simplest approach to style mapping, dimensions can be mapped to visual attributes directly by name. However often columns in the data will not directly map to a visual property, e.g. we might want to normalize values before mapping them to the alpha, or apply a scaling factor to some values before mapping them to the point size; this is where ``dim`` transforms come in. Below are a few examples of using ``dim`` transforms to map a dimension in the data to the visual style in the plot:\n",
+    "\n",
+    "The ``Angle`` mapping uses the standard Cartesian convention: ``0`` degrees points horizontally to the right along the positive x-axis, and positive angles rotate counterclockwise. This differs from compass bearings, which start at north and increase clockwise."
    ]
   },
   {


### PR DESCRIPTION
## Summary

- document that the existing `Angle` style-mapping example uses Cartesian angles
- state that `0` degrees points right along the positive x-axis and positive angles rotate counterclockwise
- distinguish this convention from compass bearings

Closes #6381.

## Validation

- `python -m pytest --nbval-lax examples/user_guide/04-Style_Mapping.ipynb -q` (27 passed)
- `pre-commit run --files examples/user_guide/04-Style_Mapping.ipynb` (all applicable hooks passed)
- notebook JSON parse
- `git diff --check`

## AI assistance

OpenAI Codex assisted with issue research, the documentation edit, validation, and PR drafting. I reviewed the complete one-cell diff. No private data or external figure assets are included.
