### PR TITLE
fix: Memory leak from streams rooted in the global registry

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -566,6 +566,7 @@ class LabelledData(param.Parameterized):
     )
 
     _deep_indexable = False
+    _streams = None
 
     def __init__(self, data, id=None, plot_id=None, **params):
         """All LabelledData subclasses must supply data to the
@@ -847,6 +848,7 @@ class LabelledData(param.Parameterized):
     def __getstate__(self):
         """Ensures pickles save options applied to this objects."""
         obj_dict = self.__dict__.copy()
+        obj_dict.pop("_streams", None)
         try:
             if Store.save_option_state and (obj_dict.get("_id", None) is not None):
                 custom_key = "_custom_option_{}".format(obj_dict["_id"])

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -267,6 +267,7 @@ class BokehPlot(DimensionedPlot, CallbackPlot):
         """
         plots = self.traverse(lambda x: x, [BokehPlot])
         for plot in plots:
+            plot._unwatch_session()
             if not isinstance(
                 plot, (GenericCompositePlot, GenericElementPlot, GenericOverlayPlot)
             ):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -289,11 +289,7 @@ class BokehPlot(DimensionedPlot, CallbackPlot):
                 stream._subscribers = [
                     (p, subscriber)
                     for p, subscriber in stream._subscribers
-                    if subscriber
-                    and (
-                        not is_param_method(subscriber)
-                        or get_method_owner(subscriber) not in plots
-                    )
+                    if not is_param_method(subscriber) or get_method_owner(subscriber) not in plots
                 ]
 
     def _fontsize(self, key, label="fontsize", common=True):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -464,7 +464,7 @@ class CompositePlot(BokehPlot):
         """
         streams = [s for s in self.streams if any(k in self.dimensions for k in s.contents)]
         for s in streams:
-            s.add_subscriber(self._stream_update, 1)
+            s.add_subscriber(self._stream_update, 1.05)
 
     def _stream_update(self, **kwargs):
         contents = [k for s in self.streams for k in s.contents]

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -356,7 +356,7 @@ class CompositePlot(GenericCompositePlot, MPLPlot):
         """
         streams = [s for s in self.streams if any(k in self.dimensions for k in s.contents)]
         for s in streams:
-            s.add_subscriber(self._stream_update, 1)
+            s.add_subscriber(self._stream_update, 1.05)
 
     def _stream_update(self, **kwargs):
         contents = [k for s in self.streams for k in s.contents]

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -201,11 +201,8 @@ class Plot(param.Parameterized):
                 stream._subscribers = [
                     (p, subscriber)
                     for p, subscriber in stream._subscribers
-                    if subscriber
-                    and (
-                        not util.is_param_method(subscriber)
-                        or util.get_method_owner(subscriber) not in plots
-                    )
+                    if not util.is_param_method(subscriber)
+                    or util.get_method_owner(subscriber) not in plots
                 ]
 
     def _session_destroy(self, session_context):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -109,6 +109,7 @@ class Plot(param.Parameterized):
 
     @document.setter
     def document(self, doc):
+        self._unwatch_session()
         if (
             doc
             and hasattr(doc, "on_session_destroyed")
@@ -116,21 +117,29 @@ class Plot(param.Parameterized):
             and not isinstance(self, GenericAdjointLayoutPlot)
         ):
             doc.on_session_destroyed(self._session_destroy)
-            if self._document:
-                if isinstance(self._document.callbacks._session_destroyed_callbacks, set):
-                    self._document.callbacks._session_destroyed_callbacks.discard(
-                        self._session_destroy
-                    )
-                else:
-                    self._document.callbacks._session_destroyed_callbacks.pop(
-                        self._session_destroy, None
-                    )
 
         self._document = doc
         if self.subplots:
             for plot in self.subplots.values():
                 if plot is not None:
                     plot.document = doc
+
+    def _unwatch_session(self):
+        """Drop the session destroy hook registered on the current document.
+
+        The document holds the callback, and through it this plot, strongly,
+        so a plot which is never deregistered lives as long as its document.
+        Outside a served session that document is the process wide
+        ``curdoc()``, which means every plot ever rendered is retained.
+        """
+        doc = self._document
+        if doc is None or not hasattr(doc, "callbacks"):
+            return
+        callbacks = doc.callbacks._session_destroyed_callbacks
+        if isinstance(callbacks, set):
+            callbacks.discard(self._session_destroy)
+        else:
+            callbacks.pop(self._session_destroy, None)
 
     @property
     def pane(self):
@@ -195,6 +204,7 @@ class Plot(param.Parameterized):
         """
         plots = self.traverse(lambda x: x, [Plot])
         for plot in plots:
+            plot._unwatch_session()
             if not isinstance(plot, (GenericElementPlot, GenericOverlayPlot)):
                 continue
             for stream in set(plot.streams):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -125,12 +125,12 @@ class Plot(param.Parameterized):
                     plot.document = doc
 
     def _unwatch_session(self):
-        """Drop the session destroy hook registered on the current document.
+        """Drop this plot's session destroy hook from its current document.
 
-        The document holds the callback, and through it this plot, strongly,
-        so a plot which is never deregistered lives as long as its document.
-        Outside a served session that document is the process wide
-        ``curdoc()``, which means every plot ever rendered is retained.
+        A document holds its callbacks, and through them this plot, strongly,
+        so the hook is dropped whenever the plot leaves the document, i.e. on
+        reassignment and on cleanup. Only the hook belonging to this plot is
+        removed.
         """
         doc = self._document
         if doc is None or not hasattr(doc, "callbacks"):

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import base64
 import os
