### PR TITLE
docs: Hide notebook-specific resampling settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: 2e6f506fab3cdfbe16bc18fd0d24e828db773b74 # frozen: v0.2.1
     hooks:
       - id: clean-notebook
-        args: [--strip-trailing-newlines]
+        args: [--strip-trailing-newlines, --ignore, tags]
   - repo: https://github.com/crate-ci/typos
     rev: bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # frozen: v1.48.0
     hooks:

--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -45,8 +45,6 @@
     "decimate.max_samples=1000\n",
     "dynspread.max_px=20\n",
     "dynspread.threshold=0.5\n",
-    "ResampleOperation2D.width=500\n",
-    "ResampleOperation2D.height=500\n",
     "\n",
     "def random_walk(n, f=5000):\n",
     "    \"\"\"Random walk in a 2D space, smoothed with a filter of length f\"\"\"\n",
@@ -71,6 +69,20 @@
     "    X = (mu-0.5*sigma**2)*t + sigma*W\n",
     "    S = S0*np.exp(X) # geometric brownian motion\n",
     "    return S"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "ResampleOperation2D.width=500\n",
+    "ResampleOperation2D.height=500"
    ]
   },
   {
@@ -682,6 +694,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "ResampleOperation2D.width=115\n",
+    "ResampleOperation2D.height=115"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -693,8 +719,6 @@
     "rect_opts = opts.Rectangles(lw=0, color=hv.dim('sign').categorize(rect_colors))\n",
     "ds_point_opts = dict(aggregator='any')\n",
     "ds_line_opts  = dict(aggregator='any', line_width=1)\n",
-    "ResampleOperation2D.width=115\n",
-    "ResampleOperation2D.height=115\n",
     "\n",
     "ds_opts = {\n",
     "    hv.Path:       ds_line_opts,\n",

--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -37,7 +37,6 @@
     "    shade,\n",
     "    spread,\n",
     ")\n",
-    "from holoviews.operation.resample import ResampleOperation2D\n",
     "\n",
     "hv.extension('bokeh','matplotlib', width=100)\n",
     "\n",
@@ -81,6 +80,8 @@
    },
    "outputs": [],
    "source": [
+    "from holoviews.operation.resample import ResampleOperation2D\n",
+    "\n",
     "ResampleOperation2D.width=500\n",
     "ResampleOperation2D.height=500"
    ]


### PR DESCRIPTION
## Summary

- move the `ResampleOperation2D` width and height overrides into dedicated hidden cells
- keep the user-facing setup focused on settings that users may actually want to copy
- configure `clean-notebook` to preserve cell tags so `hide-cell` survives linting

Closes #6044.

## Validation

- `uvx pre-commit run --files .pre-commit-config.yaml examples/user_guide/15-Large_Data.ipynb`
- verified both resampling cells retain the `hide-cell` tag after the clean-notebook hook