### PR TITLE
fix: Align bokeh GridMatrix subplot frames

### DIFF
--- a/examples/user_guide/16-Streaming_Data.ipynb
+++ b/examples/user_guide/16-Streaming_Data.ipynb
@@ -98,7 +98,7 @@
    "source": [
     "## ``Buffer``\n",
     "\n",
-    "While ``Pipe`` provides a general solution for piping arbitrary data to ``DynamicMap`` callback,  ``Buffer`` on the other hand provides a very powerful means of working with streaming tabular data, defined as pandas dataframes, arrays or dictionaries of columns (as well as StreamingDataFrame, which we will cover later). ``Buffer`` automatically accumulates the last ``N`` rows of the tabular data, where ``N`` is defined by the ``length``.\n",
+    "While ``Pipe`` provides a general solution for piping arbitrary data to ``DynamicMap`` callback,  ``Buffer`` on the other hand provides a very powerful means of working with streaming tabular data, defined as pandas dataframes, arrays or dictionaries of columns. ``Buffer`` automatically accumulates the last ``N`` rows of the tabular data, where ``N`` is defined by the ``length``.\n",
     "\n",
     "The ability to accumulate data allows performing operations on a recent history of data, while plotting backends (such as bokeh) can optimize plot updates by sending just the latest patch. This optimization works only if the ``data`` object held by the ``Buffer`` is identical to the plotted ``Element`` data, otherwise all the data will be updated as normal."
    ]

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -633,8 +633,6 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                 kwargs["frame_width"] = width
             if height is not None:
                 kwargs["frame_height"] = height
-            if c == 0:
-                kwargs["align"] = "end"
             if c == 0 and r != 0:
                 kwargs["xaxis"] = None
             if c != 0 and r == 0:

--- a/holoviews/tests/plotting/bokeh/test_gridplot.py
+++ b/holoviews/tests/plotting/bokeh/test_gridplot.py
@@ -157,15 +157,3 @@ class TestGridPlot(TestBokehPlot):
         assert "test: 1" in plot.handles["title"].text
         plot.cleanup()
         assert stream._subscribers == []
-
-    def test_grid_subplots_not_realigned(self, rng):
-        # Right-aligning the first column shifts its frames by the width of
-        # each row's tick labels, skewing the grid, see holoviews#5784
-        ds = hv.Dataset(
-            {"a": rng.random(10), "b": rng.random(10) * 100, "c": rng.random(10)},
-            kdims=["a", "b", "c"],
-        )
-        grid = gridmatrix(ds, chart_type=hv.Points)
-        plot = bokeh_renderer.get_plot(grid)
-        aligns = {sp.handles["plot"].align for sp in plot.subplots.values()}
-        assert aligns == {"start"}

--- a/holoviews/tests/plotting/bokeh/test_gridplot.py
+++ b/holoviews/tests/plotting/bokeh/test_gridplot.py
@@ -157,3 +157,15 @@ class TestGridPlot(TestBokehPlot):
         assert "test: 1" in plot.handles["title"].text
         plot.cleanup()
         assert stream._subscribers == []
+
+    def test_grid_subplots_not_realigned(self, rng):
+        # Right-aligning the first column shifts its frames by the width of
+        # each row's tick labels, skewing the grid, see holoviews#5784
+        ds = hv.Dataset(
+            {"a": rng.random(10), "b": rng.random(10) * 100, "c": rng.random(10)},
+            kdims=["a", "b", "c"],
+        )
+        grid = gridmatrix(ds, chart_type=hv.Points)
+        plot = bokeh_renderer.get_plot(grid)
+        aligns = {sp.handles["plot"].align for sp in plot.subplots.values()}
+        assert aligns == {"start"}

--- a/holoviews/tests/ui/bokeh/test_gridspace.py
+++ b/holoviews/tests/ui/bokeh/test_gridspace.py
@@ -6,8 +6,9 @@ import numpy as np
 import pytest
 
 import holoviews as hv
+from holoviews.operation import gridmatrix
 
-from .. import wait_until
+from .. import expect, wait_until
 
 pytestmark = pytest.mark.ui
 
@@ -135,3 +136,32 @@ def test_gridspace_axis_alignment(serve_hv, xaxis, yaxis, shared_xaxis, shared_y
 
     page = serve_hv(gridspace)
     assert_axes(page, x=x, y=y)
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+def test_gridmatrix_first_column_not_realigned(serve_hv):
+    ds = hv.Dataset({"a": [0, 1, 2], "b": [0, 50000, 100000]}, kdims=["a", "b"])
+    grid = gridmatrix(ds, chart_type=hv.Points)
+
+    page = serve_hv(grid)
+    plots = page.locator(".bk-Canvas")
+    expect(plots).to_have_count(4)
+    xs = sorted(plots.nth(i).bounding_box()["x"] for i in range(4))
+
+    assert xs[0] == xs[1]
+    assert xs[2] == xs[3]
+
+
+@pytest.mark.usefixtures("bokeh_backend")
+@pytest.mark.xfail(reason="bokeh#14492: a fixed frame size opts out of bokeh's frame alignment")
+def test_gridmatrix_frame_alignment(serve_hv):
+    ds = hv.Dataset({"a": [0, 1, 2], "b": [0, 50000, 100000]}, kdims=["a", "b"])
+    grid = gridmatrix(ds, chart_type=hv.Points)
+
+    page = serve_hv(grid)
+    frames = page.locator(".bk-CartesianFrame")
+    expect(frames).to_have_count(4)
+    xs = sorted(frames.nth(i).bounding_box()["x"] for i in range(4))
+
+    assert xs[0] == xs[1]
+    assert xs[2] == xs[3]


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute#ai-readme -->
<!-- First time contributor: https://www.holoviews.org/developer_guide/index.html#making-a-pull-requests -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes #5784

The forced `align="end"` seems to have been a leftover from old Bokeh layout engine. 


<img width="570" height="589" alt="image" src="https://github.com/user-attachments/assets/e84194bf-9e02-4f5f-a2b1-2d9f2a8e07aa" />

## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Claude Code:claude-opus-5[1m]
Usage: Asked to make a MRE and fix it, and then add a UI test for it where it found an existing Bokeh problem bokeh/bokeh#14492. Added an xfail for it.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Pull request title follows the conventional format
- [x] Tests added and are passing
