### PR TITLE
ci: Compare pixi.lock diff against PR base SHA instead of main tip

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,6 +122,8 @@ jobs:
           fetch-depth: 0
       - name: Generate pixi.lock diff
         id: diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           {
             echo 'body<<PIXI_LOCK_DIFF_EOF'

--- a/scripts/pixi-diff.py
+++ b/scripts/pixi-diff.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
@@ -194,19 +195,19 @@ def git_rev_parse(revision: str) -> str:
     return result.stdout.strip()
 
 
-def print_header():
+def print_header(base: str):
     current_sha = git_rev_parse("HEAD")
-    main_sha = git_rev_parse(MAIN_BRANCH)
+    base_sha = git_rev_parse(base)
 
     print(COMMENT_MARKER)
     print("## Pixi.lock changes\n")
-    print(f"Comparing `{MAIN_BRANCH}` ({main_sha}) against this branch ({current_sha}).\n")
+    print(f"Comparing `{MAIN_BRANCH}` ({base_sha}) against this branch ({current_sha}).\n")
 
 
-def lockfile_unchanged() -> bool:
-    """Cheap check to skip parsing when pixi.lock is identical to main."""
+def lockfile_unchanged(base: str) -> bool:
+    """Cheap check to skip parsing when pixi.lock is identical to the base revision."""
     result = subprocess.run(
-        ["git", "diff", "--quiet", MAIN_BRANCH, "--", LOCKFILE],
+        ["git", "diff", "--quiet", base, "--", LOCKFILE],
         capture_output=True,
         text=True,
         check=False,
@@ -215,11 +216,13 @@ def lockfile_unchanged() -> bool:
 
 
 def main():
-    if lockfile_unchanged():
+    base = os.environ.get("BASE_SHA") or MAIN_BRANCH
+
+    if lockfile_unchanged(base):
         return
 
-    print_header()
-    main_content = git_show(MAIN_BRANCH)
+    print_header(base)
+    main_content = git_show(base)
 
     with open(LOCKFILE) as f:
         current_content = f.read()


### PR DESCRIPTION


<!-- Using AI? READ FIRST: https://holoviz.org/contribute#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Compare pixi.lock diff against PR base SHA instead of main tip


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Assisted-by: Claude:Sonnet 5
Usage: Asked it to fix the problem where old PR could show diff with main branch.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
