### PR TITLE
fix: Seed subplot range streams with overlay's padded extent

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -2320,12 +2320,9 @@ class GenericOverlayPlot(GenericElementPlot):
         # Should match what is done in ElementPlot.get_extents
         if not self.drawn:
             x_range, y_range = ((y0, y1), (x0, x1)) if self.invert_axes else ((x0, x1), (y0, y1))
-            # Individual subplots (e.g. elements that were rasterized/dynspread
-            # before being overlaid) each carry their own source_streams. Their
-            # own get_extents call sees padding=0 (padding is only applied once,
-            # here, at the overlay level) so they must be seeded with this
-            # overlay's combined, padded range too, or their initial dynamic
-            # callback will be invoked with a mismatched, unpadded range.
+            # Seed subplot streams: padding is only applied at the overlay
+            # level, so without this initial subplot callback sees an unpadded
+            # range. https://github.com/holoviz/holoviews/pull/6964
             streams = list(getattr(self, "source_streams", []))
             for subplot in self.subplots.values():
                 if subplot is None:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -2313,7 +2313,20 @@ class GenericOverlayPlot(GenericElementPlot):
         # Should match what is done in ElementPlot.get_extents
         if not self.drawn:
             x_range, y_range = ((y0, y1), (x0, x1)) if self.invert_axes else ((x0, x1), (y0, y1))
-            for stream in getattr(self, "source_streams", []):
+            # Individual subplots (e.g. elements that were rasterized/dynspread
+            # before being overlaid) each carry their own source_streams. Their
+            # own get_extents call sees padding=0 (padding is only applied once,
+            # here, at the overlay level) so they must be seeded with this
+            # overlay's combined, padded range too, or their initial dynamic
+            # callback will be invoked with a mismatched, unpadded range.
+            streams = list(getattr(self, "source_streams", []))
+            for subplot in self.subplots.values():
+                if subplot is None:
+                    continue
+                for stream in getattr(subplot, "source_streams", []):
+                    if stream not in streams:
+                        streams.append(stream)
+            for stream in streams:
                 if isinstance(stream, RangeX):
                     params = {"x_range": x_range}
                 elif isinstance(stream, RangeY):

--- a/holoviews/tests/operation/test_datashader.py
+++ b/holoviews/tests/operation/test_datashader.py
@@ -1679,6 +1679,25 @@ def test_rasterize_overlay_seeds_range_streams():
 
 
 @pytest.mark.usefixtures("bokeh_backend")
+def test_rasterize_dynspread_per_element_overlay_seeds_range_streams():
+    # Test for https://github.com/holoviz/holoviews/issues/6954
+    s1 = hv.Scatter((np.array([0, 10]), np.array([0, 0])), "x", "y", label="s1")
+    s2 = hv.Scatter((np.array([0, 10]), np.array([5, 5])), "x", "y", label="s2")
+
+    d1 = dynspread(rasterize(s1), max_px=2, threshold=1)
+    d2 = dynspread(rasterize(s2), max_px=2, threshold=1)
+    overlay = hv.Overlay([d1, d2]).collate().opts(padding=0.1)
+
+    plot = hv.renderer("bokeh").get_plot(overlay)
+
+    for subplot in plot.subplots.values():
+        stream = next((s for s in subplot.source_streams if isinstance(s, RangeXY)), None)
+        assert stream
+        assert stream.x_range == (-1.0, 11.0)
+        assert stream.y_range == (-0.5, 5.5)
+
+
+@pytest.mark.usefixtures("bokeh_backend")
 def test_selector_single_categorical():
     # Test for https://github.com/holoviz/holoviews/issues/6595
     plot = hv.Points(([0, 1], [0, 1], ["A", "A"]), ["X", "Y"], "C")

--- a/holoviews/tests/ui/bokeh/test_datashader.py
+++ b/holoviews/tests/ui/bokeh/test_datashader.py
@@ -14,16 +14,6 @@ pytestmark = [pytest.mark.ui, ds_skip]
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_rasterize_dynspread_per_element_overlay_initial_range(serve_hv):
-    # Regression test for https://github.com/holoviz/holoviews/issues/6954
-    # and https://github.com/holoviz/holoviews/issues/4890
-    #
-    # rasterize/dynspread applied to each element individually before
-    # overlaying (rather than to the overlay as a whole) used to seed each
-    # element's own range stream with its unpadded extent instead of the
-    # padded extent the overlay is actually displayed with. That mismatch
-    # made the initial render incomplete (or, for constant-valued data,
-    # empty) until a pan/zoom/reset re-triggered the callback with the
-    # correct range.
     from holoviews.operation.datashader import dynspread, rasterize
 
     x = np.arange(10_000)
@@ -58,14 +48,6 @@ def test_rasterize_dynspread_per_element_overlay_initial_range(serve_hv):
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_datashade_dynspread_constant_values_overlay_not_empty(serve_hv):
-    # Regression test for https://github.com/holoviz/holoviews/issues/4890
-    #
-    # Two constant-valued Scatters, each individually datashade+dynspread'd
-    # then overlaid. Each element's own data has zero y-span, so without the
-    # fix its range stream was seeded with its own degenerate (v, v) range
-    # instead of the overlay's actual displayed range (its explicit ylim
-    # here), producing a 1x1, fully-transparent image: the points never
-    # showed up until a pan/zoom/reset re-triggered the callback.
     from holoviews.operation.datashader import datashade, dynspread
 
     x = np.arange(10_000)
@@ -78,10 +60,6 @@ def test_datashade_dynspread_constant_values_overlay_not_empty(serve_hv):
     curve_datashade1 = dynspread(datashade(curve1))
     curve_datashade2 = dynspread(datashade(curve2))
 
