### PR TITLE
enh: Move `zip(..., strict=None)` to `True`/`False`

### DIFF
--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -359,7 +359,7 @@ class Area(Curve):
             #   will yield indexes as tuples in a future version.
             levels = levels[0]
         for (key, sdf), element_vdims in zip(
-            df.groupby(level=levels, sort=False), vdims, strict=None
+            df.groupby(level=levels, sort=False), vdims, strict=False
         ):
             vdim = element_vdims[0]
             sdf = sdf.droplevel(levels).reindex(index=df.index.unique(-1), fill_value=0)

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -68,7 +68,7 @@ class layout_nodes(Operation):
             graph = nx.from_edgelist(edges)
             if "weight" in self.p.kwargs:
                 weight = self.p.kwargs["weight"]
-                for (s, t), w in zip(edges, element[weight], strict=None):
+                for (s, t), w in zip(edges, element[weight], strict=True):
                     graph.edges[s, t][weight] = w
             positions = self.p.layout(graph, **self.p.kwargs)
             nodes = [(*pos, idx) for idx, pos in sorted(positions.items())]
@@ -178,7 +178,7 @@ class Graph(Dataset, Element2D):
         nodes = self.nodes.clone(datatype=["pandas", "dictionary"])
         if isinstance(node_info, self.node_type):
             nodes = nodes.redim(
-                **dict(zip(nodes.dimensions("key", label=True), node_info.kdims, strict=None))
+                **dict(zip(nodes.dimensions("key", label=True), node_info.kdims, strict=True))
             )
 
         if not node_info.kdims and len(node_info) != len(nodes):
@@ -213,7 +213,7 @@ class Graph(Dataset, Element2D):
         if self._edgepaths is None:
             return
         mismatch = []
-        for kd1, kd2 in zip(self.nodes.kdims, self.edgepaths.kdims, strict=None):
+        for kd1, kd2 in zip(self.nodes.kdims, self.edgepaths.kdims, strict=False):
             if kd1 != kd2:
                 mismatch.append(f"{kd1} != {kd2}")
         if mismatch:
@@ -461,9 +461,9 @@ class Graph(Dataset, Element2D):
             node_columns = nodes.columns()
             idx_dim = nodes.kdims[0].name
             info_cols, values = zip(
-                *((k, v) for k, v in node_columns.items() if k != idx_dim), strict=None
+                *((k, v) for k, v in node_columns.items() if k != idx_dim), strict=True
             )
-            node_info = dict(zip(node_columns[idx_dim], zip(*values, strict=None), strict=None))
+            node_info = dict(zip(node_columns[idx_dim], zip(*values, strict=True), strict=True))
         else:
             info_cols = []
             node_info = None
@@ -764,7 +764,7 @@ class layout_chords(Operation):
 
         # Compute connectivity matrix
         matrix = np.zeros((len(nodes), len(nodes)))
-        for s, t, v in zip(src_idx, tgt_idx, values, strict=None):
+        for s, t, v in zip(src_idx, tgt_idx, values, strict=True):
             matrix[s, t] += v
 
         # Compute weighted angular slice for each connection
@@ -787,7 +787,7 @@ class layout_chords(Operation):
             n_conn = weights_of_areas[i]
             p0, p1 = points[i], points[i + 1]
             angles = np.linspace(p0, p1, int(n_conn))
-            coords = list(zip(np.cos(angles), np.sin(angles), strict=None))
+            coords = list(zip(np.cos(angles), np.sin(angles), strict=True))
             all_areas.append(coords)
 
         # Draw each chord by interpolating quadratic splines

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -73,7 +73,7 @@ class Path(SelectionPolyExpr, Geometry):
             paths = []
             for path in data:
                 if path.kdims != kdims:
-                    redim = {okd.name: nkd for okd, nkd in zip(path.kdims, kdims, strict=None)}
+                    redim = {okd.name: nkd for okd, nkd in zip(path.kdims, kdims, strict=True)}
                     path = path.redim(**redim)
                 if path.interface.multi and isinstance(path.data, list):
                     paths += path.data
@@ -485,7 +485,7 @@ class Ellipse(BaseShape):
         half_height = self.height / 2.0
         # create points
         ellipse = np.array(
-            list(zip(half_width * np.sin(angles), half_height * np.cos(angles), strict=None))
+            list(zip(half_width * np.sin(angles), half_height * np.cos(angles), strict=True))
         )
         # rotate ellipse and add offset
         rot = np.array(

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -120,7 +120,7 @@ class Raster(Element2D):
             samples = []
         if isinstance(samples, tuple):
             X, Y = samples
-            samples = zip(X, Y, strict=None)
+            samples = zip(X, Y, strict=False)
 
         params = dict(self.param.values(onlychanged=True), vdims=self.vdims)
         if len(sample_values) == self.ndims or len(samples):
@@ -132,7 +132,7 @@ class Raster(Element2D):
                             [(self.get_dimension_index(k), v) for k, v in sample_values.items()]
                         )
                     ],
-                    strict=None,
+                    strict=False,
                 )
             table_data = [(*c, self._zdata[self._coord2matrix(c)]) for c in samples]
             params["kdims"] = self.kdims
@@ -159,7 +159,7 @@ class Raster(Element2D):
             ydata = self._zdata[tuple(sample[::-1])]
             if hasattr(self, "bounds") and sample_ind == 0:
                 ydata = ydata[::-1]
-            data = list(zip(x_vals, ydata, strict=None))
+            data = list(zip(x_vals, ydata, strict=True))
             params["kdims"] = other_dimension
             return Curve(data, **params)
 
@@ -184,7 +184,7 @@ class Raster(Element2D):
             reduced = function(self._zdata, axis=oidx)
             if oidx and hasattr(self, "bounds"):
                 reduced = reduced[::-1]
-            data = zip(x_vals, reduced, strict=None)
+            data = zip(x_vals, reduced, strict=True)
             params = dict(
                 dict(self.param.values(onlychanged=True)), kdims=other_dimension, vdims=self.vdims
             )
@@ -412,7 +412,7 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
             bounds = data_bounds
 
         not_close = False
-        for r, c in zip(bounds, self.bounds.lbrt(), strict=None):
+        for r, c in zip(bounds, self.bounds.lbrt(), strict=True):
             if isinstance(r, util.datetime_types):
                 r = util.dt_to_int(r)
             if isinstance(c, util.datetime_types):
@@ -534,7 +534,7 @@ class Image(Selection2DExpr, Dataset, Raster, SheetCoordinateSystem):
                     elif coords:
                         coords = [
                             (t[abs(idx - 1)], c) if idx else (c, t[abs(idx - 1)])
-                            for c, t in zip(v, coords, strict=None)
+                            for c, t in zip(v, coords, strict=True)
                         ]
                 getter.append(idx)
         else:
@@ -756,7 +756,7 @@ class RGB(Image):
                     "Ranges must be defined on all the value dimensions of all the Images"
                 )
             arrays = [
-                (im.data - r[0]) / (r[1] - r[0]) for r, im in zip(ranges, images, strict=None)
+                (im.data - r[0]) / (r[1] - r[0]) for r, im in zip(ranges, images, strict=True)
             ]
             data = np.dstack(arrays)
         if vdims is None:

--- a/holoviews/element/sankey.py
+++ b/holoviews/element/sankey.py
@@ -97,17 +97,17 @@ class _layout_sankey(Operation):
         node_map = {}
         if element.nodes.vdims:
             values = zip(
-                *(element.nodes.dimension_values(d) for d in element.nodes.vdims), strict=None
+                *(element.nodes.dimension_values(d) for d in element.nodes.vdims), strict=True
             )
         else:
             values = cycle([()])
-        for idx, vals in zip(element.nodes.dimension_values(index), values, strict=None):
+        for idx, vals in zip(element.nodes.dimension_values(index), values, strict=False):
             node = {"index": idx, "sourceLinks": [], "targetLinks": [], "values": vals}
             graph["nodes"].append(node)
             node_map[idx] = node
 
         links = [element.dimension_values(d) for d in element.dimensions()[:3]]
-        for i, (src, tgt, value) in enumerate(zip(*links, strict=None)):
+        for i, (src, tgt, value) in enumerate(zip(*links, strict=True)):
             source, target = node_map[src], node_map[tgt]
             link = dict(index=i, source=source, target=target, value=value)
             graph["links"].append(link)

--- a/holoviews/element/selection.py
+++ b/holoviews/element/selection.py
@@ -172,7 +172,7 @@ def _mask_spatialpandas(masked_xvals, masked_yvals, geometry):
 def _mask_shapely(masked_xvals, masked_yvals, geometry):
     from shapely.geometry import Point, Polygon
 
-    points = (Point(x, y) for x, y in zip(masked_xvals, masked_yvals, strict=None))
+    points = (Point(x, y) for x, y in zip(masked_xvals, masked_yvals, strict=True))
     poly = Polygon(geometry)
     return np.array([poly.contains(p) for p in points], dtype=bool)
 
@@ -190,7 +190,7 @@ def spatial_geom_select(x0vals, y0vals, x1vals, y1vals, geometry):
 
         boxes = (
             box(x0, y0, x1, y1)
-            for x0, y0, x1, y1 in zip(x0vals, y0vals, x1vals, y1vals, strict=None)
+            for x0, y0, x1, y1 in zip(x0vals, y0vals, x1vals, y1vals, strict=True)
         )
         poly = Polygon(geometry)
         return np.array([poly.contains(p) for p in boxes])
@@ -204,7 +204,7 @@ def spatial_poly_select(xvals, yvals, geometry):
     try:
         from shapely.geometry import Polygon
 
