### PR TITLE
fix: Apply xlabel/ylabel to the visual axes under invert_axes

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -972,10 +972,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if dim:
                 axis_label = str(dim)
             else:
-                xlabel, ylabel, _zlabel = self._get_axis_labels(dims if dims else (None, None))
-                if self.invert_axes:
-                    xlabel, ylabel = ylabel, xlabel
-                axis_label = ylabel if pos else xlabel
+                axis_label = dim_axis_label(dims[0]) if dims and dims[0] else ""
+                if pos == 0 and self.xlabel is not None:
+                    axis_label = self.xlabel
+                elif pos == 1 and self.ylabel is not None:
+                    axis_label = self.ylabel
             if dims:
                 dims = dims[:2][::-1]
 
@@ -1514,8 +1515,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             for axis, dim in zip(["x", "y"], dimensions, strict=False)
         }
         xlabel, ylabel, _zlabel = self._get_axis_labels(dimensions)
-        if self.invert_axes:
-            xlabel, ylabel = ylabel, xlabel
         props["x"]["axis_label"] = xlabel if "x" in self.labelled or self.xlabel else ""
         props["y"]["axis_label"] = ylabel if "y" in self.labelled or self.ylabel else ""
         if not self._has_changed("label", props):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -972,7 +972,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if dim:
                 axis_label = str(dim)
             else:
-                axis_label = dim_axis_label(dims[0]) if dims and dims[0] else ""
+                axis_label = dim_axis_label(dims) if dims else ""
                 if pos == 0 and self.xlabel is not None:
                     axis_label = self.xlabel
                 elif pos == 1 and self.ylabel is not None:

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -405,8 +405,6 @@ class ElementPlot(GenericElementPlot, MPLPlot):
 
         """
         xlabel, ylabel, zlabel = self._get_axis_labels(dimensions, xlabel, ylabel, zlabel)
-        if self.invert_axes:
-            xlabel, ylabel = ylabel, xlabel
         if xlabel and self.xaxis and "x" in self.labelled:
             axes.set_xlabel(xlabel, **self._fontsize("xlabel"))
         if ylabel and self.yaxis and "y" in self.labelled:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1745,27 +1745,39 @@ class GenericElementPlot(DimensionedPlot):
         return (x0, y0, x1, y1)
 
     def _get_axis_labels(self, dimensions, xlabel=None, ylabel=None, zlabel=None):
-        if self.xlabel is not None:
-            xlabel = self.xlabel
-        elif dimensions and xlabel is None:
+        """Returns axis labels derived from the supplied dimensions.
+
+        Derived labels follow their data dimension and are swapped when
+        invert_axes is set. The xlabel/ylabel/zlabel plot options refer
+        to the visual axes and override the derived labels after that swap.
+        Explicit xlabel/ylabel/zlabel arguments still override the derived
+        labels before the invert_axes swap.
+
+        """
+        if dimensions and xlabel is None:
             xdims = dimensions[0]
             xlabel = dim_axis_label(xdims) if xdims else ""
 
-        if self.ylabel is not None:
-            ylabel = self.ylabel
-        elif len(dimensions) >= 2 and ylabel is None:
+        if len(dimensions) >= 2 and ylabel is None:
             ydims = dimensions[1]
             ylabel = dim_axis_label(ydims) if ydims else ""
 
-        if getattr(self, "zlabel", None) is not None:
-            zlabel = self.zlabel
-        elif (
+        if (
             isinstance(self.projection, str)
             and self.projection == "3d"
             and len(dimensions) >= 3
             and zlabel is None
         ):
             zlabel = dim_axis_label(dimensions[2]) if dimensions[2] else ""
+
+        if self.invert_axes:
+            xlabel, ylabel = ylabel, xlabel
+        if self.xlabel is not None:
+            xlabel = self.xlabel
+        if self.ylabel is not None:
+            ylabel = self.ylabel
+        if getattr(self, "zlabel", None) is not None:
+            zlabel = self.zlabel
         return xlabel, ylabel, zlabel
 
     def _format_title_components(self, key, dimensions=True, separator="\n"):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1750,8 +1750,6 @@ class GenericElementPlot(DimensionedPlot):
         Derived labels follow their data dimension and are swapped when
         invert_axes is set. The xlabel/ylabel/zlabel plot options refer
         to the visual axes and override the derived labels after that swap.
-        Explicit xlabel/ylabel/zlabel arguments still override the derived
-        labels before the invert_axes swap.
 
         """
         if dimensions and xlabel is None:

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -511,7 +511,6 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
                     "The invert_axes parameter is not supported on Tiles elements "
                     "with the plotly backend"
                 )
