### PR TITLE
fix: Don't mutate input data in DictInterface

### DIFF
--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -103,9 +103,10 @@ class DictInterface(Interface):
         if not isinstance(data, cls.types):
             raise ValueError("DictInterface interface couldn't convert data.")
 
-        unpacked = {}
+        unpacked, unchanged = {}, True
         for d, vals in data.items():
             if isinstance(d, tuple):
+                unchanged = False
                 vals = np.asarray(vals)
                 if vals.shape == (0,):
                     for sd in d:
@@ -122,6 +123,7 @@ class DictInterface(Interface):
                     vals = np.asarray(vals)
                     if not vals.ndim == 1 and d in dimensions:
                         raise ValueError("DictInterface expects data for each column to be flat.")
+                    unchanged = unchanged and vals is data[d]
                 unpacked[d] = vals
 
         if not cls.expanded(
@@ -129,7 +131,10 @@ class DictInterface(Interface):
         ):
             raise ValueError("DictInterface expects data to be of uniform shape.")
 
-        return unpacked, {"kdims": kdims, "vdims": vdims}, {}
+        # Reusing the input dict keeps `hv.Table(points.data).data is points.data`
+        # which shared_datasource=True relies on
+        data = data if unchanged else unpacked
+        return data, {"kdims": kdims, "vdims": vdims}, {}
 
     @classmethod
     def validate(cls, dataset, vdims=True):

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 import numpy as np
 
@@ -19,7 +19,7 @@ class DictInterface(Interface):
 
     """
 
-    types = (dict, OrderedDict)
+    types = (dict,)
 
     datatype = "dictionary"
 
@@ -103,36 +103,33 @@ class DictInterface(Interface):
         if not isinstance(data, cls.types):
             raise ValueError("DictInterface interface couldn't convert data.")
 
-        unpacked = []
+        unpacked = {}
         for d, vals in data.items():
             if isinstance(d, tuple):
                 vals = np.asarray(vals)
                 if vals.shape == (0,):
                     for sd in d:
-                        unpacked.append((sd, np.array([], dtype=vals.dtype)))
+                        unpacked[sd] = np.array([], dtype=vals.dtype)
                 elif not vals.ndim == 2 and vals.shape[1] == len(d):
                     raise ValueError("Values for %s dimensions did not have the expected shape.")
                 else:
                     for i, sd in enumerate(d):
-                        unpacked.append((sd, vals[:, i]))
+                        unpacked[sd] = vals[:, i]
             elif d not in dimensions:
-                unpacked.append((d, vals))
+                unpacked[d] = vals
             else:
                 if not isscalar(vals):
                     vals = np.asarray(vals)
                     if not vals.ndim == 1 and d in dimensions:
                         raise ValueError("DictInterface expects data for each column to be flat.")
-                unpacked.append((d, vals))
+                unpacked[d] = vals
 
-        if not cls.expanded([vs for d, vs in unpacked if d in dimensions and not isscalar(vs)]):
+        if not cls.expanded(
+            [vs for d, vs in unpacked.items() if d in dimensions and not isscalar(vs)]
+        ):
             raise ValueError("DictInterface expects data to be of uniform shape.")
-        # OrderedDict can't be replaced with dict: https://github.com/holoviz/holoviews/pull/5925
-        if isinstance(data, OrderedDict):
-            data.update(unpacked)
-        else:
-            data = OrderedDict(unpacked)
 
-        return data, {"kdims": kdims, "vdims": vdims}, {}
+        return unpacked, {"kdims": kdims, "vdims": vdims}, {}
 
     @classmethod
     def validate(cls, dataset, vdims=True):

--- a/holoviews/tests/core/data/test_dictinterface.py
+++ b/holoviews/tests/core/data/test_dictinterface.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import OrderedDict
+
 import numpy as np
 
 import holoviews as hv
@@ -49,6 +51,12 @@ class DictDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
     def test_dataset_allow_none_values(self):
         ds = hv.Dataset({"x": None, "y": [0, 1]}, kdims=["x", "y"])
         assert_data_equal(ds.dimension_values(0), np.array([None, None]))
+
+    def test_dataset_tuple_key_does_not_mutate_input(self):
+        geom = OrderedDict({"z": 5.0, ("x", "y"): np.array([[0.0, 0.0], [1.0, 1.0]])})
+        ds = hv.Dataset(geom, kdims=["x", "y"], vdims=["z"])
+        expected = {"x": np.array([0.0, 1.0]), "y": np.array([0.0, 1.0]), "z": 5.0}
+        np.testing.assert_equal(ds.data, expected)
 
     def test_dataset_ignore_non_dimensions(self):
         ds = hv.Dataset(

--- a/holoviews/tests/core/data/test_dictinterface.py
+++ b/holoviews/tests/core/data/test_dictinterface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import OrderedDict
 
 import numpy as np
+import pytest
 
 import holoviews as hv
 from holoviews.testing import assert_data_equal, assert_element_equal
@@ -52,11 +53,18 @@ class DictDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
         ds = hv.Dataset({"x": None, "y": [0, 1]}, kdims=["x", "y"])
         assert_data_equal(ds.dimension_values(0), np.array([None, None]))
 
-    def test_dataset_tuple_key_does_not_mutate_input(self):
-        geom = OrderedDict({"z": 5.0, ("x", "y"): np.array([[0.0, 0.0], [1.0, 1.0]])})
-        ds = hv.Dataset(geom, kdims=["x", "y"], vdims=["z"])
+    @pytest.mark.parametrize("dict_type", [dict, OrderedDict])
+    def test_dataset_tuple_key_does_not_mutate_input(self, dict_type):
+        data = dict_type({"z": 5.0, ("x", "y"): np.array([[0.0, 0.0], [1.0, 1.0]])})
+        ds = hv.Dataset(data, kdims=["x", "y"], vdims=["z"])
         expected = {"x": np.array([0.0, 1.0]), "y": np.array([0.0, 1.0]), "z": 5.0}
         np.testing.assert_equal(ds.data, expected)
+
+    @pytest.mark.parametrize("dict_type", [dict, OrderedDict])
+    def test_dataset_reuses_unchanged_input(self, dict_type):
+        data = dict_type({"x": np.array([0.0, 1.0]), "y": np.array([1.0, 2.0])})
+        ds = hv.Dataset(data, kdims=["x", "y"])
+        assert ds.data is data
 
     def test_dataset_ignore_non_dimensions(self):
         ds = hv.Dataset(


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

We now always build a fresh dict from the unpacked columns.

I have tested this locally with both hvplot and geoviews.

Also rewrote the logic so `unpack` is now a dict.


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Claude Code:claude-sonnet-5
Usage: Asked it to see if it was possible to remove the logic.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