-        boxes = (Polygon(np.column_stack([xs, ys])) for xs, ys in zip(xvals, yvals, strict=None))
+        boxes = (Polygon(np.column_stack([xs, ys])) for xs, ys in zip(xvals, yvals, strict=True))
         poly = Polygon(geometry)
         return np.array([poly.contains(p) for p in boxes])
     except ImportError:
@@ -223,7 +223,7 @@ def spatial_bounds_select(xvals, yvals, bounds):
                 & (x1 >= np.nanmax(xs))
                 & (y1 >= np.nanmax(ys))
             )
-            for xs, ys in zip(xvals, yvals, strict=None)
+            for xs, ys in zip(xvals, yvals, strict=True)
         ]
     )
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -488,7 +488,7 @@ class aggregate(LineAggregationOperation):
                 dims = (x, y)
                 df = PandasInterface.as_dframe(element)
                 if is_ndoverlay:
-                    df = df.assign(**dict(zip(obj.dimensions("key", True), key, strict=None)))
+                    df = df.assign(**dict(zip(obj.dimensions("key", True), key, strict=False)))
                 paths.append(df)
 
             is_wide, ydims = cls._overlay_wide_mapping(obj, obj.values())
@@ -1206,7 +1206,7 @@ class trimesh_rasterize(aggregate):
                 )
             simplices = element.dframe(simplex_dims)
             verts = element.nodes.dframe(vert_dims)
-        for c, dtype in zip(simplices.columns[:3], simplices.dtypes, strict=None):
+        for c, dtype in zip(simplices.columns[:3], simplices.dtypes, strict=False):
             if dtype_kind(dtype) != "i":
                 simplices[c] = simplices[c].astype("int")
         mesh = mesh(verts, simplices)
@@ -1280,7 +1280,7 @@ class trimesh_rasterize(aggregate):
 
         cvs = ds.Canvas(plot_width=width, plot_height=height, x_range=x_range, y_range=y_range)
         if wireframe:
-            rename_dict = {k: v for k, v in zip("xy", (x.name, y.name), strict=None) if k != v}
+            rename_dict = {k: v for k, v in zip("xy", (x.name, y.name), strict=True) if k != v}
             agg = cvs.line(
                 segments, x=["x0", "x1", "x2", "x0"], y=["y0", "y1", "y2", "y0"], axis=1, agg=agg
             ).rename(rename_dict)
@@ -1555,7 +1555,7 @@ class shade(LinkableOperation):
                 shade_opts["color_key"] = self.p.color_key
             elif isinstance(self.p.color_key, Iterable):
                 shade_opts["color_key"] = [
-                    c for _, c in zip(range(categories), self.p.color_key, strict=None)
+                    c for _, c in zip(range(categories), self.p.color_key, strict=False)
                 ]
             else:
                 colors = [self.p.color_key(s) for s in np.linspace(0, 1, categories)]
@@ -1686,7 +1686,7 @@ class geometry_rasterize(LineAggregationOperation):
             agg = cvs.line(data, **agg_kwargs)
         elif isinstance(element, Points):
             agg = cvs.points(data, **agg_kwargs)
-        rename_dict = {k: v for k, v in zip("xy", (xdim.name, ydim.name), strict=None) if k != v}
+        rename_dict = {k: v for k, v in zip("xy", (xdim.name, ydim.name), strict=True) if k != v}
         agg = agg.rename(rename_dict)
 
         if agg.ndim == 2:

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -416,7 +416,7 @@ class image_overlay(Operation):
     @classmethod
     def _match(cls, el, spec):
         """Return the strength of the match (None if no match)"""
-        spec_dict = dict(zip(["type", "group", "label"], spec.split("."), strict=None))
+        spec_dict = dict(zip(["type", "group", "label"], spec.split("."), strict=False))
         if not isinstance(el, Image) or spec_dict["type"] != "Image":
             raise NotImplementedError("Only Image currently supported")
 
@@ -461,9 +461,9 @@ class image_overlay(Operation):
 
         completed = []
         strongest = ordering[np.argmax(strengths)]
-        for el, spec in zip(ordering, specs, strict=None):
+        for el, spec in zip(ordering, specs, strict=True):
             if el is None:
-                spec_dict = dict(zip(["type", "group", "label"], spec.split("."), strict=None))
+                spec_dict = dict(zip(["type", "group", "label"], spec.split("."), strict=False))
                 el = Image(
                     np.ones(strongest.data.shape) * self.p.fill,
                     group=spec_dict.get("group", "Image"),
@@ -702,7 +702,7 @@ class contours(Operation):
 
             data = tuple(
                 date2num(d) if is_datetime else d
-                for d, is_datetime in zip(data, data_is_datetime, strict=None)
+                for d, is_datetime in zip(data, data_is_datetime, strict=True)
             )
 
         xdim, ydim = element.dimensions("key", label=True)

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -59,7 +59,7 @@ class _SyntheticAnnotationPlot(ColorbarPlot):
         data = element.columns(element.kdims)
         self._get_hover_data(data, element)
         default = self._element_default[self.invert_axes].kdims
-        mapping = {str(d): str(k) for d, k in zip(default, element.kdims, strict=None)}
+        mapping = {str(d): str(k) for d, k in zip(default, element.kdims, strict=True)}
         return data, mapping, style
 
     def initialize_plot(self, ranges=None, plot=None, plots=None, source=None):
@@ -74,7 +74,7 @@ class _SyntheticAnnotationPlot(ColorbarPlot):
             return figure
         labels = [self.xlabel or "x", self.ylabel or "y"]
         labels = labels[::-1] if self.invert_axes else labels
-        for ax, label in zip(figure.axis, labels, strict=None):
+        for ax, label in zip(figure.axis, labels, strict=False):
             ax.axis_label = label
         return figure
 
@@ -152,7 +152,7 @@ class TextPlot(ElementPlot, AnnotationPlot):
     def get_batched_data(self, element, ranges=None):
         data = defaultdict(list)
         zorders = self._updated_zorders(element)
-        for (_key, el), zorder in zip(element.data.items(), zorders, strict=None):
+        for (_key, el), zorder in zip(element.data.items(), zorders, strict=True):
             style = self.lookup_options(element.last, "style")
             style = style.max_cycles(len(self.ordering))[zorder]
             eldata, elmapping, style = self.get_data(el, ranges, style)
@@ -354,7 +354,7 @@ class SplinePlot(ElementPlot, AnnotationPlot):
                 skipped = len(vs) > 1
                 continue
             for x, y, xl, yl in zip(
-                vs[:, 0], vs[:, 1], data_attrs[::2], data_attrs[1::2], strict=None
+                vs[:, 0], vs[:, 1], data_attrs[::2], data_attrs[1::2], strict=True
             ):
                 data[xl].append(x)
                 data[yl].append(y)
@@ -364,7 +364,7 @@ class SplinePlot(ElementPlot, AnnotationPlot):
                 "splines were skipped during plotting."
             )
         data = {da: data[da] for da in data_attrs}
-        return (data, dict(zip(data_attrs, data_attrs, strict=None)), style)
+        return (data, dict(zip(data_attrs, data_attrs, strict=True)), style)
 
 
 class ArrowPlot(CompositeElementPlot, AnnotationPlot):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1623,7 +1623,7 @@ class BoxEditCallback(GlyphDrawCallback):
         element = self.plot.current_frame
 
         l, b, r, t = [], [], [], []
-        for x, y in zip(data["xs"], data["ys"], strict=None):
+        for x, y in zip(data["xs"], data["ys"], strict=True):
             x0, x1 = (np.nanmin(x), np.nanmax(x))
             y0, y1 = (np.nanmin(y), np.nanmax(y))
             l.append(x0)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -207,7 +207,7 @@ class PointPlot(SizebarMixin, ColorbarPlot):
         # Angles need special handling since they are tied to the
         # marker in certain cases
         has_angles = False