-            xlabel, ylabel = ylabel, xlabel
             ydim, xdim = xdim, ydim
             l, b, r, t = b, l, t, r
 

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -628,19 +628,19 @@ class TestBarPlot(TestBokehPlot):
 
     def test_bars_invert_axes_xlabel_only(self):
         bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
-            invert_axes=True, xlabel="Species"
+            invert_axes=True, xlabel="Body Mass (g)"
         )
         plot = bokeh_renderer.get_plot(bars).state
-        assert plot.xaxis[0].axis_label == "Species"
+        assert plot.xaxis[0].axis_label == "Body Mass (g)"
         assert plot.yaxis[0].axis_label == "species"
 
     def test_bars_invert_axes_ylabel_only(self):
         bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
-            invert_axes=True, ylabel="Body Mass (g)"
+            invert_axes=True, ylabel="Species"
         )
         plot = bokeh_renderer.get_plot(bars).state
         assert plot.xaxis[0].axis_label == "body_mass_g"
-        assert plot.yaxis[0].axis_label == "Body Mass (g)"
+        assert plot.yaxis[0].axis_label == "Species"
 
 
 @pytest.mark.parametrize("stacked", [True, False])

--- a/holoviews/tests/plotting/bokeh/test_barplot.py
+++ b/holoviews/tests/plotting/bokeh/test_barplot.py
@@ -612,6 +612,36 @@ class TestBarPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(bars)
         assert np.isclose(plot.handles["glyph"].width, 0.232)
 