-    # Attaching explicit streams is what surfaces the bug: it is the
-    # additional RangeXY registered against the same source that ends up
-    # seeded (or not) with the overlay's real, ylim-clamped range instead of
-    # each element's own degenerate (v, v) extent.
     stream1 = RangeXY(source=curve_datashade1)
     stream2 = RangeXY(source=curve_datashade2)
 

--- a/holoviews/tests/ui/bokeh/test_datashader.py
+++ b/holoviews/tests/ui/bokeh/test_datashader.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import holoviews as hv
+from holoviews.streams import RangeXY
+
+from ..._deps import ds_skip
+from .. import expect, wait_until
+
+pytestmark = [pytest.mark.ui, ds_skip]
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_rasterize_dynspread_per_element_overlay_initial_range(serve_hv):
+    # Regression test for https://github.com/holoviz/holoviews/issues/6954
+    # and https://github.com/holoviz/holoviews/issues/4890
+    #
+    # rasterize/dynspread applied to each element individually before
+    # overlaying (rather than to the overlay as a whole) used to seed each
+    # element's own range stream with its unpadded extent instead of the
+    # padded extent the overlay is actually displayed with. That mismatch
+    # made the initial render incomplete (or, for constant-valued data,
+    # empty) until a pan/zoom/reset re-triggered the callback with the
+    # correct range.
+    from holoviews.operation.datashader import dynspread, rasterize
+
+    x = np.arange(10_000)
+    s1 = hv.Scatter((x, np.full(x.size, 5.0)), "x", "y", label="s1")
+    s2 = hv.Scatter((x, np.full(x.size, 8.0)), "x", "y", label="s2")
+
+    d1 = dynspread(rasterize(s1), max_px=2, threshold=1)
+    d2 = dynspread(rasterize(s2), max_px=2, threshold=1)
+
+    # Attach streams so the seeded range can be inspected once the plot
+    # is served, without needing any pan/zoom interaction to trigger it.
+    stream1 = RangeXY(source=d1)
+    stream2 = RangeXY(source=d2)
+
+    overlay = (d1 * d2).opts(padding=0.1)
+
+    page = serve_hv(overlay)
+    hv_plot = page.locator(".bk-events")
+    expect(hv_plot).to_have_count(1)
+
+    expected_xrange = (-999.9, 10998.9)
+    expected_yrange = (4.7, 8.3)
+
+    def check():
+        np.testing.assert_allclose(stream1.x_range, expected_xrange)
+        np.testing.assert_allclose(stream1.y_range, expected_yrange)
+        np.testing.assert_allclose(stream2.x_range, expected_xrange)
+        np.testing.assert_allclose(stream2.y_range, expected_yrange)
+
+    wait_until(check, page)
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_datashade_dynspread_constant_values_overlay_not_empty(serve_hv):
+    # Regression test for https://github.com/holoviz/holoviews/issues/4890
+    #
+    # Two constant-valued Scatters, each individually datashade+dynspread'd
+    # then overlaid. Each element's own data has zero y-span, so without the
+    # fix its range stream was seeded with its own degenerate (v, v) range
+    # instead of the overlay's actual displayed range (its explicit ylim
+    # here), producing a 1x1, fully-transparent image: the points never
+    # showed up until a pan/zoom/reset re-triggered the callback.
+    from holoviews.operation.datashader import datashade, dynspread
+
+    x = np.arange(10_000)
+    y1 = np.full(x.size, 5.0)
+    y2 = np.full(x.size, 8.0)
+
+    curve1 = hv.Scatter((x, y1), label="variable1")
+    curve2 = hv.Scatter((x, y2), label="variable2")
+
+    curve_datashade1 = dynspread(datashade(curve1))
+    curve_datashade2 = dynspread(datashade(curve2))
+
+    # Attaching explicit streams is what surfaces the bug: it is the
+    # additional RangeXY registered against the same source that ends up
+    # seeded (or not) with the overlay's real, ylim-clamped range instead of
+    # each element's own degenerate (v, v) extent.
+    stream1 = RangeXY(source=curve_datashade1)
+    stream2 = RangeXY(source=curve_datashade2)
+
+    overlay = (curve_datashade1 * curve_datashade2).opts(ylim=(4, 9))
+
+    plot = hv.renderer("bokeh").get_plot(overlay)
+    page = serve_hv(plot)
+    hv_plot = page.locator(".bk-events")
+    expect(hv_plot).to_have_count(1)
+
+    def check():
+        assert stream1.y_range == (4, 9)
+        assert stream2.y_range == (4, 9)
+        for subplot in plot.subplots.values():
+            source = subplot.handles["source"]
+            image = np.asarray(source.data["image"][0])
+            assert image.size > 1, "image was never resized past its 1x1 placeholder"
+            alpha = image.view(np.uint8).reshape(*image.shape, 4)[..., 3]
+            assert np.count_nonzero(alpha) > 0, "image is fully transparent"
+
+    wait_until(check, page)


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->


Fixes #6954 
Fixes #4890
Fixes #4841
Fixes #5070

`rasterize`/`dynspread` applied to each element individually before overlaying (rather than to the whole overlay) attaches range streams to each subplot instead of the `OverlayPlot` itself. 

Those subplot streams were seeded with each element's own unpadded (and un-ylim'd) extent instead of the overlay's actual combined, padded display range. Causing an incomplete or, for constant-valued data, fully empty initial render until a pan/zoom/reset re-triggered the callback.

## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Claude Code:claude-sonnet-5
Usage: Asked it to fix the problem in #6954

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
- [x] Added documentation
