### PR TITLE
enh: Add offset to Area.stack for streamgraphs

### DIFF
--- a/examples/reference/elements/bokeh/Area.ipynb
+++ b/examples/reference/elements/bokeh/Area.ipynb
@@ -102,6 +102,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Streamgraph\n",
+    "\n",
+    "The ``offset`` argument controls where the lowest baseline of the stack sits. ``'sym'`` centers the stack on zero, also known as a ThemeRiver, while ``'wiggle'`` and ``'weighted_wiggle'`` minimize the slope of each layer to produce a streamgraph. Here we stack the raw ``values`` rather than the percentages above, since a streamgraph is most useful when the total varies over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "streams = hv.Overlay([hv.Area(values[i], vdims=['value']) for i in range(5)])\n",
+    "\n",
+    "hv.Area.stack(streams, offset='sym') + hv.Area.stack(streams, offset='wiggle')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.Area).``"
    ]
   }

--- a/examples/reference/elements/matplotlib/Area.ipynb
+++ b/examples/reference/elements/matplotlib/Area.ipynb
@@ -102,6 +102,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Streamgraph\n",
+    "\n",
+    "The ``offset`` argument controls where the lowest baseline of the stack sits. ``'sym'`` centers the stack on zero, also known as a ThemeRiver, while ``'wiggle'`` and ``'weighted_wiggle'`` minimize the slope of each layer to produce a streamgraph. Here we stack the raw ``values`` rather than the percentages above, since a streamgraph is most useful when the total varies over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "streams = hv.Overlay([hv.Area(values[i], vdims=['value']) for i in range(5)])\n",
+    "\n",
+    "hv.Area.stack(streams, offset='sym') + hv.Area.stack(streams, offset='wiggle')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.Area).``"
    ]
   }

--- a/examples/reference/elements/plotly/Area.ipynb
+++ b/examples/reference/elements/plotly/Area.ipynb
@@ -104,6 +104,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Streamgraph\n",
+    "\n",
+    "The ``offset`` argument controls where the lowest baseline of the stack sits. ``'sym'`` centers the stack on zero, also known as a ThemeRiver, while ``'wiggle'`` and ``'weighted_wiggle'`` minimize the slope of each layer to produce a streamgraph. Here we stack the raw ``values`` rather than the percentages above, since a streamgraph is most useful when the total varies over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "streams = hv.Overlay([hv.Area(values[i], vdims=['value']) for i in range(5)])\n",
+    "\n",
+    "hv.Area.stack(streams, offset='sym') + hv.Area.stack(streams, offset='wiggle')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For full documentation and the available style and plot options, use ``hv.help(hv.Area).``"
    ]
   }

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -336,11 +336,49 @@ class Area(Curve):
 
     group = param.String(default="Area", constant=True)
 
+    @staticmethod
+    def _stack_offset(y, offset):
+        """Compute the lowest baseline for a stack of layers.
+
+        ``y`` is a (layers, samples) array of layer heights in stacking
+        order. Returns the y-position of the bottom of the first layer,
+        following the baselines described in Byron & Wattenberg, "Stacked
+        Graphs - Geometry & Aesthetics".
+
+        """
+        if offset == "sym":
+            return -np.sum(y, 0) * 0.5
+        if offset == "wiggle":
+            m = y.shape[0]
+            return -(y * (m - 0.5 - np.arange(m)[:, None])).sum(0) / m
+        if offset == "weighted_wiggle":
+            total = np.sum(y, 0)
+            # Multiply by 1/total (or zero) to avoid infinities in the division
+            inv_total = np.zeros_like(total)
+            mask = total > 0
+            inv_total[mask] = 1.0 / total[mask]
+            increase = np.hstack((y[:, 0:1], np.diff(y)))
+            below_size = total - np.cumsum(y, 0) + 0.5 * y
+            move_up = below_size * inv_total
+            move_up[:, 0] = 0.5
+            center = np.cumsum(((move_up - 0.5) * increase).sum(0))
+            return center - 0.5 * total
+        raise ValueError(
+            f"Invalid offset {offset!r}, must be one of 'zero', 'sym', 'wiggle' "
+            f"or 'weighted_wiggle'."
+        )
+
     @classmethod
-    def stack(cls, areas, baseline_name="Baseline"):
+    def stack(cls, areas, baseline_name="Baseline", offset="zero"):
         """Stacks an (Nd)Overlay of Area or Curve Elements by offsetting
         their baselines. To stack a HoloMap or DynamicMap use the map
         method.
+
+        The offset controls where the lowest baseline sits: 'zero' for a
+        conventional stacked area chart, 'sym' to center the stack on
+        zero (also called a ThemeRiver), and 'wiggle' or
+        'weighted_wiggle' to minimize the slope of the layers, producing
+        a streamgraph.
 
         """
         if not len(areas):
@@ -351,23 +389,31 @@ class Area(Curve):
         df = areas.dframe(multi_index=True)
         levels = list(range(areas.ndims))
         vdims = [[el.vdims[0], baseline_name] for el in areas]
-        baseline = None
         stacked = areas.clone(shared_data=False)
         if len(levels) == 1:
             # Pandas 2.1 gives the following FutureWarning:
             #   Creating a Groupby object with a length-1 list-like level parameter
             #   will yield indexes as tuples in a future version.
             levels = levels[0]