+    def test_bars_invert_axes_custom_labels_visual_axes(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
+            invert_axes=True, xlabel="Species", ylabel="Body Mass (g)"
+        )
+        plot = bokeh_renderer.get_plot(bars).state
+        assert plot.xaxis[0].axis_label == "Species"
+        assert plot.yaxis[0].axis_label == "Body Mass (g)"
+
+    def test_bars_invert_axes_auto_labels_follow_dimensions(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(invert_axes=True)
+        plot = bokeh_renderer.get_plot(bars).state
+        assert plot.xaxis[0].axis_label == "body_mass_g"
+        assert plot.yaxis[0].axis_label == "species"
+
+    def test_bars_invert_axes_xlabel_only(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
+            invert_axes=True, xlabel="Species"
+        )
+        plot = bokeh_renderer.get_plot(bars).state
+        assert plot.xaxis[0].axis_label == "Species"
+        assert plot.yaxis[0].axis_label == "species"
+
+    def test_bars_invert_axes_ylabel_only(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
+            invert_axes=True, ylabel="Body Mass (g)"
+        )
+        plot = bokeh_renderer.get_plot(bars).state
+        assert plot.xaxis[0].axis_label == "body_mass_g"
+        assert plot.yaxis[0].axis_label == "Body Mass (g)"
+
 
 @pytest.mark.parametrize("stacked", [True, False])
 def test_grouped_bars_color(stacked):

--- a/holoviews/tests/plotting/bokeh/test_elementplot.py
+++ b/holoviews/tests/plotting/bokeh/test_elementplot.py
@@ -265,6 +265,14 @@ class TestElementPlot(LoggingComparison, TestBokehPlot):
         plot = bokeh_renderer.get_plot(curve).state
         assert plot.yaxis[0].axis_label == "custom y-label"
 
+    def test_element_invert_axes_custom_labels_visual_axes(self):
+        curve = hv.Curve(range(10)).opts(
+            invert_axes=True, xlabel="custom x-label", ylabel="custom y-label"
+        )
+        plot = bokeh_renderer.get_plot(curve).state
+        assert plot.xaxis[0].axis_label == "custom x-label"
+        assert plot.yaxis[0].axis_label == "custom y-label"
+
     def test_element_labelled_x_disabled(self):
         curve = hv.Curve(range(10)).opts(labelled=["y"])
         plot = bokeh_renderer.get_plot(curve).state

--- a/holoviews/tests/plotting/bokeh/test_multiaxis.py
+++ b/holoviews/tests/plotting/bokeh/test_multiaxis.py
@@ -325,3 +325,25 @@ class TestCurveTwinAxes(LoggingComparison, TestBokehPlot):
 
         # Should not error
         bokeh_renderer.get_plot(overlay)
+
+    def test_multi_y_grouped_bars_axis_labels(self):
+        bars = hv.Bars(
+            [("A", "X", 1), ("A", "Y", 2), ("B", "X", 3), ("B", "Y", 4)],
+            kdims=["Category", "Subcategory"],
+            vdims=["Value"],
+        ).opts(multi_y=True)
+        plot = bokeh_renderer.get_plot(bars).state
+
+        assert plot.xaxis[0].axis_label == "Category, Subcategory"
+        assert plot.yaxis[0].axis_label == "Value"
+
+    def test_multi_y_grouped_bars_inverted_axis_labels(self):
+        bars = hv.Bars(
+            [("A", "X", 1), ("A", "Y", 2), ("B", "X", 3), ("B", "Y", 4)],
+            kdims=["Category", "Subcategory"],
+            vdims=["Value"],
+        ).opts(multi_y=True, invert_axes=True)
+        plot = bokeh_renderer.get_plot(bars).state
+
+        assert plot.xaxis[0].axis_label == "Value"
+        assert plot.yaxis[0].axis_label == "Category, Subcategory"

--- a/holoviews/tests/plotting/matplotlib/test_barplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_barplot.py
@@ -258,16 +258,16 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
 
     def test_bars_invert_axes_xlabel_only(self):
         bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
-            invert_axes=True, xlabel="Species"
+            invert_axes=True, xlabel="Body Mass (g)"
         )
         ax = mpl_renderer.get_plot(bars).handles["axis"]
-        assert ax.get_xlabel() == "Species"
+        assert ax.get_xlabel() == "Body Mass (g)"
         assert ax.get_ylabel() == "species"
 
     def test_bars_invert_axes_ylabel_only(self):
         bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
-            invert_axes=True, ylabel="Body Mass (g)"
+            invert_axes=True, ylabel="Species"
         )
         ax = mpl_renderer.get_plot(bars).handles["axis"]
         assert ax.get_xlabel() == "body_mass_g"
-        assert ax.get_ylabel() == "Body Mass (g)"
+        assert ax.get_ylabel() == "Species"

--- a/holoviews/tests/plotting/matplotlib/test_barplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_barplot.py
@@ -241,3 +241,33 @@ class TestBarPlot(LoggingComparison, TestMPLPlot):
         bars = hv.Bars(df, "x", ["high"]).opts(baseline="nope")
         mpl_renderer.get_plot(bars)
         self.log_handler.assert_contains("WARNING", "Could not use baseline dimension 'nope'")