-        for (key, el), zorder in zip(element.data.items(), zorders, strict=None):
+        for (key, el), zorder in zip(element.data.items(), zorders, strict=True):
             el_opts = self.lookup_options(el, "plot").options
             self.param.update(
                 **{k: v for k, v in el_opts.items() if k not in OverlayPlot._propagate_options}
@@ -241,7 +241,7 @@ class PointPlot(SizebarMixin, ColorbarPlot):
                 data["__angle"].append(np.zeros(len(v)))
 
             if "hover" in self.handles:
-                for d, k in zip(element.dimensions(), key, strict=None):
+                for d, k in zip(element.dimensions(), key, strict=False):
                     sanitized = dimension_sanitizer(d.name)
                     data[sanitized].append([k] * nvals)
 
@@ -433,7 +433,7 @@ class CurvePlot(ElementPlot):
         data = defaultdict(list)
 
         zorders = self._updated_zorders(overlay)
-        for (key, el), zorder in zip(overlay.data.items(), zorders, strict=None):
+        for (key, el), zorder in zip(overlay.data.items(), zorders, strict=True):
             el_opts = self.lookup_options(el, "plot").options
             self.param.update(
                 **{k: v for k, v in el_opts.items() if k not in OverlayPlot._propagate_options}
@@ -457,7 +457,7 @@ class CurvePlot(ElementPlot):
             for k, v in sdata.items():
                 data[k].append(v[0])
 
-            for d, k in zip(overlay.kdims, key, strict=None):
+            for d, k in zip(overlay.kdims, key, strict=True):
                 sanitized = dimension_sanitizer(d.name)
                 data[sanitized].append(k)
         data = {opt: vals for opt, vals in data.items() if not any(v is None for v in vals)}
@@ -710,7 +710,7 @@ class SpreadPlot(ElementPlot):
         lower = np.split(lower, split)
         upper = np.split(upper, split)
         band_x, band_y = [], []
-        for i, (x, l, u) in enumerate(zip(xvals, lower, upper, strict=None)):
+        for i, (x, l, u) in enumerate(zip(xvals, lower, upper, strict=True)):
             if i:
                 x, l, u = x[1:], l[1:], u[1:]
             if not len(x):
@@ -943,7 +943,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
 
         """
         bottoms, tops = [], []
-        for x, y in zip(xvals, yvals, strict=None):
+        for x, y in zip(xvals, yvals, strict=True):
             baseline = baselines[x][sign]
             if sign == "positive":
                 bottom = baseline

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1066,7 +1066,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         ax_specs, yaxes, dimensions = {}, {}, {}
         subcoordinate_axes = 0
-        for el, (sp_key, sp) in zip(element, self.subplots.items(), strict=None):
+        for el, (sp_key, sp) in zip(element, self.subplots.items(), strict=False):
             ax_dims = sp._get_axis_dims(el)[:2]
             if sp.invert_axes:
                 ax_dims[::-1]
@@ -1079,7 +1079,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     continue
                 if sp.overlay_dims:
                     ax_name = ", ".join(
-                        d.pprint_value(k) for d, k in zip(element.kdims, sp_key, strict=None)
+                        d.pprint_value(k) for d, k in zip(element.kdims, sp_key, strict=True)
                     )
                 else:
                     ax_name = el.label
@@ -1429,7 +1429,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 ticks, labels = [], []
                 idx = 0
                 for el, (sp_key, sp) in zip(
-                    self.current_frame, self.subplots.items(), strict=None
+                    self.current_frame, self.subplots.items(), strict=False
                 ):
                     if not sp.subcoordinate_y:
                         continue
@@ -1446,12 +1446,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                         labels.append(
                             ", ".join(
                                 d.pprint_value(k)
-                                for d, k in zip(self.current_frame.kdims, sp_key, strict=None)
+                                for d, k in zip(self.current_frame.kdims, sp_key, strict=True)
                             )
                         )
                 axis_props["ticker"] = FixedTicker(ticks=ticks)
                 if labels is not None:
-                    axis_props["major_label_overrides"] = dict(zip(ticks, labels, strict=None))
+                    axis_props["major_label_overrides"] = dict(zip(ticks, labels, strict=True))
         formatter = self.xformatter if axis == "x" else self.yformatter
         if formatter:
             formatter = wrap_formatter(formatter, axis)
@@ -1511,7 +1511,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         dimensions = self._get_axis_dims(el)
         props = {
             axis: self._axis_properties(axis, key, plot, dim)
-            for axis, dim in zip(["x", "y"], dimensions, strict=None)
+            for axis, dim in zip(["x", "y"], dimensions, strict=False)
         }
         xlabel, ylabel, _zlabel = self._get_axis_labels(dimensions)
         if self.invert_axes:
@@ -3752,7 +3752,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             for subplot_zoom, overlay_zoom in zip(
                 subplot.handles["zooms_subcoordy"].values(),
                 self.handles["zooms_subcoordy"].values(),
-                strict=None,
+                strict=False,
             ):
                 renderers = list(
                     util.unique_iterator(overlay_zoom.renderers + subplot_zoom.renderers)

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -153,13 +153,13 @@ class GraphPlot(GraphMixin, CompositeElementPlot, ColorbarPlot, LegendPlot):
             index = np.array([node_indices[n] for n in nodes], dtype=np.int32)
             layout = {
                 node_indices[k]: (y, x) if self.invert_axes else (x, y)
-                for k, (x, y) in zip(nodes, node_positions, strict=None)
+                for k, (x, y) in zip(nodes, node_positions, strict=True)
             }
         else:
             index = nodes.astype(np.int32)
             layout = {
                 k: (y, x) if self.invert_axes else (x, y)
-                for k, (x, y) in zip(index, node_positions, strict=None)
+                for k, (x, y) in zip(index, node_positions, strict=True)
             }
 
         point_data = {"index": index}

--- a/holoviews/plotting/bokeh/heatmap.py
+++ b/holoviews/plotting/bokeh/heatmap.py
@@ -494,7 +494,7 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
         if reverse:
             bins = bins[::-1]
 
-        return dict(zip(order, bins, strict=None))
+        return dict(zip(order, bins, strict=True))
 
     @staticmethod
     def _get_bounds(mapper, values):
@@ -612,7 +612,7 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
 
         values = [(text, ((end - start) / 2) + start) for text, (start, end) in mapping.items()]
 
-        labels, radiant = zip(*values, strict=None)
+        labels, radiant = zip(*values, strict=True)
         radiant = np.array(radiant)
 
         y_coord = np.sin(radiant) * self.max_radius + self.max_radius
@@ -628,7 +628,7 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
         mapping = self._compute_tick_mapping("radius", order_ann, bins_ann)
         values = [(label, radius[0]) for label, radius in mapping.items()]
 
-        labels, radius = zip(*values, strict=None)
+        labels, radius = zip(*values, strict=True)
         radius = np.array(radius)
 
         y_coord = np.sin(np.deg2rad(self.yrotation)) * radius + self.max_radius
@@ -667,8 +667,8 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
         x_start = np.cos(angles) * inner + self.max_radius
         x_end = np.cos(angles) * outer + self.max_radius
 
-        xs = zip(x_start, x_end, strict=None)
-        ys = zip(y_start, y_end, strict=None)
+        xs = zip(x_start, x_end, strict=True)
+        ys = zip(y_start, y_end, strict=True)
 
         return dict(xs=list(xs), ys=list(ys))
 

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -146,11 +146,11 @@ class PathPlot(LegendPlot, ColorbarPlot):
 
             xpaths += [
                 xs[s1 : s2 + 1]
-                for (s1, s2) in zip(range(alen - 1), range(1, alen + 1), strict=None)
+                for (s1, s2) in zip(range(alen - 1), range(1, alen + 1), strict=False)
             ]
             ypaths += [
                 ys[s1 : s2 + 1]
-                for (s1, s2) in zip(range(alen - 1), range(1, alen + 1), strict=None)
+                for (s1, s2) in zip(range(alen - 1), range(1, alen + 1), strict=False)
             ]
             if not hover:
                 continue
@@ -172,14 +172,14 @@ class PathPlot(LegendPlot, ColorbarPlot):
         data = defaultdict(list)
 
         zorders = self._updated_zorders(element)
-        for (key, el), zorder in zip(element.data.items(), zorders, strict=None):
+        for (key, el), zorder in zip(element.data.items(), zorders, strict=True):
             el_opts = self.lookup_options(el, "plot").options
             self.param.update(
                 **{k: v for k, v in el_opts.items() if k not in OverlayPlot._propagate_options}
             )
             style = self.lookup_options(el, "style")
             style = style.max_cycles(len(self.ordering))[zorder]
-            self.overlay_dims = dict(zip(element.kdims, key, strict=None))
+            self.overlay_dims = dict(zip(element.kdims, key, strict=True))
             eldata, elmapping, style = self.get_data(el, ranges, style)
             for k, eld in eldata.items():
                 data[k].extend(eld)

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -470,7 +470,7 @@ class CompositePlot(BokehPlot):
         contents = [k for s in self.streams for k in s.contents]
         key = tuple(
             None if d in contents else k
-            for d, k in zip(self.dimensions, self.current_key, strict=None)
+            for d, k in zip(self.dimensions, self.current_key, strict=False)
         )
         key = wrap_tuple_streams(key, self.dimensions, self.streams)
         self._get_title_div(key)
@@ -895,7 +895,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             # to create the correct subaxes for all plots in the layout
             layout_key, _ = layout_items.get((r, c), (None, None))
             if isinstance(layout, NdLayout) and layout_key:
-                layout_dimensions = dict(zip(layout_dimensions, layout_key, strict=None))
+                layout_dimensions = dict(zip(layout_dimensions, layout_key, strict=True))
 
             # Generate the axes and create the subplots with the appropriate
             # axis objects, handling any Empty objects.

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -494,7 +494,7 @@ class ImageStackPlot(RasterPlot, SyntheticLegendMixin):
                     "The supplied cmap dictionary must have the same "
                     f"value dimensions as the element. Missing: '{missing_str}'"
                 )
-            keys, values = zip(*dict_cmap.items(), strict=None)
+            keys, values = zip(*dict_cmap.items(), strict=True)
             style["cmap"] = list(values)
             indices = [keys.index(vd.name) for vd in vdims]
 
@@ -629,7 +629,7 @@ class QuadMeshPlot(ColorbarPlot):
             XS, YS = [], []
             mask = []
             xc, yc = [], []
-            for xs, ys, zval in zip(X, Y, zvals, strict=None):
+            for xs, ys, zval in zip(X, Y, zvals, strict=True):
                 xs, ys = xs[:-1], ys[:-1]
                 if isfinite(zval) and all(isfinite(xs)) and all(isfinite(ys)):
                     XS.append(list(xs))
@@ -689,7 +689,7 @@ class QuadMeshPlot(ColorbarPlot):
         hover_dims = element.dimensions()[3:]
         hover_vals = [element.dimension_values(hover_dim, flat=False) for hover_dim in hover_dims]
         hover_data = {}
-        for hdim, hvals in zip(hover_dims, hover_vals, strict=None):
+        for hdim, hvals in zip(hover_dims, hover_vals, strict=True):
             hdat = hvals.T.flatten() if transpose else hvals.flatten()
             hover_data[dimension_sanitizer(hdim.name)] = hdat[mask]
         return hover_data

--- a/holoviews/plotting/bokeh/sankey.py
+++ b/holoviews/plotting/bokeh/sankey.py
@@ -245,7 +245,7 @@ class SankeyPlot(GraphPlot):
             src += "_values"
         if tgt == "end":
             tgt += "_values"
-        lookup = dict(zip(*(element.nodes.dimension_values(d) for d in (2, lidx)), strict=None))
+        lookup = dict(zip(*(element.nodes.dimension_values(d) for d in (2, lidx)), strict=True))
         src_vals = data["patches_1"][src]
         tgt_vals = data["patches_1"][tgt]
         data["patches_1"][src] = [lookup.get(v, v) for v in src_vals]

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -145,7 +145,7 @@ class BoxWhiskerPlot(MultiDistributionMixin, CompositeElementPlot, ColorbarPlot,
             if element.ndims > 1:
                 factors = sorted(factors)
             factors = [
-                tuple(d.pprint_value(k) for d, k in zip(element.kdims, key, strict=None))
+                tuple(d.pprint_value(k) for d, k in zip(element.kdims, key, strict=True))
                 for key in factors
             ]
             factors = [f[0] if len(f) == 1 else f for f in factors]
@@ -229,7 +229,7 @@ class BoxWhiskerPlot(MultiDistributionMixin, CompositeElementPlot, ColorbarPlot,
         for key, g in groups.items():
             # Compute group label
             if element.kdims:
-                label = tuple(d.pprint_value(v) for d, v in zip(element.kdims, key, strict=None))
+                label = tuple(d.pprint_value(v) for d, v in zip(element.kdims, key, strict=True))
                 if len(label) == 1:
                     label = label[0]
             else:
@@ -268,10 +268,10 @@ class BoxWhiskerPlot(MultiDistributionMixin, CompositeElementPlot, ColorbarPlot,
                 out_data["index"] += [label] * len(outliers)
                 out_data[vdim] += list(outliers)
                 if hover:
-                    for kd, k in zip(element.kdims, wrap_tuple(key), strict=None):
+                    for kd, k in zip(element.kdims, wrap_tuple(key), strict=True):
                         out_data[dimension_sanitizer(kd.name)] += [k] * len(outliers)
             if hover:
-                for kd, k in zip(element.kdims, wrap_tuple(key), strict=None):
+                for kd, k in zip(element.kdims, wrap_tuple(key), strict=True):
                     kd_name = dimension_sanitizer(kd.name)
                     if kd_name in r1_data:
                         r1_data[kd_name].append(k)
@@ -421,7 +421,7 @@ class ViolinPlot(BoxWhiskerPlot):
             if element.ndims > 1:
                 factors = sorted(factors)
             factors = [
-                tuple(d.pprint_value(k) for d, k in zip(kdims, key, strict=None))
+                tuple(d.pprint_value(k) for d, k in zip(kdims, key, strict=True))
                 for key in factors
             ]
             factors = [f[0] if len(f) == 1 else f for f in factors]
@@ -589,7 +589,7 @@ class ViolinPlot(BoxWhiskerPlot):
         for key, g in groups.items():
             key = decode_bytes(key)
             if element.kdims:
-                key = tuple(d.pprint_value(k) for d, k in zip(element.kdims, key, strict=None))
+                key = tuple(d.pprint_value(k) for d, k in zip(element.kdims, key, strict=False))
             kde, line, segs, bars, scatter = self._kde_data(
                 element, g, key, split_dim, split_cats, **kwargs
             )

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -213,7 +213,7 @@ def compute_plot_size(plot):
             w_agg, h_agg = (np.max, np.max)
         else:
             w_agg, h_agg = (np.max, np.sum)
-        widths, heights = zip(*[compute_plot_size(child) for child in plot.children], strict=None)
+        widths, heights = zip(*[compute_plot_size(child) for child in plot.children], strict=True)
         return w_agg(widths), h_agg(heights)
     elif isinstance(plot, figure):
         if plot.width:
@@ -774,9 +774,9 @@ def pad_plots(plots):
     plots = [
         [
             Column(p, width=w) if isinstance(p, (DataTable, Tabs)) else p
-            for p, w in zip(row, ws, strict=None)
+            for p, w in zip(row, ws, strict=True)
         ]
-        for row, ws in zip(plots, widths, strict=None)
+        for row, ws in zip(plots, widths, strict=True)
     ]
     return plots
 
@@ -818,7 +818,7 @@ def get_tab_title(key, frame, overlay):
         title = " ".join(title)
     else:
         title = " | ".join(
-            [d.pprint_value_string(k) for d, k in zip(overlay.kdims, key, strict=None)]
+            [d.pprint_value_string(k) for d, k in zip(overlay.kdims, key, strict=True)]
         )
     return title
 
@@ -1151,14 +1151,14 @@ def multi_polygons_data(element):
     xs, ys = (element.dimension_values(kd, expanded=False) for kd in element.kdims)
     holes = element.holes()
     xsh, ysh = [], []
-    for x, y, multi_hole in zip(xs, ys, holes, strict=None):
+    for x, y, multi_hole in zip(xs, ys, holes, strict=True):
         xhs = [[h[:, 0] for h in hole] for hole in multi_hole]
         yhs = [[h[:, 1] for h in hole] for hole in multi_hole]
         array = np.column_stack([x, y])
         splits = np.where(np.isnan(array[:, :2].astype("float")).sum(axis=1))[0]
         arrays = np.split(array, splits + 1) if len(splits) else [array]
         multi_xs, multi_ys = [], []
-        for i, (path, hx, hy) in enumerate(zip(arrays, xhs, yhs, strict=None)):
+        for i, (path, hx, hy) in enumerate(zip(arrays, xhs, yhs, strict=False)):
             if i != (len(arrays) - 1):
                 path = path[:-1]
             multi_xs.append([path[:, 0], *hx])
@@ -1320,7 +1320,7 @@ def get_ticker_axis_props(ticker):
         axis_props["ticker"] = BasicTicker(desired_num_ticks=ticker)
     elif isinstance(ticker, (tuple, list)):
         if all(isinstance(t, tuple) for t in ticker):
-            ticks, labels = zip(*ticker, strict=None)
+            ticks, labels = zip(*ticker, strict=False)
             # Ensure floats which are integers are serialized as ints
             # because in JS the lookup fails otherwise
             ticks = [int(t) if isinstance(t, float) and t.is_integer() else t for t in ticks]
@@ -1331,5 +1331,5 @@ def get_ticker_axis_props(ticker):
             ticks = [util.dt_to_int(tick, "ms") for tick in ticks]
         axis_props["ticker"] = FixedTicker(ticks=ticks)
         if labels is not None:
-            axis_props["major_label_overrides"] = dict(zip(ticks, labels, strict=None))
+            axis_props["major_label_overrides"] = dict(zip(ticks, labels, strict=True))
     return axis_props

--- a/holoviews/plotting/mixins.py
+++ b/holoviews/plotting/mixins.py
@@ -19,7 +19,7 @@ class GeomMixin:
         # loop over start and end points of segments
         # simultaneously in each dimension
         for kdim0, kdim1 in zip(
-            [kdims[i].label for i in range(2)], [kdims[i].label for i in range(2, 4)], strict=None
+            [kdims[i].label for i in range(2)], [kdims[i].label for i in range(2, 4)], strict=True
         ):
             new_range = {}
             for kdim in [kdim0, kdim1]:

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -229,7 +229,7 @@ class LabelsPlot(ColorbarPlot):
         vectorized = {k: v for k, v in plot_kwargs.items() if isinstance(v, np.ndarray)}
 
         texts = []
-        for i, item in enumerate(zip(*plot_args, strict=None)):
+        for i, item in enumerate(zip(*plot_args, strict=False)):
             x, y, text = item[:3]
             if len(item) == 4 and cmap is not None:
                 color = item[3]
@@ -318,7 +318,7 @@ class _SyntheticAnnotationPlot(AnnotationPlot):
         else:
             size = len(self.hmap.last.kdims)
             first_keys = list(positions)[:size]
-            values = zip(*[positions[n] for n in first_keys], strict=None)
+            values = zip(*[positions[n] for n in first_keys], strict=True)
         fn = getattr(axis, self._methods[self.invert_axes])
         return [fn(*val, **opts) for val in values]
 

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -471,7 +471,7 @@ class HistogramPlot(ColorbarPlot):
 
         """
         axis_settings = dict(
-            zip(self.axis_settings, [None, None, (None if self.overlaid else ticks)], strict=None)
+            zip(self.axis_settings, [None, None, (None if self.overlaid else ticks)], strict=True)
         )
         return axis_settings
 
@@ -487,7 +487,7 @@ class HistogramPlot(ColorbarPlot):
         allow updating of further artists.
 
         """
-        plot_vals = zip(self.handles["artist"], edges, hvals, widths, strict=None)
+        plot_vals = zip(self.handles["artist"], edges, hvals, widths, strict=True)
         for bar, edge, height, width in plot_vals:
             if self.invert_axes:
                 bar.set_y(edge)
@@ -593,7 +593,7 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
         lower_bound = main_range[0]
         colors = np.array(element.dimension_values(dim))
         colors = (colors - lower_bound) / (cmap_range)
-        for c, bar in zip(colors, bars, strict=None):
+        for c, bar in zip(colors, bars, strict=True):
             bar.set_facecolor(cmap(c))
             bar.set_clip_on(False)
 
@@ -936,7 +936,7 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         alignments = None
         ticks = xticks or yticks
         if ticks is not None:
-            ticks, labels, alignments = zip(*sorted(ticks, key=lambda x: x[0]), strict=None)
+            ticks, labels, alignments = zip(*sorted(ticks, key=lambda x: x[0]), strict=True)
             ticks = (list(ticks), list(labels))
         if xticks:
             xticks = ticks
@@ -945,10 +945,10 @@ class BarPlot(BarsMixin, ColorbarPlot, LegendPlot):
         super()._finalize_ticks(axis, element, xticks, yticks, zticks)
         if alignments:
             if xticks:
-                for t, y in zip(axis.get_xticklabels(), alignments, strict=None):
+                for t, y in zip(axis.get_xticklabels(), alignments, strict=False):
                     t.set_y(y)
             elif yticks:
-                for t, x in zip(axis.get_yticklabels(), alignments, strict=None):
+                for t, x in zip(axis.get_yticklabels(), alignments, strict=False):
                     t.set_x(x)
 
     def _create_bars(self, axis, element, ranges, style):
@@ -1161,7 +1161,7 @@ class SpikesPlot(SpikesMixin, PathPlot, ColorbarPlot):
         if ndims > 1 and "spike_length" not in opts:
             data = element.columns([0, 1])
             xs, ys = data[dimensions[0]], data[dimensions[1]]
-            data = [[(x, pos), (x, pos + y)] for x, y in zip(xs, ys, strict=None)]
+            data = [[(x, pos), (x, pos + y)] for x, y in zip(xs, ys, strict=True)]
         else:
             xs = element.array([0])
             height = self.spike_length
@@ -1173,7 +1173,7 @@ class SpikesPlot(SpikesMixin, PathPlot, ColorbarPlot):
         dims = element.dimensions()
         clean_spikes = []
         for spike in data:
-            xs, ys = zip(*spike, strict=None)
+            xs, ys = zip(*spike, strict=True)
             cols = []
             for i, vs in enumerate((xs, ys)):
                 vs = np.array(vs)
@@ -1409,7 +1409,7 @@ class WaterfallPlot(WaterfallMixin, ColorbarPlot, LegendPlot):
         str_labels = [
             lbl if isinstance(lbl, str) else element.kdims[0].pprint_value(lbl) for lbl in labels
         ]
-        xticks = list(zip(x_positions, str_labels, strict=None))
+        xticks = list(zip(x_positions, str_labels, strict=True))
         return bars, xticks
 
     def _draw_connectors(self, axis, x_positions, cumulative, width, bar_style):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -291,7 +291,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             axes_str += "z"
             axes_list.append(axis.zaxis)
 
-        for ax, ax_obj in zip(axes_str, axes_list, strict=None):
+        for ax, ax_obj in zip(axes_str, axes_list, strict=True):
             tick_fontsize = self._fontsize(f"{ax}ticks", "labelsize", common=False)
             if tick_fontsize:
                 ax_obj.set_tick_params(**tick_fontsize)
@@ -670,7 +670,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         element = self.hmap.last
         ax = self.handles["axis"]
         key = list(self.hmap.data.keys())[-1]
-        dim_map = dict(zip((d.name for d in self.hmap.kdims), key, strict=None))
+        dim_map = dict(zip((d.name for d in self.hmap.kdims), key, strict=True))
         key = tuple(dim_map.get(d.name, None) for d in self.dimensions)
         ranges = self.compute_ranges(self.hmap, key, ranges)
         self.current_ranges = ranges
@@ -983,10 +983,10 @@ class ColorbarPlot(ElementPlot):
             cbar.ax.yaxis.set_major_locator(locator)
         elif isinstance(self.cbar_ticks, list):
             if all(isinstance(t, tuple) for t in self.cbar_ticks):
-                ticks, labels = zip(*self.cbar_ticks, strict=None)
+                ticks, labels = zip(*self.cbar_ticks, strict=False)
             else:
                 ticks, labels = zip(
-                    *[(t, dim.pprint_value(t)) for t in self.cbar_ticks], strict=None
+                    *[(t, dim.pprint_value(t)) for t in self.cbar_ticks], strict=True
                 )
             cbar.set_ticks(ticks)
             cbar.set_ticklabels(labels)
@@ -1395,7 +1395,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
                 label = ",".join(
                     [
                         dim.pprint_value(k, print_unit=True)
-                        for k, dim in zip(key, dimensions, strict=None)
+                        for k, dim in zip(key, dimensions, strict=True)
                     ]
                 )
                 if handle:
@@ -1404,10 +1404,10 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
                 legend_data += subplot.handles.get("legend_data", {}).items()
             elif element.label and handle:
                 legend_data.append((handle, labels.get(element.label, element.label)))
-        all_handles, all_labels = list(zip(*legend_data, strict=None)) if legend_data else ([], [])
+        all_handles, all_labels = list(zip(*legend_data, strict=True)) if legend_data else ([], [])
         data = {}
         used_labels = []
-        for handle, label in zip(all_handles, all_labels, strict=None):
+        for handle, label in zip(all_handles, all_labels, strict=True):
             # Ensure that artists with multiple handles are supported
             if isinstance(handle, list):
                 handle = tuple(handle)

--- a/holoviews/plotting/mpl/geometry.py
+++ b/holoviews/plotting/mpl/geometry.py
@@ -38,7 +38,7 @@ class SegmentPlot(GeomMixin, ColorbarPlot):
         dims = element.dimensions()
         data = [
             [(x0, y0), (x1, y1)]
-            for x0, y0, x1, y1 in zip(*(element.dimension_values(d) for d in inds), strict=None)
+            for x0, y0, x1, y1 in zip(*(element.dimension_values(d) for d in inds), strict=True)
         ]
         with abbreviated_exception():
             style = self._apply_transforms(element, ranges, style)
@@ -77,7 +77,7 @@ class RectanglesPlot(GeomMixin, ColorbarPlot):
         dims = element.dimensions()
         data = [
             Rectangle((x0, y0), x1, y1)
-            for (x0, y0, x1, y1) in zip(x0s, y0s, x1s - x0s, y1s - y0s, strict=None)
+            for (x0, y0, x1, y1) in zip(x0s, y0s, x1s - x0s, y1s - y0s, strict=True)
         ]
 
         with abbreviated_exception():

--- a/holoviews/plotting/mpl/graphs.py
+++ b/holoviews/plotting/mpl/graphs.py
@@ -302,7 +302,7 @@ class ChordPlot(ChordMixin, GraphPlot):
         if "text" in plot_args:
             fontsize = plot_kwargs.get("text_font_size", 8)
             labels = []
-            for x, y, l, a in zip(*plot_args["text"], strict=None):
+            for x, y, l, a in zip(*plot_args["text"], strict=False):
                 label = ax.annotate(
                     l,
                     xy=(x, y),
@@ -345,7 +345,7 @@ class ChordPlot(ChordMixin, GraphPlot):
             return
         labels = []
         fontsize = style.get("text_font_size", 8)
-        for x, y, l, a in zip(*data["text"], strict=None):
+        for x, y, l, a in zip(*data["text"], strict=False):
             label = ax.annotate(
                 l,
                 xy=(x, y),

--- a/holoviews/plotting/mpl/heatmap.py
+++ b/holoviews/plotting/mpl/heatmap.py
@@ -110,7 +110,7 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
         ypos = yvals[:-1] + np.diff(yvals) / 2.0
         plot_coords = product(xpos, ypos)
         annotations = {}
-        for plot_coord, v in zip(plot_coords, vals, strict=None):
+        for plot_coord, v in zip(plot_coords, vals, strict=True):
             text = "-" if is_nan(v) else val_dim.pprint_value(v)
             annotations[plot_coord] = text
         return annotations
@@ -128,7 +128,7 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
             if not xfactors:
                 xfactors = element.gridded.dimension_values(xdim, False)
             xlabels = [xdim.pprint_value(k) for k in xfactors]
-            xticks = list(zip(xpos, xlabels, strict=None))
+            xticks = list(zip(xpos, xlabels, strict=True))
 
         yticks = opts.get("yticks")
         if yticks is None:
@@ -136,7 +136,7 @@ class HeatMapPlot(HeatMapMixin, QuadMeshPlot):
             if not yfactors:
                 yfactors = element.gridded.dimension_values(ydim, False)
             ylabels = [ydim.pprint_value(k) for k in yfactors]
-            yticks = list(zip(ypos, ylabels, strict=None))
+            yticks = list(zip(ypos, ylabels, strict=True))
         return xticks, yticks
 
     def _draw_markers(self, ax, element, marks, values, factors, axis="x"):
@@ -311,7 +311,7 @@ class RadialHeatMapPlot(ColorbarPlot):
         bounds = np.linspace(start, end, size + 1)
         if reverse:
             bounds = bounds[::-1]
-        mapping = list(zip(bounds[:-1] % (np.pi * 2), order, strict=None))
+        mapping = list(zip(bounds[:-1] % (np.pi * 2), order, strict=True))
         return mapping
 
     @staticmethod
@@ -341,7 +341,7 @@ class RadialHeatMapPlot(ColorbarPlot):
             ticks = ticks[::nth_mark]
         elif isinstance(ticker, (tuple, list)):
             nth_mark = max([np.ceil(len(ticks) / len(ticker)).astype(int), 1])
-            ticks = [(v, tl) for (v, l), tl in zip(ticks[::nth_mark], ticker, strict=None)]
+            ticks = [(v, tl) for (v, l), tl in zip(ticks[::nth_mark], ticker, strict=False)]
         elif ticker:
             ticks = list(ticker)
         else:

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -86,7 +86,7 @@ class PathPlot(ColorbarPlot):
                 paths.append(arr)
                 continue
             length = len(xarr)
-            for s1, s2 in zip(range(length - 1), range(1, length + 1), strict=None):
+            for s1, s2 in zip(range(length - 1), range(1, length + 1), strict=False):
                 if cdim is not None:
                     pv = path[cdim.name]
                     if isinstance(pv, util.arraylike_types) and len(pv) == length:
@@ -168,7 +168,7 @@ class ContourPlot(PathPlot):
             # If there are multi-geometries the list of scalar values
             # will not match the list of paths and has to be expanded
             array = np.array(
-                [v for v, sps in zip(array, subpaths, strict=None) for _ in range(len(sps))]
+                [v for v, sps in zip(array, subpaths, strict=False) for _ in range(len(sps))]
             )
 
         if dtype_kind(array) not in "uif":

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -362,7 +362,7 @@ class CompositePlot(GenericCompositePlot, MPLPlot):
         contents = [k for s in self.streams for k in s.contents]
         key = tuple(
             None if d in contents else k
-            for d, k in zip(self.dimensions, self.current_key, strict=None)
+            for d, k in zip(self.dimensions, self.current_key, strict=True)
         )
         key = wrap_tuple_streams(key, self.dimensions, self.streams)
         self._update_title(key)
@@ -633,7 +633,7 @@ class GridPlot(CompositePlot):
             layout_axis.set_position(self.position)
         layout_axis.patch.set_visible(False)
 
-        for ax, ax_obj in zip(["x", "y"], [layout_axis.xaxis, layout_axis.yaxis], strict=None):
+        for ax, ax_obj in zip(["x", "y"], [layout_axis.xaxis, layout_axis.yaxis], strict=True):
             tick_fontsize = self._fontsize(f"{ax}ticks", "labelsize", common=False)
             if tick_fontsize:
                 ax_obj.set_tick_params(**tick_fontsize)
@@ -651,7 +651,7 @@ class GridPlot(CompositePlot):
             dim2_keys = [0]
             layout_axis.get_yaxis().set_visible(False)
         else:
-            dim1_keys, dim2_keys = zip(*keys, strict=None)
+            dim1_keys, dim2_keys = zip(*keys, strict=True)
             layout_axis.set_ylabel(dims[1].pprint_label)
             layout_axis.set_aspect(float(self.rows) / self.cols)
 
@@ -758,7 +758,7 @@ class AdjointLayoutPlot(MPLPlot, GenericAdjointLayoutPlot):
         self.view_positions = self.layout_dict[self.layout_type]
 
         # The supplied (axes, view) objects as indexed by position
-        self.subaxes = {pos: ax for ax, pos in zip(subaxes, self.view_positions, strict=None)}
+        self.subaxes = {pos: ax for ax, pos in zip(subaxes, self.view_positions, strict=True)}
         super().__init__(subplots=subplots, **params)
 
     @mpl_rc_context
@@ -1089,7 +1089,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
 
             layout_key, _ = layout_items.get((r, c), (None, None))
             if isinstance(layout, NdLayout) and layout_key:
-                layout_dimensions = dict(zip(layout_dimensions, layout_key, strict=None))
+                layout_dimensions = dict(zip(layout_dimensions, layout_key, strict=True))
 
             # Generate the axes and create the subplots with the appropriate
             # axis objects, handling any Empty objects.
@@ -1108,14 +1108,14 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
                 layout_count += 1
             subaxes = [
                 plt.subplot(self.gs[ind], projection=proj)
-                for ind, proj in zip(gsinds, projs, strict=None)
+                for ind, proj in zip(gsinds, projs, strict=True)
             ]
             subplot_data = self._create_subplots(
                 obj,
                 positions,
                 layout_dimensions,
                 frame_ranges,
-                dict(zip(positions, subaxes, strict=None)),
+                dict(zip(positions, subaxes, strict=True)),
                 num=0 if empty else layout_count,
             )
             subplots, adjoint_layout, _ = subplot_data

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -311,7 +311,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
         self.overlaid = False
         self.hmap = layout
         if layout.ndims > 1:
-            xkeys, ykeys = zip(*layout.keys(), strict=None)
+            xkeys, ykeys = zip(*layout.keys(), strict=True)
         else:
             xkeys = layout.keys()
             ykeys = [None]
@@ -361,7 +361,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
                 pane = vmap.select(
                     **{
                         d.name: val
-                        for d, val in zip(self.dimensions, key, strict=None)
+                        for d, val in zip(self.dimensions, key, strict=False)
                         if d in vmap.kdims
                     }
                 )

--- a/holoviews/plotting/mpl/stats.py
+++ b/holoviews/plotting/mpl/stats.py
@@ -101,7 +101,7 @@ class BoxPlot(MultiDistributionMixin, ChartPlot):
         for key, group in groups:
             if element.kdims:
                 label = ",".join(
-                    [d.pprint_value(v) for d, v in zip(element.kdims, key, strict=None)]
+                    [d.pprint_value(v) for d, v in zip(element.kdims, key, strict=True)]
                 )
             else:
                 label = key
@@ -243,7 +243,7 @@ class ViolinPlot(BoxPlot):
                 **labels,
             )
             artists.update(box)
-        for body, color in zip(artists["bodies"], facecolors, strict=None):
+        for body, color in zip(artists["bodies"], facecolors, strict=False):
             body.set_facecolors(color)
             body.set_edgecolors(edgecolors)
             body.set_alpha(alpha)
@@ -265,7 +265,7 @@ class ViolinPlot(BoxPlot):
         for i, (key, group) in enumerate(groups):
             if element.kdims:
                 label = ",".join(
-                    [d.pprint_value(v) for d, v in zip(element.kdims, key, strict=None)]
+                    [d.pprint_value(v) for d, v in zip(element.kdims, key, strict=True)]
                 )
             else:
                 label = key

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -212,7 +212,7 @@ def unpack_adjoints(ratios):
 
 def normalize_ratios(ratios):
     normalized = {}
-    for i, v in enumerate(zip(*ratios.values(), strict=None)):
+    for i, v in enumerate(zip(*ratios.values(), strict=True)):
         arr = np.array(v)
         normalized[i] = arr / float(np.nanmax(arr))
     return normalized

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -251,7 +251,7 @@ class Plot(param.Parameterized):
             stream_params = stream_parameters(dim_streams)
             key = tuple(
                 None if d in stream_params else k
-                for d, k in zip(self.dimensions, key, strict=None)
+                for d, k in zip(self.dimensions, key, strict=False)
             )
             stream_key = util.wrap_tuple_streams(key, self.dimensions, self.streams)
 
@@ -554,14 +554,14 @@ class DimensionedPlot(Plot):
 
         """
         if self.layout_dimensions is not None:
-            dimensions, key = zip(*self.layout_dimensions.items(), strict=None)
+            dimensions, key = zip(*self.layout_dimensions.items(), strict=True)
         elif not self.dynamic and (not self.uniform or len(self) == 1) or self.subplot:
             return ""
         else:
             key = key if isinstance(key, tuple) else (key,)
             dimensions = self.dimensions
         dimension_labels = [
-            dim.pprint_value_string(k) for dim, k in zip(dimensions, key, strict=None)
+            dim.pprint_value_string(k) for dim, k in zip(dimensions, key, strict=False)
         ]
         groups = [
             ", ".join(dimension_labels[i * group_size : (i + 1) * group_size])
@@ -989,7 +989,9 @@ class DimensionedPlot(Plot):
                 merged = {}
                 for g, drange in dranges["values"].items():
                     filtered = [
-                        r for i, r in zip(ids, values.get(g, []), strict=None) if i not in prev_ids
+                        r
+                        for i, r in zip(ids, values.get(g, []), strict=False)
+                        if i not in prev_ids
                     ]
                     filtered += drange
                     merged[g] = filtered
@@ -1498,7 +1500,7 @@ class GenericElementPlot(DimensionedPlot):
             return self.current_frame
 
         cached = self.current_key is None and not any(s._triggering for s in self.streams)
-        key_map = dict(zip([d.name for d in self.dimensions], key, strict=None))
+        key_map = dict(zip([d.name for d in self.dimensions], key, strict=False))
         # Re-enable pipeline tracking for the DynamicMap callback evaluation.
         # Plot.refresh() disables pipeline for the entire update path (see
         # the disable_pipeline() call there), but user callbacks may call
@@ -1699,7 +1701,7 @@ class GenericElementPlot(DimensionedPlot):
             )
         else:
             max_extent = []
-            for l1, l2 in zip(range_extents, extents, strict=None):
+            for l1, l2 in zip(range_extents, extents, strict=True):
                 if isfinite(l2):
                     max_extent.append(l2)
                 else:
@@ -2020,7 +2022,7 @@ class GenericOverlayPlot(GenericElementPlot):
             sliced_keys = [tuple(k[i] for i in dim_inds) for k in keys]
             frame_ranges = {
                 slckey: self.compute_ranges(holomap, key, ranges[key])
-                for key, slckey in zip(keys, sliced_keys, strict=None)
+                for key, slckey in zip(keys, sliced_keys, strict=True)
                 if slckey in holomap.data.keys()
             }
         else:
@@ -2061,7 +2063,7 @@ class GenericOverlayPlot(GenericElementPlot):
         if isinstance(self.hmap, DynamicMap):
             dmap_streams = [
                 streams + get_nested_streams(layer)
-                for layer, streams in zip(*split_dmap_overlay(self.hmap), strict=None)
+                for layer, streams in zip(*split_dmap_overlay(self.hmap), strict=True)
             ]
         else:
             dmap_streams = [None] * len(keys)
@@ -2073,7 +2075,7 @@ class GenericOverlayPlot(GenericElementPlot):
             self.map_lengths[group_fn(m)[:length]] += 1
 
         subplots = {}
-        for key, vmap, streams in zip(keys, vmaps, dmap_streams, strict=None):
+        for key, vmap, streams in zip(keys, vmaps, dmap_streams, strict=False):
             if streams:
                 streams = list(unique_iterator(streams))
             subplot = self._create_subplot(key, vmap, streams, ranges)
@@ -2106,7 +2108,7 @@ class GenericOverlayPlot(GenericElementPlot):
             if not isinstance(key, tuple):
                 key = (key,)
             style_key = group_fn(obj) + key
-            opts["overlay_dims"] = dict(zip(self.hmap.last.kdims, key, strict=None))
+            opts["overlay_dims"] = dict(zip(self.hmap.last.kdims, key, strict=False))
 
         if self.batched:
             vtype = type(obj.last.last)
@@ -2237,7 +2239,7 @@ class GenericOverlayPlot(GenericElementPlot):
         subplot.cyclic_index = cyclic_index
         if subplot.overlay_dims:
             odim_key = util.wrap_tuple(spec[-1])
-            new_dims = zip(subplot.overlay_dims, odim_key, strict=None)
+            new_dims = zip(subplot.overlay_dims, odim_key, strict=False)
             subplot.overlay_dims = dict(new_dims)
 
     def _get_subplot_extents(self, overlay, ranges, range_type, dimension=None):
@@ -2387,7 +2389,7 @@ class GenericCompositePlot(DimensionedPlot):
         else:
             self.current_key = key
 
-        key_map = dict(zip([d.name for d in self.dimensions], key, strict=None))
+        key_map = dict(zip([d.name for d in self.dimensions], key, strict=False))
         # Re-enable pipeline tracking for the DynamicMap callback evaluation.
         # See GenericElementPlot._get_frame for rationale.
         with enable_pipeline():

--- a/holoviews/plotting/plotly/dash.py
+++ b/holoviews/plotting/plotly/dash.py
@@ -590,7 +590,7 @@ def to_dash(
         # Get kdim values
         store_data.setdefault("kdims", {})
         for i, kdim in zip(
-            range(num_figs * 2, num_figs * 2 + len(all_kdims)), all_kdims, strict=None
+            range(num_figs * 2, num_figs * 2 + len(all_kdims)), all_kdims, strict=True
         ):
             if kdim not in store_data["kdims"] or store_data["kdims"][kdim] != args[i]:
                 store_data["kdims"][kdim] = args[i]

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -652,7 +652,7 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
         axis_props = {}
         if isinstance(ticker, (tuple, list)):
             if all(isinstance(t, tuple) for t in ticker):
-                ticks, labels = zip(*ticker, strict=None)
+                ticks, labels = zip(*ticker, strict=False)
                 labels = [l if isinstance(l, str) else str(l) for l in labels]
                 axis_props["tickvals"] = ticks
                 axis_props["ticktext"] = labels

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -103,7 +103,7 @@ class LayoutPlot(PlotlyPlot, GenericLayoutPlot):
             # to create the correct subaxes for all plots in the layout
             layout_key, _ = layout_items.get((r, c), (None, None))
             if isinstance(layout, NdLayout) and layout_key:
-                layout_dimensions = dict(zip(layout_dimensions, layout_key, strict=None))
+                layout_dimensions = dict(zip(layout_dimensions, layout_key, strict=True))
 
             # Generate the axes and create the subplots with the appropriate
             # axis objects, handling any Empty objects.

--- a/holoviews/plotting/plotly/shapes.py
+++ b/holoviews/plotting/plotly/shapes.py
@@ -37,7 +37,7 @@ class ShapePlot(ElementPlot):
 
     @staticmethod
     def build_path(xs, ys, closed=True):
-        line_tos = "".join([f"L{x} {y}" for x, y in zip(xs[1:], ys[1:], strict=None)])
+        line_tos = "".join([f"L{x} {y}" for x, y in zip(xs[1:], ys[1:], strict=True)])
         path = f"M{xs[0]} {ys[0]}{line_tos}"
 
         if closed:
@@ -68,10 +68,10 @@ class BoxShapePlot(GeomMixin, ShapePlot):
                             [lat0, lat1, lat1, lat0, lat0, np.nan],
                         )
                         for (lon0, lat0, lon1, lat1) in zip(
-                            lon0s, lat0s, lon1s, lat1s, strict=None
+                            lon0s, lat0s, lon1s, lat1s, strict=True
                         )
                     ],
-                    strict=None,
+                    strict=True,
                 )
 
                 lon = np.concatenate(lon_chunks)
