### PR TITLE
fix: client align axis for GridSpace

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -54,7 +54,7 @@ from ..plot import (
 from ..util import attach_streams, collate, displayable
 from .links import LinkCallback
 from .util import (
-    bind_dynamic_axis_sizing,
+    _bind_dynamic_axis_sizing,
     cds_column_replace,
     decode_bytes,
     empty_plot,
@@ -763,7 +763,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                 label_size=lsize,
                 tick_size=tsize,
             )
-        bind_dynamic_axis_sizing(
+        _bind_dynamic_axis_sizing(
             plots, x_axis=x_axis, x_ticker=x_ticker, y_axis=y_axis, y_ticker=y_ticker
         )
         if x_axis and y_axis:

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -54,6 +54,7 @@ from ..plot import (
 from ..util import attach_streams, collate, displayable
 from .links import LinkCallback
 from .util import (
+    bind_dynamic_axis_sizing,
     cds_column_replace,
     decode_bytes,
     empty_plot,
@@ -704,7 +705,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
         )
         if self.sync_legends:
             sync_legends(plot)
-        plot = self._make_axes(plot)
+        plot = self._make_axes(plot, plots)
         if hasattr(plot, "toolbar") and self.merge_tools:
             plot.toolbar = merge_tools(plots, hide_toolbar=True)
         title = self._get_title_div(self.keys[-1])
@@ -725,9 +726,10 @@ class GridPlot(CompositePlot, GenericCompositePlot):
 
         return self.handles["plot"]
 
-    def _make_axes(self, plot):
+    def _make_axes(self, plot, plots):
         width, height = self.renderer.get_size(plot)
         x_axis, y_axis = None, None
+        x_ticker = y_ticker = None
         keys = self.layout.keys(full_grid=True)
         if self.xaxis:
             flip = self.shared_xaxis
@@ -735,7 +737,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             lsize = self._fontsize("xlabel").get("fontsize")
             tsize = self._fontsize("xticks", common=False).get("fontsize")
             xfactors = list(unique_iterator([wrap_tuple(k)[0] for k in keys]))
-            x_axis = make_axis(
+            x_axis, x_ticker = make_axis(
                 "x",
                 width,
                 xfactors,
@@ -751,7 +753,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             lsize = self._fontsize("ylabel").get("fontsize")
             tsize = self._fontsize("yticks", common=False).get("fontsize")
             yfactors = list(unique_iterator([k[1] for k in keys]))
-            y_axis = make_axis(
+            y_axis, y_ticker = make_axis(
                 "y",
                 height,
                 yfactors,
@@ -761,6 +763,9 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                 label_size=lsize,
                 tick_size=tsize,
             )
+        bind_dynamic_axis_sizing(
+            plots, x_axis=x_axis, x_ticker=x_ticker, y_axis=y_axis, y_ticker=y_ticker
+        )
         if x_axis and y_axis:
             plot = filter_toolboxes(plot)
             r1, r2 = ([y_axis, plot], [None, x_axis])

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -729,7 +729,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
     def _make_axes(self, plot, plots):
         width, height = self.renderer.get_size(plot)
         x_axis, y_axis = None, None
-        x_ticker = y_ticker = None
+        x_ticker, y_ticker = None, None
         keys = self.layout.keys(full_grid=True)
         if self.xaxis:
             flip = self.shared_xaxis

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -12,12 +12,17 @@ from bokeh.models import (
     ColorBar,
     Column,
     ColumnDataSource,
+    CustomJS,
+    CustomJSTickFormatter,
     Div,
     Legend,
     Row,
     Title,
 )
 from bokeh.models.layouts import TabPanel, Tabs
+from bokeh.models.ranges import Range1d
+from bokeh.models.tickers import FixedTicker
+from bokeh.plotting import figure
 
 from ...core import (
     AdjointLayout,
@@ -51,16 +56,15 @@ from ..plot import (
     GenericLayoutPlot,
     GenericOverlayPlot,
 )
-from ..util import attach_streams, collate, displayable
+from ..util import attach_streams, collate, dim_axis_label, displayable
 from .links import LinkCallback
 from .util import (
-    _bind_dynamic_axis_sizing,
     cds_column_replace,
     decode_bytes,
     empty_plot,
     filter_toolboxes,
+    font_size_to_pixels,
     get_default,
-    make_axis,
     merge_tools,
     select_legends,
     sync_legends,
@@ -726,6 +730,228 @@ class GridPlot(CompositePlot, GenericCompositePlot):
 
         return self.handles["plot"]
 
+    @staticmethod
+    def _make_axis(
+        axis,
+        size,
+        factors,
+        dim,
+        flip=False,
+        rotation=0,
+        label_size=None,
+        tick_size=None,
+        axis_height=35,
+    ):
+        """Builds a toolbar-less, dataless figure used to draw a categorical
+        axis shared across a GridPlot's grid of subplots.
+
+        ``size`` is only an initial estimate; the true length and tick
+        positions are set later by _bind_dynamic_axis_sizing once the grid
+        has actually rendered. Returns (figure, ticker).
+
+        """
+        factors = list(map(dim.pprint_value, factors))
+        nchars = np.max([len(f) for f in factors])
+        axis_label = dim_axis_label(dim)
+
+        ticker = FixedTicker(ticks=[])
+        formatter = CustomJSTickFormatter(
+            args=dict(ticker=ticker, labels=factors),
+            code="const i = ticker.ticks.indexOf(tick); return i >= 0 ? String(labels[i]) : ''",
+        )
+
+        axis_props = {}
+        if label_size:
+            axis_props["axis_label_text_font_size"] = label_size
+        if tick_size:
+            axis_props["major_label_text_font_size"] = tick_size
+
+        tick_px = font_size_to_pixels(tick_size)
+        if tick_px is None:
+            tick_px = 8
+        label_px = font_size_to_pixels(label_size)
+        if label_px is None:
+            label_px = 10
+
+        rotation = np.radians(rotation)
+        if axis == "x":
+            align = "center"
+            # Adjust height to compensate for label rotation
+            height = (
+                int(axis_height + np.abs(np.sin(rotation)) * ((nchars * tick_px) * 0.82))
+                + tick_px
+                + label_px
+            )
+            opts = dict(
+                x_axis_type="auto",
+                x_axis_label=axis_label,
+                x_range=Range1d(start=0, end=1),
+                y_range=Range1d(start=0, end=1),
+                height=height,
+                width=size,
+                min_border_left=0,
+                min_border_right=0,
+            )
+        else:
+            # Adjust width to compensate for label rotation
+            align = "left" if flip else "right"
+            width = (
+                int(axis_height + np.abs(np.cos(rotation)) * ((nchars * tick_px) * 0.82))
+                + tick_px
+                + label_px
+            )
+            opts = dict(
+                y_axis_label=axis_label,
+                x_range=Range1d(start=0, end=1),
+                y_range=Range1d(start=0, end=1),
+                height=size,
+                width=width,
+                min_border_top=0,
+                min_border_bottom=0,
+            )
+
+        p = figure(toolbar_location=None, tools=[], **opts)
+        p.outline_line_alpha = 0
+        p.grid.grid_line_alpha = 0
+
+        if axis == "x":
+            p.align = "start"
+            p.yaxis.visible = False
+            pax = p.xaxis[0]
+            if flip:
+                p.above = p.below
+                p.below = []
+                p.xaxis[:] = p.above
+        else:
+            p.align = "end"
+            p.xaxis.visible = False
+            pax = p.yaxis[0]
+            if flip:
+                p.right = p.left
+                p.left = []
+                p.yaxis[:] = p.right
+        pax.ticker = ticker
+        pax.formatter = formatter
+        pax.major_label_orientation = rotation
+        pax.major_label_text_align = align
+        pax.major_label_text_baseline = "middle"
+        pax.update(**axis_props)
+        return p, ticker
+
+    @staticmethod
+    def _bind_dynamic_axis_sizing(plots, x_axis=None, x_ticker=None, y_axis=None, y_ticker=None):
+        """Wires a CustomJS callback that measures the grid's real rendered
+        column/row sizes and drives the shared fake x/y axis figures
+        (built by _make_axis) to match exactly -- correct regardless of
+        why a subplot's canvas grew beyond its frame_width/frame_height
+        (a legend, a colorbar, an un-merged toolbar, a real per-cell
+        axis, ...), since it reads the real rendered geometry (via
+        Bokeh.index) instead of estimating it.
+
+        The axis figure is sized to the plot frame only, not the full
+        canvas, so its line/label track the actual plot rather than
+        being centered across the plot+border canvas. See the comments
+        in the callback body for the mechanics.
+
+        """
+        if x_axis is None and y_axis is None:
+            return
+        figs = [fig for row in plots for fig in row if fig is not None]
+        if not figs:
+            return
+
+        callback = CustomJS(
+            args=dict(
+                plots=plots, x_axis=x_axis, x_ticker=x_ticker, y_axis=y_axis, y_ticker=y_ticker
+            ),
+            code="""
+            function frameRect(fig) {
+                const view = Bokeh.index.find_one_by_id(fig.id)
+                if (view == null) return null
+                const outer = view.bbox
+                const inner = view.frame_view ? view.frame_view.bbox : null
+                if (outer == null || inner == null) return null
+                // bbox is parent-relative, frame_view.bbox is canvas-local (0-based)
+                // -- different reference frames, so never mix deltas across them.
+                const outerWidth = outer.x1 - outer.x0
+                const outerHeight = outer.y1 - outer.y0
+                return {
+                    outerWidth,
+                    outerHeight,
+                    frameWidth: inner.x1 - inner.x0,
+                    frameHeight: inner.y1 - inner.y0,
+                    leadingLeft: inner.x0,
+                    leadingBottom: outerHeight - inner.y1,
+                }
+            }
+            // outerSizeOf/leadingOf locate the frame within a cell's full canvas,
+            // for offsets; frameSizeOf is the plot itself, for length/centers.
+            function measureDim(nOuter, nInner, cellAt, outerSizeOf, frameSizeOf, leadingOf) {
+                const outerSizes = [], frameSizes = [], leadings = []
+                for (let o = 0; o < nOuter; o++) {
+                    let outerSize = null, frameSize = null, leading = null
+                    for (let i = 0; i < nInner; i++) {
+                        const fig = cellAt(o, i)
+                        if (fig == null) continue
+                        const rect = frameRect(fig)
+                        if (rect == null) continue
+                        const os = outerSizeOf(rect)
+                        if (outerSize == null || os > outerSize) {
+                            outerSize = os
+                            frameSize = frameSizeOf(rect)
+                            leading = leadingOf(rect)
+                        }
+                    }
+                    if (outerSize == null) return null
+                    outerSizes.push(outerSize)
+                    frameSizes.push(frameSize)
+                    leadings.push(leading)
+                }
+                let offset = 0
+                const plotStarts = []
+                for (let i = 0; i < outerSizes.length; i++) {
+                    plotStarts.push(offset + leadings[i])
+                    offset += outerSizes[i]
+                }
+                // Round before computing centers, not after -- otherwise a tick's
+                // rendered position drifts from its intended one, more so for
+                // later ticks, since width/margin can only be set to whole pixels.
+                const base = Math.round(plotStarts[0])
+                const total = Math.round(plotStarts[plotStarts.length - 1] + frameSizes[frameSizes.length - 1]) - base
+                if (total === 0) return null
+                const centers = plotStarts.map((s, i) => (s - base + frameSizes[i] / 2) / total)
+                return {total, centers, lead: base}
+            }
+            const nRows = plots.length
+            const nCols = nRows > 0 ? plots[0].length : 0
+            if (x_axis != null) {
+                const result = measureDim(
+                    nCols, nRows, (c, r) => plots[r][c],
+                    (rect) => rect.outerWidth, (rect) => rect.frameWidth, (rect) => rect.leadingLeft,
+                )
+                if (result != null) {
+                    x_axis.width = result.total
+                    x_ticker.ticks = result.centers
+                    x_axis.margin = [0, 0, 0, result.lead]  // shifts past the leading gutter
+                }
+            }
+            if (y_axis != null) {
+                const result = measureDim(
+                    nRows, nCols, (r, c) => plots[r][c],
+                    (rect) => rect.outerHeight, (rect) => rect.frameHeight, (rect) => rect.leadingBottom,
+                )
+                if (result != null) {
+                    y_axis.height = result.total
+                    y_ticker.ticks = result.centers
+                    y_axis.margin = [0, 0, result.lead, 0]
+                }
+            }
+            """,
+        )
+        for fig in figs:
+            fig.js_on_change("outer_width", callback)
+            fig.js_on_change("outer_height", callback)
+
     def _make_axes(self, plot, plots):
         width, height = self.renderer.get_size(plot)
         x_axis, y_axis = None, None
@@ -737,7 +963,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             lsize = self._fontsize("xlabel").get("fontsize")
             tsize = self._fontsize("xticks", common=False).get("fontsize")
             xfactors = list(unique_iterator([wrap_tuple(k)[0] for k in keys]))
-            x_axis, x_ticker = make_axis(
+            x_axis, x_ticker = self._make_axis(
                 "x",
                 width,
                 xfactors,
@@ -753,7 +979,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             lsize = self._fontsize("ylabel").get("fontsize")
             tsize = self._fontsize("yticks", common=False).get("fontsize")
             yfactors = list(unique_iterator([k[1] for k in keys]))
-            y_axis, y_ticker = make_axis(
+            y_axis, y_ticker = self._make_axis(
                 "y",
                 height,
                 yfactors,
@@ -763,7 +989,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                 label_size=lsize,
                 tick_size=tsize,
             )
-        _bind_dynamic_axis_sizing(
+        self._bind_dynamic_axis_sizing(
             plots, x_axis=x_axis, x_ticker=x_ticker, y_axis=y_axis, y_ticker=y_ticker
         )
         if x_axis and y_axis:

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -734,23 +734,8 @@ def _bind_dynamic_axis_sizing(plots, x_axis=None, x_ticker=None, y_axis=None, y_
     callback = CustomJS(
         args=dict(plots=plots, x_axis=x_axis, x_ticker=x_ticker, y_axis=y_axis, y_ticker=y_ticker),
         code="""
-        // Bokeh.index only holds root-level views; a subplot's own view is
-        // nested under it (child_views), so it has to be found by walking down.
-        function collectViews() {
-            const map = {}
-            function walk(view) {
-                if (view.model != null) map[view.model.id] = view
-                const cv = view.child_views
-                if (cv != null) {
-                    for (const child of cv.values()) walk(child)
-                }
-            }
-            for (const rootId of Object.keys(Bokeh.index)) walk(Bokeh.index[rootId])
-            return map
-        }
-        const views = collectViews()
         function frameRect(fig) {
-            const view = views[fig.id]
+            const view = Bokeh.index.find_one_by_id(fig.id)
             if (view == null) return null
             const outer = view.bbox
             const inner = view.frame_view ? view.frame_view.bbox : null

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -621,14 +621,6 @@ def make_axis(
     tick_size=None,
     axis_height=35,
 ):
-    """Builds a toolbar-less, dataless figure used to draw a categorical
-    axis shared across a GridPlot's grid of subplots.
-
-    ``size`` is only an initial estimate; the true length and tick
-    positions are set later by bind_dynamic_axis_sizing once the grid
-    has actually rendered. Returns (figure, ticker).
-
-    """
     factors = list(map(dim.pprint_value, factors))
     nchars = np.max([len(f) for f in factors])
     axis_label = dim_axis_label(dim)
@@ -718,7 +710,7 @@ def make_axis(
     return p, ticker
 
 
-def bind_dynamic_axis_sizing(plots, x_axis=None, x_ticker=None, y_axis=None, y_ticker=None):
+def _bind_dynamic_axis_sizing(plots, x_axis=None, x_ticker=None, y_axis=None, y_ticker=None):
     """Wires a CustomJS callback that measures the grid's real rendered
     column/row sizes and drives the shared fake x/y axis figures
     (built by make_axis) to match exactly -- correct regardless of

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -15,7 +15,7 @@ from bokeh.core.validation import silence
 from bokeh.core.validation.check import is_silenced
 from bokeh.layouts import group_tools
 from bokeh.model import Model
-from bokeh.models import CustomJS, CustomJSTickFormatter, Range, Scale, tools
+from bokeh.models import CustomJS, Range, Scale, tools
 from bokeh.models.axes import (
     CategoricalAxis,
     DatetimeAxis,
@@ -49,7 +49,7 @@ from ...core.util import (
     unique_array,
 )
 from ...core.util.dependencies import _no_import_version
-from ...util.warnings import warn
+from ...util.warnings import deprecated, warn
 from ..util import dim_axis_label
 
 BOKEH_VERSION = _no_import_version("bokeh")
@@ -621,15 +621,15 @@ def make_axis(
     tick_size=None,
     axis_height=35,
 ):
+    deprecated("1.26.0", "make_axis")
     factors = list(map(dim.pprint_value, factors))
     nchars = np.max([len(f) for f in factors])
+    ranges = FactorRange(factors=factors)
+    ranges2 = Range1d(start=0, end=1)
     axis_label = dim_axis_label(dim)
-
-    ticker = FixedTicker(ticks=[])
-    formatter = CustomJSTickFormatter(
-        args=dict(ticker=ticker, labels=factors),
-        code="const i = ticker.ticks.indexOf(tick); return i >= 0 ? String(labels[i]) : ''",
-    )
+    reset = "range.setv({start: 0, end: range.factors.length})"
+    customjs = CustomJS(args=dict(range=ranges), code=reset)
+    ranges.js_on_change("start", customjs)
 
     axis_props = {}
     if label_size:
@@ -656,12 +656,10 @@ def make_axis(
         opts = dict(
             x_axis_type="auto",
             x_axis_label=axis_label,
-            x_range=Range1d(start=0, end=1),
-            y_range=Range1d(start=0, end=1),
+            x_range=ranges,
+            y_range=ranges2,
             height=height,
             width=size,
-            min_border_left=0,
-            min_border_right=0,
         )
     else:
         # Adjust width to compensate for label rotation
@@ -672,13 +670,7 @@ def make_axis(
             + label_px
         )
         opts = dict(
-            y_axis_label=axis_label,
-            x_range=Range1d(start=0, end=1),
-            y_range=Range1d(start=0, end=1),
-            height=size,
-            width=width,
-            min_border_top=0,
-            min_border_bottom=0,
+            y_axis_label=axis_label, x_range=ranges2, y_range=ranges, height=size, width=width
         )
 
     p = figure(toolbar_location=None, tools=[], **opts)
@@ -686,140 +678,25 @@ def make_axis(
     p.grid.grid_line_alpha = 0
 
     if axis == "x":
-        p.align = "start"
+        p.align = "end"
         p.yaxis.visible = False
-        pax = p.xaxis[0]
+        axis = p.xaxis[0]
         if flip:
             p.above = p.below
             p.below = []
             p.xaxis[:] = p.above
     else:
-        p.align = "end"
         p.xaxis.visible = False
-        pax = p.yaxis[0]
+        axis = p.yaxis[0]
         if flip:
             p.right = p.left
             p.left = []
             p.yaxis[:] = p.right
-    pax.ticker = ticker
-    pax.formatter = formatter
-    pax.major_label_orientation = rotation
-    pax.major_label_text_align = align
-    pax.major_label_text_baseline = "middle"
-    pax.update(**axis_props)
-    return p, ticker
-
-
-def _bind_dynamic_axis_sizing(plots, x_axis=None, x_ticker=None, y_axis=None, y_ticker=None):
-    """Wires a CustomJS callback that measures the grid's real rendered
-    column/row sizes and drives the shared fake x/y axis figures
-    (built by make_axis) to match exactly -- correct regardless of
-    why a subplot's canvas grew beyond its frame_width/frame_height
-    (a legend, a colorbar, an un-merged toolbar, a real per-cell
-    axis, ...), since it reads the real rendered geometry (via
-    Bokeh.index) instead of estimating it.
-
-    The axis figure is sized to the plot frame only, not the full
-    canvas, so its line/label track the actual plot rather than
-    being centered across the plot+border canvas. See the comments
-    in the callback body for the mechanics.
-
-    """
-    if x_axis is None and y_axis is None:
-        return
-    figs = [fig for row in plots for fig in row if fig is not None]
-    if not figs:
-        return
-
-    callback = CustomJS(
-        args=dict(plots=plots, x_axis=x_axis, x_ticker=x_ticker, y_axis=y_axis, y_ticker=y_ticker),
-        code="""
-        function frameRect(fig) {
-            const view = Bokeh.index.find_one_by_id(fig.id)
-            if (view == null) return null
-            const outer = view.bbox
-            const inner = view.frame_view ? view.frame_view.bbox : null
-            if (outer == null || inner == null) return null
-            // bbox is parent-relative, frame_view.bbox is canvas-local (0-based)
-            // -- different reference frames, so never mix deltas across them.
-            const outerWidth = outer.x1 - outer.x0
-            const outerHeight = outer.y1 - outer.y0
-            return {
-                outerWidth,
-                outerHeight,
-                frameWidth: inner.x1 - inner.x0,
-                frameHeight: inner.y1 - inner.y0,
-                leadingLeft: inner.x0,
-                leadingBottom: outerHeight - inner.y1,
-            }
-        }
-        // outerSizeOf/leadingOf locate the frame within a cell's full canvas,
-        // for offsets; frameSizeOf is the plot itself, for length/centers.
-        function measureDim(nOuter, nInner, cellAt, outerSizeOf, frameSizeOf, leadingOf) {
-            const outerSizes = [], frameSizes = [], leadings = []
-            for (let o = 0; o < nOuter; o++) {
-                let outerSize = null, frameSize = null, leading = null
-                for (let i = 0; i < nInner; i++) {
-                    const fig = cellAt(o, i)
-                    if (fig == null) continue
-                    const rect = frameRect(fig)
-                    if (rect == null) continue
-                    const os = outerSizeOf(rect)
-                    if (outerSize == null || os > outerSize) {
-                        outerSize = os
-                        frameSize = frameSizeOf(rect)
-                        leading = leadingOf(rect)
-                    }
-                }
-                if (outerSize == null) return null
-                outerSizes.push(outerSize)
-                frameSizes.push(frameSize)
-                leadings.push(leading)
-            }
-            let offset = 0
-            const plotStarts = []
-            for (let i = 0; i < outerSizes.length; i++) {
-                plotStarts.push(offset + leadings[i])
-                offset += outerSizes[i]
-            }
-            // Round before computing centers, not after -- otherwise a tick's
-            // rendered position drifts from its intended one, more so for
-            // later ticks, since width/margin can only be set to whole pixels.
-            const base = Math.round(plotStarts[0])
-            const total = Math.round(plotStarts[plotStarts.length - 1] + frameSizes[frameSizes.length - 1]) - base
-            if (total === 0) return null
-            const centers = plotStarts.map((s, i) => (s - base + frameSizes[i] / 2) / total)
-            return {total, centers, lead: base}
-        }
-        const nRows = plots.length
-        const nCols = nRows > 0 ? plots[0].length : 0
-        if (x_axis != null) {
-            const result = measureDim(
-                nCols, nRows, (c, r) => plots[r][c],
-                (rect) => rect.outerWidth, (rect) => rect.frameWidth, (rect) => rect.leadingLeft,
-            )
-            if (result != null) {
-                x_axis.width = result.total
-                x_ticker.ticks = result.centers
-                x_axis.margin = [0, 0, 0, result.lead]  // shifts past the leading gutter
-            }
-        }
-        if (y_axis != null) {
-            const result = measureDim(
-                nRows, nCols, (r, c) => plots[r][c],
-                (rect) => rect.outerHeight, (rect) => rect.frameHeight, (rect) => rect.leadingBottom,
-            )
-            if (result != null) {
-                y_axis.height = result.total
-                y_ticker.ticks = result.centers
-                y_axis.margin = [0, 0, result.lead, 0]
-            }
-        }
-        """,
-    )
-    for fig in figs:
-        fig.js_on_change("outer_width", callback)
-        fig.js_on_change("outer_height", callback)
+    axis.major_label_orientation = rotation
+    axis.major_label_text_align = align
+    axis.major_label_text_baseline = "middle"
+    axis.update(**axis_props)
+    return p
 
 
 def hsv_to_rgb(hsv):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -15,7 +15,7 @@ from bokeh.core.validation import silence
 from bokeh.core.validation.check import is_silenced
 from bokeh.layouts import group_tools
 from bokeh.model import Model
-from bokeh.models import CustomJS, Range, Scale, tools
+from bokeh.models import CustomJS, CustomJSTickFormatter, Range, Scale, tools
 from bokeh.models.axes import (
     CategoricalAxis,
     DatetimeAxis,
@@ -621,14 +621,23 @@ def make_axis(
     tick_size=None,
     axis_height=35,
 ):
+    """Builds a toolbar-less, dataless figure used to draw a categorical
+    axis shared across a GridPlot's grid of subplots.
+
+    ``size`` is only an initial estimate; the true length and tick
+    positions are set later by bind_dynamic_axis_sizing once the grid
+    has actually rendered. Returns (figure, ticker).
+
+    """
     factors = list(map(dim.pprint_value, factors))
     nchars = np.max([len(f) for f in factors])
-    ranges = FactorRange(factors=factors)
-    ranges2 = Range1d(start=0, end=1)
     axis_label = dim_axis_label(dim)
-    reset = "range.setv({start: 0, end: range.factors.length})"
-    customjs = CustomJS(args=dict(range=ranges), code=reset)
-    ranges.js_on_change("start", customjs)
+
+    ticker = FixedTicker(ticks=[])
+    formatter = CustomJSTickFormatter(
+        args=dict(ticker=ticker, labels=factors),
+        code="const i = ticker.ticks.indexOf(tick); return i >= 0 ? String(labels[i]) : ''",
+    )
 
     axis_props = {}
     if label_size:
@@ -655,10 +664,12 @@ def make_axis(
         opts = dict(
             x_axis_type="auto",
             x_axis_label=axis_label,
-            x_range=ranges,
-            y_range=ranges2,
+            x_range=Range1d(start=0, end=1),
+            y_range=Range1d(start=0, end=1),
             height=height,
             width=size,
+            min_border_left=0,
+            min_border_right=0,
         )
     else:
         # Adjust width to compensate for label rotation
@@ -669,7 +680,13 @@ def make_axis(
             + label_px
         )
         opts = dict(
-            y_axis_label=axis_label, x_range=ranges2, y_range=ranges, height=size, width=width
+            y_axis_label=axis_label,
+            x_range=Range1d(start=0, end=1),
+            y_range=Range1d(start=0, end=1),
+            height=size,
+            width=width,
+            min_border_top=0,
+            min_border_bottom=0,
         )
 
     p = figure(toolbar_location=None, tools=[], **opts)
@@ -677,25 +694,155 @@ def make_axis(
     p.grid.grid_line_alpha = 0
 
     if axis == "x":
-        p.align = "end"
+        p.align = "start"
         p.yaxis.visible = False
-        axis = p.xaxis[0]
+        pax = p.xaxis[0]
         if flip:
             p.above = p.below
             p.below = []
             p.xaxis[:] = p.above
     else:
+        p.align = "end"
         p.xaxis.visible = False
-        axis = p.yaxis[0]
+        pax = p.yaxis[0]
         if flip:
             p.right = p.left
             p.left = []
             p.yaxis[:] = p.right
-    axis.major_label_orientation = rotation
-    axis.major_label_text_align = align
-    axis.major_label_text_baseline = "middle"
-    axis.update(**axis_props)
-    return p
+    pax.ticker = ticker
+    pax.formatter = formatter
+    pax.major_label_orientation = rotation
+    pax.major_label_text_align = align
+    pax.major_label_text_baseline = "middle"
+    pax.update(**axis_props)
+    return p, ticker
+
+
+def bind_dynamic_axis_sizing(plots, x_axis=None, x_ticker=None, y_axis=None, y_ticker=None):
+    """Wires a CustomJS callback that measures the grid's real rendered
+    column/row sizes and drives the shared fake x/y axis figures
+    (built by make_axis) to match exactly -- correct regardless of
+    why a subplot's canvas grew beyond its frame_width/frame_height
+    (a legend, a colorbar, an un-merged toolbar, a real per-cell
+    axis, ...), since it reads the real rendered geometry (via
+    Bokeh.index) instead of estimating it.
+
+    The axis figure is sized to the plot frame only, not the full
+    canvas, so its line/label track the actual plot rather than
+    being centered across the plot+border canvas. See the comments
+    in the callback body for the mechanics.
+
+    """
+    if x_axis is None and y_axis is None:
+        return
+    figs = [fig for row in plots for fig in row if fig is not None]
+    if not figs:
+        return
+
+    callback = CustomJS(
+        args=dict(plots=plots, x_axis=x_axis, x_ticker=x_ticker, y_axis=y_axis, y_ticker=y_ticker),
+        code="""
+        // Bokeh.index only holds root-level views; a subplot's own view is
+        // nested under it (child_views), so it has to be found by walking down.
+        function collectViews() {
+            const map = {}
+            function walk(view) {
+                if (view.model != null) map[view.model.id] = view
+                const cv = view.child_views
+                if (cv != null) {
+                    for (const child of cv.values()) walk(child)
+                }
+            }
+            for (const rootId of Object.keys(Bokeh.index)) walk(Bokeh.index[rootId])
+            return map
+        }
+        const views = collectViews()
+        function frameRect(fig) {
+            const view = views[fig.id]
+            if (view == null) return null
+            const outer = view.bbox
+            const inner = view.frame_view ? view.frame_view.bbox : null
+            if (outer == null || inner == null) return null
+            // bbox is parent-relative, frame_view.bbox is canvas-local (0-based)
+            // -- different reference frames, so never mix deltas across them.
+            const outerWidth = outer.x1 - outer.x0
+            const outerHeight = outer.y1 - outer.y0
+            return {
+                outerWidth,
+                outerHeight,
+                frameWidth: inner.x1 - inner.x0,
+                frameHeight: inner.y1 - inner.y0,
+                leadingLeft: inner.x0,
+                leadingBottom: outerHeight - inner.y1,
+            }
+        }
+        // outerSizeOf/leadingOf locate the frame within a cell's full canvas,
+        // for offsets; frameSizeOf is the plot itself, for length/centers.
+        function measureDim(nOuter, nInner, cellAt, outerSizeOf, frameSizeOf, leadingOf) {
+            const outerSizes = [], frameSizes = [], leadings = []
+            for (let o = 0; o < nOuter; o++) {
+                let outerSize = null, frameSize = null, leading = null
+                for (let i = 0; i < nInner; i++) {
+                    const fig = cellAt(o, i)
+                    if (fig == null) continue
+                    const rect = frameRect(fig)
+                    if (rect == null) continue
+                    const os = outerSizeOf(rect)
+                    if (outerSize == null || os > outerSize) {
+                        outerSize = os
+                        frameSize = frameSizeOf(rect)
+                        leading = leadingOf(rect)
+                    }
+                }
+                if (outerSize == null) return null
+                outerSizes.push(outerSize)
+                frameSizes.push(frameSize)
+                leadings.push(leading)
+            }
+            let offset = 0
+            const plotStarts = []
+            for (let i = 0; i < outerSizes.length; i++) {
+                plotStarts.push(offset + leadings[i])
+                offset += outerSizes[i]
+            }
+            // Round before computing centers, not after -- otherwise a tick's
+            // rendered position drifts from its intended one, more so for
+            // later ticks, since width/margin can only be set to whole pixels.
+            const base = Math.round(plotStarts[0])
+            const total = Math.round(plotStarts[plotStarts.length - 1] + frameSizes[frameSizes.length - 1]) - base
+            if (total === 0) return null
+            const centers = plotStarts.map((s, i) => (s - base + frameSizes[i] / 2) / total)
+            return {total, centers, lead: base}
+        }
+        const nRows = plots.length
+        const nCols = nRows > 0 ? plots[0].length : 0
+        if (x_axis != null) {
+            const result = measureDim(
+                nCols, nRows, (c, r) => plots[r][c],
+                (rect) => rect.outerWidth, (rect) => rect.frameWidth, (rect) => rect.leadingLeft,
+            )
+            if (result != null) {
+                x_axis.width = result.total
+                x_ticker.ticks = result.centers
+                x_axis.margin = [0, 0, 0, result.lead]  // shifts past the leading gutter
+            }
+        }
+        if (y_axis != null) {
+            const result = measureDim(
+                nRows, nCols, (r, c) => plots[r][c],
+                (rect) => rect.outerHeight, (rect) => rect.frameHeight, (rect) => rect.leadingBottom,
+            )
+            if (result != null) {
+                y_axis.height = result.total
+                y_ticker.ticks = result.centers
+                y_axis.margin = [0, 0, result.lead, 0]
+            }
+        }
+        """,
+    )
+    for fig in figs:
+        fig.js_on_change("outer_width", callback)
+        fig.js_on_change("outer_height", callback)
 
 
 def hsv_to_rgb(hsv):

--- a/holoviews/tests/ui/bokeh/test_gridplot.py
+++ b/holoviews/tests/ui/bokeh/test_gridplot.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from itertools import product
+
 import numpy as np
 import pytest
 
@@ -13,10 +15,6 @@ pytestmark = pytest.mark.ui
 TICK_TOL = 0.01
 SIZE_TOL = 2  # pixels
 
-# Reads the real rendered geometry (Bokeh.index walk + view.frame_view.bbox,
-# same technique GridPlot's own dynamic axis sizing uses) of GridPlot's
-# shared fake x/y axis figures -- identified by carrying a FixedTicker,
-# which only make_axis's axes use.
 _MEASURE_JS = """() => {
     function collectViews() {
         const map = {}
@@ -28,6 +26,10 @@ _MEASURE_JS = """() => {
         for (const rootId of Object.keys(Bokeh.index)) walk(Bokeh.index[rootId])
         return map
     }
+    function fixedTicks(axes) {
+        const axis = (axes || []).find((a) => a.ticker && a.ticker.type === "FixedTicker")
+        return axis && axis.ticker.ticks.length ? axis.ticker.ticks.slice() : null
+    }
     const views = collectViews()
     const out = []
     for (const id of Object.keys(views)) {
@@ -35,23 +37,17 @@ _MEASURE_JS = """() => {
         if (model == null || model.type !== "Figure") continue
         const inner = views[id].frame_view ? views[id].frame_view.bbox : null
         if (inner == null) continue
-        // model.xaxis/model.yaxis are Python-only convenience properties,
-        // not real BokehJS getters -- find axes via the actual above/
-        // below/left/right layout lists instead.
-        function fixedTicks(axes) {
-            const axis = (axes || []).find((a) => a.ticker && a.ticker.type === "FixedTicker")
-            return axis && axis.ticker.ticks.length ? axis.ticker.ticks.slice() : null
-        }
         const xTicks = fixedTicks([...(model.above || []), ...(model.below || [])])
         const yTicks = fixedTicks([...(model.left || []), ...(model.right || [])])
         if (xTicks || yTicks) {
             const outerRect = views[id].el.getBoundingClientRect()
             out.push({
-                frameStartX: outerRect.x + inner.x0,
-                frameStartY: outerRect.y + inner.y0,
-                frameWidth: inner.x1 - inner.x0,
-                frameHeight: inner.y1 - inner.y0,
-                xTicks, yTicks,
+                start_x: outerRect.x + inner.x0,
+                start_y: outerRect.y + inner.y0,
+                width: inner.x1 - inner.x0,
+                height: inner.y1 - inner.y0,
+                ticks_x: xTicks,
+                ticks_y: yTicks,
             })
         }
     }
@@ -59,118 +55,65 @@ _MEASURE_JS = """() => {
 }"""
 
 
-def _measure_axes(page):
-    return page.evaluate(_MEASURE_JS)
-
-
-def _assert_axes(page, x=None, y=None):
-    """Asserts GridPlot's shared fake x/y axes render at fixed, previously
-    verified pixel start/end positions and tick fractions -- golden values,
-    not values re-measured from the same page, so a Bokeh-side layout
-    change actually surfaces as a failure instead of silently moving both
-    sides together.
-
-    `x`/`y` are (start, end, ticks) triples; pass None to skip an axis.
-    """
-    wait_until(lambda: bool(_measure_axes(page)), page)
-    axes = _measure_axes(page)
+def assert_axes(page, x=None, y=None) -> None:
+    wait_until(lambda: bool(page.evaluate(_MEASURE_JS)), page)
+    axes = page.evaluate(_MEASURE_JS)
 
     if x is not None:
-        start, end, ticks = x
-        entry = next(a for a in axes if a["xTicks"])
-        assert entry["frameStartX"] == pytest.approx(start, abs=SIZE_TOL)
-        assert entry["frameStartX"] + entry["frameWidth"] == pytest.approx(end, abs=SIZE_TOL)
-        np.testing.assert_allclose(entry["xTicks"], ticks, atol=TICK_TOL)
+        start, end, *ticks = x
+        entry = next(a for a in axes if a["ticks_x"])
+        assert entry["start_x"] == pytest.approx(start, abs=SIZE_TOL)
+        assert entry["start_x"] + entry["width"] == pytest.approx(end, abs=SIZE_TOL)
+        np.testing.assert_allclose(entry["ticks_x"], ticks, atol=TICK_TOL)
 
     if y is not None:
-        start, end, ticks = y
-        entry = next(a for a in axes if a["yTicks"])
-        assert entry["frameStartY"] == pytest.approx(start, abs=SIZE_TOL)
-        assert entry["frameStartY"] + entry["frameHeight"] == pytest.approx(end, abs=SIZE_TOL)
-        np.testing.assert_allclose(entry["yTicks"], ticks, atol=TICK_TOL)
+        start, end, *ticks = y
+        entry = next(a for a in axes if a["ticks_y"])
+        assert entry["start_y"] == pytest.approx(start, abs=SIZE_TOL)
+        assert entry["start_y"] + entry["height"] == pytest.approx(end, abs=SIZE_TOL)
+        np.testing.assert_allclose(entry["ticks_y"], ticks, atol=TICK_TOL)
 
 
 @pytest.mark.usefixtures("bokeh_backend")
-@pytest.mark.parametrize("shared_xaxis", [True, False])
-@pytest.mark.parametrize("shared_yaxis", [True, False])
-def test_gridplot_axis_alignment_combinations(serve_hv, shared_xaxis, shared_yaxis):
-    curves = {(x, y): hv.Curve(np.arange(10) * (x + y + 1)) for x in range(2) for y in range(2)}
-    gridspace = hv.GridSpace(curves, kdims=["x", "y"]).opts(
-        shared_xaxis=shared_xaxis, shared_yaxis=shared_yaxis
-    )
+def test_gridplot(serve_hv):
+    curves = {(x, y): hv.Curve([0, 1]) for x, y in product(range(2), range(2, 4))}
+    gridspace = hv.GridSpace(curves, kdims=["x", "y"])
 
-    plot = BokehRenderer.get_plot(gridspace)
-    page = serve_hv(plot)
+    page = serve_hv(gridspace)
 
-    ticks = [0.243902, 0.756098]
-    # Flipping shared_xaxis/shared_yaxis moves the fake axis to the far
-    # side of the grid, so start/end differ per combination even though
-    # size and tick fractions don't.
-    x_start_end, y_start_end = {
-        (True, True): ((49, 295), (92, 338)),
-        (True, False): ((71, 317), (92, 338)),
-        (False, True): ((49, 295), (33, 279)),
-        (False, False): ((71, 317), (33, 279)),
-    }[shared_xaxis, shared_yaxis]
-
-    _assert_axes(
-        page,
-        x=(*x_start_end, ticks),
-        y=(*y_start_end, ticks),
-    )
+    ticks = (0.243902, 0.756098)
+    assert_axes(page, x=(71, 317, *ticks), y=(33, 279, *ticks))
 
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_gridplot_legend_alignment(serve_hv):
-    # A legend on one cell grows that cell's rendered canvas past
-    # frame_width -- the fake axis has to track the real width, not the
-    # nominal frame_width, or its ticks drift out from under later columns.
-    powers = [1, 2, 3]
-    amplitudes = [0.5, 0.75, 1.0]
-    gridspace = hv.GridSpace(kdims=["Amplitude", "Power"])
-    for power in powers:
-        for amplitude in amplitudes:
-            lines = hv.NdOverlay({0: hv.Curve([0, 1]), 1: hv.Curve([1, 0])}, kdims="Phase")
-            gridspace[amplitude, power] = lines
-    gridspace = gridspace.opts(show_legend=True)
+    plot = hv.NdOverlay({0: hv.Curve([0, 1]), 1: hv.Curve([1, 0])})
+    gridspace = hv.GridSpace(kdims=["x", "y"]).opts(show_legend=True)
+    for power, amplitude in product(range(3), range(3, 6)):
+        gridspace[amplitude, power] = plot
 
-    plot = BokehRenderer.get_plot(gridspace)
-    page = serve_hv(plot)
+    page = serve_hv(gridspace)
 
-    ticks = [0.161290, 0.5, 0.838710]
-    _assert_axes(page, x=(71, 443, ticks), y=(33, 405, ticks))
+    ticks = (0.161290, 0.5, 0.838710)
+    assert_axes(page, x=(71, 443, *ticks), y=(33, 405, *ticks))
 
 
 @pytest.mark.usefixtures("bokeh_backend")
-@pytest.mark.parametrize(
-    ("colorbar", "end"),
-    [(True, 1132), (False, 788)],
-)
-def test_gridplot_colorbar_alignment(serve_hv, colorbar, end):
-    # A per-cell colorbar grows that cell's canvas the same way a legend
-    # does; exercised separately since colorbar width tracks its own
-    # formatter/label width rather than a legend's entries.
-    np.random.seed(0)
-    data = np.random.randn(5, 3, 4)
-    lons = np.linspace(1, 100, 4)
-    lats = np.linspace(1, 100, 3)
-    images = {
-        t: hv.Image((lons, lats, data[i]), kdims=["lon", "lat"], vdims=["value"])
-        for i, t in enumerate([1, 2, 3, 4, 5])
-    }
-    gridspace = hv.GridSpace(images, kdims=["time"]).opts(
-        hv.opts.Image(colorbar=colorbar),
-        hv.opts.GridSpace(shared_xaxis=True, shared_yaxis=True),
-    )
+@pytest.mark.parametrize("colorbar", [True, False])
+def test_gridplot_colorbar_alignment(serve_hv, colorbar):
+    x, y = np.arange(4), np.arange(3)
+    z = np.arange(12).reshape((3, 4))
+    img = hv.Image((x, y, z), kdims=["x", "y"], vdims=["z"]).opts(colorbar=colorbar)
+    gridspace = hv.GridSpace(dict.fromkeys(range(5), img), kdims=["t"])
 
-    plot = BokehRenderer.get_plot(gridspace)
-    page = serve_hv(plot)
+    page = serve_hv(gridspace)
 
-    ticks = {
-        True: [0.055762, 0.277881, 0.5, 0.722119, 0.944238],
-        False: [0.081967, 0.290984, 0.5, 0.709016, 0.918033],
-    }[colorbar]
-    _assert_axes(page, x=(56, end, ticks))
+    if colorbar:
+        x = (3, 1075, 0.055762, 0.277881, 0.5, 0.722119, 0.944238)
+    else:  # Without colorbar it has toolbar to right
+        x = (3, 735, 0.081967, 0.290984, 0.5, 0.709016, 0.918033)
+
+    assert_axes(page, x=x)
 
 
 @pytest.mark.usefixtures("bokeh_backend")
@@ -211,8 +154,8 @@ def test_gridplot_per_cell_axis_alignment(serve_hv, xaxis, yaxis):
         "bottom": ((92, 548), [0.131579, 0.5, 0.868421]),
     }[xaxis]
 
-    _assert_axes(
+    assert_axes(
         page,
-        x=(*x_start_end, x_ticks),
-        y=(*y_start_end, y_ticks),
+        x=(*x_start_end, *x_ticks),
+        y=(*y_start_end, *y_ticks),
     )

--- a/holoviews/tests/ui/bokeh/test_gridplot.py
+++ b/holoviews/tests/ui/bokeh/test_gridplot.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import holoviews as hv
+from holoviews.plotting.bokeh.renderer import BokehRenderer
+
+from .. import wait_until
+
+pytestmark = pytest.mark.ui
+
+TICK_TOL = 0.01
+SIZE_TOL = 2  # pixels
+
+# Reads the real rendered geometry (Bokeh.index walk + view.frame_view.bbox,
+# same technique GridPlot's own dynamic axis sizing uses) of GridPlot's
+# shared fake x/y axis figures -- identified by carrying a FixedTicker,
+# which only make_axis's axes use.
+_MEASURE_JS = """() => {
+    function collectViews() {
+        const map = {}
+        function walk(view) {
+            if (view.model != null) map[view.model.id] = view
+            const cv = view.child_views
+            if (cv != null) for (const child of cv.values()) walk(child)
+        }
+        for (const rootId of Object.keys(Bokeh.index)) walk(Bokeh.index[rootId])
+        return map
+    }
+    const views = collectViews()
+    const out = []
+    for (const id of Object.keys(views)) {
+        const model = views[id].model
+        if (model == null || model.type !== "Figure") continue
+        const inner = views[id].frame_view ? views[id].frame_view.bbox : null
+        if (inner == null) continue
+        // model.xaxis/model.yaxis are Python-only convenience properties,
+        // not real BokehJS getters -- find axes via the actual above/
+        // below/left/right layout lists instead.
+        function fixedTicks(axes) {
+            const axis = (axes || []).find((a) => a.ticker && a.ticker.type === "FixedTicker")
+            return axis && axis.ticker.ticks.length ? axis.ticker.ticks.slice() : null
+        }
+        const xTicks = fixedTicks([...(model.above || []), ...(model.below || [])])
+        const yTicks = fixedTicks([...(model.left || []), ...(model.right || [])])
+        if (xTicks || yTicks) {
+            const outerRect = views[id].el.getBoundingClientRect()
+            out.push({
+                frameStartX: outerRect.x + inner.x0,
+                frameStartY: outerRect.y + inner.y0,
+                frameWidth: inner.x1 - inner.x0,
+                frameHeight: inner.y1 - inner.y0,
+                xTicks, yTicks,
+            })
+        }
+    }
+    return out
+}"""
+
+
+def _measure_axes(page):
+    return page.evaluate(_MEASURE_JS)
+
+
+def _assert_axes(page, x=None, y=None):
+    """Asserts GridPlot's shared fake x/y axes render at fixed, previously
+    verified pixel start/end positions and tick fractions -- golden values,
+    not values re-measured from the same page, so a Bokeh-side layout
+    change actually surfaces as a failure instead of silently moving both
+    sides together.
+
+    `x`/`y` are (start, end, ticks) triples; pass None to skip an axis.
+    """
+    wait_until(lambda: bool(_measure_axes(page)), page)
+    axes = _measure_axes(page)
+
+    if x is not None:
+        start, end, ticks = x
+        entry = next(a for a in axes if a["xTicks"])
+        assert entry["frameStartX"] == pytest.approx(start, abs=SIZE_TOL)
+        assert entry["frameStartX"] + entry["frameWidth"] == pytest.approx(end, abs=SIZE_TOL)
+        np.testing.assert_allclose(entry["xTicks"], ticks, atol=TICK_TOL)
+
+    if y is not None:
+        start, end, ticks = y
+        entry = next(a for a in axes if a["yTicks"])
+        assert entry["frameStartY"] == pytest.approx(start, abs=SIZE_TOL)
+        assert entry["frameStartY"] + entry["frameHeight"] == pytest.approx(end, abs=SIZE_TOL)
+        np.testing.assert_allclose(entry["yTicks"], ticks, atol=TICK_TOL)
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+@pytest.mark.parametrize("shared_xaxis", [True, False])
+@pytest.mark.parametrize("shared_yaxis", [True, False])
+def test_gridplot_axis_alignment_combinations(serve_hv, shared_xaxis, shared_yaxis):
+    curves = {(x, y): hv.Curve(np.arange(10) * (x + y + 1)) for x in range(2) for y in range(2)}
+    gridspace = hv.GridSpace(curves, kdims=["x", "y"]).opts(
+        shared_xaxis=shared_xaxis, shared_yaxis=shared_yaxis
+    )
+
+    plot = BokehRenderer.get_plot(gridspace)
+    page = serve_hv(plot)
+
+    ticks = [0.243902, 0.756098]
+    # Flipping shared_xaxis/shared_yaxis moves the fake axis to the far
+    # side of the grid, so start/end differ per combination even though
+    # size and tick fractions don't.
+    x_start_end, y_start_end = {
+        (True, True): ((49, 295), (92, 338)),
+        (True, False): ((71, 317), (92, 338)),
+        (False, True): ((49, 295), (33, 279)),
+        (False, False): ((71, 317), (33, 279)),
+    }[shared_xaxis, shared_yaxis]
+
+    _assert_axes(
+        page,
+        x=(*x_start_end, ticks),
+        y=(*y_start_end, ticks),
+    )
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_gridplot_legend_alignment(serve_hv):
+    # A legend on one cell grows that cell's rendered canvas past
+    # frame_width -- the fake axis has to track the real width, not the
+    # nominal frame_width, or its ticks drift out from under later columns.
+    powers = [1, 2, 3]
+    amplitudes = [0.5, 0.75, 1.0]
+    gridspace = hv.GridSpace(kdims=["Amplitude", "Power"])
+    for power in powers:
+        for amplitude in amplitudes:
+            lines = hv.NdOverlay({0: hv.Curve([0, 1]), 1: hv.Curve([1, 0])}, kdims="Phase")
+            gridspace[amplitude, power] = lines
+    gridspace = gridspace.opts(show_legend=True)
+
+    plot = BokehRenderer.get_plot(gridspace)
+    page = serve_hv(plot)
+
+    ticks = [0.161290, 0.5, 0.838710]
+    _assert_axes(page, x=(71, 443, ticks), y=(33, 405, ticks))
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+@pytest.mark.parametrize(
+    ("colorbar", "end"),
+    [(True, 1132), (False, 788)],
+)
+def test_gridplot_colorbar_alignment(serve_hv, colorbar, end):
+    # A per-cell colorbar grows that cell's canvas the same way a legend
+    # does; exercised separately since colorbar width tracks its own
+    # formatter/label width rather than a legend's entries.
+    np.random.seed(0)
+    data = np.random.randn(5, 3, 4)
+    lons = np.linspace(1, 100, 4)
+    lats = np.linspace(1, 100, 3)
+    images = {
+        t: hv.Image((lons, lats, data[i]), kdims=["lon", "lat"], vdims=["value"])
+        for i, t in enumerate([1, 2, 3, 4, 5])
+    }
+    gridspace = hv.GridSpace(images, kdims=["time"]).opts(
+        hv.opts.Image(colorbar=colorbar),
+        hv.opts.GridSpace(shared_xaxis=True, shared_yaxis=True),
+    )
+
+    plot = BokehRenderer.get_plot(gridspace)
+    page = serve_hv(plot)
+
+    ticks = {
+        True: [0.055762, 0.277881, 0.5, 0.722119, 0.944238],
+        False: [0.081967, 0.290984, 0.5, 0.709016, 0.918033],
+    }[colorbar]
+    _assert_axes(page, x=(56, end, ticks))
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+@pytest.mark.parametrize("xaxis", [None, "bottom"])
+@pytest.mark.parametrize("yaxis", [None, "right"])
+def test_gridplot_per_cell_axis_alignment(serve_hv, xaxis, yaxis):
+    # A real (visible) per-cell x/y-axis on every cell adds the same
+    # "leading gutter" to every cell in a row/column, unlike a legend
+    # or colorbar which only widens the one cell that carries it -- a
+    # different code path in bind_dynamic_axis_sizing's leading-edge
+    # tracking. Sparse on purpose, to also exercise empty cells.
+    years = [2023, 2024]
+    months = [5, 6, 7]
+    points = {(2023, 5): [(1, 4)], (2024, 6): [(1, 8)], (2024, 7): [(1, 8)]}
+    items = {
+        (year, month): hv.Scatter(points.get((year, month), []))
+        for year in years
+        for month in months
+    }
+    gridspace = hv.GridSpace(items, kdims=["year", "month"]).opts(
+        hv.opts.Scatter(xaxis=xaxis, yaxis=yaxis, show_legend=False),
+        hv.opts.GridSpace(shared_xaxis=True, shared_yaxis=True),
+    )
+
+    plot = BokehRenderer.get_plot(gridspace)
+    page = serve_hv(plot)
+
+    # A real per-cell y-axis grows every cell's horizontal space, which
+    # the fake x-axis has to track; a real per-cell x-axis grows every
+    # cell's vertical space, tracked by the fake y-axis -- crossed, not
+    # matched by name.
+    x_start_end, x_ticks = {
+        None: ((3, 249), [0.243902, 0.756098]),
+        "right": ((3, 289), [0.209790, 0.790210]),
+    }[yaxis]
+    y_start_end, y_ticks = {
+        None: ((92, 464), [0.161290, 0.5, 0.838710]),
+        "bottom": ((92, 548), [0.131579, 0.5, 0.868421]),
+    }[xaxis]
+
+    _assert_axes(
+        page,
+        x=(*x_start_end, x_ticks),
+        y=(*y_start_end, y_ticks),
+    )

--- a/holoviews/tests/ui/bokeh/test_gridspace.py
+++ b/holoviews/tests/ui/bokeh/test_gridspace.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 import holoviews as hv
-from holoviews.plotting.bokeh.renderer import BokehRenderer
 
 from .. import wait_until
 
@@ -75,10 +74,9 @@ def assert_axes(page, x=None, y=None) -> None:
 
 
 @pytest.mark.usefixtures("bokeh_backend")
-def test_gridplot(serve_hv):
+def test_gridspace(serve_hv):
     curves = {(x, y): hv.Curve([0, 1]) for x, y in product(range(2), range(2, 4))}
     gridspace = hv.GridSpace(curves, kdims=["x", "y"])
-
     page = serve_hv(gridspace)
 
     ticks = (0.243902, 0.756098)
@@ -86,12 +84,11 @@ def test_gridplot(serve_hv):
 
 
 @pytest.mark.usefixtures("bokeh_backend")
-def test_gridplot_legend_alignment(serve_hv):
+def test_gridspace_legend_alignment(serve_hv):
     plot = hv.NdOverlay({0: hv.Curve([0, 1]), 1: hv.Curve([1, 0])})
     gridspace = hv.GridSpace(kdims=["x", "y"]).opts(show_legend=True)
     for power, amplitude in product(range(3), range(3, 6)):
         gridspace[amplitude, power] = plot
-
     page = serve_hv(gridspace)
 
     ticks = (0.161290, 0.5, 0.838710)
@@ -100,12 +97,11 @@ def test_gridplot_legend_alignment(serve_hv):
 
 @pytest.mark.usefixtures("bokeh_backend")
 @pytest.mark.parametrize("colorbar", [True, False])
-def test_gridplot_colorbar_alignment(serve_hv, colorbar):
+def test_gridspace_colorbar_alignment(serve_hv, colorbar):
     x, y = np.arange(4), np.arange(3)
     z = np.arange(12).reshape((3, 4))
     img = hv.Image((x, y, z), kdims=["x", "y"], vdims=["z"]).opts(colorbar=colorbar)
     gridspace = hv.GridSpace(dict.fromkeys(range(5), img), kdims=["t"])
-
     page = serve_hv(gridspace)
 
     if colorbar:
@@ -117,45 +113,44 @@ def test_gridplot_colorbar_alignment(serve_hv, colorbar):
 
 
 @pytest.mark.usefixtures("bokeh_backend")
-@pytest.mark.parametrize("xaxis", [None, "bottom"])
-@pytest.mark.parametrize("yaxis", [None, "right"])
-def test_gridplot_per_cell_axis_alignment(serve_hv, xaxis, yaxis):
-    # A real (visible) per-cell x/y-axis on every cell adds the same
-    # "leading gutter" to every cell in a row/column, unlike a legend
-    # or colorbar which only widens the one cell that carries it -- a
-    # different code path in bind_dynamic_axis_sizing's leading-edge
-    # tracking. Sparse on purpose, to also exercise empty cells.
-    years = [2023, 2024]
-    months = [5, 6, 7]
-    points = {(2023, 5): [(1, 4)], (2024, 6): [(1, 8)], (2024, 7): [(1, 8)]}
-    items = {
-        (year, month): hv.Scatter(points.get((year, month), []))
-        for year in years
-        for month in months
-    }
-    gridspace = hv.GridSpace(items, kdims=["year", "month"]).opts(
-        hv.opts.Scatter(xaxis=xaxis, yaxis=yaxis, show_legend=False),
-        hv.opts.GridSpace(shared_xaxis=True, shared_yaxis=True),
+@pytest.mark.parametrize("xaxis", [None, "bottom", "top"])
+@pytest.mark.parametrize("yaxis", [None, "right", "left"])
+@pytest.mark.parametrize("shared_xaxis", [True, False])
+@pytest.mark.parametrize("shared_yaxis", [True, False])
+def test_gridspace_axis_alignment(serve_hv, xaxis, yaxis, shared_xaxis, shared_yaxis):
+    curves = {(x, y): hv.Curve([0, 1]) for x, y in product(range(2), range(2, 5))}
+    gridspace = hv.GridSpace(curves, kdims=["x", "y"]).opts(
+        hv.opts.Curve(xaxis=xaxis, yaxis=yaxis),
+        hv.opts.GridSpace(shared_xaxis=shared_xaxis, shared_yaxis=shared_yaxis),
     )
+    page = serve_hv(gridspace)
 
-    plot = BokehRenderer.get_plot(gridspace)
-    page = serve_hv(plot)
+    match shared_yaxis, yaxis:
+        case False, None:
+            x = (71, 317, 0.243902, 0.756098)
+        case False, "left":
+            x = (120, 415, 0.203390, 0.796610)
+        case False, "right":
+            x = (71, 366, 0.203390, 0.796610)
+        case True, None:
+            x = (3, 249, 0.243902, 0.756098)
+        case True, "left":
+            x = (52, 347, 0.203390, 0.796610)
+        case True, "right":
+            x = (3, 298, 0.203390, 0.796610)
 
-    # A real per-cell y-axis grows every cell's horizontal space, which
-    # the fake x-axis has to track; a real per-cell x-axis grows every
-    # cell's vertical space, tracked by the fake y-axis -- crossed, not
-    # matched by name.
-    x_start_end, x_ticks = {
-        None: ((3, 249), [0.243902, 0.756098]),
-        "right": ((3, 289), [0.209790, 0.790210]),
-    }[yaxis]
-    y_start_end, y_ticks = {
-        None: ((92, 464), [0.161290, 0.5, 0.838710]),
-        "bottom": ((92, 548), [0.131579, 0.5, 0.868421]),
-    }[xaxis]
+    match shared_xaxis, xaxis:
+        case False, None:
+            y = (33, 405, 0.161290, 0.5, 0.838710)
+        case False, "bottom":
+            y = (33, 489, 0.131579, 0.5, 0.868421)
+        case False, "top":
+            y = (75, 531, 0.131579, 0.5, 0.868421)
+        case True, None:
+            y = (92, 464, 0.161290, 0.5, 0.838710)
+        case True, "bottom":
+            y = (92, 548, 0.131579, 0.5, 0.868421)
+        case True, "top":
+            y = (134, 590, 0.131579, 0.5, 0.868421)
 
-    assert_axes(
-        page,
-        x=(*x_start_end, *x_ticks),
-        y=(*y_start_end, *y_ticks),
-    )
+    assert_axes(page, x=x, y=y)

--- a/holoviews/tests/ui/bokeh/test_gridspace.py
+++ b/holoviews/tests/ui/bokeh/test_gridspace.py
@@ -11,7 +11,6 @@ from .. import wait_until
 
 pytestmark = pytest.mark.ui
 
-TICK_TOL = 0.01
 SIZE_TOL = 2  # pixels
 
 _MEASURE_JS = """() => {
@@ -59,18 +58,20 @@ def assert_axes(page, x=None, y=None) -> None:
     axes = page.evaluate(_MEASURE_JS)
 
     if x is not None:
-        start, end, *ticks = x
+        start, *ticks, end = x
         entry = next(a for a in axes if a["ticks_x"])
         assert entry["start_x"] == pytest.approx(start, abs=SIZE_TOL)
         assert entry["start_x"] + entry["width"] == pytest.approx(end, abs=SIZE_TOL)
-        np.testing.assert_allclose(entry["ticks_x"], ticks, atol=TICK_TOL)
+        tick_px = entry["start_x"] + np.array(entry["ticks_x"]) * entry["width"]
+        np.testing.assert_allclose(tick_px, ticks, atol=SIZE_TOL)
 
     if y is not None:
-        start, end, *ticks = y
+        start, *ticks, end = y
         entry = next(a for a in axes if a["ticks_y"])
         assert entry["start_y"] == pytest.approx(start, abs=SIZE_TOL)
         assert entry["start_y"] + entry["height"] == pytest.approx(end, abs=SIZE_TOL)
-        np.testing.assert_allclose(entry["ticks_y"], ticks, atol=TICK_TOL)
+        tick_px = entry["start_y"] + np.array(entry["ticks_y"]) * entry["height"]
+        np.testing.assert_allclose(tick_px, ticks, atol=SIZE_TOL)
 
 
 @pytest.mark.usefixtures("bokeh_backend")
@@ -79,8 +80,7 @@ def test_gridspace(serve_hv):
     gridspace = hv.GridSpace(curves, kdims=["x", "y"])
     page = serve_hv(gridspace)
 
-    ticks = (0.243902, 0.756098)
-    assert_axes(page, x=(71, 317, *ticks), y=(33, 279, *ticks))
+    assert_axes(page, x=(71, 131, 257, 317), y=(33, 93, 219, 279))
 
 
 @pytest.mark.usefixtures("bokeh_backend")
@@ -91,8 +91,7 @@ def test_gridspace_legend_alignment(serve_hv):
         gridspace[amplitude, power] = plot
     page = serve_hv(gridspace)
 
-    ticks = (0.161290, 0.5, 0.838710)
-    assert_axes(page, x=(71, 443, *ticks), y=(33, 405, *ticks))
+    assert_axes(page, x=(71, 131, 257, 383, 443), y=(33, 93, 219, 345, 405))
 
 
 @pytest.mark.usefixtures("bokeh_backend")
@@ -105,9 +104,9 @@ def test_gridspace_colorbar_alignment(serve_hv, colorbar):
     page = serve_hv(gridspace)
 
     if colorbar:
-        x = (3, 1075, 0.055762, 0.277881, 0.5, 0.722119, 0.944238)
+        x = (3, 63, 301, 539, 777, 1015, 1075)
     else:  # Without colorbar it has toolbar to right
-        x = (3, 735, 0.081967, 0.290984, 0.5, 0.709016, 0.918033)
+        x = (3, 63, 216, 369, 522, 675, 735)
 
     assert_axes(page, x=x)
 
@@ -127,30 +126,30 @@ def test_gridspace_axis_alignment(serve_hv, xaxis, yaxis, shared_xaxis, shared_y
 
     match shared_yaxis, yaxis:
         case False, None:
-            x = (71, 317, 0.243902, 0.756098)
+            x = (71, 131, 257, 317)
         case False, "left":
-            x = (120, 415, 0.203390, 0.796610)
+            x = (120, 180, 355, 415)
         case False, "right":
-            x = (71, 366, 0.203390, 0.796610)
+            x = (71, 131, 306, 366)
         case True, None:
-            x = (3, 249, 0.243902, 0.756098)
+            x = (3, 63, 189, 249)
         case True, "left":
-            x = (52, 347, 0.203390, 0.796610)
+            x = (52, 112, 287, 347)
         case True, "right":
-            x = (3, 298, 0.203390, 0.796610)
+            x = (3, 63, 238, 298)
 
     match shared_xaxis, xaxis:
         case False, None:
-            y = (33, 405, 0.161290, 0.5, 0.838710)
+            y = (33, 93, 219, 345, 405)
         case False, "bottom":
-            y = (33, 489, 0.131579, 0.5, 0.868421)
+            y = (33, 93, 261, 429, 489)
         case False, "top":
-            y = (75, 531, 0.131579, 0.5, 0.868421)
+            y = (75, 135, 303, 471, 531)
         case True, None:
-            y = (92, 464, 0.161290, 0.5, 0.838710)
+            y = (92, 152, 278, 404, 464)
         case True, "bottom":
-            y = (92, 548, 0.131579, 0.5, 0.868421)
+            y = (92, 152, 320, 488, 548)
         case True, "top":
-            y = (134, 590, 0.131579, 0.5, 0.868421)
+            y = (134, 194, 362, 530, 590)
 
     assert_axes(page, x=x, y=y)

--- a/holoviews/tests/ui/bokeh/test_gridspace.py
+++ b/holoviews/tests/ui/bokeh/test_gridspace.py
@@ -11,34 +11,21 @@ from .. import wait_until
 
 pytestmark = pytest.mark.ui
 
-SIZE_TOL = 2  # pixels
-
 _MEASURE_JS = """() => {
-    function collectViews() {
-        const map = {}
-        function walk(view) {
-            if (view.model != null) map[view.model.id] = view
-            const cv = view.child_views
-            if (cv != null) for (const child of cv.values()) walk(child)
-        }
-        for (const rootId of Object.keys(Bokeh.index)) walk(Bokeh.index[rootId])
-        return map
-    }
     function fixedTicks(axes) {
         const axis = (axes || []).find((a) => a.ticker && a.ticker.type === "FixedTicker")
         return axis && axis.ticker.ticks.length ? axis.ticker.ticks.slice() : null
     }
-    const views = collectViews()
     const out = []
-    for (const id of Object.keys(views)) {
-        const model = views[id].model
+    for (const view of Bokeh.index.all_views()) {
+        const model = view.model
         if (model == null || model.type !== "Figure") continue
-        const inner = views[id].frame_view ? views[id].frame_view.bbox : null
+        const inner = view.frame_view ? view.frame_view.bbox : null
         if (inner == null) continue
         const xTicks = fixedTicks([...(model.above || []), ...(model.below || [])])
         const yTicks = fixedTicks([...(model.left || []), ...(model.right || [])])
         if (xTicks || yTicks) {
-            const outerRect = views[id].el.getBoundingClientRect()
+            const outerRect = view.el.getBoundingClientRect()
             out.push({
                 start_x: outerRect.x + inner.x0,
                 start_y: outerRect.y + inner.y0,
@@ -56,41 +43,42 @@ _MEASURE_JS = """() => {
 def assert_axes(page, x=None, y=None) -> None:
     wait_until(lambda: bool(page.evaluate(_MEASURE_JS)), page)
     axes = page.evaluate(_MEASURE_JS)
+    assert len(axes) == bool(x) + bool(y)
 
     if x is not None:
         start, *ticks, end = x
         entry = next(a for a in axes if a["ticks_x"])
-        assert entry["start_x"] == pytest.approx(start, abs=SIZE_TOL)
-        assert entry["start_x"] + entry["width"] == pytest.approx(end, abs=SIZE_TOL)
+        assert entry["start_x"] == pytest.approx(start, abs=2)
+        assert entry["start_x"] + entry["width"] == pytest.approx(end, abs=2)
         tick_px = entry["start_x"] + np.array(entry["ticks_x"]) * entry["width"]
-        np.testing.assert_allclose(tick_px, ticks, atol=SIZE_TOL)
+        np.testing.assert_allclose(tick_px, ticks, atol=2)
 
     if y is not None:
         start, *ticks, end = y
         entry = next(a for a in axes if a["ticks_y"])
-        assert entry["start_y"] == pytest.approx(start, abs=SIZE_TOL)
-        assert entry["start_y"] + entry["height"] == pytest.approx(end, abs=SIZE_TOL)
+        assert entry["start_y"] == pytest.approx(start, abs=2)
+        assert entry["start_y"] + entry["height"] == pytest.approx(end, abs=2)
         tick_px = entry["start_y"] + np.array(entry["ticks_y"]) * entry["height"]
-        np.testing.assert_allclose(tick_px, ticks, atol=SIZE_TOL)
+        np.testing.assert_allclose(tick_px, ticks, atol=2)
 
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_gridspace(serve_hv):
-    curves = {(x, y): hv.Curve([0, 1]) for x, y in product(range(2), range(2, 4))}
-    gridspace = hv.GridSpace(curves, kdims=["x", "y"])
-    page = serve_hv(gridspace)
+    plot = hv.Curve([0, 1])
+    plots = dict.fromkeys(product(range(2), range(2, 4)), plot)
+    gridspace = hv.GridSpace(plots, kdims=["x", "y"])
 
+    page = serve_hv(gridspace)
     assert_axes(page, x=(71, 131, 257, 317), y=(33, 93, 219, 279))
 
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_gridspace_legend_alignment(serve_hv):
     plot = hv.NdOverlay({0: hv.Curve([0, 1]), 1: hv.Curve([1, 0])})
-    gridspace = hv.GridSpace(kdims=["x", "y"]).opts(show_legend=True)
-    for power, amplitude in product(range(3), range(3, 6)):
-        gridspace[amplitude, power] = plot
-    page = serve_hv(gridspace)
+    plots = dict.fromkeys(product(range(3), range(3, 6)), plot)
+    gridspace = hv.GridSpace(plots, kdims=["x", "y"]).opts(show_legend=True)
 
+    page = serve_hv(gridspace)
     assert_axes(page, x=(71, 131, 257, 383, 443), y=(33, 93, 219, 345, 405))
 
 
@@ -101,13 +89,13 @@ def test_gridspace_colorbar_alignment(serve_hv, colorbar):
     z = np.arange(12).reshape((3, 4))
     img = hv.Image((x, y, z), kdims=["x", "y"], vdims=["z"]).opts(colorbar=colorbar)
     gridspace = hv.GridSpace(dict.fromkeys(range(5), img), kdims=["t"])
-    page = serve_hv(gridspace)
 
     if colorbar:
         x = (3, 63, 301, 539, 777, 1015, 1075)
-    else:  # Without colorbar it has toolbar to right
+    else:  # Without colorbar it still has toolbar to the right
         x = (3, 63, 216, 369, 522, 675, 735)
 
+    page = serve_hv(gridspace)
     assert_axes(page, x=x)
 
 
@@ -117,12 +105,11 @@ def test_gridspace_colorbar_alignment(serve_hv, colorbar):
 @pytest.mark.parametrize("shared_xaxis", [True, False])
 @pytest.mark.parametrize("shared_yaxis", [True, False])
 def test_gridspace_axis_alignment(serve_hv, xaxis, yaxis, shared_xaxis, shared_yaxis):
-    curves = {(x, y): hv.Curve([0, 1]) for x, y in product(range(2), range(2, 5))}
-    gridspace = hv.GridSpace(curves, kdims=["x", "y"]).opts(
-        hv.opts.Curve(xaxis=xaxis, yaxis=yaxis),
-        hv.opts.GridSpace(shared_xaxis=shared_xaxis, shared_yaxis=shared_yaxis),
+    plot = hv.Curve([0, 1]).opts(xaxis=xaxis, yaxis=yaxis)
+    plots = dict.fromkeys(product(range(2), range(2, 5)), plot)
+    gridspace = hv.GridSpace(plots, kdims=["x", "y"]).opts(
+        shared_xaxis=shared_xaxis, shared_yaxis=shared_yaxis
     )
-    page = serve_hv(gridspace)
 
     match shared_yaxis, yaxis:
         case False, None:
@@ -152,4 +139,5 @@ def test_gridspace_axis_alignment(serve_hv, xaxis, yaxis, shared_xaxis, shared_y
         case True, "top":
             y = (134, 194, 362, 530, 590)
 
+    page = serve_hv(gridspace)
     assert_axes(page, x=x, y=y)


### PR DESCRIPTION
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes https://github.com/holoviz/holoviews/issues/5438
Fixes https://github.com/holoviz/holoviews/issues/6064


This pr now makes it so we client side calculate the size and tick locations of the plot.

Also seems to work with all the issues marked as duplicate. 

Screenshots of the UI test with before and after.

`test_gridspace` / `test_gridspace_legend_alignment` / `test_gridspace_colorbar_alignment`

| Case | Before (main) vs. After (fix) |
|---|---|
| test_gridspace | <img src="https://github.com/user-attachments/assets/daa747f2-bb34-4d06-bf34-182dd4f3e002" width="420"> |
| test_gridspace_legend_alignment | <img src="https://github.com/user-attachments/assets/bc778724-8ff5-4c3b-8dfc-95fd19651380" width="420"> |
| test_gridspace_colorbar_alignment[colorbar=True] | <img src="https://github.com/user-attachments/assets/f2222125-d0d6-4201-85e1-130e6927f705" width="420"> |
| test_gridspace_colorbar_alignment[colorbar=False] | <img src="https://github.com/user-attachments/assets/3956f24a-10bb-45f5-9f2d-4049578b86cf" width="420"> |

`test_gridspace_axis_alignment`

| Config | Before (main) vs. After (fix) |
|---|---|
| shared_yaxis=shared<br>shared_xaxis=shared<br>yaxis=none<br>xaxis=none | <img src="https://github.com/user-attachments/assets/1f49855e-49e6-4f91-bfa9-06324c0f784e" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=shared<br>yaxis=none<br>xaxis=top | <img src="https://github.com/user-attachments/assets/ce72fb7b-a247-4b10-a973-4fb7d4a52a07" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=shared<br>yaxis=none<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/f2cdf6e5-f4cf-4cb6-b007-a30a0a20eb32" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=shared<br>yaxis=left<br>xaxis=none | <img src="https://github.com/user-attachments/assets/e5323f25-17f6-45d3-936b-d8e37518942a" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=shared<br>yaxis=left<br>xaxis=top | <img src="https://github.com/user-attachments/assets/311e9b82-4a4d-43f2-9d4c-f59f931eb3e9" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=shared<br>yaxis=left<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/4b0f4cc5-e468-46a6-9ddf-f0bc67e9dad9" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=shared<br>yaxis=right<br>xaxis=none | <img src="https://github.com/user-attachments/assets/e9c36a6a-8ca8-4686-9dea-bc717800d5e2" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=shared<br>yaxis=right<br>xaxis=top | <img src="https://github.com/user-attachments/assets/74544346-47ce-4d7f-bbe2-be50b5200d52" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=shared<br>yaxis=right<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/cf289064-5995-45dd-a2e8-992cd8edefe4" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=independent<br>yaxis=none<br>xaxis=none | <img src="https://github.com/user-attachments/assets/aad6e2e2-6606-470e-96a9-11493b38e4be" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=independent<br>yaxis=none<br>xaxis=top | <img src="https://github.com/user-attachments/assets/907bf787-a77b-459c-b41e-93b81641169c" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=independent<br>yaxis=none<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/54316cd3-729a-4276-9c5e-c8078228db90" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=independent<br>yaxis=left<br>xaxis=none | <img src="https://github.com/user-attachments/assets/ef33db63-f067-485e-af54-b632e1d0ee0d" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=independent<br>yaxis=left<br>xaxis=top | <img src="https://github.com/user-attachments/assets/129dc8c9-463e-4e3b-bc89-9726e1946362" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=independent<br>yaxis=left<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/ba58f9f3-f2e4-4137-ab76-d5ec06cfce0d" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=independent<br>yaxis=right<br>xaxis=none | <img src="https://github.com/user-attachments/assets/05f875f1-e2b6-4f3e-b8e1-0fe9d27d766b" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=independent<br>yaxis=right<br>xaxis=top | <img src="https://github.com/user-attachments/assets/995774c7-1c5a-4b1e-9c16-ff94765053be" width="420"> |
| shared_yaxis=shared<br>shared_xaxis=independent<br>yaxis=right<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/5d0665a2-b56d-4de7-a69c-db4c974ef0e7" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=shared<br>yaxis=none<br>xaxis=none | <img src="https://github.com/user-attachments/assets/d988f0f0-9499-4389-a805-ba327b4707b3" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=shared<br>yaxis=none<br>xaxis=top | <img src="https://github.com/user-attachments/assets/00954d18-fd8d-4dfa-a163-355cd5399f39" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=shared<br>yaxis=none<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/21fd7c12-3958-42f0-b46c-93f5b963e79e" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=shared<br>yaxis=left<br>xaxis=none | <img src="https://github.com/user-attachments/assets/199b8000-1570-43b4-bd5e-69ae75b41532" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=shared<br>yaxis=left<br>xaxis=top | <img src="https://github.com/user-attachments/assets/4fa9ac68-089c-42d5-8874-78a4a8f50d23" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=shared<br>yaxis=left<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/dee9ced8-b020-4b64-ac80-a2d210ee7c13" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=shared<br>yaxis=right<br>xaxis=none | <img src="https://github.com/user-attachments/assets/41c23684-8534-4cae-a81e-3c69b299b39a" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=shared<br>yaxis=right<br>xaxis=top | <img src="https://github.com/user-attachments/assets/bb57c6e4-3ab3-49a4-a20a-a6a4b531d8cc" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=shared<br>yaxis=right<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/0c894493-3b29-4db3-ba6e-d30864eca502" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=independent<br>yaxis=none<br>xaxis=none | <img src="https://github.com/user-attachments/assets/9f276fa8-3736-4069-904a-0d65699cfe7d" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=independent<br>yaxis=none<br>xaxis=top | <img src="https://github.com/user-attachments/assets/020bb26d-a902-450c-b449-ff2a781f2522" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=independent<br>yaxis=none<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/21cb12bb-f6e8-4625-8b83-02ee4d458ade" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=independent<br>yaxis=left<br>xaxis=none | <img src="https://github.com/user-attachments/assets/2557574b-abef-482b-9a52-276dc7a327ff" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=independent<br>yaxis=left<br>xaxis=top | <img src="https://github.com/user-attachments/assets/f571409a-111f-45cc-9243-9353d7fa5204" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=independent<br>yaxis=left<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/e1f7b508-0432-4d9e-a603-26e8b32fe59e" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=independent<br>yaxis=right<br>xaxis=none | <img src="https://github.com/user-attachments/assets/8070f032-6a4d-479b-a729-1fcdd186e039" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=independent<br>yaxis=right<br>xaxis=top | <img src="https://github.com/user-attachments/assets/f66c08d2-6573-4be9-ae07-51dabda74f65" width="420"> |
| shared_yaxis=independent<br>shared_xaxis=independent<br>yaxis=right<br>xaxis=bottom | <img src="https://github.com/user-attachments/assets/bd1949e4-5a84-4c34-801f-50d36e32b580" width="420"> |



## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Claude Code:claude-sonnet-5
Usage:

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
