### PR TITLE
docs: Incorrect docstring for `yoffset` parameter

### DIFF
--- a/holoviews/plotting/plotly/annotation.py
+++ b/holoviews/plotting/plotly/annotation.py
@@ -15,7 +15,7 @@ class LabelPlot(ScatterPlot):
 
     yoffset = param.Number(
         default=None,
-        doc="Amount of offset to apply to labels along x-axis.",
+        doc="Amount of offset to apply to labels along y-axis.",
     )
 
     style_opts = ["visible", "color", "family", "size"]


### PR DESCRIPTION
## Summary

Quality: Incorrect docstring for `yoffset` parameter

## Problem

**Severity**: `Low` | **File**: `holoviews/plotting/plotly/annotation.py:L22`

In `LabelPlot`, the `yoffset` parameter's docstring incorrectly states that it applies to the 'x-axis' instead of the 'y-axis'.

## Solution

Update the docstring for `yoffset` to say 'Amount of offset to apply to labels along y-axis.'

## Changes

- `holoviews/plotting/plotly/annotation.py` (modified)