+import weakref
 from contextlib import contextmanager
 from functools import partial
 from io import BytesIO, StringIO
@@ -234,8 +235,16 @@ class Renderer(Exporter):
     _render_with_panel = False
 
     def __init__(self, **params):
-        self.last_plot = None
+        self._last_plot = None
         super().__init__(**params)
+
+    @property
+    def last_plot(self):
+        return None if self._last_plot is None else self._last_plot()
+
+    @last_plot.setter
+    def last_plot(self, plot):
+        self._last_plot = None if plot is None else weakref.ref(plot)
 
     def __call__(self, obj, fmt="auto", **kwargs):
         plot, fmt = self._validate(obj, fmt)

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -1163,7 +1163,7 @@ def attach_streams(plot, obj, precedence=1.1):
 
     def append_refresh(dmap):
         for stream in get_nested_streams(dmap):
-            if plot.refresh not in stream._subscribers:
+            if plot.refresh not in stream.subscribers:
                 stream.add_subscriber(plot.refresh, precedence)
 
     return obj.traverse(append_refresh, [DynamicMap])

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -56,12 +56,10 @@ class _SkipTrigger:
 class _StreamRegistry(weakref.WeakKeyDictionary):
     """Weak index from a source object to the streams sourced from it.
 
-    Unlike a plain ``WeakKeyDictionary`` the values are held weakly as well.
-    A stream reaches its own source back through its subscribers, so holding
-    the streams strongly here would make the weak key reachable from its own
-    value and every source that ever had a stream would become immortal
-    (#6875). Strong ownership lives on the source instead, see
-    ``LabelledData._streams``, so a source and its streams die together.
+    Both the keys and the values are weak, so the registry never keeps a
+    source or a stream alive. Ownership lives on the source, in
+    ``LabelledData._streams``, and a source and its streams are collected
+    together once nothing else refers to them.
 
     Reads resolve the references, i.e. this behaves like a mapping of source
     to a list of live streams.

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -6,7 +6,6 @@ server-side or in Javascript in the Jupyter notebook (client-side).
 
 from __future__ import annotations
 
-import inspect
 import typing as t
 import weakref
 from collections import defaultdict
@@ -54,47 +53,52 @@ class _SkipTrigger:
     pass
 
 
-class _WeakSubscriber:
-    def __init__(self, subscriber):
-        if inspect.ismethod(subscriber):
-            self._ref = weakref.WeakMethod(subscriber)
-        else:
-            self._ref = weakref.ref(subscriber)
+class _StreamRegistry(weakref.WeakKeyDictionary):
+    """Weak index from a source object to the streams sourced from it.
 