@@ -80,7 +80,7 @@ class BoxShapePlot(GeomMixin, ShapePlot):
         else:
             return [
                 dict(x0=x0, x1=x1, y0=y0, y1=y1, xref="x", yref="y")
-                for (x0, y0, x1, y1) in zip(x0s, y0s, x1s, y1s, strict=None)
+                for (x0, y0, x1, y1) in zip(x0s, y0s, x1s, y1s, strict=True)
             ]
 
 
@@ -102,10 +102,10 @@ class SegmentShapePlot(GeomMixin, ShapePlot):
                     *[
                         ([lon0, lon1, np.nan], [lat0, lat1, np.nan])
                         for (lon0, lat0, lon1, lat1) in zip(
-                            lon0s, lat0s, lon1s, lat1s, strict=None
+                            lon0s, lat0s, lon1s, lat1s, strict=True
                         )
                     ],
-                    strict=None,
+                    strict=True,
                 )
 
                 lon = np.concatenate(lon_chunks)
@@ -114,7 +114,7 @@ class SegmentShapePlot(GeomMixin, ShapePlot):
         else:
             return [
                 dict(x0=x0, x1=x1, y0=y0, y1=y1, xref="x", yref="y")
-                for (x0, y0, x1, y1) in zip(x0s, y0s, x1s, y1s, strict=None)
+                for (x0, y0, x1, y1) in zip(x0s, y0s, x1s, y1s, strict=True)
             ]
 
 

