### PR TITLE
fix: Improve `functools.partial` as stream subscriber

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -107,6 +107,30 @@ class _WeakSubscriber:
         return self._hash
 
 
+def _keep_subscriber_alive(subscriber):
+    """Keep a strong reference to a weakly-referenced subscriber for the
+    lifetime of a served Panel session.
+
+    Method subscribers are held weakly (see ``_WeakSubscriber``) so the objects
+    they are bound to can be garbage collected once a session ends, avoiding the
+    leak in #6934. But when the bound object is *only* reachable through the
+    subscription -- common for ``pn.viewable.Viewer`` apps -- it would be
+    collected immediately and the subscriber would never fire (#6945). Tying a
+    strong reference to the current session's document keeps the subscriber
+    working while the plot is displayed and releases it when the session is
+    destroyed. Outside a served session (e.g. notebooks) there is no document to
+    tie to and the weak reference is used as-is.
+    """
+    import panel as pn
+
+    doc = pn.state.curdoc
+    if doc is None or not hasattr(doc, "on_session_destroyed"):
+        return
+    # The closure over ``subscriber`` is held by the document until the session
+    # is destroyed, at which point it -- and the subscriber -- are released.
+    doc.on_session_destroyed(lambda context, _sub=subscriber: None)
+
+
 @contextmanager
 def triggering_streams(streams):
     """Temporarily declares the streams as being in a triggered state.
@@ -437,6 +461,7 @@ class Stream(param.Parameterized):
         if not callable(subscriber):
             raise TypeError("Subscriber must be a callable.")
         if _WeakSubscriber.check(subscriber):
+            _keep_subscriber_alive(subscriber)
             subscriber = _WeakSubscriber(subscriber)
         self._subscribers.append((precedence, subscriber))
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -56,13 +56,10 @@ class _SkipTrigger:
 
 class _WeakSubscriber:
     def __init__(self, subscriber):
-        if inspect.ismethod(subscriber):
-            self._ref = weakref.WeakMethod(subscriber)
-        else:
-            self._ref = weakref.ref(subscriber)
-
-        self._hash = self._generate_hash(subscriber)
-        self._is_param_method = util.is_param_method(subscriber)
+        method, self._args, self._kwargs = self._unwrap(subscriber)
+        self._ref = weakref.WeakMethod(method)
+        self._is_param_method = util.is_param_method(method)
+        self._hash = self._generate_hash(method, self._args, self._kwargs)
 
     def __bool__(self) -> bool:
         method = self._ref()
@@ -71,7 +68,16 @@ class _WeakSubscriber:
     def __call__(self, *args, **kwargs):
         method = self._ref()
         if method is not None:
-            return method(*args, **kwargs)
+            return method(*self._args, *args, **{**self._kwargs, **kwargs})
+
+    @staticmethod
+    def _unwrap(method):
+        args, kwargs = (), {}
+        while isinstance(method, partial):
+            args = method.args + args
+            kwargs = {**method.keywords, **kwargs}
+            method = method.func
+        return method, args, kwargs
 
     @staticmethod
     def check(subscriber):
@@ -80,17 +86,21 @@ class _WeakSubscriber:
         return inspect.ismethod(subscriber)
 
     @staticmethod
-    def _generate_hash(subscriber) -> int:
-        if inspect.ismethod(subscriber):
-            return hash((id(subscriber.__func__), id(subscriber.__self__)))
-        else:
-            return hash(id(subscriber))
+    def _generate_hash(method, args, kwargs) -> int:
+        return hash(
+            (
+                id(method.__func__),
+                id(method.__self__),
+                tuple(map(id, args)),
+                tuple((k, id(v)) for k, v in kwargs.items()),
+            )
+        )
 
     def __eq__(self, other) -> bool:
         if isinstance(other, _WeakSubscriber):
             return self._hash == other._hash
         if self.check(other):
-            return self._hash == self._generate_hash(other)
+            return self._hash == self._generate_hash(*self._unwrap(other))
         return NotImplemented
 
     def __hash__(self) -> int:

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -4,6 +4,7 @@ Unit test of the streams system
 
 from __future__ import annotations
 
+import gc
 import weakref
 from collections import defaultdict
 from functools import partial
@@ -866,6 +867,53 @@ class TestWeakSubscriber:
         assert len(subscribers) == 2
         viewer.stream.event(index=[0])
         assert sorted(kwargs["tag"] for _, kwargs in viewer.calls) == ["a", "b"]
+
+    @staticmethod
+    def _destroy_session(doc):
+        for callback in list(doc.callbacks._session_destroyed_callbacks):
+            callback(None)
+        doc.callbacks._session_destroyed_callbacks.clear()
+
+    def test_served_session_keeps_subscriber_alive(self):
+        # In a served session a subscriber whose instance is only reachable
+        # through the subscription must stay alive and fire (#6945).
+        from bokeh.document import Document
+        from panel.io.state import set_curdoc
+
+        doc = Document()
+
+        def make():
+            with set_curdoc(doc):
+                viewer = self._make_viewer(lambda method: partial(method, value="value"))
+            return viewer.stream, weakref.ref(viewer)
+
+        stream, ref = make()
+        gc.collect()
+        assert ref() is not None
+        assert all(bool(s) for s in stream.subscribers)
+        stream.event(index=[0])
+        assert ref().calls == [((), {"index": [0], "value": "value"})]
+
+    def test_session_destroyed_releases_subscriber(self):
+        # Destroying the session releases the strong reference so the instance
+        # can be garbage collected (#6934).
+        from bokeh.document import Document
+        from panel.io.state import set_curdoc
+
+        doc = Document()
+
+        def make():
+            with set_curdoc(doc):
+                viewer = self._make_viewer(lambda method: partial(method, value="value"))
+            return weakref.ref(viewer)
+
+        ref = make()
+        gc.collect()
+        assert ref() is not None  # kept alive for the session
+
+        self._destroy_session(doc)
+        gc.collect()
+        assert ref() is None
 
 
 class TestStreamSource:

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -15,7 +15,7 @@ import pytest
 from panel.widgets import IntSlider
 
 import holoviews as hv
-from holoviews.core.util import NUMPY_GE_2_0_0, PARAM_VERSION
+from holoviews.core.util import NUMPY_GE_2_0_0, PARAM_VERSION, unique_iterator
 from holoviews.plotting.renderer import PANEL_VERSION
 from holoviews.streams import (
     Buffer,
@@ -809,33 +809,63 @@ class TestSubscribers:
 
 
 class TestWeakSubscriber:
-    def check(self, Viewer):
-        viewer = Viewer()
+    @staticmethod
+    def _make_viewer(make_subscriber):
+        class Viewer:
+            def __init__(self):
+                self.calls = []
+                self.plot = hv.Points([(0, 0)])
+                self.stream = hv.streams.Selection1D(source=self.plot)
+                self.stream.add_subscriber(make_subscriber(self.on_update))
+
+            def on_update(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+
+        return Viewer()
+
+    @pytest.mark.parametrize(
+        "make_subscriber",
+        [lambda method: method, lambda method: partial(method, extra=1)],
+        ids=["bound_method", "partial"],
+    )
+    def test_instance_not_pinned(self, make_subscriber):
+        viewer = self._make_viewer(make_subscriber)
         ref = weakref.ref(viewer)
         del viewer
         assert ref() is None
 
-    def test_bound_method(self):
-        class Viewer:
-            def __init__(self):
-                self.plot = hv.Points([])
-                self.stream = hv.streams.RangeX(source=self.plot)
-                self.stream.add_subscriber(self.on_update)
+    @pytest.mark.parametrize(
+        ("make_subscriber", "expected"),
+        [
+            (
+                lambda method: partial(method, value="value"),
+                ((), {"index": [0], "value": "value"}),
+            ),
+            (
+                lambda method: partial(method, "pos"),
+                (("pos",), {"index": [0]}),
+            ),
+            (
+                lambda method: partial(method, data=[1, 2, 3]),
+                ((), {"index": [0], "data": [1, 2, 3]}),
+            ),
+        ],
+        ids=["keyword", "positional", "unhashable"],
+    )
+    def test_partial_subscriber_is_invoked(self, make_subscriber, expected):
+        viewer = self._make_viewer(make_subscriber)
+        assert all(bool(s) for s in viewer.stream.subscribers)
+        viewer.stream.event(index=[0])
+        assert viewer.calls == [expected]
 
-            def on_update(self, x_range=None): ...
+    def test_distinct_partials_not_deduplicated(self):
+        viewer = self._make_viewer(lambda method: partial(method, tag="a"))
+        viewer.stream.add_subscriber(partial(viewer.on_update, tag="b"))
 
-        self.check(Viewer)
-
-    def test_bound_method_partial(self):
-        class Viewer:
-            def __init__(self):
-                self.plot = hv.Points([])
-                self.stream = hv.streams.RangeX(source=self.plot)
-                self.stream.add_subscriber(partial(self.on_update, extra=1))
-
-            def on_update(self, x_range=None, extra=0): ...
-
-        self.check(Viewer)
+        subscribers = list(unique_iterator(viewer.stream.subscribers))
+        assert len(subscribers) == 2
+        viewer.stream.event(index=[0])
+        assert sorted(kwargs["tag"] for _, kwargs in viewer.calls) == ["a", "b"]
 
 
 class TestStreamSource:


### PR DESCRIPTION


<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes #6945

`_WeakSubscriber` now unwrap `functools.partial` down to the bound method, hold a `WeakMethod` to it, and store the partial's args/kwargs to reapply on call. 

Also pin a strong reference to the subscriber on the document via `on_session_destroyed` so it survives while displayed and is released when the session ends.

## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Claude Code:claude-opus-4-8
Usage: 1) Add to make an unwrap of functool.partial to remove the `weakref`. 2) Make a `on_session_destroyed` to strong pin it. 

- [ ] I have tested all AI-generated content in my PR.
- [ ] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [ ] Pull request title follows the conventional format
- [ ] Tests added and are passing
- [ ] Added documentation
