### PR TITLE
docs: add markdown and llms.txt docs

### DIFF
--- a/doc/developer_guide/index.md
+++ b/doc/developer_guide/index.md
@@ -249,6 +249,17 @@ You can also disable the reference gallery by setting the environment variable `
 
 A development version of HoloViews can be found [here](https://dev.holoviews.org/). You can ask a maintainer if they want to make a dev release for your PR, but there is no guarantee they will say yes.
 
+### Markdown docs and `llms.txt`
+
+As part of `docs-build`, HoloViews also generates clean Markdown versions of its documentation together with an `llms.txt` index file that points AI assistants at the most relevant pages.
+
+The build produces:
+
+- `builtdocs/markdown/` - a Markdown rendering of the documentation
+- `builtdocs/llms.txt` - an index of the most useful documentation pages for LLM-assisted development
+
+See [Using HoloViews with an AI assistant](../user_guide/use_llms.md) for how to consume these docs with an AI assistant.
+
 ## Build
 
 HoloViews have two build tasks. One is for building packages for Pip, and the other is for building packages for Conda.

--- a/doc/developer_guide/index.md
+++ b/doc/developer_guide/index.md
@@ -249,17 +249,6 @@ You can also disable the reference gallery by setting the environment variable `
 
 A development version of HoloViews can be found [here](https://dev.holoviews.org/). You can ask a maintainer if they want to make a dev release for your PR, but there is no guarantee they will say yes.
 
-### Markdown docs and `llms.txt`
-
-As part of `docs-build`, HoloViews also generates clean Markdown versions of its documentation together with an `llms.txt` index file that points AI assistants at the most relevant pages.
-
-The build produces:
-
-- `builtdocs/markdown/` - a Markdown rendering of the documentation
-- `builtdocs/llms.txt` - an index of the most useful documentation pages for LLM-assisted development
-
-See [Using HoloViews with an AI assistant](../user_guide/use_llms.md) for how to consume these docs with an AI assistant.
-
 ## Build
 
 HoloViews have two build tasks. One is for building packages for Pip, and the other is for building packages for Conda.

--- a/doc/user_guide/index.md
+++ b/doc/user_guide/index.md
@@ -97,6 +97,10 @@ These guides provide detail about specific additional features in HoloViews:
 
 : Information about configuration options.
 
+[Using HoloViews with an AI assistant]
+
+: How to give an AI assistant up-to-date HoloViews documentation context.
+
 [Customizing Plots]
 
 : How to customize plots including their titles, axis labels, ranges, ticks and more.
@@ -182,6 +186,7 @@ These guides provide detail about specific additional features in HoloViews:
  Annotators <Annotators>
  Exporting and Archiving <Exporting_and_Archiving>
  Continuous Coordinates <Continuous_Coordinates>
+ Using HoloViews with an AI assistant <use_llms>
 ```
 
 [annotating your data]: Annotating_Data.html
@@ -218,3 +223,4 @@ These guides provide detail about specific additional features in HoloViews:
 [working with large data]: Large_Data.html
 [working with renderers and plots]: Plots_and_Renderers.html
 [working with streaming data]: Streaming_Data.html
+[using holoviews with an ai assistant]: use_llms.html

--- a/doc/user_guide/use_llms.md
+++ b/doc/user_guide/use_llms.md
@@ -1,0 +1,70 @@
+# Using HoloViews with an AI assistant
+
+AI assistants (like Claude, GitHub Copilot, or OpenAI Codex) can write HoloViews code much more reliably when they have access to up-to-date, structured documentation instead of guessing from stale training data. This guide shows you how to give your assistant that context, either by pointing it at HoloViews' generated `llms.txt` and Markdown docs, or by installing the HoloViz Agent Skills.
+
+## What you'll accomplish
+
+By the end of this guide you'll be able to:
+
+- Install the HoloViz skills so your assistant follows HoloViews best practices automatically
+- Give your AI assistant a curated index of the most useful HoloViews documentation pages
+
+## Prerequisites
+
+- A python package installer like `pip` or `uvx` if you want to install the skills
+- An AI assistant that can read web content or local files (for example Claude, GitHub Copilot, or OpenAI Codex)
+
+## Install the HoloViz skills
+
+The [holoviz-skills](https://holoviz-dev.github.io/holoviz-skills/) repository provides a curated collection of [Agent Skills](https://www.anthropic.com/news/skills) for the HoloViz ecosystem, including HoloViews. Agent Skills are folders of instructions and references that teach an assistant how to work with a library correctly.
+
+::::{tab-set}
+
+:::{tab-item} uv
+
+```bash
+uvx holoviz-skills@latest install
+```
+
+:::
+
+:::{tab-item} pip
+
+```bash
+pip install holoviz-skills
+holoviz-skills install
+```
+
+:::
+
+::::
+
+The `install` command auto-detects the AI tools on your machine. You can also target a specific tool, for example:
+
+```bash
+holoviz-skills install --claude-code
+holoviz-skills install --copilot
+```
+
+You may need to restart your assistant so it picks up the newly installed skills.
+
+## Point your assistant at the docs
+
+HoloViews publishes a machine-friendly index of its documentation that your assistant can fetch directly.
+
+1. Tell your assistant to fetch the index:
+
+   `https://holoviews.org/llms.txt`
+
+2. The index lists the most relevant pages and links to their Markdown versions under:
+
+   `https://holoviews.org/markdown/`, for example `https://holoviews.org/markdown/getting_started/1-Introduction.md`
+
+3. Ask your assistant to read the pages relevant to your task before writing code. For example, to create a plot you might have it read the Getting Started tutorial and the API reference page for the method you need.
+
+The Markdown pages are intentionally free of the navigation chrome, CSS, and JavaScript of the full HTML site, so they consume far fewer tokens and are easier for an assistant to parse.
+
+## Which approach should I use?
+
+- **Point your assistant at the docs** is a good fit for a one-off task or when you can't install packages, and it always reflects the latest published docs.
+- **Install the HoloViz skills** gives your assistant packaged, opinionated guidance that works offline, but you need to update it as HoloViews evolves. Once the skills are installed, pointing to the Markdown docs should no longer be needed if you want your agent to be able to fetch the latest docs, as the skills already teach the agent how to do that.

--- a/doc/user_guide/use_llms.md
+++ b/doc/user_guide/use_llms.md
@@ -58,7 +58,7 @@ HoloViews publishes a machine-friendly index of its documentation that your assi
 
 2. The index lists the most relevant pages and links to their Markdown versions under:
 
-   `https://holoviews.org/markdown/`, for example `https://holoviews.org/markdown/getting_started/1-Introduction.md`
+   `https://holoviews.org/markdown/`, for example `https://holoviews.org/markdown/getting_started/Introduction.md`
 
 3. Ask your assistant to read the pages relevant to your task before writing code. For example, to create a plot you might have it read the Getting Started tutorial and the API reference page for the method you need.
 


### PR DESCRIPTION
## Description

This PR documents the addition of the markdown and `llms.txt` build process to the docs following 85b69cebe. See https://github.com/holoviz/hvplot/pull/1751

- [x] Added documentation