### PR TITLE
fix: set axis tick rotation mode

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -52,6 +52,8 @@ from .tree import AttrTree
 from .util import group_sanitizer, label_sanitizer, sanitize_identifier
 
 if t.TYPE_CHECKING:
+    from holoviews.plotting import Renderer
+
     from ..util import _BackendT
     from ..util.settings import OutputSettings
 
@@ -1193,7 +1195,7 @@ class Store:
 
     """
 
-    renderers = {}  # The set of available Renderers across all backends.
+    renderers: dict[str, Renderer] = {}  # The set of available Renderers across all backends.
 
     # A mapping from ViewableElement types to their corresponding plot
     # types grouped by the backend. Set using the register method.

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib as mpl
 import numpy as np
 import param
@@ -28,6 +30,9 @@ from .element import ColorbarPlot, ElementPlot, LegendPlot
 from .path import PathPlot
 from .plot import AdjoinedPlot, mpl_rc_context
 from .util import MPL_GE_3_7_0, MPL_GE_3_9_0, MPL_VERSION
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
 
 
 class ChartPlot(ElementPlot):
@@ -926,7 +931,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
             key, ranges=ranges, element=element, dimensions=[xdims, vdim], **kwargs
         )
 
-    def _finalize_ticks(self, axis, element, xticks, yticks, zticks):
+    def _finalize_ticks(self, axis: Axes, element, xticks, yticks, zticks):
         """Apply ticks with appropriate offsets."""
         alignments = None
         ticks = xticks or yticks

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -598,7 +598,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 axis.set_ticklabels(labels)
         for tick in axis.get_ticklabels():
             tick.set_rotation(rotation)
-            if axis.axis_name in "xy":
+            if MPL_GE_3_11_0 and axis.axis_name in "xy":
                 tick.set_rotation_mode(f"{axis.axis_name}tick")
 
     @mpl_rc_context

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -4,6 +4,7 @@ import copy
 import math
 import warnings
 from types import FunctionType
+from typing import TYPE_CHECKING
 
 import matplotlib.colors as mpl_colors
 import numpy as np
@@ -31,6 +32,10 @@ from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import color_intervals, dim_range_key, process_cmap
 from .plot import MPLPlot, mpl_rc_context
 from .util import MPL_GE_3_11_0, MPL_VERSION, EqHistNormalize, validate, wrap_formatter
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.axis import Axis
 
 
 class ElementPlot(GenericElementPlot, MPLPlot):
@@ -249,7 +254,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         super()._execute_hooks(element)
         self._update_backend_opts()
 
-    def _finalize_ticks(self, axis, dimensions, xticks, yticks, zticks):
+    def _finalize_ticks(self, axis: Axes, dimensions, xticks, yticks, zticks):
         """Finalizes the ticks on the axes based on the supplied ticks
         and Elements. Sets the axes position as well as tick positions,
         labels and fontsize.
@@ -560,7 +565,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             )
             axes.spines[pos].set_visible(False)
 
