### PR TITLE
fix: Flatten title Column instead of nesting it around GridPlot

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -714,7 +714,8 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             plot.toolbar = merge_tools(plots, hide_toolbar=True)
         title = self._get_title_div(self.keys[-1])
         if title:
-            plot = Column(title, plot)
+            children = plot.children if isinstance(plot, (Row, Column)) else [plot]
+            plot = Column(title, *children)
             self.handles["title"] = title
 
         self.handles["plot"] = plot

--- a/holoviews/tests/plotting/bokeh/test_gridplot.py
+++ b/holoviews/tests/plotting/bokeh/test_gridplot.py
@@ -52,6 +52,13 @@ class TestGridPlot(TestBokehPlot):
         )
         assert title.text == text
 
+    def test_grid_title_flat_layout(self):
+        # Has Title + GridPlot + Axis
+        grid = hv.HoloMap({"a": hv.Curve([0, 1]).relabel("a")}, kdims=["a"]).grid("a")
+        plot = bokeh_renderer.get_plot(grid)
+        assert isinstance(plot.state, Column)
+        assert len(plot.state.children) == 3
+
     def test_gridmatrix_overlaid_batched(self, rng):
         ds = hv.Dataset(
             (["A"] * 5 + ["B"] * 5, rng.random(10), rng.random(10)), kdims=["a", "b", "c"]


### PR DESCRIPTION
# Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes https://github.com/holoviz/holoviews/issues/6777


``` python
import holoviews as hv

hv.extension("bokeh")

data = {
    (model, cls): hv.Curve([1, 2], "x", "y").relabel(f"{model} / {cls}")
    for cls in ["class_a", "class_b"]
    for model in ["model_a", "model_b"]
}

hm = hv.HoloMap(data, kdims=["model", "class"])
grid = hm.overlay("model").grid("class")
grid
```

Before (main):

<img width="334" height="223" alt="image" src="https://github.com/user-attachments/assets/cf614b1e-b198-4a02-8c58-7702a86a5745" />



After:

<img width="343" height="222" alt="image" src="https://github.com/user-attachments/assets/e5410c3a-8911-4ad8-88ae-ad2857e9dd96" />



## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
