### PR TITLE
fix: Register colorcet colormap before checking matplotlib

### DIFF
--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -1051,9 +1051,9 @@ def process_cmap(cmap, ncolors=None, provider=None, categorical=False):
     elif isinstance(cmap, list):
         palette = cmap
     elif isinstance(cmap, str):
+        cet_cmaps = _list_cmaps("colorcet")  # first to register colorcet colormaps with matplotlib
         mpl_cmaps = _list_cmaps("matplotlib")
         bk_cmaps = _list_cmaps("bokeh")
-        cet_cmaps = _list_cmaps("colorcet")
         if provider == "matplotlib" or (
             provider is None and (cmap in mpl_cmaps or cmap.lower() in mpl_cmaps)
         ):


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes https://github.com/holoviz/holoviews/pull/6982#issuecomment-5200592572

We register colorcet colormap before checking matplotlib colormap:

<img width="978" height="583" alt="image" src="https://github.com/user-attachments/assets/ac5a8330-a665-45a3-aa44-3907511d0259" />

`python -c "from holoviews.plotting.util import process_cmap; print(process_cmap('cet_fire'))"`


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