--- a/holoviews/plotting/plotly/stats.py
+++ b/holoviews/plotting/plotly/stats.py
@@ -95,7 +95,7 @@ class MultiDistributionPlot(MultiDistributionMixin, ElementPlot):
                 if isinstance(key, str):
                     key = (key,)
                 label = ",".join(
-                    [d.pprint_value(v) for d, v in zip(element.kdims, key, strict=None)]
+                    [d.pprint_value(v) for d, v in zip(element.kdims, key, strict=True)]
                 )
             else:
                 label = key

--- a/holoviews/plotting/plotly/util.py
+++ b/holoviews/plotting/plotly/util.py
@@ -717,8 +717,8 @@ def figure_grid(
 
     output_figure = {"data": [], "layout": {}}
 
-    for r, (fig_row, row_domain) in enumerate(zip(figures_grid, row_domains, strict=None)):
-        for c, (fig, column_domain) in enumerate(zip(fig_row, column_domains, strict=None)):
+    for r, (fig_row, row_domain) in enumerate(zip(figures_grid, row_domains, strict=True)):
+        for c, (fig, column_domain) in enumerate(zip(fig_row, column_domains, strict=True)):
             if fig:
                 fig = copy.deepcopy(fig)
 

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -295,7 +295,7 @@ class Renderer(Exporter):
             plot = self_or_cls.plotting_class(obj)(obj, renderer=renderer, **plot_opts)
             defaults = [kd.default for kd in plot.dimensions]
             init_key = tuple(
-                v if d is None else d for v, d in zip(plot.keys[0], defaults, strict=None)
+                v if d is None else d for v, d in zip(plot.keys[0], defaults, strict=True)
             )
             plot.update(init_key)
         else:

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -349,7 +349,7 @@ def get_nested_plot_frame(obj, key_map, cached=False):
 
     # Ensure that DynamicMaps in the cloned frame have
     # identical callback inputs to allow memoization to work
-    for it1, it2 in zip(obj.traverse(lambda x: x), clone.traverse(lambda x: x), strict=None):
+    for it1, it2 in zip(obj.traverse(lambda x: x), clone.traverse(lambda x: x), strict=True):
         if isinstance(it1, DynamicMap):
             with disable_constant(it2.callback):
                 it2.callback.inputs = it1.callback.inputs
@@ -517,7 +517,7 @@ def get_dynamic_mode(composite):
 
 def initialize_unbounded(obj, dimensions, key):
     """Initializes any DynamicMaps in unbounded mode."""
-    select = dict(zip([d.name for d in dimensions], key, strict=None))
+    select = dict(zip([d.name for d in dimensions], key, strict=True))
     try:
         obj.select(selection_specs=[DynamicMap], **select)
     except KeyError:
@@ -1121,7 +1121,7 @@ def color_intervals(colors, levels, clip=None, N=255):
     cmin, cmax = min(levels), max(levels)
     interval = cmax - cmin
     cmap = []
-    for intv, c in zip(intervals, colors, strict=None):
+    for intv, c in zip(intervals, colors, strict=True):
         cmap += [c] * round(N * (intv / interval))
     if clip is not None:
         clmin, clmax = clip


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Have tested it locally against GeoViews and hvplot.

This was initially developed for https://github.com/holoviz/holoviews/pull/6862, which is why no files in holoviews/core/data/ has been touched. This is because `strict=None` would give a type error. 


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Claude Code:claude-sonnet-5
Usage: Asked it to move all `zip(..., strict=None)` to either True

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

Created the following skill to apply it and the following python code to find all.

<details><summary>Skill</summary>
<p>


 
```` markdown
---
name: zip-strict-audit
description: Find zip(..., strict=None) call sites in this repo and resolve each to strict=True or strict=False by reading the surrounding code's length invariants AND verifying empirically. Use when migrating zip-strict usage or continuing that migration in a new directory.
---

# Zip strict audit

This repo is mid-migration from bare `zip(...)` to explicit `zip(..., strict=...)`. Many call
sites still have `strict=None` as a placeholder. This skill finds them and resolves each one
individually — by reading the code AND by testing actual behavior, not by reasoning alone.

**Reading the code is not sufficient by itself.** In the first pass over `holoviews/core/data/`,
3 of ~33 sites marked `strict=True` from code-reading alone turned out to be wrong — each one
broke a real, working feature that wasn't visible from reading the containing method in
isolation. Do not repeat that mistake: see "Verify empirically" below before trusting any answer
that isn't in the trivially-safe bucket.

## 1. Find occurrences

```
python .claude/skills/zip-strict-audit/find_zip_strict_none.py <path>
```

Takes a directory, parses every `.py` file's AST, and prints `file:line: source` for every
`zip(...)` call that has an explicit `strict=None` keyword. Multi-line `zip(...)` calls are
reported at the line containing `zip(`.

## 2. Resolve each site — read the code first

For every match, open the file and read the function around it. Do not batch-apply a single
answer to lines that merely look similar — near-identical `zip(...)` calls in different
functions can have opposite answers.

**Trivially `strict=True`, no empirical test needed** — the guarantee is a hard Python/pandas
structural fact, not an assumption about caller behavior:
- `zip(*dict_obj.items(), strict=True)` — items() always yields 2-tuples.
- `zip(df.columns, df.dtypes, strict=True)` / `zip(series.index, series.values, strict=True)` —
  two attributes of the same object.
- Two lists built by appending in the same loop, in the same iteration, with **no**
  `continue`/conditional between the two `.append()` calls (check this carefully — a `continue`
  or an `if` guarding only one of the two appends means they can diverge).
- A dimension/key list zipped against a tuple produced by transposing or cartesian-producting
  that *same* list, where the arithmetic is visible in the same method (e.g. `keys` was built as
  `[... for d in dimensions]`, then a later zip pairs `dimensions` against something derived from
  `keys`).

**Needs empirical verification before committing to `strict=True`** — anything where the
guarantee depends on a caller's contract, a class invariant established in a *different* method,
or "this is probably how the data is normally shaped":
- A tuple/array/coordinate value zipped against a fixed dimension-name list inside an `init()`,
  `sample()`, or similar constructor-ish method. **This is the exact pattern that broke three
  times.** The giveaway: the method accepts external input (constructor data, a user-supplied
  sample tuple) and pairs it against `dimensions`/`columns`/`kdims`. These often support
  deliberately shorter input with fill-in or broadcast semantics that isn't visible from reading
  the local code:
  - `pandas.py` DataFrame construction: `pd.DataFrame(dict(zip(columns, data)), columns=columns)`
    — passing `columns=` to the DataFrame constructor NaN-fills any column missing from the dict.
    A short `data` tuple is a **supported partial-vdim feature**, not a bug.
  - `xarray.py`/`grid.py` `sample()`: an under-length sample tuple means "leave this dimension
    unconstrained" (broadcast/select-all), not "malformed input". `grid.py`'s version pads the
    tuple explicitly (visible in-method); `xarray.py`'s equivalent does the same thing but
    **without** visible padding, so reading the method alone gives a false sense of safety.
  - Any `ndloc`/`iloc`-style indexing method: partial indexing (fewer indices than kdims) is a
    common supported pattern across interfaces.
- A mask (`selection_mask`, boolean arrays) zipped against data, unless the mask is visibly
  computed from that exact data earlier in the same method.
- Anything relying on "this function's caller always passes matching lengths" where the caller
  is in a different file/class.

**`strict=False`** — a length mismatch is legitimate/intentional:
- One sequence is deliberately longer/shorter by design (a dimensions list that includes vdim
  names not present in a kdim-only data tuple; `zip(range(n-1), range(1, n+1))` to form adjacent
  pairs).
- Partial/optional indexing or partial/broadcast sampling is supported (see above).
- One accumulator list is appended unconditionally per loop iteration while the other is
  appended conditionally (via `continue` or an `if`), so lengths can diverge by design.
- Validation earlier in the function only checks a lower bound (e.g. `min_dims`) or checks one
  representative element, not every element — a lower-bound-only check is a strong signal that
  the remaining gap up to the full length is deliberately allowed, not an oversight.

**If a "needs verification" site can't actually be verified, leave/restore it as `strict=None` —
do not guess `True` or `False`.** This includes: the optional dependency that would exercise the
code path isn't installed in this environment (e.g. `spatialpandas`, a specific database driver);
the code path needs live infrastructure you don't have (a DB connection, a browser); or you
simply ran out of good ideas for a repro. `strict=None` is this codebase's existing convention
for "not yet resolved" (it's valid Python — `zip` treats it as falsy — so nothing breaks by
leaving it), and it is the honest answer here: `False` is still an assertion you're making
without evidence, not a neutral default. "I read the loop carefully and it looks like it can't
diverge" is not verification — it's the same kind of reasoning that produced three confirmed-wrong
`True`s earlier in this skill's history. Do not let confidence in your own reading substitute for
running the code, and do not let an inability to test push you toward silently picking an answer
either way. Note in your summary to the user exactly which sites were left as `None` and why, so
they (or a future run in an environment with the dependency) can pick this back up.

## 3. Verify empirically — don't trust reasoning alone for the "needs verification" bucket

For every site in the "needs empirical verification" bucket, before locking in the answer:

1. Write a short repro that exercises the code path through the **public API** (e.g.
   `hv.Dataset(...)`, `ds.sample(...)`, `ds.groupby(...)`), not just a direct classmethod call —
   the public API sometimes pre-validates or pre-pads arguments in ways that mask what the
   interface method itself would do with truly mismatched input.
2. Isolate just the file you're editing and compare before/after:
   ```
   git stash push -- path/to/file.py   # removes your strict= edits
   python repro.py                      # behavior WITHOUT your change
   git stash pop
   python repro.py                      # behavior WITH your change
   ```
3. Deliberately try an under-length input (fewer elements than the fixed side) even if you can't
   immediately think why a caller would do that — that's exactly the case that broke the pandas
   and xarray sites. If the pre-change behavior does something *useful and structured* (e.g.
   NaN-filled columns, a sensible broadcast selection) rather than an obvious garbage/error
   result, that usefulness is a real feature — set `strict=False`.
4. If pre-change behavior on mismatch is already silently wrong/nonsensical either way (e.g.
   ragged input silently produces a corrupted dataset with no error), `strict=True` is a genuine
   improvement and safe to keep, even without a "designed for this" caller.

A full-suite pass after the change is necessary but not sufficient — the three bugs found in the
first pass all passed the full `holoviews/tests/core/data/` suite (weak coverage of that specific
input shape), and were only caught by writing a targeted repro for the exact pattern above.

## 4. Apply and verify

- Edit `strict=None` to `strict=True`/`strict=False` per site.
- Run the narrowest relevant test file(s) after each file, plus a broader sweep (e.g.
  `holoviews/tests/element/`) at the end — see repo test-scoping conventions, and don't run the
  full suite unprompted.
- Some call sites feed from code that has an independent latent bug (e.g. a value that should
  have been transposed but wasn't, as in `xarray.py`'s `data = tuple(data)` at `init()`). Don't
  fix unrelated bugs while doing this audit — set `strict=False` to preserve current behavior and
  flag the bug separately.

## Reference

`holoviews/core/data/` was mostly audited this way (40 of 42 sites resolved, across grid.py,
ibis.py, image.py, multipath.py, narwhals.py, pandas.py, spatialpandas.py, xarray.py). Three
sites were initially marked `True` from code-reading alone and had to be corrected to `False`
after empirical testing surfaced real regressions: `pandas.py`'s tuple-to-DataFrame constructor
(broke NaN-filled optional vdims), `image.py`'s equivalent tuple-init path (same shape, fixed
pre-emptively), and `xarray.py`'s `sample()` (broke broadcast/under-specified sample tuples). Two
sites (`spatialpandas.py:713` and `:853`) are left as `strict=None` — see the rule above —
because `spatialpandas` wasn't installed in the audit environment, so the reasoning behind them
("the loop looks lockstep with no skip") could never actually be run. Pick those two up first if
you land in an environment with `spatialpandas` available; otherwise re-run the finder against
other directories (`holoviews/element/`, `holoviews/plotting/`, etc.) to continue the migration,
and apply step 3 rigorously for every "needs verification" site.
````




