### PR TITLE
fix: Support pyspark with Narwhals data backend

### DIFF
--- a/holoviews/core/data/narwhals.py
+++ b/holoviews/core/data/narwhals.py
@@ -40,10 +40,11 @@ _EAGER_TYPE = {
     nw.Implementation.DASK: nw.Implementation.PANDAS,
     nw.Implementation.IBIS: nw.Implementation.PYARROW,
     nw.Implementation.DUCKDB: nw.Implementation.PYARROW,
+    nw.Implementation.PYSPARK: nw.Implementation.PYARROW,
 }
 
 # Does not support drop_nulls
-_NO_DROP_NULL = [nw.Implementation.DUCKDB, nw.Implementation.IBIS]
+_NO_DROP_NULL = [nw.Implementation.DUCKDB, nw.Implementation.IBIS, nw.Implementation.PYSPARK]
 
 
 class NarwhalsDtype:


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes #2572

This is done by using the Narwhals data backend. I have chosen to not add it to our test suite as it a very big dependency to pull in. 

``` python
from pyspark.sql import SparkSession
import holoviews as hv
hv.extension("bokeh")

spark = SparkSession.builder.appName("SimpleDataFrame").getOrCreate()
df = spark.createDataFrame([(1, 5), (2,  30), (3, 35)], ["A","B"])
hv.Curve(df)
```

<img width="314" height="285" alt="image" src="https://github.com/user-attachments/assets/9f53be9c-cadb-4867-8ea9-febed41524a4" />

Used `conda install openjdk="21.*" pyspark` to set it up

## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