-        for (key, sdf), element_vdims in zip(
-            df.groupby(level=levels, sort=False), vdims, strict=None
-        ):
+        index = df.index.unique(-1)
+        groups = [
+            (key, sdf.droplevel(levels).reindex(index=index, fill_value=0))
+            for key, sdf in df.groupby(level=levels, sort=False)
+        ]
+        if offset == "zero":
+            baseline = 0
+        else:
+            ys = np.vstack(
+                [
+                    sdf[element_vdims[0].name].to_numpy(dtype=float)
+                    for (_, sdf), element_vdims in zip(groups, vdims, strict=None)
+                ]
+            )
+            baseline = cls._stack_offset(ys, offset)
+        for (key, sdf), element_vdims in zip(groups, vdims, strict=None):
             vdim = element_vdims[0]
-            sdf = sdf.droplevel(levels).reindex(index=df.index.unique(-1), fill_value=0)
-            if baseline is None:
-                sdf[baseline_name] = 0
-            else:
-                sdf[vdim.name] = sdf[vdim.name] + baseline
-                sdf[baseline_name] = baseline
+            sdf[vdim.name] = sdf[vdim.name] + baseline
+            sdf[baseline_name] = baseline
             baseline = sdf[vdim.name]
             stacked[key] = areas[key].clone(sdf, vdims=element_vdims)
         return Overlay(stacked.values()) if is_overlay else stacked

--- a/holoviews/tests/operation/test_operation.py
+++ b/holoviews/tests/operation/test_operation.py
@@ -965,6 +965,55 @@ class OperationTests:
         area2 = hv.Area(([0, 1, 2], [2, 4, 6], [1, 2, 3]), vdims=["y", "Baseline"])
         assert_element_equal(stacked, hv.NdOverlay([(0, area1), (1, area2)]))
 
+    @pytest.mark.parametrize(
+        ("offset", "expected"),
+        [
+            ("zero", [0, 0, 0, 0, 0]),
+            ("sym", [-4, -4, -5, -5, -4]),
+            ("wiggle", [-11 / 3, -4, -14 / 3, -5, -5]),
+            ("weighted_wiggle", [-4, -3.625, -4.925, -4.625, -2.5]),
+        ],
+    )
+    def test_stack_area_offset(self, offset, expected):
+        # Expected baselines are matplotlib.pyplot.stackplot's for the same data
+        layers = [[1, 2, 3, 4, 5], [5, 4, 3, 2, 1], [2, 2, 4, 4, 2]]
+        overlay = hv.Overlay([hv.Area(ys, label=f"l{i}") for i, ys in enumerate(layers)])
+        stacked = hv.Area.stack(overlay, offset=offset)
+        elements = list(stacked.data.values())
+        np.testing.assert_allclose(elements[0].dimension_values("Baseline"), expected)
+        # every layer keeps its own height regardless of where the stack sits
+        for element, ys in zip(elements, layers, strict=True):
+            heights = element.dimension_values("y") - element.dimension_values("Baseline")
+            np.testing.assert_allclose(heights, ys)
+
+    def test_stack_area_offset_integer_data(self):
+        # integer columns must not truncate the baseline arithmetic
+        layers = [[1, 2, 3, 4, 5], [5, 4, 3, 2, 1], [2, 2, 4, 4, 2]]
+        ints = hv.Overlay([hv.Area(ys, label=f"l{i}") for i, ys in enumerate(layers)])
+        floats = hv.Overlay(
+            [hv.Area(np.array(ys, dtype=float), label=f"l{i}") for i, ys in enumerate(layers)]
+        )
+        for int_el, float_el in zip(
+            hv.Area.stack(ints, offset="weighted_wiggle").data.values(),
+            hv.Area.stack(floats, offset="weighted_wiggle").data.values(),
+            strict=True,
+        ):
+            np.testing.assert_allclose(
+                int_el.dimension_values("Baseline"), float_el.dimension_values("Baseline")
+            )
+
+    def test_stack_area_offset_zero_sample(self):
+        # a sample where every layer is zero must not divide by zero
+        overlay = hv.Overlay([hv.Area([1, 0, 3], label=f"l{i}") for i in range(2)])
+        stacked = hv.Area.stack(overlay, offset="weighted_wiggle")
+        for element in stacked.data.values():
+            assert np.isfinite(element.dimension_values("Baseline")).all()
+
+    def test_stack_area_offset_invalid(self):
+        overlay = hv.Area([1, 2, 3]) * hv.Area([1, 2, 3])
+        with pytest.raises(ValueError, match="Invalid offset 'silhouette'"):
+            hv.Area.stack(overlay, offset="silhouette")
+
     def test_pre_and_postprocess_hooks(self):
         pre_backup = operation._preprocess_hooks
         post_backup = operation._postprocess_hooks


### PR DESCRIPTION
## Description

Adds `offset` to `Area.stack`, mirroring [`stackplot`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.stackplot.html)'s `baseline={'zero', 'sym', 'wiggle', 'weighted_wiggle'}`. `wiggle` gives a streamgraph.

## Before
<img width="1089" height="438" alt="pr_before" src="https://github.com/user-attachments/assets/98151aab-1720-49d7-bffd-2ab90ee4db92" />

```python
hv.Area.stack(overlay, offset="wiggle")
```
## After
<img width="1104" height="438" alt="pr_after" src="https://github.com/user-attachments/assets/eaf05944-bb5d-4335-a348-cbe52e1b86fd" />

<!-- SCREENSHOT: drag pr_after.png here -->

## AI Disclosure

- Tool & Model: Claude Code + Opus 4.8
- Usage: scaffolded the tests and the matplotlib comparison script

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
- [x] Added documentation
