### PR TITLE
fix: Merge toolbar tools even when GridPlot wraps a single axis

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -20,6 +20,7 @@ from bokeh.models import (
     Title,
 )
 from bokeh.models.layouts import TabPanel, Tabs
+from bokeh.models.plots import GridPlot as BkGridPlot
 from bokeh.models.ranges import Range1d
 from bokeh.models.tickers import FixedTicker
 from bokeh.plotting import figure
@@ -710,8 +711,13 @@ class GridPlot(CompositePlot, GenericCompositePlot):
         if self.sync_legends:
             sync_legends(plot)
         plot = self._make_axes(plot, plots)
-        if hasattr(plot, "toolbar") and self.merge_tools:
-            plot.toolbar = merge_tools(plots, hide_toolbar=True)
+        if self.merge_tools:
+            grid = (
+                plot
+                if hasattr(plot, "toolbar")
+                else next(c for c in plot.children if isinstance(c, BkGridPlot))
+            )
+            grid.toolbar = merge_tools(plots, hide_toolbar=True)
         title = self._get_title_div(self.keys[-1])
         if title:
             children = plot.children if isinstance(plot, (Row, Column)) else [plot]

--- a/holoviews/tests/ui/bokeh/test_gridspace.py
+++ b/holoviews/tests/ui/bokeh/test_gridspace.py
@@ -83,20 +83,14 @@ def test_gridspace_legend_alignment(serve_hv):
 
 
 @pytest.mark.usefixtures("bokeh_backend")
-@pytest.mark.parametrize("colorbar", [True, False])
-def test_gridspace_colorbar_alignment(serve_hv, colorbar):
+def test_gridspace_colorbar_alignment(serve_hv):
     x, y = np.arange(4), np.arange(3)
     z = np.arange(12).reshape((3, 4))
-    img = hv.Image((x, y, z), kdims=["x", "y"], vdims=["z"]).opts(colorbar=colorbar)
+    img = hv.Image((x, y, z), kdims=["x", "y"], vdims=["z"]).opts(colorbar=True)
     gridspace = hv.GridSpace(dict.fromkeys(range(5), img), kdims=["t"])
 
-    if colorbar:
-        x = (3, 63, 301, 539, 777, 1015, 1075)
-    else:  # Without colorbar it still has toolbar to the right
-        x = (3, 63, 216, 369, 522, 675, 735)
-
     page = serve_hv(gridspace)
-    assert_axes(page, x=x)
+    assert_axes(page, x=(3, 63, 271, 479, 687, 895, 955))
 
 
 @pytest.mark.usefixtures("bokeh_backend")


### PR DESCRIPTION
## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes https://github.com/holoviz/holoviews/issues/6222

<img width="543" height="1074" alt="image" src="https://github.com/user-attachments/assets/91b1921b-474f-4b64-9e6a-9e0d86db5832" />


This also fixes the problem in colorbar where it had multiple toolbars, update that test.

<img width="897" height="160" alt="image" src="https://github.com/user-attachments/assets/3a8c1a6c-caff-4926-8e7c-2f7bd07c530e" />


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Claude Code:claude-sonnet-5
Usage: Asked it to find the problem.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