+
+    def test_bars_invert_axes_custom_labels_visual_axes(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
+            invert_axes=True, xlabel="Species", ylabel="Body Mass (g)"
+        )
+        ax = mpl_renderer.get_plot(bars).handles["axis"]
+        assert ax.get_xlabel() == "Species"
+        assert ax.get_ylabel() == "Body Mass (g)"
+
+    def test_bars_invert_axes_auto_labels_follow_dimensions(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(invert_axes=True)
+        ax = mpl_renderer.get_plot(bars).handles["axis"]
+        assert ax.get_xlabel() == "body_mass_g"
+        assert ax.get_ylabel() == "species"
+
+    def test_bars_invert_axes_xlabel_only(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
+            invert_axes=True, xlabel="Species"
+        )
+        ax = mpl_renderer.get_plot(bars).handles["axis"]
+        assert ax.get_xlabel() == "Species"
+        assert ax.get_ylabel() == "species"
+
+    def test_bars_invert_axes_ylabel_only(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
+            invert_axes=True, ylabel="Body Mass (g)"
+        )
+        ax = mpl_renderer.get_plot(bars).handles["axis"]
+        assert ax.get_xlabel() == "body_mass_g"
+        assert ax.get_ylabel() == "Body Mass (g)"

--- a/holoviews/tests/plotting/matplotlib/test_elementplot.py
+++ b/holoviews/tests/plotting/matplotlib/test_elementplot.py
@@ -110,6 +110,14 @@ class TestElementPlot(LoggingComparison, TestMPLPlot):
         axes = mpl_renderer.get_plot(element).handles["axis"]
         assert axes.get_ylabel() == "custom y-label"
 
+    def test_element_invert_axes_custom_labels_visual_axes(self):
+        element = hv.Curve(range(10)).opts(
+            invert_axes=True, xlabel="custom x-label", ylabel="custom y-label"
+        )
+        axes = mpl_renderer.get_plot(element).handles["axis"]
+        assert axes.get_xlabel() == "custom x-label"
+        assert axes.get_ylabel() == "custom y-label"
+
     def test_element_xformatter_string(self):
         curve = hv.Curve(range(10)).opts(xformatter="%d")
         plot = mpl_renderer.get_plot(curve)

--- a/holoviews/tests/plotting/plotly/test_barplot.py
+++ b/holoviews/tests/plotting/plotly/test_barplot.py
@@ -244,3 +244,33 @@ class TestBarsPlot(LoggingComparison, TestPlotlyPlot):
         fig = self._get_plot_state(bars)
         data = fig["data"][0]
         assert data["marker"]["color"] == "gold"
+
+    def test_bars_invert_axes_custom_labels_visual_axes(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
+            invert_axes=True, xlabel="Species", ylabel="Body Mass (g)"
+        )
+        state = self._get_plot_state(bars)
+        assert state["layout"]["xaxis"]["title"]["text"] == "Species"
+        assert state["layout"]["yaxis"]["title"]["text"] == "Body Mass (g)"
+
+    def test_bars_invert_axes_auto_labels_follow_dimensions(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(invert_axes=True)
+        state = self._get_plot_state(bars)
+        assert state["layout"]["xaxis"]["title"]["text"] == "body_mass_g"
+        assert state["layout"]["yaxis"]["title"]["text"] == "species"
+
+    def test_bars_invert_axes_xlabel_only(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
+            invert_axes=True, xlabel="Species"
+        )
+        state = self._get_plot_state(bars)
+        assert state["layout"]["xaxis"]["title"]["text"] == "Species"
+        assert state["layout"]["yaxis"]["title"]["text"] == "species"
+
+    def test_bars_invert_axes_ylabel_only(self):
+        bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
+            invert_axes=True, ylabel="Body Mass (g)"
+        )
+        state = self._get_plot_state(bars)
+        assert state["layout"]["xaxis"]["title"]["text"] == "body_mass_g"
+        assert state["layout"]["yaxis"]["title"]["text"] == "Body Mass (g)"

--- a/holoviews/tests/plotting/plotly/test_barplot.py
+++ b/holoviews/tests/plotting/plotly/test_barplot.py
@@ -261,16 +261,16 @@ class TestBarsPlot(LoggingComparison, TestPlotlyPlot):
 
     def test_bars_invert_axes_xlabel_only(self):
         bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
-            invert_axes=True, xlabel="Species"
+            invert_axes=True, xlabel="Body Mass (g)"
         )
         state = self._get_plot_state(bars)