-    def _set_axis_ticks(self, axis, ticks, log=False, rotation=0):
+    def _set_axis_ticks(self, axis: Axis, ticks, log=False, rotation=0):
         """Allows setting the ticks for a particular axis either with
         a tuple of ticks, a tick locator object, an integer number
         of ticks, a list of tuples containing positions and labels
@@ -593,6 +598,8 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 axis.set_ticklabels(labels)
         for tick in axis.get_ticklabels():
             tick.set_rotation(rotation)
+            if axis.axis_name in "xy":
+                tick.set_rotation_mode(f"{axis.axis_name}tick")
 
     @mpl_rc_context
     def update_frame(self, key, ranges=None, element=None):

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -253,7 +253,7 @@ class Renderer(Exporter):
             return data, info
 
     @bothmethod
-    def get_plot(self_or_cls, obj, doc=None, renderer=None, comm=None, **kwargs):
+    def get_plot(self_or_cls, obj, doc=None, renderer=None, comm=None, **kwargs) -> Plot:
         """Given a HoloViews Viewable return a corresponding plot instance."""
         if isinstance(obj, DynamicMap) and obj.unbounded:
             dims = ", ".join(f"{dim!r}" for dim in obj.unbounded)

--- a/holoviews/tests/plotting/matplotlib/test_elementplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_elementplot.py
@@ -10,6 +10,7 @@ from matplotlib.projections import PolarAxes
 from matplotlib.ticker import FormatStrFormatter, FuncFormatter, PercentFormatter
 
 import holoviews as hv
+from holoviews.plotting.mpl.util import MPL_GE_3_11_0
 from holoviews.streams import Stream
 from holoviews.testing import assert_data_equal
 
@@ -201,9 +202,10 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         plot = mpl_renderer.get_plot(heat_map)
         ax = plot.handles["axis"]
         assert {ticklabel.get_rotation() for ticklabel in ax.get_xticklabels()} == {30}
-        assert {ticklabel.get_rotation_mode() for ticklabel in ax.get_xticklabels()} == {"xtick"}
         assert {ticklabel.get_rotation() for ticklabel in ax.get_yticklabels()} == {60}
-        assert {ticklabel.get_rotation_mode() for ticklabel in ax.get_yticklabels()} == {"ytick"}
+        if MPL_GE_3_11_0:
+            assert {ticklabel.get_rotation_mode() for ticklabel in ax.get_xticklabels()} == {"xtick"}
+            assert {ticklabel.get_rotation_mode() for ticklabel in ax.get_yticklabels()} == {"ytick"}
 
     #################################################################
     # Custom opts tests

--- a/holoviews/tests/plotting/matplotlib/test_elementplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_elementplot.py
@@ -196,6 +196,15 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         assert isinstance(ax, PolarAxes)
         assert ax.get_xlim() == (0, 2 * np.pi)
 
+    def test_element_tick_label_rotation(self):
+        heat_map = hv.HeatMap([(1, 2, 3), (2, 3, 4), (3, 4, 5)]).opts(xrotation=30, yrotation=60)
+        plot = mpl_renderer.get_plot(heat_map)
+        ax = plot.handles["axis"]
+        assert {ticklabel.get_rotation() for ticklabel in ax.get_xticklabels()} == {30}
+        assert {ticklabel.get_rotation_mode() for ticklabel in ax.get_xticklabels()} == {"xtick"}
+        assert {ticklabel.get_rotation() for ticklabel in ax.get_yticklabels()} == {60}
+        assert {ticklabel.get_rotation_mode() for ticklabel in ax.get_yticklabels()} == {"ytick"}
+
     #################################################################
     # Custom opts tests
     #################################################################

--- a/holoviews/tests/plotting/matplotlib/test_elementplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_elementplot.py
@@ -203,9 +203,10 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         ax = plot.handles["axis"]
         assert {ticklabel.get_rotation() for ticklabel in ax.get_xticklabels()} == {30}
         assert {ticklabel.get_rotation() for ticklabel in ax.get_yticklabels()} == {60}
-        if MPL_GE_3_11_0:
-            assert {ticklabel.get_rotation_mode() for ticklabel in ax.get_xticklabels()} == {"xtick"}
-            assert {ticklabel.get_rotation_mode() for ticklabel in ax.get_yticklabels()} == {"ytick"}
+        if not MPL_GE_3_11_0:
+            return
+        assert {ticklabel.get_rotation_mode() for ticklabel in ax.get_xticklabels()} == {"xtick"}
+        assert {ticklabel.get_rotation_mode() for ticklabel in ax.get_yticklabels()} == {"ytick"}
 
     #################################################################
     # Custom opts tests


### PR DESCRIPTION
## Description
Fixes #6967 (with matplotlib 3.11, lmk if we should expand the fix for older versions)

It’s enough to just `set_rotation_mode` as described in https://matplotlib.org/stable/gallery/ticks/ticklabels_rotation.html

----

changing the rotation in the [“bars economic” example](https://holoviews.org/gallery/demos/matplotlib/bars_economic.html) to `xrotation=30` now gives this:

<img width="902" height="257" alt="grafik" src="https://github.com/user-attachments/assets/5ee8d708-7fe2-402c-802d-a6a1ac33f7a6" />

it’s not perfect (I think the distance to the ticks is a bit large) but now it’s readable,

## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
