### PR TITLE
compat: matplotlib 3.11.1

### DIFF
--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -272,15 +272,16 @@ class MPLRenderer(Renderer):
         bbox_inches = get_tight_bbox(fig, extra_artists, pad=pad)
 
         orig_w, orig_h = fig.get_size_inches()
-        new_w = bbox_inches.width
-        new_h = bbox_inches.height
+
+        # Use round to avoid floating point error
+        pw, ph = round(bbox_inches.width * dpi), round(bbox_inches.height * dpi)
 
         # Video codecs like libx264 require even pixel dimensions.
         # Round up to the nearest even number of pixels for video formats.
         if fmt in ("mp4", "webm"):
-            pw, ph = int(new_w * dpi), int(new_h * dpi)
-            new_w = (pw + pw % 2) / dpi
-            new_h = (ph + ph % 2) / dpi
+            pw, ph = pw + pw % 2, ph + ph % 2
+
+        new_w, new_h = pw / dpi, ph / dpi
 
         # Compute how to transform positions from old figure coordinates
         # to new figure coordinates. The tight bbox defines the visible


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes failing test caused by last matplotlib release.

## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: claude-code:sonnet-4.5
Usage: Asked to fix `pytest holoviews/tests/plotting/matplotlib/test_renderer.py::TestAnimationBbox::test_gif_single_plot_not_clipped`. 

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