-        assert state["layout"]["xaxis"]["title"]["text"] == "Species"
+        assert state["layout"]["xaxis"]["title"]["text"] == "Body Mass (g)"
         assert state["layout"]["yaxis"]["title"]["text"] == "species"
 
     def test_bars_invert_axes_ylabel_only(self):
         bars = hv.Bars([("A", 1), ("B", 2)], "species", "body_mass_g").opts(
-            invert_axes=True, ylabel="Body Mass (g)"
+            invert_axes=True, ylabel="Species"
         )
         state = self._get_plot_state(bars)
         assert state["layout"]["xaxis"]["title"]["text"] == "body_mass_g"
-        assert state["layout"]["yaxis"]["title"]["text"] == "Body Mass (g)"
+        assert state["layout"]["yaxis"]["title"]["text"] == "Species"

--- a/holoviews/tests/plotting/plotly/test_elementplot.py
+++ b/holoviews/tests/plotting/plotly/test_elementplot.py
@@ -57,6 +57,14 @@ class TestElementPlot(TestPlotlyPlot):
         state = self._get_plot_state(curve)
         assert state["layout"]["yaxis"]["title"]["text"] == "Y-Axis"
 
+    def test_element_invert_axes_custom_labels_visual_axes(self):
+        curve = hv.Curve(range(10)).opts(
+            invert_axes=True, xlabel="custom x-label", ylabel="custom y-label"
+        )
+        state = self._get_plot_state(curve)
+        assert state["layout"]["xaxis"]["title"]["text"] == "custom x-label"
+        assert state["layout"]["yaxis"]["title"]["text"] == "custom y-label"
+
     def test_element_plot_zlabel(self):
         scatter = hv.Scatter3D([(10, 1, 2), (100, 2, 3), (1000, 3, 5)]).opts(zlabel="Z-Axis")
         state = self._get_plot_state(scatter)


### PR DESCRIPTION
Fixes #7033

## Description

This PR fixes the label swap on inverted plots (e.g. `hvplot.barh`, which is `Bars + invert_axes=True`). Custom `xlabel/ylabel` previously labeled the element's data dimensions and were swapped by each backend under `invert_axes`.

This PR makes `xlabel/ylabel/zlabel` refer to the visual axes, never swapped, while auto-derived dimension labels still follow their dimension (swapped under `invert_axes`). 


## Result screenshot

### HoloViews
```python
import pandas as pd
import holoviews as hv
hv.extension('bokeh', 'matplotlib')

mpg = pd.read_csv('https://raw.githubusercontent.com/tidyverse/ggplot2/master/data-raw/mpg.csv')
mpg = mpg['manufacturer'].value_counts(sort=False)

# bokeh
hv.Bars(mpg).opts(
    invert_axes=True,
    xlabel='Car count',
    ylabel='Car Make'
)
```
<img width="600" height="600" alt="bokeh_axes" src="https://github.com/user-attachments/assets/193a4304-d216-40ce-af99-71908edd1f0b" />


```python
# mpl
hv.output(backend='matplotlib')

hv.Bars(mpg).opts(
    invert_axes=True,
    xlabel='Car count',
    ylabel='Car Make'
)
```
<img width="394" height="266" alt="Screenshot 2026-09-01 at 4 49 37 PM" src="https://github.com/user-attachments/assets/0988dd0e-e0b4-478c-954e-fe5ff7e6ca22" />

### hvPlot

```python
import hvplot.pandas  # noqa

df = hvplot.sampledata.penguins('pandas')
grouped = df.groupby('species', observed=True)['body_mass_g'].mean()

grouped.hvplot.barh(
    x='species',
    y='body_mass_g',
    title='Horizontal Bar Chart (Bokeh)',
    xlabel='Body Mass (g)',
    ylabel='Species',
)
```
<img width="1400" height="600" alt="hvplot_axes" src="https://github.com/user-attachments/assets/651678b9-aa8d-4d9d-87d4-97847023e8c4" />

## AI Disclosure

Tool & Model: Kilo (kilo-auto/balanced)
Usage: Drafted the implementation and tests; reviewed and edited by me.

Tool & Model:
Usage:

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing