### PR TITLE
ci: pixi.lock updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,6 +47,7 @@
       "schedule": ["before 5am"],  // Happens every second month
       "enabled": true,
       "automerge": false,  // Need to run outside CI
+      "commitMessagePrefix": "compat:"
     },
     {
       "groupName": "Pixi Lock",
@@ -54,6 +55,7 @@
       "matchUpdateTypes": ["lockFileMaintenance"],
       "description": "Weekly update of Pixi Lock",
       "schedule": ["before 5am on monday"],
+      "automergeSchedule": ["after 5am on monday"], // avoid multiple PRs in the same day
       "minimumReleaseAge": null, // Handled in pixi itself
       "commitMessageAction": "Update",
       "commitMessageTopic": "pixi.lock",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,5 @@
 name: tests
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - "*"

--- a/scripts/pixi-diff.py
+++ b/scripts/pixi-diff.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["pyyaml"]
+# dependencies = ["packaging", "pyyaml"]
 # ///
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ from functools import cache
 
 import tomllib
 import yaml
+from packaging.version import InvalidVersion, Version  # noqa: TID251
 
 COMMENT_MARKER = "<!-- pixi-lock-diff -->"
 
@@ -117,9 +118,15 @@ def version_change(old_version: str | None, new_version: str | None) -> str:
     if old_version is None or new_version is None:
         return "Changed"
     try:
-        return "Upgraded" if version_key(new_version) > version_key(old_version) else "Downgraded"
-    except TypeError:
-        return "Changed"
+        # PEP440-aware so e.g. "2.4.2rc1" -> "2.4.2" is an upgrade, not a downgrade.
+        return "Upgraded" if Version(new_version) > Version(old_version) else "Downgraded"
+    except InvalidVersion:
+        try:
+            return (
+                "Upgraded" if version_key(new_version) > version_key(old_version) else "Downgraded"
+            )
+        except TypeError:
+            return "Changed"
 
 
 def compare(main_platforms: dict, current_platforms: dict) -> list:


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

- Avoid multiple pixi.lock prs in one window.
- Disable main test run. With pixi.lock this should not be needed anymore
- support python versioning showing right ratio.
