### PR TITLE
fix: allow auto-sharing categorical axes in layouts

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from itertools import chain
 from textwrap import dedent
 from types import FunctionType
+from typing import TYPE_CHECKING, cast
 
 import bokeh
 import bokeh.plotting
@@ -14,6 +15,7 @@ import param
 from bokeh.document.events import ModelChangedEvent
 from bokeh.model import Model
 from bokeh.models import (
+    Axis,
     BinnedTicker,
     ColorBar,
     ColorMapper,
@@ -22,6 +24,8 @@ from bokeh.models import (
     EqHistColorMapper,
     GlyphRenderer,
     Legend,
+    Plot,
+    Range,
     Renderer,
     Span,
     Title,
@@ -106,6 +110,11 @@ from .util import (
 
 if BOKEH_GE_3_8_0:
     from bokeh.models.axes import TimedeltaAxis
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from .util import AxisType
 
 try:
     TOOLS_MAP = Tool._known_aliases
@@ -813,28 +822,34 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if dim not in data:
                 data[dim] = [v] * len(next(iter(data.values())))
 
-    def _shared_axis_range(self, plots, specs, range_type, axis_type, pos):
+    def _shared_axis_range(
+        self,
+        plots: Iterable[Plot] | None,
+        specs: Iterable[object] | None,
+        axis_type: AxisType,
+        pos: int,
+        *,
+        is_categorical: bool,
+    ) -> Range | None:
         """Given a list of other plots return the shared axis from another
         plot by matching the dimensions specs stored as tags on the
         dimensions. Returns None if there is no such axis.
 
         """
-        dim_range = None
-        categorical = range_type is FactorRange
+        dim_range: Range | None = None
         for plot in plots:
             if plot is None or specs is None:
                 continue
             ax = "x" if pos == 0 else "y"
-            plot_range = getattr(plot, f"{ax}_range", None)
-            axes = getattr(plot, f"{ax}axis", None)
-            extra_ranges = getattr(plot, f"extra_{ax}_ranges", {})
+            plot_range = cast("Range | None", getattr(plot, f"{ax}_range", None))
+            axes = cast("Axis | None", getattr(plot, f"{ax}axis", None))
+            extra_ranges = cast("dict[str, Range] | None", getattr(plot, f"extra_{ax}_ranges", {}))
 
             if (
                 plot_range
                 and plot_range.tags
                 and match_dim_specs(plot_range.tags[0], specs)
-                and match_ax_type(axes[0], axis_type)
-                and not (categorical and not isinstance(dim_range, FactorRange))
+                and match_ax_type(axes[0], axis_type, is_categorical=is_categorical)
             ):
                 dim_range = plot_range
 
@@ -845,8 +860,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 if (
                     extra_range.tags
                     and match_dim_specs(extra_range.tags[0], specs)
-                    and match_yaxis_type_to_range(axes, axis_type, extra_range.name)
-                    and not (categorical and not isinstance(dim_range, FactorRange))
+                    and match_yaxis_type_to_range(
+                        axes, axis_type, extra_range.name, is_categorical=is_categorical
+                    )
                 ):
                     dim_range = extra_range
                     break
@@ -878,7 +894,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         dim=None,
         range_tags_extras=None,
         extra_range_name=None,
-    ):
+    ) -> tuple[AxisType, str, Range]:
 
         if range_tags_extras is None:
             range_tags_extras = []
@@ -963,39 +979,50 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if dims:
                 dims = dims[:2][::-1]
 
-        categorical = any(self.traverse(lambda plot: plot._categorical))
-        if self.subcoordinate_y:
-            categorical = False
-        elif dims is not None and any(
-            dim.label in ranges and "factors" in ranges[dim.label] for dim in dims
-        ):
-            categorical = True
-        else:
-            categorical = any(isinstance(v, (str, bytes)) for v in (v0, v1))
-
         range_types = (self._x_range_type, self._y_range_type)
         if self.invert_axes:
             range_types = range_types[::-1]
         range_type = range_types[pos]
+
+        axis_dim = dims[0] if dims else None
+        dim_type = (
+            el.get_dimension_type(axis_dim)
+            if axis_dim is not None and el.get_dimension(axis_dim)
+            else None
+        )
+        is_categorical = not self.subcoordinate_y and (
+            # the plot or range declares itself categorical
+            any(self.traverse(lambda plot: plot._categorical))
+            or range_type is FactorRange
+            # more than one dimension on this axis
+            or bool(dims and len(dims) > 1)
+            # the axis dimension's own declared values/type are string-like
+            or bool(axis_dim and axis_dim.values)
+            or (isinstance(dim_type, type) and issubclass(dim_type, (str, bytes)))
+            # `ranges` (populated by `Plot._compute_group_range`) recorded factors for the dimension.
+            # While `ranges` and `v0`/`v1` are merged by dimension *name* across a layout/overlay,
+            # ranges are excluded if their types don't match.
+            or bool(axis_dim and axis_dim.label in ranges and "factors" in ranges[axis_dim.label])
+            # extents are string-like (e.g. done in Waterfall)
+            or any(isinstance(v, (str, bytes)) for v in (v0, v1))
+        )
+
         # If multi_x/y then grab opts from element
-        axis_type = "log" if (self.logx, self.logy)[pos] else "auto"
-        if dims:
-            if len(dims) > 1 or range_type is FactorRange:
-                axis_type = "auto"
-                categorical = True
-            elif el.get_dimension(dims[0]):
-                dim_type = el.get_dimension_type(dims[0])
-                if isinstance(v0, util.datetime_types) or dim_type in util.datetime_types:
-                    axis_type = "datetime"
-                elif BOKEH_GE_3_8_0 and (
-                    isinstance(v0, util.timedelta_types) or dim_type in util.timedelta_types
-                ):
-                    axis_type = "timedelta"
+        axis_type: AxisType = "log" if (self.logx, self.logy)[pos] else "auto"
+        if not is_categorical and dim_type is not None:
+            if isinstance(v0, util.datetime_types) or dim_type in util.datetime_types:
+                axis_type = "datetime"
+            elif BOKEH_GE_3_8_0 and (
+                isinstance(v0, util.timedelta_types) or dim_type in util.timedelta_types
+            ):
+                axis_type = "timedelta"
 
         norm_opts = self.lookup_options(el, "norm").options
         shared_name = extra_range_name or ("x-main-range" if pos == 0 else "y-main-range")
         if plots and self.shared_axes and not norm_opts.get("axiswise", False) and not dim:
-            dim_range = self._shared_axis_range(plots, specs, range_type, axis_type, pos)
+            dim_range = self._shared_axis_range(
+                plots, specs, axis_type, pos, is_categorical=is_categorical
+            )
             if dim_range:
                 self._shared[shared_name] = True
 
@@ -1008,8 +1035,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         if self._shared.get(shared_name) and not dim:
             pass
-        elif categorical:
-            axis_type = "auto"
+        elif is_categorical:
             dim_range = FactorRange(name=name)
         elif None in [v0, v1] or any(
             True if isinstance(el, (str, bytes, *util.cftime_types)) else not util.isfinite(el)
@@ -1355,7 +1381,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             opts["text_font_size"] = title_font
         return opts
 
-    def _populate_axis_handles(self, plot):
+    def _populate_axis_handles(self, plot: Plot) -> None:
         self.handles["xaxis"] = plot.xaxis[0]
         self.handles["x_range"] = plot.x_range
         self.handles["extra_x_ranges"] = plot.extra_x_ranges

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -997,7 +997,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             # more than one dimension on this axis
             or bool(dims and len(dims) > 1)
             # the axis dimension's own declared values/type are string-like
-            or bool(axis_dim and axis_dim.values)
+            or (axis_dim is not None and any(isinstance(v, (str, bytes)) for v in axis_dim.values))
             or (isinstance(dim_type, type) and issubclass(dim_type, (str, bytes)))
             # `ranges` (populated by `Plot._compute_group_range`) recorded factors for the dimension.
             # While `ranges` and `v0`/`v1` are merged by dimension *name* across a layout/overlay,
@@ -1009,7 +1009,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         # If multi_x/y then grab opts from element
         axis_type: AxisType = "log" if (self.logx, self.logy)[pos] else "auto"
-        if not is_categorical and dim_type is not None:
+        if is_categorical:
+            axis_type = "auto"
+        elif dim_type is not None:
             if isinstance(v0, util.datetime_types) or dim_type in util.datetime_types:
                 axis_type = "datetime"
             elif BOKEH_GE_3_8_0 and (

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -992,6 +992,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         )
         is_categorical = not self.subcoordinate_y and (
             # the plot or range declares itself categorical
+            # NOTE: does not seem to be done anywhere in HoloViews.
             any(self.traverse(lambda plot: plot._categorical))
             or range_type is FactorRange
             # more than one dimension on this axis

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -1263,7 +1263,7 @@ def match_yaxis_type_to_range(
     """Apply match_ax_type to the y-axis found by the given range name"""
     for axis in yax:
         if axis.y_range_name == range_name:
-            return match_ax_type(axis, range_type, is_categorical)
+            return match_ax_type(axis, range_type, is_categorical=is_categorical)
     raise ValueError("No axis with given range found")
 
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -1238,27 +1238,32 @@ def get_axis_class(axis_type, range_input, dim):  # Copied from bokeh
         raise ValueError(f"Unrecognized axis_type: '{axis_type!r}'")
 
 
-def match_ax_type(ax: Axis, axis_type: AxisType, *, is_categorical: bool) -> bool:
+def match_ax_type(ax: Axis, range_type: AxisType, *, is_categorical: bool | None = None) -> bool:
     """Ensure the range_type matches the axis model being matched."""
+    is_categorical = range_type == "categorical" if is_categorical is None else is_categorical
     if isinstance(ax, CategoricalAxis):
         return is_categorical
     elif is_categorical:
         return False
     elif isinstance(ax, DatetimeAxis):
-        return axis_type == "datetime"
+        return range_type == "datetime"
     elif BOKEH_GE_3_8_0 and isinstance(ax, TimedeltaAxis):
-        return axis_type == "timedelta"
+        return range_type == "timedelta"
     else:
-        return axis_type in {"auto", "log"}
+        return range_type in {"auto", "log"}
 
 
 def match_yaxis_type_to_range(
-    yax: Iterable[Axis], axis_type: AxisType, range_name: str | None, *, is_categorical: bool
+    yax: Iterable[Axis],
+    range_type: AxisType,
+    range_name: str | None,
+    *,
+    is_categorical: bool | None = None,
 ) -> bool:
     """Apply match_ax_type to the y-axis found by the given range name"""
     for axis in yax:
         if axis.y_range_name == range_name:
-            return match_ax_type(axis, axis_type, is_categorical)
+            return match_ax_type(axis, range_type, is_categorical)
     raise ValueError("No axis with given range found")
 
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -7,6 +7,7 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager, suppress
 from itertools import permutations
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from bokeh.core.property.datetime import Datetime
@@ -14,7 +15,7 @@ from bokeh.core.validation import silence
 from bokeh.core.validation.check import is_silenced
 from bokeh.layouts import group_tools
 from bokeh.model import Model
-from bokeh.models import CustomJS, tools
+from bokeh.models import CustomJS, Range, Scale, tools
 from bokeh.models.axes import (
     CategoricalAxis,
     DatetimeAxis,
@@ -64,6 +65,13 @@ BOKEH_GE_3_9_0 = BOKEH_VERSION >= (3, 9, 0)
 
 if BOKEH_GE_3_8_0:
     from bokeh.models.axes import TimedeltaAxis
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
+    from bokeh.models.axes import Axis
+
+    AxisType = Literal["linear", "log", "datetime", "auto", "mercator", "timedelta"]
 
 
 TOOL_TYPES = {
@@ -1160,7 +1168,7 @@ def multi_polygons_data(element):
     return xsh, ysh
 
 
-def match_dim_specs(specs1, specs2):
+def match_dim_specs(specs1: Collection[object] | None, specs2: Collection[object] | None):
     """Matches dimension specs used to link axes.
 
     Axis dimension specs consists of a list of tuples corresponding
@@ -1171,8 +1179,8 @@ def match_dim_specs(specs1, specs2):
     """
     if (specs1 is None or specs2 is None) or (len(specs1) != len(specs2)):
         return False
-    for spec1, spec2 in zip(specs1, specs2, strict=None):
-        for s1, s2 in zip(spec1, spec2, strict=None):
+    for spec1, spec2 in zip(specs1, specs2, strict=False):
+        for s1, s2 in zip(spec1, spec2, strict=False):
             if s1 is None or s2 is None:
                 continue
             if s1 != s2:
@@ -1180,7 +1188,7 @@ def match_dim_specs(specs1, specs2):
     return True
 
 
-def get_scale(range_input, axis_type):
+def get_scale(range_input: Range, axis_type: AxisType) -> Scale:
     if isinstance(range_input, (DataRange1d, Range1d)) and axis_type in [
         "linear",
         "datetime",
@@ -1230,23 +1238,27 @@ def get_axis_class(axis_type, range_input, dim):  # Copied from bokeh
         raise ValueError(f"Unrecognized axis_type: '{axis_type!r}'")
 
 
-def match_ax_type(ax, range_type):
+def match_ax_type(ax: Axis, axis_type: AxisType, *, is_categorical: bool) -> bool:
     """Ensure the range_type matches the axis model being matched."""
     if isinstance(ax, CategoricalAxis):
-        return range_type == "categorical"
+        return is_categorical
+    elif is_categorical:
+        return False
     elif isinstance(ax, DatetimeAxis):
-        return range_type == "datetime"
+        return axis_type == "datetime"
     elif BOKEH_GE_3_8_0 and isinstance(ax, TimedeltaAxis):
-        return range_type == "timedelta"
+        return axis_type == "timedelta"
     else:
-        return range_type in ("auto", "log")
+        return axis_type in {"auto", "log"}
 
 
-def match_yaxis_type_to_range(yax, range_type, range_name):
+def match_yaxis_type_to_range(
+    yax: Iterable[Axis], axis_type: AxisType, range_name: str | None, *, is_categorical: bool
+) -> bool:
     """Apply match_ax_type to the y-axis found by the given range name"""
     for axis in yax:
         if axis.y_range_name == range_name:
-            return match_ax_type(axis, range_type)
+            return match_ax_type(axis, axis_type, is_categorical)
     raise ValueError("No axis with given range found")
 
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -806,9 +806,15 @@ class DimensionedPlot(Plot):
                 else:
                     dtype = None
 
+                # dtype_kind reports "O" (not "S"/"U") for pandas.StringDtype
+                is_string_dtype = dtype is not None and (
+                    dtype_kind(dtype) in "SU"
+                    or (util.pd and isinstance(dtype, util.pd.StringDtype))
+                )
+
                 if all(util.isfinite(r) for r in el_dim.range):
                     data_range = (None, None)
-                elif dtype is not None and dtype_kind(dtype) in "SU":
+                elif is_string_dtype:
                     data_range = ("", "")
                 elif isinstance(el, Graph) and el_dim in el.kdims[:2]:
                     data_range = el.nodes.range(2, dimension_range=False)
@@ -829,7 +835,7 @@ class DimensionedPlot(Plot):
                 if (
                     any(isinstance(r, str) for r in data_range)
                     or (el_dim.type is not None and issubclass(el_dim.type, str))
-                    or (dtype is not None and dtype_kind(dtype) in "SU")
+                    or is_string_dtype
                 ):
                     categorical_dims.append(el_dim)
 
@@ -935,7 +941,11 @@ class DimensionedPlot(Plot):
                 matching &= (
                     len(
                         {
-                            "date" if isinstance(v, util.datetime_types) else "number"
+                            "date"
+                            if isinstance(v, util.datetime_types)
+                            else "string"
+                            if isinstance(v, (str, bytes))
+                            else "number"
                             for rng in rs
                             for v in rng
                             if util.isfinite(v)

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -8,13 +8,18 @@ import param
 import pytest
 from bokeh.document import Document
 from bokeh.models import (
+    CategoricalAxis,
+    CategoricalScale,
     EqHistColorMapper,
+    FactorRange,
     FixedTicker,
+    LinearAxis,
     LinearColorMapper,
     LogColorMapper,
     LogTicker,
     NumeralTickFormatter,
     PrintfTickFormatter,
+    Range1d,
     tools,
 )
 
@@ -530,6 +535,19 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         plot = bokeh_renderer.get_plot(curve)
         x_range = plot.handles["x_range"]
         assert x_range.factors == []
+
+    def test_numeric_dimension_values_not_categorical(self):
+        curve = hv.Curve([(1, 1), (2, 3)]).redim.values(x=[1, 2, 3])
+        plot = bokeh_renderer.get_plot(curve)
+        assert isinstance(plot.handles["x_range"], Range1d)
+        assert isinstance(plot.handles["xaxis"], LinearAxis)
+
+    def test_categorical_axis_ignores_log(self):
+        curve = hv.Curve([("C", 1), ("B", 3)]).opts(logx=True)
+        plot = bokeh_renderer.get_plot(curve)
+        assert isinstance(plot.handles["x_range"], FactorRange)
+        assert isinstance(plot.handles["xaxis"], CategoricalAxis)
+        assert isinstance(plot.state.x_scale, CategoricalScale)
 
     def test_style_map_dimension_object(self):
         x = hv.Dimension("x")

--- a/holoviews/tests/plotting/bokeh/test_layoutplot.py
+++ b/holoviews/tests/plotting/bokeh/test_layoutplot.py
@@ -363,6 +363,19 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         assert (x_range.start, x_range.end) == (-0.5, 0.5)
         assert (y_range.start, y_range.end) == (-0.5, 0.5)
 
+    def test_shared_axes_multi_y(self):
+        c1 = hv.Curve([1, 2, 3], "x", "y1")
+        c2 = hv.Curve([3, 2, 1], "x", "y2")
+        c3 = hv.Curve([1, 4, 9], "x", "y2")
+        overlay = (c1 * c2).opts(multi_y=True) + c3
+        plot = bokeh_renderer.get_plot(overlay)
+        plot1 = plot.subplots[(0, 0)].subplots["main"]
+        plot2 = plot.subplots[(0, 1)].subplots["main"]
+        x_range1, y_range1 = plot1.handles["x_range"], plot1.handles["y_range"]
+        x_range2, y_range2 = plot2.handles["x_range"], plot2.handles["y_range"]
+        assert x_range1 is x_range2
+        assert y_range1 is not y_range2
+
     def test_layout_empty_subplots(self):
         layout = (
             hv.Curve(range(10))

--- a/holoviews/tests/plotting/bokeh/test_layoutplot.py
+++ b/holoviews/tests/plotting/bokeh/test_layoutplot.py
@@ -4,7 +4,7 @@ import datetime as dt
 import re
 
 import numpy as np
-from bokeh.models import Div, GlyphRenderer, GridPlot, Spacer, Tabs, Title, Toolbar
+from bokeh.models import Div, GlyphRenderer, GridPlot, Plot, Spacer, Tabs, Title, Toolbar
 from bokeh.models.layouts import TabPanel
 from bokeh.plotting import figure
 
@@ -342,6 +342,17 @@ class TestLayoutPlot(LoggingComparison, TestBokehPlot):
         x_range2, y_range2 = plot2.handles["x_range"], plot2.handles["y_range"]
         assert x_range1 is x_range2
         assert y_range1 is y_range2
+
+    def test_shared_axes_categorical(self):
+        xs = [f"cat{i}" for i in range(5)]
+        c1 = hv.Curve((xs, [1, 2, 3, 4, 5]), "x", "y1")
+        c2 = hv.Curve((xs, [5, 4, 3, 2, 1]), "x", "y2")
+
+        layout = (c1 + c2).opts(shared_axes=True)
+        model = hv.render(layout, backend="bokeh")
+
+        figs = list(model.select(dict(type=Plot)))
+        assert len({id(f.x_range) for f in figs}) == 1
 
     def test_shared_axes_disable(self):
         curve = hv.Curve(range(10))


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description

- added type annotations so I understand the code
- make the “categorical” classification of overlays/layouts more complete
- `is_categorical` is distinct from axis type, so reflect that in helper functions
- Stop `Plot._compute_group_range` from merging numeric/date ranges with string (“categorical”) ones

Fixes #6948


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Claude Code + Sonnet 5
Usage: figure out all the various conditions under which something’s considered “categorical”

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

PS: your issue template link https://holoviz.org/contribute.html#ai-readme is broken, it’s `contribute/` not `contribute.html`

## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
- [x] Added documentation