-        self._hash = self._generate_hash(subscriber)
-        self._is_param_method = util.is_param_method(subscriber)
+    Unlike a plain ``WeakKeyDictionary`` the values are held weakly as well.
+    A stream reaches its own source back through its subscribers, so holding
+    the streams strongly here would make the weak key reachable from its own
+    value and every source that ever had a stream would become immortal
+    (#6875). Strong ownership lives on the source instead, see
+    ``LabelledData._streams``, so a source and its streams die together.
 
-    def __bool__(self) -> bool:
-        method = self._ref()
-        return method is not None and not self._is_param_method
+    Reads resolve the references, i.e. this behaves like a mapping of source
+    to a list of live streams.
+    """
 
-    def __call__(self, *args, **kwargs):
-        method = self._ref()
-        if method is not None:
-            return method(*args, **kwargs)
+    def register(self, source, stream):
+        # super().get to see the stored references rather than live streams
+        refs = super().get(source)
+        if refs is None:
+            self[source] = refs = []
+        if not any(ref() is stream for ref in refs):
+            refs.append(weakref.ref(stream))
+
+    def unregister(self, source, stream):
+        refs = super().get(source)
+        if refs is None:
+            return
+        refs[:] = [ref for ref in refs if ref() is not None and ref() is not stream]
+        if not refs:
+            self.pop(source, None)
 
     @staticmethod
-    def check(subscriber):
-        while isinstance(subscriber, partial):
-            subscriber = subscriber.func
-        return inspect.ismethod(subscriber)
+    def _alive(refs):
+        return [stream for stream in (ref() for ref in refs) if stream is not None]
 
-    @staticmethod
-    def _generate_hash(subscriber) -> int:
-        if inspect.ismethod(subscriber):
-            return hash((id(subscriber.__func__), id(subscriber.__self__)))
-        else:
-            return hash(id(subscriber))
+    def __getitem__(self, key):
+        return self._alive(super().__getitem__(key))
 
-    def __eq__(self, other) -> bool:
-        if isinstance(other, _WeakSubscriber):
-            return self._hash == other._hash
-        if self.check(other):
-            return self._hash == self._generate_hash(other)
-        return NotImplemented
+    def get(self, key, default=None):
+        refs = super().get(key)
+        return default if refs is None else self._alive(refs)
 
-    def __hash__(self) -> int:
-        return self._hash
+    def items(self):
+        return [(src, self._alive(refs)) for src, refs in super().items()]
+
+    def values(self):
+        return [self._alive(refs) for refs in super().values()]
 
 
 @contextmanager
@@ -166,10 +170,10 @@ class Stream(param.Parameterized):
 
     """
 
-    # Mapping from a source to a list of streams
-    # WeakKeyDictionary to allow garbage collection
-    # of unreferenced sources
-    registry = weakref.WeakKeyDictionary()
+    # Weak index from a source to the streams sourced from it, see
+    # _StreamRegistry. The sources own their streams, this only allows them
+    # to be looked up from a clone sharing the same _plot_id.
+    registry = _StreamRegistry()
 
     # Mapping to define callbacks by backend and Stream type.
     # e.g. Stream._callbacks['bokeh'][Stream] = Callback
@@ -370,10 +374,28 @@ class Stream(param.Parameterized):
         super().__init__(**params)
         self._rename = self._validate_rename(rename)
         if source is not None:
-            if source in self.registry:
-                self.registry[source].append(self)
-            else:
-                self.registry[source] = [self]
+            self._attach(source)
+
+    def _attach(self, source):
+        """Make ``source`` the owner of this stream.
+
+        The source holds the stream strongly, so a stream stays alive for as
+        long as the object it observes and no longer, while the registry only
+        indexes it weakly.
+        """
+        streams = source._streams
+        if streams is None:
+            source._streams = streams = []
+        if self not in streams:
+            streams.append(self)
+        self.registry.register(source, self)
+
+    def _detach(self, source):
+        """Undo ``_attach``, dropping the source's ownership of this stream."""
+        streams = source._streams
+        if streams is not None and self in streams:
+            streams.remove(self)
+        self.registry.unregister(source, self)
 
     def clone(self):
         """Return new stream with identical properties and no subscribers"""
@@ -426,8 +448,6 @@ class Stream(param.Parameterized):
         """
         if not callable(subscriber):
             raise TypeError("Subscriber must be a callable.")
-        if _WeakSubscriber.check(subscriber):
-            subscriber = _WeakSubscriber(subscriber)
         self._subscribers.append((precedence, subscriber))
 
     def _validate_rename(self, mapping):
@@ -464,21 +484,14 @@ class Stream(param.Parameterized):
     @source.setter
     def source(self, source):
         if self.source is not None:
-            source_list = self.registry[self.source]
-            if self in source_list:
-                source_list.remove(self)
-            if not source_list:
-                self.registry.pop(self.source)
+            self._detach(self.source)
 
         if source is None:
             self._source = None
             return
 
         self._source = weakref.ref(source)
-        if source in self.registry:
-            self.registry[source].append(self)
-        else:
-            self.registry[source] = [self]
+        self._attach(source)
 
     def transform(self):
         """Method that can be overwritten by subclasses to process the

--- a/holoviews/tests/core/test_dynamic.py
+++ b/holoviews/tests/core/test_dynamic.py
@@ -924,35 +924,25 @@ class TestStreamSubscribersAddandClear:
         self.fn3 = lambda x: x**3
         self.fn4 = lambda x: x**4
 
-    def test_subscriber_clear_all(self):
+    # Precedence one and below is the user range, above one is reserved for
+    # HoloViews, as documented on Stream.add_subscriber
+    @pytest.mark.parametrize(
+        ("policy", "remaining"),
+        [
+            ("all", []),
+            ("user", ["fn3", "fn4"]),
+            ("internal", ["fn1", "fn2"]),
+        ],
+    )
+    def test_subscriber_clear(self, policy, remaining):
         pointerx = PointerX(x=2)
         pointerx.add_subscriber(self.fn1, precedence=0)
         pointerx.add_subscriber(self.fn2, precedence=1)
         pointerx.add_subscriber(self.fn3, precedence=1.5)
         pointerx.add_subscriber(self.fn4, precedence=10)
         assert pointerx.subscribers == [self.fn1, self.fn2, self.fn3, self.fn4]
-        pointerx.clear("all")
-        assert pointerx.subscribers == []
-
-    def test_subscriber_clear_user(self):
-        pointerx = PointerX(x=2)
-        pointerx.add_subscriber(self.fn1, precedence=0)
-        pointerx.add_subscriber(self.fn2, precedence=1)
-        pointerx.add_subscriber(self.fn3, precedence=1.5)
-        pointerx.add_subscriber(self.fn4, precedence=10)
-        assert pointerx.subscribers == [self.fn1, self.fn2, self.fn3, self.fn4]
-        pointerx.clear("user")
-        assert pointerx.subscribers == [self.fn3, self.fn4]
-
-    def test_subscriber_clear_internal(self):
-        pointerx = PointerX(x=2)
-        pointerx.add_subscriber(self.fn1, precedence=0)
-        pointerx.add_subscriber(self.fn2, precedence=1)
-        pointerx.add_subscriber(self.fn3, precedence=1.5)
-        pointerx.add_subscriber(self.fn4, precedence=10)
-        assert pointerx.subscribers == [self.fn1, self.fn2, self.fn3, self.fn4]
-        pointerx.clear("internal")
-        assert pointerx.subscribers == [self.fn1, self.fn2]
+        pointerx.clear(policy)
+        assert pointerx.subscribers == [getattr(self, name) for name in remaining]
 
 
 class TestDynamicStreamReset:

--- a/holoviews/tests/core/test_dynamic.py
+++ b/holoviews/tests/core/test_dynamic.py
@@ -918,23 +918,15 @@ class TestDynamicMapRX:
 
 
 class TestStreamSubscribersAddandClear:
-    def setup_method(self):
+    @pytest.mark.parametrize(
+        ("policy", "remaining"),
+        [("all", []), ("user", ["fn3", "fn4"]), ("internal", ["fn1", "fn2"])],
+    )
+    def test_subscriber_clear(self, policy, remaining):
         self.fn1 = lambda x: x
         self.fn2 = lambda x: x**2
         self.fn3 = lambda x: x**3
         self.fn4 = lambda x: x**4
-
-    # Precedence one and below is the user range, above one is reserved for
-    # HoloViews, as documented on Stream.add_subscriber
-    @pytest.mark.parametrize(
-        ("policy", "remaining"),
-        [
-            ("all", []),
-            ("user", ["fn3", "fn4"]),
-            ("internal", ["fn1", "fn2"]),
-        ],
-    )
-    def test_subscriber_clear(self, policy, remaining):
         pointerx = PointerX(x=2)
         pointerx.add_subscriber(self.fn1, precedence=0)
         pointerx.add_subscriber(self.fn2, precedence=1)

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+import gc
+import weakref
+
 import numpy as np
+import panel as pn
+import param
 import pyviz_comms as comms
+from bokeh.document import Document
 from bokeh.models import (
     ColumnDataSource,
     CrosshairTool,
@@ -133,6 +139,70 @@ def test_layout_plot_stream_cleanup():
 
     assert not stream1._subscribers
     assert not stream2._subscribers
+
+
+def test_user_subscriber_survives_stream_cleanup():
+    class App(param.Parameterized):
+        def __init__(self, **params):
+            super().__init__(**params)
+            self.calls = []
+
+        def on_update(self, data):
+            self.calls.append(data)
+
+    app = App()
+    stream = Pipe()
+    dmap = hv.DynamicMap(hv.Curve, streams=[stream])
+    stream.add_subscriber(app.on_update)
+
+    plot = bokeh_renderer.get_plot(dmap)
+    plot.cleanup()
+
+    assert len(stream._subscribers) == 1
+    stream.send([1, 2, 3])
+    assert app.calls == [[1, 2, 3]]
+
+
+def test_stream_cleanup_keeps_other_plot_subscriber():
+    stream = Pipe(data=[1, 2, 3])
+    dmap = hv.DynamicMap(hv.Curve, streams=[stream])
+
+    plot1 = bokeh_renderer.get_plot(dmap)
+    plot2 = bokeh_renderer.get_plot(dmap)
+    assert len(stream._subscribers) == 2
+
+    plot1.cleanup()
+
+    assert stream.subscribers == [plot2.refresh]
+
+    # The surviving plot must still refresh on a stream event
+    stream.send([8, 9])
+    assert len(plot2.current_frame.dimension_values(0)) == 2
+
+    plot2.cleanup()
+    assert not stream._subscribers
+
+
+def test_rendered_plot_is_collected():
+    # The panel#8580 object graph: build holds the only references to it, so
+    # tearing the view down and dropping its frame has to be enough (#6875)
+    def build():
+        points = hv.Points([(0, 0), (1, 1)])
+        rng = hv.streams.RangeXY(source=points)
+        dmap = hv.DynamicMap(lambda x_range, y_range: hv.Curve([]), streams=[rng])
+        doc = Document()
+        pane = pn.pane.HoloViews(points * dmap)
+        model = pane.get_root(doc)
+
+        # What panel does when the session ends, see Viewable._server_destroy
+        pane._cleanup(model)
+        pn.state._views.pop(model.ref["id"], None)
+
+        return {"element": points, "stream": rng, "dmap": dmap, "document": doc, "pane": pane}
+
+    refs = {name: weakref.ref(obj) for name, obj in build().items()}
+    gc.collect()
+    assert not [name for name, ref in refs.items() if ref() is not None]
 
 
 def test_sync_two_plots():

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -236,6 +236,20 @@ def test_rendered_plot_is_collected():
     assert not [name for name, ref in refs.items() if ref() is not None]
 
 
+def test_renderer_does_not_retain_last_plot():
+    # The renderer is a long lived singleton, so holding the last plot
+    # strongly retains it, and the data it displays, for the whole process
+    def build():
+        points = hv.Points([(0, 0), (1, 1)])
+        plot = bokeh_renderer.get_plot(points)
+        plot.cleanup()
+        return {"element": points, "plot": plot}
+
+    refs = {name: weakref.ref(obj) for name, obj in build().items()}
+    gc.collect()
+    assert not [name for name, ref in refs.items() if ref() is not None]
+
+
 def test_sync_two_plots():
     curve = lambda i: hv.Curve(np.arange(10) * i, label="ABC"[i])
     plot1 = curve(0) * curve(1)

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -17,6 +17,7 @@ from bokeh.models import (
     LogColorMapper,
     Span,
 )
+from panel.io.state import set_curdoc
 from param import concrete_descendents
 
 import holoviews as hv
@@ -181,6 +182,36 @@ def test_stream_cleanup_keeps_other_plot_subscriber():
 
     plot2.cleanup()
     assert not stream._subscribers
+
+
+def test_shared_stream_survives_one_session_teardown():
+    # Two served sessions sharing a module-level stream: destroying one
+    # session must leave the other one working. Rendered in server mode, as
+    # that is what gives each session its own document.
+    server_renderer = bokeh_renderer.instance(mode="server")
+    stream = Pipe(data=[1, 2, 3])
+    dmap = hv.DynamicMap(hv.Curve, streams=[stream])
+
+    doc1, doc2 = Document(), Document()
+    with set_curdoc(doc1):
+        plot1 = server_renderer.get_plot(dmap, doc1)
+    with set_curdoc(doc2):
+        plot2 = server_renderer.get_plot(dmap, doc2)
+
+    assert plot1.document is doc1
+    assert plot2.document is doc2
+    destroy_callbacks = list(doc1.callbacks._session_destroyed_callbacks)
+    assert plot1._session_destroy in destroy_callbacks
+
+    for callback in destroy_callbacks:
+        callback(None)
+
+    stream.send([8, 9])
+    assert len(plot2.current_frame.dimension_values(0)) == 2
+
+    # Tearing the session down deregisters the hook rather than leaving the
+    # plot pinned to the document for as long as that document lives
+    assert plot1._session_destroy not in doc1.callbacks._session_destroyed_callbacks
 
 
 def test_rendered_plot_is_collected():

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -115,8 +115,11 @@ def test_overlay_plot_stream_cleanup():
 
     plot = bokeh_renderer.get_plot(dmap1 * dmap2)
 
-    assert len(stream1._subscribers) == 4
-    assert len(stream2._subscribers) == 4
+    # The overlay plot subscribes once per stream. It used to subscribe four
+    # times, as attach_streams compared the refresh method against the
+    # (precedence, subscriber) pairs and so never recognised it
+    assert stream1.subscribers == [plot.refresh]
+    assert stream2.subscribers == [plot.refresh]
 
     plot.cleanup()
 

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -23,7 +23,7 @@ from param import concrete_descendents
 import holoviews as hv
 from holoviews.plotting.bokeh.callbacks import Callback
 from holoviews.plotting.bokeh.element import ElementPlot
-from holoviews.streams import Pipe
+from holoviews.streams import Pipe, Stream
 
 bokeh_renderer = hv.Store.renderers["bokeh"]
 
@@ -185,6 +185,25 @@ def test_stream_cleanup_keeps_other_plot_subscriber():
 
     plot2.cleanup()
     assert not stream._subscribers
+
+
+def test_dimensioned_stream_subscriber_survives_user_clear():
+    # _stream_update belongs to HoloViews, so it has to sit above the user
+    # precedence range, otherwise clear("user") drops the title updates
+    Dim = Stream.define("Dim", value=0)
+    stream = Dim()
+    dmap = hv.DynamicMap(lambda value: hv.Curve([1, 2, value]), kdims=["value"], streams=[stream])
+
+    # _link_dimensioned_streams is called by GenericCompositePlot, so the
+    # DynamicMap has to sit in a Layout for _stream_update to be registered
+    plot = bokeh_renderer.get_plot(dmap + hv.Curve([1, 2, 3]))
+    assert plot._stream_update in stream.subscribers
+
+    stream.clear("user")
+    assert plot._stream_update in stream.subscribers
+
+    stream.clear("internal")
+    assert plot._stream_update not in stream.subscribers
 
 
 def test_shared_stream_survives_one_session_teardown():

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -4,7 +4,6 @@ import gc
 import weakref
 
 import numpy as np
-import panel as pn
 import param
 import pyviz_comms as comms
 from bokeh.document import Document
@@ -23,7 +22,7 @@ from param import concrete_descendents
 import holoviews as hv
 from holoviews.plotting.bokeh.callbacks import Callback
 from holoviews.plotting.bokeh.element import ElementPlot
-from holoviews.streams import Pipe, Stream
+from holoviews.streams import Pipe
 
 bokeh_renderer = hv.Store.renderers["bokeh"]
 
@@ -115,9 +114,6 @@ def test_overlay_plot_stream_cleanup():
 
     plot = bokeh_renderer.get_plot(dmap1 * dmap2)
 
-    # The overlay plot subscribes once per stream. It used to subscribe four
-    # times, as attach_streams compared the refresh method against the
-    # (precedence, subscriber) pairs and so never recognised it
     assert stream1.subscribers == [plot.refresh]
     assert stream2.subscribers == [plot.refresh]
 
@@ -179,7 +175,6 @@ def test_stream_cleanup_keeps_other_plot_subscriber():
 
     assert stream.subscribers == [plot2.refresh]
 
-    # The surviving plot must still refresh on a stream event
     stream.send([8, 9])
     assert len(plot2.current_frame.dimension_values(0)) == 2
 
@@ -187,29 +182,7 @@ def test_stream_cleanup_keeps_other_plot_subscriber():
     assert not stream._subscribers
 
 
-def test_dimensioned_stream_subscriber_survives_user_clear():
-    # _stream_update belongs to HoloViews, so it has to sit above the user
-    # precedence range, otherwise clear("user") drops the title updates
-    Dim = Stream.define("Dim", value=0)
-    stream = Dim()
-    dmap = hv.DynamicMap(lambda value: hv.Curve([1, 2, value]), kdims=["value"], streams=[stream])
-
-    # _link_dimensioned_streams is called by GenericCompositePlot, so the
-    # DynamicMap has to sit in a Layout for _stream_update to be registered
-    plot = bokeh_renderer.get_plot(dmap + hv.Curve([1, 2, 3]))
-    assert plot._stream_update in stream.subscribers
-
-    stream.clear("user")
-    assert plot._stream_update in stream.subscribers
-
-    stream.clear("internal")
-    assert plot._stream_update not in stream.subscribers
-
-
 def test_shared_stream_survives_one_session_teardown():
-    # Two served sessions sharing a module-level stream: destroying one
-    # session must leave the other one working. Rendered in server mode, as
-    # that is what gives each session its own document.
     server_renderer = bokeh_renderer.instance(mode="server")
     stream = Pipe(data=[1, 2, 3])
     dmap = hv.DynamicMap(hv.Curve, streams=[stream])
@@ -231,31 +204,7 @@ def test_shared_stream_survives_one_session_teardown():
     stream.send([8, 9])
     assert len(plot2.current_frame.dimension_values(0)) == 2
 
-    # Tearing the session down deregisters the hook rather than leaving the
-    # plot pinned to the document for as long as that document lives
     assert plot1._session_destroy not in doc1.callbacks._session_destroyed_callbacks
-
-
-def test_rendered_plot_is_collected():
-    # The panel#8580 object graph: build holds the only references to it, so
-    # tearing the view down and dropping its frame has to be enough (#6875)
-    def build():
-        points = hv.Points([(0, 0), (1, 1)])
-        rng = hv.streams.RangeXY(source=points)
-        dmap = hv.DynamicMap(lambda x_range, y_range: hv.Curve([]), streams=[rng])
-        doc = Document()
-        pane = pn.pane.HoloViews(points * dmap)
-        model = pane.get_root(doc)
-
-        # What panel does when the session ends, see Viewable._server_destroy
-        pane._cleanup(model)
-        pn.state._views.pop(model.ref["id"], None)
-
-        return {"element": points, "stream": rng, "dmap": dmap, "document": doc, "pane": pane}
-
-    refs = {name: weakref.ref(obj) for name, obj in build().items()}
-    gc.collect()
-    assert not [name for name, ref in refs.items() if ref() is not None]
 
 
 def test_renderer_does_not_retain_last_plot():

--- a/holoviews/tests/plotting/bokeh/test_plot.py
+++ b/holoviews/tests/plotting/bokeh/test_plot.py
@@ -208,8 +208,8 @@ def test_shared_stream_survives_one_session_teardown():
 
 
 def test_renderer_does_not_retain_last_plot():
-    # The renderer is a long lived singleton, so holding the last plot
-    # strongly retains it, and the data it displays, for the whole process
+    # The renderer is a long lived singleton which holds last_plot weakly,
+    # so a rendered plot and its data go away with the caller's reference
     def build():
         points = hv.Points([(0, 0), (1, 1)])
         plot = bokeh_renderer.get_plot(points)

--- a/holoviews/tests/plotting/plotly/test_plot.py
+++ b/holoviews/tests/plotting/plotly/test_plot.py
@@ -37,9 +37,6 @@ def test_overlay_plot_stream_cleanup():
 
     plot = plotly_renderer.get_plot(dmap1 * dmap2)
 
-    # The overlay plot subscribes once per stream. It used to subscribe four
-    # times, as attach_streams compared the refresh method against the
-    # (precedence, subscriber) pairs and so never recognised it
     assert stream1.subscribers == [plot.refresh]
     assert stream2.subscribers == [plot.refresh]
 

--- a/holoviews/tests/plotting/plotly/test_plot.py
+++ b/holoviews/tests/plotting/plotly/test_plot.py
@@ -37,8 +37,11 @@ def test_overlay_plot_stream_cleanup():
 
     plot = plotly_renderer.get_plot(dmap1 * dmap2)
 
-    assert len(stream1._subscribers) == 4
-    assert len(stream2._subscribers) == 4
+    # The overlay plot subscribes once per stream. It used to subscribe four
+    # times, as attach_streams compared the refresh method against the
+    # (precedence, subscriber) pairs and so never recognised it
+    assert stream1.subscribers == [plot.refresh]
+    assert stream2.subscribers == [plot.refresh]
 
     plot.cleanup()
 

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -4,8 +4,8 @@ Unit test of the streams system
 
 from __future__ import annotations
 
+import gc
 import weakref
-from collections import defaultdict
 from functools import partial
 
 import numpy as np
@@ -808,40 +808,118 @@ class TestSubscribers:
         assert subscriber.call_count == 3
 
 
-class TestWeakSubscriber:
-    def check(self, Viewer):
-        viewer = Viewer()
-        ref = weakref.ref(viewer)
-        del viewer
-        assert ref() is None
+class _App(param.Parameterized):
+    """The object graph of panel#8580 and #6934.
 
-    def test_bound_method(self):
-        class Viewer:
-            def __init__(self):
-                self.plot = hv.Points([])
-                self.stream = hv.streams.RangeX(source=self.plot)
-                self.stream.add_subscriber(self.on_update)
+    An app owns an element, a stream sourced from that element and a
+    subscriber which reaches back into the app. Parameterized so that
+    ``on_update`` is a param method, as it is for the ``pn.viewable.Viewer``
+    of #6945.
+    """
 
-            def on_update(self, x_range=None): ...
+    def __init__(self, make_subscriber, **params):
+        super().__init__(**params)
+        self.calls = []
+        self.element = hv.Points([(0, 0)])
+        self.stream = RangeXY(source=self.element)
+        self.stream.add_subscriber(make_subscriber(self))
 
-        self.check(Viewer)
+    def on_update(self, **kwargs):
+        self.calls.append(kwargs)
 
-    def test_bound_method_partial(self):
-        class Viewer:
-            def __init__(self):
-                self.plot = hv.Points([])
-                self.stream = hv.streams.RangeX(source=self.plot)
-                self.stream.add_subscriber(partial(self.on_update, extra=1))
 
-            def on_update(self, x_range=None, extra=0): ...
+def _closure(app):
+    def on_update(**kwargs):
+        app.calls.append(kwargs)
 
-        self.check(Viewer)
+    return on_update
+
+
+# The four ways a subscriber can reach back into its owner. Only the first two
+# were ever wrapped weakly, so the closure forms have always leaked.
+subscriber_kinds = pytest.mark.parametrize(
+    "make_subscriber",
+    [
+        lambda app: app.on_update,
+        lambda app: partial(app.on_update, extra=1),
+        _closure,
+        lambda app: lambda **kwargs: app.calls.append(kwargs),
+    ],
+    ids=["bound_method", "partial", "closure", "lambda"],
+)
+
+
+class TestSubscriberLifetime:
+    """The source element, its streams and their subscribers must all die
+    together once nothing else refers to them, and must all stay alive for as
+    long as the element does.
+    """
+
+    @subscriber_kinds
+    def test_app_is_collected(self, make_subscriber):
+        def build():
+            app = _App(make_subscriber)
+            return {"app": app, "element": app.element, "stream": app.stream}
+
+        # build holds the only references, so dropping its frame has to be
+        # enough for the whole graph to go
+        refs = {name: weakref.ref(obj) for name, obj in build().items()}
+        gc.collect()
+        assert not [name for name, ref in refs.items() if ref() is not None]
+
+    @subscriber_kinds
+    def test_subscriber_is_invoked(self, make_subscriber):
+        app = _App(make_subscriber)
+        app.stream.event(x_range=(0, 1), y_range=(2, 3))
+        assert [call["x_range"] for call in app.calls] == [(0, 1)]
+
+    def test_stream_survives_dropped_local_reference(self):
+        # A stream is kept alive by its source element, so it keeps firing
+        # after the local variable it was assigned to goes out of scope.
+        element = hv.Points([(0, 0)])
+        calls = []
+
+        def register():
+            stream = RangeXY(source=element)
+            stream.add_subscriber(lambda **kwargs: calls.append(kwargs))
+
+        register()
+        gc.collect()
+
+        (stream,) = Stream.registry[element]
+        stream.event(x_range=(0, 1), y_range=(2, 3))
+        assert calls == [{"x_range": (0, 1), "y_range": (2, 3)}]
+
+    def test_subscription_is_only_reference(self):
+        # An app whose only remaining reference is the subscription itself
+        # must survive for as long as the displayed element does (#6945).
+        def build():
+            app = _App(lambda app: app.on_update)
+            return app.element, weakref.ref(app)
+
+        element, ref = build()
+        gc.collect()
+        assert ref() is not None
+
+        (stream,) = Stream.registry[element]
+        stream.event(x_range=(0, 1), y_range=(2, 3))
+        assert ref().calls == [{"x_range": (0, 1), "y_range": (2, 3)}]
+
+    def test_distinct_partials_not_deduplicated(self):
+        app = _App(lambda app: partial(app.on_update, tag="a"))
+        app.stream.add_subscriber(partial(app.on_update, tag="b"))
+
+        assert len(app.stream.subscribers) == 2
+        app.stream.event(x_range=(0, 1), y_range=(2, 3))
+        assert sorted(call["tag"] for call in app.calls) == ["a", "b"]
 
 
 class TestStreamSource:
     def teardown_method(self):
+        # Only drop the leftover entries, replacing the registry itself would
+        # swap in a strongly keyed mapping and mask any leak
         with param.logging_level("ERROR"):
-            Stream.registry = defaultdict(list)
+            Stream.registry.clear()
 
     def test_source_empty_element(self):
         points = hv.Points([])
@@ -871,6 +949,31 @@ class TestStreamSource:
         points = hv.Points([])
         PointerX(source=points)
         assert points in Stream.registry
+
+    def test_source_registry_releases_source(self):
+        # The registry indexes its streams weakly, so an entry can never keep
+        # its own source alive, not even through a subscriber reaching back to
+        # it (#6875). Collecting the source drops the entry with it, as the
+        # registry is still keyed weakly.
+        def build():
+            points = hv.Points([(0, 0)])
+            stream = PointerX(source=points)
+            stream.add_subscriber(lambda **kwargs: points)
+            assert points in Stream.registry
+            return {"source": points, "stream": stream}
+
+        refs = {name: weakref.ref(obj) for name, obj in build().items()}
+        gc.collect()
+        assert not [name for name, ref in refs.items() if ref() is not None]
+
+    def test_source_remap_releases_previous_source(self):
+        points = hv.Points([])
+        curve = hv.Curve([])
+        stream = PointerX(source=points)
+        stream.source = curve
+
+        assert points._streams == []
+        assert curve._streams == [stream]
 
 
 class TestParameterRenaming:

--- a/holoviews/tests/test_streams.py
+++ b/holoviews/tests/test_streams.py
@@ -809,14 +809,6 @@ class TestSubscribers:
 
 
 class _App(param.Parameterized):
-    """The object graph of panel#8580 and #6934.
-
-    An app owns an element, a stream sourced from that element and a
-    subscriber which reaches back into the app. Parameterized so that
-    ``on_update`` is a param method, as it is for the ``pn.viewable.Viewer``
-    of #6945.
-    """
-
     def __init__(self, make_subscriber, **params):
         super().__init__(**params)
         self.calls = []
@@ -828,41 +820,24 @@ class _App(param.Parameterized):
         self.calls.append(kwargs)
 
 
-def _closure(app):
-    def on_update(**kwargs):
-        app.calls.append(kwargs)
-
-    return on_update
-
-
-# The four ways a subscriber can reach back into its owner. Only the first two
-# were ever wrapped weakly, so the closure forms have always leaked.
 subscriber_kinds = pytest.mark.parametrize(
     "make_subscriber",
     [
         lambda app: app.on_update,
         lambda app: partial(app.on_update, extra=1),
-        _closure,
         lambda app: lambda **kwargs: app.calls.append(kwargs),
     ],
-    ids=["bound_method", "partial", "closure", "lambda"],
+    ids=["bound_method", "partial", "lambda"],
 )
 
 
 class TestSubscriberLifetime:
-    """The source element, its streams and their subscribers must all die
-    together once nothing else refers to them, and must all stay alive for as
-    long as the element does.
-    """
-
     @subscriber_kinds
     def test_app_is_collected(self, make_subscriber):
         def build():
             app = _App(make_subscriber)
             return {"app": app, "element": app.element, "stream": app.stream}
 
-        # build holds the only references, so dropping its frame has to be
-        # enough for the whole graph to go
         refs = {name: weakref.ref(obj) for name, obj in build().items()}
         gc.collect()
         assert not [name for name, ref in refs.items() if ref() is not None]
@@ -874,8 +849,6 @@ class TestSubscriberLifetime:
         assert [call["x_range"] for call in app.calls] == [(0, 1)]
 
     def test_stream_survives_dropped_local_reference(self):
-        # A stream is kept alive by its source element, so it keeps firing
-        # after the local variable it was assigned to goes out of scope.
         element = hv.Points([(0, 0)])
         calls = []
 
@@ -885,14 +858,11 @@ class TestSubscriberLifetime:
 
         register()
         gc.collect()
-
         (stream,) = Stream.registry[element]
         stream.event(x_range=(0, 1), y_range=(2, 3))
         assert calls == [{"x_range": (0, 1), "y_range": (2, 3)}]
 
     def test_subscription_is_only_reference(self):
-        # An app whose only remaining reference is the subscription itself
-        # must survive for as long as the displayed element does (#6945).
         def build():
             app = _App(lambda app: app.on_update)
             return app.element, weakref.ref(app)
@@ -916,8 +886,6 @@ class TestSubscriberLifetime:
 
 class TestStreamSource:
     def teardown_method(self):
-        # Only drop the leftover entries, replacing the registry itself would
-        # swap in a strongly keyed mapping and mask any leak
         with param.logging_level("ERROR"):
             Stream.registry.clear()
 
@@ -951,10 +919,6 @@ class TestStreamSource:
         assert points in Stream.registry
 
     def test_source_registry_releases_source(self):
-        # The registry indexes its streams weakly, so an entry can never keep
-        # its own source alive, not even through a subscriber reaching back to
-        # it (#6875). Collecting the source drops the entry with it, as the
-        # registry is still keyed weakly.
         def build():
             points = hv.Points([(0, 0)])
             stream = PointerX(source=points)


### PR DESCRIPTION
## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Closes #6945
Closes #6988

Alternative to https://github.com/holoviz/holoviews/pull/6970


### The problem

`Stream.registry` used to be a `WeakKeyDictionary`, so an entry should disappear once the element does. It never did, because only the keys were weak. The values were ordinary references [`self.registry[source] = [self]`, and a stream reaches its own source back through its subscribers:

```
    Stream.registry                <- module level, never goes away
    └─ [stream]                    <- the value, held strongly
       └─ subscriber
          └─ your app object
             └─ source element     <- and this is the weak key
```

https://github.com/holoviz/holoviews/blob/fff801d420ee8c40879d7a79430f47eb2be210f5/holoviews/streams.py#L172

https://github.com/holoviz/holoviews/blob/fff801d420ee8c40879d7a79430f47eb2be210f5/holoviews/streams.py#L376

The key was reachable from its own value, so the entry never expired. Any element ever passed as `source=` stayed alive until the process exited, along with its data, its streams and whatever those subscribers were bound to.

#6875 tried to fix this by holding subscribers weakly, in `_WeakSubscriber`. That cut the wrong link, and it only did anything for bound methods:

- `check` required `inspect.ismethod`, so closures and lambdas were never
  wrapped and kept leaking
- a `functools.partial` passed the `check` but fell through to
  `weakref.ref(subscriber)`. Nothing else referenced the partial, so it was
  collected straight away and the subscriber never fired (#6945)
- `__bool__` reported param methods as dead, so calling `cleanup()` on one plot
  removed subscribers belonging to another (#6988)

### What changed in this PR

Ownership was turned around. The source element now keeps its own streams in `LabelledData._streams`, and `Stream.registry` was reduced to a weak index that only exists so a clone with the same `_plot_id` can still find them. An element, its streams and their subscribers are now just a cycle, which the garbage collector frees once nothing else refers to it.

With the global reference gone, `_WeakSubscriber` was deleted and subscribers went back to being ordinary strong references. #6945 and #6988 stopped being possible rather than being worked around.

A second leak with the same effect turned up while measuring the first. Every plot registers `on_session_destroyed` on its document, and the document keeps that callback, and the whole plot with it. `BokehPlot.cleanup` set `plot._document = None` directly instead of going through the setter, so nothing ever removed the callback. 

Outside a server that document is `curdoc()`, which lives for the whole process, so every plot ever rendered was kept. The deregistration was pulled out into `Plot._unwatch_session` and is now called from the setter and from both `cleanup` implementations.

### Also fixed
- `Renderer.last_plot` held the last plot for the life of the process. It is now a weak reference.
- `attach_streams` compared `plot.refresh` against the `(precedence, subscriber)` pairs, so its guard never matched and an overlay subscribed the same plot four times. It now compares against `stream.subscribers`.
- `_link_dimensioned_streams` registered `_stream_update` at precedence exactly one, inside the range `Stream.clear` treats as belonging to the user, so `clear("user")` dropped it. It registers at 1.05 now.


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Claude Code:claude-opus-5
Usage:

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
