### PR TITLE
docs: Document downsample algorithms

### DIFF
--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -566,7 +566,7 @@
     "\n",
     "- `lttb` (the default) uses Largest Triangle Three Buckets and preserves the visual shape of a curve. HoloViews uses the high-performance [tsdownsample](https://github.com/predict-idlab/tsdownsample) implementation when that optional package is installed, and otherwise falls back to its NumPy implementation.\n",
     "- `minmax`, `minmax-lttb`, and `m4` are provided by `tsdownsample` and require that package to be installed. They preserve extrema, combine extrema selection with LTTB, and retain the first, last, minimum, and maximum values of each bin, respectively.\n",
-    "- `nth` selects every *n*th point and does not require `tsdownsample`.\n",
+    "- `nth` selects every *n*th point.\n",
     "- `viewport` keeps all points in the current viewport, which is useful when the visible range already contains a manageable number of samples.\n",
     "\n",
     "Set the output resolution with `width` and select an algorithm with `algorithm`. Here, the default LTTB result and the `nth` result are each overlaid on the original curve for comparison:"

--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -562,7 +562,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another option when working with time series is to downsample the data before plotting it. This can be done with `downsample1D`. Algorithms supported are `lttb` (Largest Triangle Three Buckets) and `nth` element. The two algorithm is overlaid on top of the original curve in the example below. "
+    "Another option when working with time series is to downsample the data before plotting it. The `downsample1d` operation supports several algorithms:\n",
+    "\n",
+    "- `lttb` (the default) uses Largest Triangle Three Buckets and preserves the visual shape of a curve. HoloViews uses the high-performance [tsdownsample](https://github.com/predict-idlab/tsdownsample) implementation when that optional package is installed, and otherwise falls back to its NumPy implementation.\n",
+    "- `minmax`, `minmax-lttb`, and `m4` are provided by `tsdownsample` and require that package to be installed. They preserve extrema, combine extrema selection with LTTB, and retain the first, last, minimum, and maximum values of each bin, respectively.\n",
+    "- `nth` selects every *n*th point and does not require `tsdownsample`.\n",
+    "- `viewport` keeps all points in the current viewport, which is useful when the visible range already contains a manageable number of samples.\n",
+    "\n",
+    "Set the output resolution with `width` and select an algorithm with `algorithm`. Here, the default LTTB result and the `nth` result are each overlaid on the original curve for comparison:"
    ]
   },
   {
@@ -576,8 +583,8 @@
     "lttb = downsample1d(curve)\n",
     "nth = downsample1d(curve, algorithm=\"nth\")\n",
     "\n",
-    "lttb_com = (curve * lttb).opts(width=800, title=\"lttb comparison\")\n",
-    "nth_com = (curve * nth).opts(width=800, title=\"nth comparison\")\n",
+    "lttb_com = (curve * lttb).opts(width=800, title=\"LTTB comparison\")\n",
+    "nth_com = (curve * nth).opts(width=800, title=\"Nth-point comparison\")\n",
     "\n",
     "(lttb_com + nth_com).cols(1)"
    ]


### PR DESCRIPTION
## Description

Document every algorithm supported by `downsample1d`, including which algorithms require the optional `tsdownsample` package and when LTTB falls back to HoloViews' NumPy implementation. This also corrects the operation name from `downsample1D` to `downsample1d` and makes the comparison titles easier to scan.

Fixes #6080

## Verification

- `uvx pre-commit run --files examples/user_guide/15-Large_Data.ipynb`
- Executed the documented LTTB and nth-point examples against the current source in an isolated `uv` environment

## AI Disclosure

Tool & Model: OpenAI Codex (GPT-5)

Usage: Used to inspect the implementation and draft the documentation update. I reviewed the API against the current source and ran the checks listed above.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
- [x] Added documentation