</p>
</details>


<details><summary>Code</summary>
<p>

``` python

import argparse
import ast
from pathlib import Path


class ZipStrictNoneVisitor(ast.NodeVisitor):
    def __init__(self, source_lines):
        self.source_lines = source_lines
        self.matches = []

    def visit_Call(self, node):
        if isinstance(node.func, ast.Name) and node.func.id == "zip":
            for kw in node.keywords:
                if (
                    kw.arg == "strict"
                    and isinstance(kw.value, ast.Constant)
                    and kw.value.value is None
                ):
                    line = self.source_lines[node.lineno - 1].strip()
                    self.matches.append((node.lineno, line))
        self.generic_visit(node)


def find_zip_strict_none(root: Path):
    results = {}
    for pyfile in sorted(root.rglob("*.py")):
        source = pyfile.read_text()
        try:
            tree = ast.parse(source, filename=str(pyfile))
        except SyntaxError as e:
            print(f"SyntaxError parsing {pyfile}: {e}")
            continue
        visitor = ZipStrictNoneVisitor(source.splitlines())
        visitor.visit(tree)
        if visitor.matches:
            results[pyfile] = visitor.matches
    return results


def main():
    parser = argparse.ArgumentParser(
        description="Find zip(..., strict=None) call sites via AST parsing"
    )
    parser.add_argument("path", type=Path, help="Directory to search recursively for .py files")
    args = parser.parse_args()

    if not args.path.is_dir():
        raise SystemExit(f"Not a directory: {args.path}")

    results = find_zip_strict_none(args.path)
    total = 0
    for pyfile, matches in results.items():
        for lineno, line in matches:
            print(f"{pyfile}:{lineno}: {line}")
            total += 1

    print(f"\nTotal: {total} occurrence(s) in {len(results)} file(s)")


if __name__ == "__main__":
    main()


```

</p>
</details> 

## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
